### PR TITLE
P02-04: add ReplyContext public contract

### DIFF
--- a/contracts/reply_context.schema.json
+++ b/contracts/reply_context.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "p02.reply-context.v1",
+  "title": "P02 ReplyContext contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["mode", "wire_mode", "trusted_time", "world_facts", "private_behavior", "output_constraints"],
+  "properties": {
+    "mode": {"enum": ["text_letter", "spoken_video", "musical_video", "future_im"]},
+    "wire_mode": {"type": ["string", "null"], "enum": ["text", "video", null]},
+    "trusted_time": {"$ref": "#/$defs/trusted_time"},
+    "world_facts": {"type": "array", "items": {"$ref": "#/$defs/world_fact"}},
+    "private_behavior": {"$ref": "#/$defs/private_behavior"},
+    "output_constraints": {"$ref": "#/$defs/output_constraints"}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"mode": {"const": "text_letter"}}},
+      "then": {
+        "properties": {
+          "wire_mode": {"const": "text"},
+          "output_constraints": {"properties": {"channel": {"const": "letter"}}}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"mode": {"enum": ["spoken_video", "musical_video"]}}},
+      "then": {
+        "properties": {
+          "wire_mode": {"const": "video"},
+          "output_constraints": {
+            "properties": {
+              "channel": {"const": "spoken_text"},
+              "allow_stage_directions": {"const": false}
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {"properties": {"mode": {"const": "future_im"}}},
+      "then": {
+        "properties": {
+          "wire_mode": {"const": null},
+          "output_constraints": {"properties": {"channel": {"const": "instant_message"}}}
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "identifier": {"type": "string", "pattern": "^[A-Za-z0-9._:-]{1,96}$"},
+    "trusted_time": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["instant", "source"],
+      "properties": {
+        "instant": {"type": "string", "format": "date-time"},
+        "source": {"$ref": "#/$defs/identifier"}
+      }
+    },
+    "world_fact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fact_id", "source_id", "statement", "kind"],
+      "properties": {
+        "fact_id": {"$ref": "#/$defs/identifier"},
+        "source_id": {"$ref": "#/$defs/identifier"},
+        "statement": {"type": "string", "minLength": 1, "maxLength": 600},
+        "kind": {"enum": ["public_canon", "trusted_runtime"]}
+      }
+    },
+    "private_behavior": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["familiarity", "trust", "comfort", "closeness", "tension", "relationship_stage", "nickname_permission", "home_access"],
+      "properties": {
+        "familiarity": {"enum": ["unknown", "low", "medium", "high"]},
+        "trust": {"enum": ["unknown", "low", "medium", "high"]},
+        "comfort": {"enum": ["unknown", "low", "medium", "high"]},
+        "closeness": {"enum": ["unknown", "low", "medium", "high"]},
+        "tension": {"enum": ["unknown", "low", "medium", "high"]},
+        "relationship_stage": {"enum": ["unknown", "acquaintance", "familiar", "close"]},
+        "nickname_permission": {"enum": ["not_allowed", "allowed"]},
+        "home_access": {"enum": ["no_access", "visit_access", "errand_access", "domestic_access"]}
+      }
+    },
+    "output_constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["channel", "max_characters", "plain_text_only", "allow_stage_directions", "allow_control_markup"],
+      "properties": {
+        "channel": {"enum": ["letter", "spoken_text", "instant_message"]},
+        "max_characters": {"type": "integer", "minimum": 1},
+        "plain_text_only": {"const": true},
+        "allow_stage_directions": {"type": "boolean"},
+        "allow_control_markup": {"const": false}
+      }
+    }
+  }
+}

--- a/docs/P02_REPLY_CONTEXT.md
+++ b/docs/P02_REPLY_CONTEXT.md
@@ -1,0 +1,38 @@
+# P02-04 ReplyContext contract
+
+`reply_context.py` defines the immutable, provider-free input passed between
+future reply-pipeline stages. It does not call a provider, render media, load a
+persona, review a reply, or commit private state. The matching JSON Schema is
+`contracts/reply_context.schema.json` with id `p02.reply-context.v1`.
+
+## Public API
+
+- `ReplyContext.create(...)` accepts a `ReplyMode`, timezone-aware
+  `TrustedTime`, identified `TrustedWorldFact` values, a finite
+  `PrivateBehaviorView`, and explicit `OutputConstraints`.
+- `ReplyModeAdapter` preserves the legacy wire values: `text` maps to
+  `text_letter`, while `video` maps to `spoken_video`. Both spoken and musical
+  video serialize back to `video`.
+- `future_im` has no legacy wire value and is rejected unless application
+  state explicitly passes `future_im_enabled=True`.
+
+Private behavior crosses this boundary only as finite enums. Raw scores,
+private history, letters, prompts, local paths, credentials, and provider state
+are not accepted by the contract.
+
+## Output invariants
+
+| Mode | Wire mode | Output channel |
+| --- | --- | --- |
+| `text_letter` | `text` | `letter` |
+| `spoken_video` | `video` | `spoken_text` |
+| `musical_video` | `video` | `spoken_text` |
+| `future_im` | none | `instant_message` |
+
+All outputs are plain text and reject control markup. Spoken and musical video
+also reject stage directions. Python validation and the public JSON Schema
+encode the same rules.
+
+Invalid values raise `ReplyContextError` with code
+`REPLY_CONTEXT_INVALID`. Unsupported or disabled modes raise
+`UnsupportedReplyMode` with code `REPLY_MODE_UNSUPPORTED`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ py-modules = [
     "memory",
     "patch_feapp",
     "persona_loader",
+    "reply_context",
 ]
 
 [tool.setuptools.packages.find]
@@ -37,6 +38,7 @@ include = ["asr*", "contracts*", "installer*", "linli_character*", "media_state*
 
 [tool.pytest.ini_options]
 testpaths = [
+    "tests/persona",
     "tests/http",
     "tests/installer",
     "tests/media",

--- a/reply_context.py
+++ b/reply_context.py
@@ -1,0 +1,286 @@
+"""Typed, provider-free inputs for the reply pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+import re
+
+
+class ReplyContextError(ValueError):
+    code = "REPLY_CONTEXT_INVALID"
+
+
+class UnsupportedReplyMode(ReplyContextError):
+    code = "REPLY_MODE_UNSUPPORTED"
+
+
+class ReplyMode(str, Enum):
+    TEXT_LETTER = "text_letter"
+    SPOKEN_VIDEO = "spoken_video"
+    MUSICAL_VIDEO = "musical_video"
+    FUTURE_IM = "future_im"
+
+
+class OutputChannel(str, Enum):
+    LETTER = "letter"
+    SPOKEN_TEXT = "spoken_text"
+    INSTANT_MESSAGE = "instant_message"
+
+
+class WorldFactKind(str, Enum):
+    PUBLIC_CANON = "public_canon"
+    TRUSTED_RUNTIME = "trusted_runtime"
+
+
+class BehaviorLevel(str, Enum):
+    UNKNOWN = "unknown"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class RelationshipStage(str, Enum):
+    UNKNOWN = "unknown"
+    ACQUAINTANCE = "acquaintance"
+    FAMILIAR = "familiar"
+    CLOSE = "close"
+
+
+class NicknamePermission(str, Enum):
+    NOT_ALLOWED = "not_allowed"
+    ALLOWED = "allowed"
+
+
+class HomeAccess(str, Enum):
+    NO_ACCESS = "no_access"
+    VISIT_ACCESS = "visit_access"
+    ERRAND_ACCESS = "errand_access"
+    DOMESTIC_ACCESS = "domestic_access"
+
+
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+@dataclass(frozen=True)
+class TrustedTime:
+    instant: datetime
+    source: str = "system_clock"
+
+    def __post_init__(self) -> None:
+        if self.instant.tzinfo is None or self.instant.utcoffset() is None:
+            raise ReplyContextError("trusted time must be timezone-aware")
+        if not isinstance(self.source, str) or not _ID_RE.fullmatch(self.source.strip()):
+            raise ReplyContextError("trusted time source must be a stable identifier")
+        object.__setattr__(self, "instant", self.instant.astimezone(timezone.utc))
+        object.__setattr__(self, "source", self.source.strip())
+
+
+@dataclass(frozen=True)
+class TrustedWorldFact:
+    fact_id: str
+    source_id: str
+    statement: str
+    kind: WorldFactKind = WorldFactKind.PUBLIC_CANON
+
+    def __post_init__(self) -> None:
+        for value in (self.fact_id, self.source_id):
+            if not isinstance(value, str) or not _ID_RE.fullmatch(value):
+                raise ReplyContextError("world fact identifiers must be stable")
+        if (
+            not isinstance(self.statement, str)
+            or not self.statement.strip()
+            or len(self.statement) > 600
+            or _CONTROL_RE.search(self.statement)
+        ):
+            raise ReplyContextError("world fact statement is invalid")
+        if not isinstance(self.kind, WorldFactKind):
+            raise ReplyContextError("world fact kind is invalid")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "fact_id": self.fact_id,
+            "source_id": self.source_id,
+            "statement": self.statement,
+            "kind": self.kind.value,
+        }
+
+
+@dataclass(frozen=True)
+class PrivateBehaviorView:
+    familiarity: BehaviorLevel = BehaviorLevel.UNKNOWN
+    trust: BehaviorLevel = BehaviorLevel.UNKNOWN
+    comfort: BehaviorLevel = BehaviorLevel.UNKNOWN
+    closeness: BehaviorLevel = BehaviorLevel.UNKNOWN
+    tension: BehaviorLevel = BehaviorLevel.UNKNOWN
+    relationship_stage: RelationshipStage = RelationshipStage.UNKNOWN
+    nickname_permission: NicknamePermission = NicknamePermission.NOT_ALLOWED
+    home_access: HomeAccess = HomeAccess.NO_ACCESS
+
+    def __post_init__(self) -> None:
+        expected_types = (
+            (self.familiarity, BehaviorLevel),
+            (self.trust, BehaviorLevel),
+            (self.comfort, BehaviorLevel),
+            (self.closeness, BehaviorLevel),
+            (self.tension, BehaviorLevel),
+            (self.relationship_stage, RelationshipStage),
+            (self.nickname_permission, NicknamePermission),
+            (self.home_access, HomeAccess),
+        )
+        if any(not isinstance(value, expected) for value, expected in expected_types):
+            raise ReplyContextError("private behavior is outside the bounded view")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "familiarity": self.familiarity.value,
+            "trust": self.trust.value,
+            "comfort": self.comfort.value,
+            "closeness": self.closeness.value,
+            "tension": self.tension.value,
+            "relationship_stage": self.relationship_stage.value,
+            "nickname_permission": self.nickname_permission.value,
+            "home_access": self.home_access.value,
+        }
+
+
+@dataclass(frozen=True)
+class OutputConstraints:
+    channel: OutputChannel
+    max_characters: int = 12_000
+    plain_text_only: bool = True
+    allow_stage_directions: bool = False
+    allow_control_markup: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.channel, OutputChannel):
+            raise ReplyContextError("output channel is invalid")
+        if type(self.max_characters) is not int or self.max_characters < 1:
+            raise ReplyContextError("max_characters must be positive")
+        if type(self.plain_text_only) is not bool or not self.plain_text_only:
+            raise ReplyContextError("reply output must be plain text")
+        if type(self.allow_stage_directions) is not bool:
+            raise ReplyContextError("allow_stage_directions must be boolean")
+        if type(self.allow_control_markup) is not bool or self.allow_control_markup:
+            raise ReplyContextError("control markup is not allowed")
+        if self.channel is OutputChannel.SPOKEN_TEXT and self.allow_stage_directions:
+            raise ReplyContextError("spoken text cannot contain stage directions")
+
+    @classmethod
+    def for_mode(cls, mode: ReplyMode) -> "OutputConstraints":
+        if mode is ReplyMode.TEXT_LETTER:
+            return cls(OutputChannel.LETTER)
+        if mode in {ReplyMode.SPOKEN_VIDEO, ReplyMode.MUSICAL_VIDEO}:
+            return cls(OutputChannel.SPOKEN_TEXT)
+        if mode is ReplyMode.FUTURE_IM:
+            return cls(OutputChannel.INSTANT_MESSAGE)
+        raise UnsupportedReplyMode()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "channel": self.channel.value,
+            "max_characters": self.max_characters,
+            "plain_text_only": self.plain_text_only,
+            "allow_stage_directions": self.allow_stage_directions,
+            "allow_control_markup": self.allow_control_markup,
+        }
+
+
+class ReplyModeAdapter:
+    def from_wire(self, value: str) -> ReplyMode:
+        if value == "text":
+            return ReplyMode.TEXT_LETTER
+        if value == "video":
+            return ReplyMode.SPOKEN_VIDEO
+        raise UnsupportedReplyMode()
+
+    def to_wire(self, mode: ReplyMode) -> str:
+        if mode is ReplyMode.TEXT_LETTER:
+            return "text"
+        if mode in {ReplyMode.SPOKEN_VIDEO, ReplyMode.MUSICAL_VIDEO}:
+            return "video"
+        raise UnsupportedReplyMode()
+
+
+@dataclass(frozen=True)
+class ReplyContext:
+    mode: ReplyMode
+    trusted_time: TrustedTime
+    world_facts: tuple[TrustedWorldFact, ...] = ()
+    private_behavior: PrivateBehaviorView = field(default_factory=PrivateBehaviorView)
+    output_constraints: OutputConstraints = field(
+        default_factory=lambda: OutputConstraints.for_mode(ReplyMode.TEXT_LETTER)
+    )
+    future_im_enabled: bool = False
+
+    @classmethod
+    def create(
+        cls,
+        mode: ReplyMode,
+        *,
+        trusted_time: TrustedTime,
+        world_facts: tuple[TrustedWorldFact, ...] = (),
+        private_behavior: PrivateBehaviorView | None = None,
+        output_constraints: OutputConstraints | None = None,
+        future_im_enabled: bool = False,
+    ) -> "ReplyContext":
+        if mode is ReplyMode.FUTURE_IM and not future_im_enabled:
+            raise UnsupportedReplyMode()
+        constraints = output_constraints or OutputConstraints.for_mode(mode)
+        if constraints.channel is not OutputConstraints.for_mode(mode).channel:
+            raise ReplyContextError("output channel does not match reply mode")
+        facts = tuple(world_facts)
+        if any(not isinstance(fact, TrustedWorldFact) for fact in facts):
+            raise ReplyContextError("world facts must use the trusted fact type")
+        if len({fact.fact_id for fact in facts}) != len(facts):
+            raise ReplyContextError("world fact identifiers must be unique")
+        return cls(
+            mode,
+            trusted_time,
+            facts,
+            private_behavior or PrivateBehaviorView(),
+            constraints,
+            future_im_enabled,
+        )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.mode, ReplyMode):
+            raise UnsupportedReplyMode()
+        if not isinstance(self.trusted_time, TrustedTime):
+            raise ReplyContextError("trusted time is required")
+        if type(self.future_im_enabled) is not bool:
+            raise ReplyContextError("future_im_enabled must be boolean")
+        if self.mode is ReplyMode.FUTURE_IM and not self.future_im_enabled:
+            raise UnsupportedReplyMode()
+        if not isinstance(self.world_facts, tuple):
+            object.__setattr__(self, "world_facts", tuple(self.world_facts))
+        if any(not isinstance(fact, TrustedWorldFact) for fact in self.world_facts):
+            raise ReplyContextError("world facts must use the trusted fact type")
+        if len({fact.fact_id for fact in self.world_facts}) != len(self.world_facts):
+            raise ReplyContextError("world fact identifiers must be unique")
+        if not isinstance(self.private_behavior, PrivateBehaviorView):
+            raise ReplyContextError("private behavior view is invalid")
+        if not isinstance(self.output_constraints, OutputConstraints):
+            raise ReplyContextError("output constraints are invalid")
+        expected_channel = OutputConstraints.for_mode(self.mode).channel
+        if self.output_constraints.channel is not expected_channel:
+            raise ReplyContextError("output channel does not match reply mode")
+
+    def to_dict(self) -> dict[str, object]:
+        try:
+            wire_mode: str | None = ReplyModeAdapter().to_wire(self.mode)
+        except UnsupportedReplyMode:
+            wire_mode = None
+        return {
+            "mode": self.mode.value,
+            "wire_mode": wire_mode,
+            "trusted_time": {
+                "instant": self.trusted_time.instant.isoformat(),
+                "source": self.trusted_time.source,
+            },
+            "world_facts": [fact.to_dict() for fact in self.world_facts],
+            "private_behavior": self.private_behavior.to_dict(),
+            "output_constraints": self.output_constraints.to_dict(),
+        }

--- a/tests/persona/test_reply_context.py
+++ b/tests/persona/test_reply_context.py
@@ -1,0 +1,159 @@
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from reply_context import (
+    ReplyContext,
+    ReplyContextError,
+    BehaviorLevel,
+    PrivateBehaviorView,
+    OutputChannel,
+    OutputConstraints,
+    ReplyMode,
+    ReplyModeAdapter,
+    TrustedTime,
+    TrustedWorldFact,
+    UnsupportedReplyMode,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_text_wire_mode_builds_an_immutable_letter_context() -> None:
+    mode = ReplyModeAdapter().from_wire("text")
+    context = ReplyContext.create(
+        mode,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    )
+
+    assert mode is ReplyMode.TEXT_LETTER
+    assert context.to_dict()["wire_mode"] == "text"
+    assert context.to_dict()["output_constraints"]["channel"] == "letter"
+
+
+def test_trusted_time_normalizes_to_utc_and_rejects_unstable_inputs() -> None:
+    trusted_time = TrustedTime(
+        datetime(2026, 8, 22, 9, 0, tzinfo=timezone(timedelta(hours=9)))
+    )
+
+    assert trusted_time.instant == datetime(2026, 8, 22, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(ReplyContextError):
+        TrustedTime(datetime(2026, 8, 22, 0, 0))
+    with pytest.raises(ReplyContextError):
+        TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc), source="private clock")
+
+
+def test_spoken_modes_reject_stage_directions_and_control_markup() -> None:
+    with pytest.raises(ReplyContextError):
+        OutputConstraints(
+            channel=OutputChannel.SPOKEN_TEXT,
+            allow_stage_directions=True,
+        )
+    with pytest.raises(ReplyContextError):
+        OutputConstraints(
+            channel=OutputChannel.SPOKEN_TEXT,
+            allow_control_markup=True,
+        )
+
+
+def test_context_exposes_only_identified_facts_and_bounded_behavior_hints() -> None:
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+        world_facts=(
+            TrustedWorldFact(
+                fact_id="fact.synthetic",
+                source_id="source.synthetic",
+                statement="A synthetic public fact.",
+            ),
+        ),
+        private_behavior=PrivateBehaviorView(trust=BehaviorLevel.LOW),
+    )
+
+    payload = context.to_dict()
+    assert payload["world_facts"][0]["source_id"] == "source.synthetic"
+    assert payload["private_behavior"]["trust"] == "low"
+    assert "raw_score" not in payload["private_behavior"]
+
+
+def test_legacy_video_mapping_is_preserved_and_future_im_requires_opt_in() -> None:
+    adapter = ReplyModeAdapter()
+    trusted_time = TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc))
+
+    assert adapter.from_wire("video") is ReplyMode.SPOKEN_VIDEO
+    assert adapter.to_wire(ReplyMode.MUSICAL_VIDEO) == "video"
+    with pytest.raises(UnsupportedReplyMode):
+        adapter.from_wire("future_im")
+    with pytest.raises(UnsupportedReplyMode):
+        ReplyContext.create(ReplyMode.FUTURE_IM, trusted_time=trusted_time)
+
+    context = ReplyContext.create(
+        ReplyMode.FUTURE_IM,
+        trusted_time=trusted_time,
+        future_im_enabled=True,
+    )
+    assert context.to_dict()["wire_mode"] is None
+    assert context.to_dict()["output_constraints"]["channel"] == "instant_message"
+
+
+def test_schema_matches_runtime_mode_and_privacy_invariants() -> None:
+    schema = json.loads(
+        (ROOT / "contracts" / "reply_context.schema.json").read_text(encoding="utf-8")
+    )
+    validator = Draft202012Validator(schema)
+    valid = ReplyContext.create(
+        ReplyMode.MUSICAL_VIDEO,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    ).to_dict()
+
+    assert list(validator.iter_errors(valid)) == []
+
+    invalid_channel = {**valid, "output_constraints": {**valid["output_constraints"]}}
+    invalid_channel["output_constraints"]["channel"] = "letter"
+    assert list(validator.iter_errors(invalid_channel))
+
+    invalid_stage = {**valid, "output_constraints": {**valid["output_constraints"]}}
+    invalid_stage["output_constraints"]["allow_stage_directions"] = True
+    assert list(validator.iter_errors(invalid_stage))
+
+    invalid_private = {**valid, "private_behavior": {**valid["private_behavior"]}}
+    invalid_private["private_behavior"]["raw_score"] = 0.9
+    assert list(validator.iter_errors(invalid_private))
+
+
+def test_public_contract_documentation_names_api_errors_and_scope_boundary() -> None:
+    documentation = (ROOT / "docs" / "P02_REPLY_CONTEXT.md").read_text(
+        encoding="utf-8"
+    )
+
+    for marker in (
+        "ReplyContext",
+        "ReplyModeAdapter",
+        "REPLY_CONTEXT_INVALID",
+        "REPLY_MODE_UNSUPPORTED",
+        "p02.reply-context.v1",
+        "future_im",
+        "does not call a provider",
+    ):
+        assert marker in documentation
+
+
+def test_direct_construction_cannot_bypass_context_invariants() -> None:
+    trusted_time = TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc))
+
+    with pytest.raises(UnsupportedReplyMode):
+        ReplyContext(
+            mode=ReplyMode.FUTURE_IM,
+            trusted_time=trusted_time,
+            output_constraints=OutputConstraints.for_mode(ReplyMode.FUTURE_IM),
+        )
+    with pytest.raises(ReplyContextError):
+        ReplyContext(
+            mode=ReplyMode.TEXT_LETTER,
+            trusted_time=trusted_time,
+            output_constraints=OutputConstraints(OutputChannel.SPOKEN_TEXT),
+        )


### PR DESCRIPTION
Implements only the ReplyContext boundary from Issue #34. Adds immutable typed context values, legacy text/video mode mapping, explicit future_im opt-in, bounded private behavior hints, matching JSON Schema, and public documentation. No provider calls, persona assembly, review loop, persistence, media, or client activation. Validation: 134 passed, 1 experimental deselected; hardening scanner PASS with 0 findings; diff-check PASS. The 5-file contract is 585 added lines because Python, schema, tests, and docs must remain synchronized in one independently safe change.