### PR TITLE
P02-05: add deterministic prompt budget planner

### DIFF
--- a/docs/P02_PROMPT_BUDGET.md
+++ b/docs/P02_PROMPT_BUDGET.md
@@ -1,0 +1,30 @@
+# P02-05 deterministic prompt budget planner
+
+`prompt_budget.py` plans whole prompt blocks against caller-supplied cost units.
+It is pure and content-agnostic: it does not tokenize, render prompts, call a
+provider, load a persona, or alter user text.
+
+Required blocks are never dropped: Constitution, Forbidden rules, mode/output
+constraints, and the complete user input. If their combined cost exceeds the
+limit, planning raises `PromptBudgetExceeded` with code
+`PROMPT_REQUIRED_BUDGET_EXCEEDED` and a report; it never returns a partial
+required block.
+
+When optional content must be removed, complete blocks are dropped in this
+fixed order:
+
+1. history;
+2. evidence summaries;
+3. Soft Canon;
+4. Inferred Traits;
+5. private behavior hints;
+6. trusted world facts;
+7. Public Canon.
+
+Within one section, later items are dropped first so callers can place more
+relevant items earlier. `PromptBudgetPlan` keeps included blocks in their
+original order. `PromptBudgetReport` contains only identifiers and numeric
+costs, not prompt content or private state.
+
+Malformed limits, duplicate identifiers, invalid sections, or invalid costs
+raise `PromptBudgetError` with code `PROMPT_BUDGET_INVALID`.

--- a/prompt_budget.py
+++ b/prompt_budget.py
@@ -1,0 +1,134 @@
+"""Deterministic, content-agnostic prompt budget planning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import re
+
+
+class PromptBudgetError(ValueError):
+    code = "PROMPT_BUDGET_INVALID"
+
+
+class PromptBudgetExceeded(PromptBudgetError):
+    code = "PROMPT_REQUIRED_BUDGET_EXCEEDED"
+
+    def __init__(self, report: "PromptBudgetReport") -> None:
+        super().__init__(self.code)
+        self.report = report
+
+
+class PromptSection(str, Enum):
+    CONSTITUTION = "constitution"
+    FORBIDDEN = "forbidden"
+    MODE_CONSTRAINTS = "mode_constraints"
+    USER_INPUT = "user_input"
+    PRIVATE_BEHAVIOR = "private_behavior"
+    WORLD_FACT = "world_fact"
+    PUBLIC_CANON = "public_canon"
+    HISTORY = "history"
+    EVIDENCE_SUMMARY = "evidence_summary"
+    SOFT_CANON = "soft_canon"
+    INFERRED_TRAIT = "inferred_trait"
+
+
+_REQUIRED = frozenset(
+    {
+        PromptSection.CONSTITUTION,
+        PromptSection.FORBIDDEN,
+        PromptSection.MODE_CONSTRAINTS,
+        PromptSection.USER_INPUT,
+    }
+)
+_DROP_ORDER = (
+    PromptSection.HISTORY,
+    PromptSection.EVIDENCE_SUMMARY,
+    PromptSection.SOFT_CANON,
+    PromptSection.INFERRED_TRAIT,
+    PromptSection.PRIVATE_BEHAVIOR,
+    PromptSection.WORLD_FACT,
+    PromptSection.PUBLIC_CANON,
+)
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
+
+
+@dataclass(frozen=True)
+class PromptBudgetItem:
+    item_id: str
+    section: PromptSection
+    cost_units: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.item_id, str) or not _ID_RE.fullmatch(self.item_id):
+            raise PromptBudgetError("item_id must be a stable identifier")
+        if not isinstance(self.section, PromptSection):
+            raise PromptBudgetError("section is invalid")
+        if type(self.cost_units) is not int or self.cost_units < 0:
+            raise PromptBudgetError("cost_units must be a non-negative integer")
+
+
+@dataclass(frozen=True)
+class PromptBudgetReport:
+    max_units: int
+    input_units: int
+    required_units: int
+    used_units: int
+    overflow_units: int
+    included_ids: tuple[str, ...]
+    dropped_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PromptBudgetPlan:
+    items: tuple[PromptBudgetItem, ...]
+    report: PromptBudgetReport
+
+
+def plan_prompt_budget(
+    items: tuple[PromptBudgetItem, ...], *, max_units: int
+) -> PromptBudgetPlan:
+    if type(max_units) is not int or max_units < 1:
+        raise PromptBudgetError("max_units must be a positive integer")
+    candidates = tuple(items)
+    item_ids = [item.item_id for item in candidates]
+    if len(item_ids) != len(set(item_ids)):
+        raise PromptBudgetError("item identifiers must be unique")
+    required_units = sum(item.cost_units for item in candidates if item.section in _REQUIRED)
+    input_units = sum(item.cost_units for item in candidates)
+    if required_units > max_units:
+        report = PromptBudgetReport(
+            max_units=max_units,
+            input_units=input_units,
+            required_units=required_units,
+            used_units=required_units,
+            overflow_units=required_units - max_units,
+            included_ids=tuple(item.item_id for item in candidates if item.section in _REQUIRED),
+            dropped_ids=(),
+        )
+        raise PromptBudgetExceeded(report)
+    kept = [True] * len(candidates)
+    dropped_ids: list[str] = []
+    used_units = input_units
+    for section in _DROP_ORDER:
+        for index in range(len(candidates) - 1, -1, -1):
+            item = candidates[index]
+            if used_units <= max_units:
+                break
+            if item.section is section:
+                kept[index] = False
+                used_units -= item.cost_units
+                dropped_ids.append(item.item_id)
+        if used_units <= max_units:
+            break
+    included = tuple(item for index, item in enumerate(candidates) if kept[index])
+    report = PromptBudgetReport(
+        max_units=max_units,
+        input_units=input_units,
+        required_units=required_units,
+        used_units=used_units,
+        overflow_units=0,
+        included_ids=tuple(item.item_id for item in included),
+        dropped_ids=tuple(dropped_ids),
+    )
+    return PromptBudgetPlan(included, report)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ py-modules = [
     "memory",
     "patch_feapp",
     "persona_loader",
+    "prompt_budget",
     "reply_context",
 ]
 

--- a/tests/persona/test_prompt_budget.py
+++ b/tests/persona/test_prompt_budget.py
@@ -1,0 +1,88 @@
+import pytest
+
+from prompt_budget import (
+    PromptBudgetError,
+    PromptBudgetExceeded,
+    PromptBudgetItem,
+    PromptSection,
+    plan_prompt_budget,
+)
+
+
+def test_required_content_fails_explicitly_instead_of_being_truncated() -> None:
+    items = (
+        PromptBudgetItem("constitution", PromptSection.CONSTITUTION, 40),
+        PromptBudgetItem("forbidden", PromptSection.FORBIDDEN, 20),
+        PromptBudgetItem("user", PromptSection.USER_INPUT, 80),
+    )
+
+    with pytest.raises(PromptBudgetExceeded) as captured:
+        plan_prompt_budget(items, max_units=100)
+
+    assert captured.value.code == "PROMPT_REQUIRED_BUDGET_EXCEEDED"
+    assert captured.value.report.required_units == 140
+    assert captured.value.report.overflow_units == 40
+    assert captured.value.report.dropped_ids == ()
+
+
+def test_optional_blocks_are_dropped_whole_in_the_fixed_priority_order() -> None:
+    items = (
+        PromptBudgetItem("constitution", PromptSection.CONSTITUTION, 20),
+        PromptBudgetItem("forbidden", PromptSection.FORBIDDEN, 10),
+        PromptBudgetItem("mode", PromptSection.MODE_CONSTRAINTS, 10),
+        PromptBudgetItem("user", PromptSection.USER_INPUT, 40),
+        PromptBudgetItem("history", PromptSection.HISTORY, 15),
+        PromptBudgetItem("evidence", PromptSection.EVIDENCE_SUMMARY, 15),
+        PromptBudgetItem("soft", PromptSection.SOFT_CANON, 15),
+        PromptBudgetItem("inferred", PromptSection.INFERRED_TRAIT, 15),
+        PromptBudgetItem("behavior", PromptSection.PRIVATE_BEHAVIOR, 10),
+        PromptBudgetItem("world", PromptSection.WORLD_FACT, 10),
+        PromptBudgetItem("canon", PromptSection.PUBLIC_CANON, 10),
+    )
+
+    plan = plan_prompt_budget(items, max_units=130)
+
+    assert plan.report.used_units == 125
+    assert plan.report.dropped_ids == ("history", "evidence", "soft")
+    assert tuple(item.item_id for item in plan.items) == (
+        "constitution",
+        "forbidden",
+        "mode",
+        "user",
+        "inferred",
+        "behavior",
+        "world",
+        "canon",
+    )
+
+
+def test_invalid_budget_descriptors_are_rejected_before_planning() -> None:
+    with pytest.raises(PromptBudgetError):
+        plan_prompt_budget(
+            (PromptBudgetItem("user", PromptSection.USER_INPUT, 10),),
+            max_units=0,
+        )
+    with pytest.raises(PromptBudgetError):
+        plan_prompt_budget(
+            (
+                PromptBudgetItem("duplicate", PromptSection.USER_INPUT, 10),
+                PromptBudgetItem("duplicate", PromptSection.HISTORY, 5),
+            ),
+            max_units=20,
+        )
+    with pytest.raises(PromptBudgetError):
+        PromptBudgetItem("broken", PromptSection.HISTORY, -1)
+
+
+def test_bounded_blocks_keep_earlier_relevant_items_and_drop_later_whole_items() -> None:
+    items = (
+        PromptBudgetItem("user", PromptSection.USER_INPUT, 60),
+        PromptBudgetItem("world.primary", PromptSection.WORLD_FACT, 25),
+        PromptBudgetItem("world.secondary", PromptSection.WORLD_FACT, 25),
+    )
+
+    plan = plan_prompt_budget(items, max_units=90)
+
+    assert plan.report.used_units == 85
+    assert plan.report.dropped_ids == ("world.secondary",)
+    assert plan.report.included_ids == ("user", "world.primary")


### PR DESCRIPTION
Implements only the pure prompt budget planner from Issue #34. Required Constitution, Forbidden, mode/output, and user-input blocks are never truncated; required overflow fails explicitly. Optional and bounded blocks are dropped whole in the documented deterministic order, with an immutable content-free report. No prompt rendering, PersonaAssembly, provider call, runtime wiring, persistence, or media changes. Scope: 4 files, 253 added lines. Validation: 138 passed, 1 experimental deselected; hardening scanner PASS with 0 findings; compile and diff-check PASS.