### PR TITLE
P02-07: add deterministic ReplyPolicy

### DIFF
--- a/docs/P02_REPLY_POLICY.md
+++ b/docs/P02_REPLY_POLICY.md
@@ -1,0 +1,19 @@
+# P02-07 deterministic ReplyPolicy
+
+`reply_policy.py` performs narrow, deterministic checks on a reply candidate
+and a typed `ReplyContext`. It returns stable `ViolationCode` values, hard/soft
+severity, and character spans. It does not call a model, rewrite text, persist
+state, or attempt broad semantic hallucination detection.
+
+Hard checks cover output length, standalone stage directions in spoken output,
+known internal control markup, serialized private-state keys, and a small list
+of explicit permanent-availability or exclusive-relationship promises.
+
+Shared-history authorization is deliberately structured. A caller may provide
+`SharedHistoryClaim` spans with an explicit authorization result; unauthorized
+claims are blocked. Without that evidence, this deterministic scanner does not
+guess whether ordinary prose describes invented history. Semantic review
+belongs to P02-08 rather than an over-broad regular expression.
+
+Violations contain only code, severity, and offsets. They do not duplicate the
+candidate text, private state, prompt, or evidence content.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ py-modules = [
     "persona_assembly",
     "prompt_budget",
     "reply_context",
+    "reply_policy",
 ]
 
 [tool.setuptools.packages.find]

--- a/reply_policy.py
+++ b/reply_policy.py
@@ -1,0 +1,156 @@
+"""Deterministic checks for reply text and typed policy evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+import re
+
+from reply_context import ReplyContext
+
+
+class ViolationSeverity(StrEnum):
+    HARD = "hard"
+    SOFT = "soft"
+
+
+class ViolationCode(StrEnum):
+    OUTPUT_LIMIT_EXCEEDED = "OUTPUT_LIMIT_EXCEEDED"
+    STAGE_DIRECTION_IN_SPOKEN_TEXT = "STAGE_DIRECTION_IN_SPOKEN_TEXT"
+    INTERNAL_CONTROL_MARKUP = "INTERNAL_CONTROL_MARKUP"
+    PRIVATE_STATE_EXPOSED = "PRIVATE_STATE_EXPOSED"
+    PERMANENT_AVAILABILITY_PROMISE = "PERMANENT_AVAILABILITY_PROMISE"
+    EXCLUSIVE_RELATIONSHIP_PROMISE = "EXCLUSIVE_RELATIONSHIP_PROMISE"
+    UNAUTHORIZED_SHARED_HISTORY = "UNAUTHORIZED_SHARED_HISTORY"
+
+
+@dataclass(frozen=True)
+class Violation:
+    code: ViolationCode
+    severity: ViolationSeverity
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class ReplyPolicyResult:
+    violations: tuple[Violation, ...]
+
+    @property
+    def passed(self) -> bool:
+        return not any(item.severity is ViolationSeverity.HARD for item in self.violations)
+
+
+@dataclass(frozen=True)
+class SharedHistoryClaim:
+    claim_id: str
+    start: int
+    end: int
+    authorized: bool
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.claim_id, str) or not re.fullmatch(
+            r"[A-Za-z0-9._:-]{1,96}", self.claim_id
+        ):
+            raise ValueError("claim_id must be a stable identifier")
+        if type(self.start) is not int or type(self.end) is not int:
+            raise ValueError("claim span must use integers")
+        if self.start < 0 or self.end <= self.start:
+            raise ValueError("claim span is invalid")
+        if type(self.authorized) is not bool:
+            raise ValueError("claim authorization must be boolean")
+
+
+_CONTROL_MARKUP_RE = re.compile(
+    r"</?(?:PERSONA_POLICY|PRIVATE_WORLD|CONTROL|SYSTEM|CONSTITUTION)(?:\s[^>]*)?>|\[\[CONTROL:",
+    re.IGNORECASE,
+)
+_PRIVATE_STATE_RE = re.compile(
+    r"(?i)(?:[\"']?)(?:familiarity|trust|comfort|closeness|tension|relationship_stage|nickname_permission|home_access)(?:[\"']?)\s*[:=]"
+)
+_STAGE_DIRECTION_RE = re.compile(
+    r"(?m)^\s*(?:[\(（\[【][^\n]{1,120}[\)）\]】]|\*[^\n*]{1,120}\*)\s*$"
+)
+_PERMANENT_PROMISE_RE = re.compile(
+    "|".join(
+        re.escape(value)
+        for value in (
+            "我会永远在线",
+            "我永远不会离开你",
+            "I will always be online",
+            "I will never leave you",
+        )
+    ),
+    re.IGNORECASE,
+)
+_EXCLUSIVE_PROMISE_RE = re.compile(
+    "|".join(
+        re.escape(value)
+        for value in (
+            "我只属于你",
+            "你只需要我",
+            "你只能有我",
+            "I belong only to you",
+            "you only need me",
+        )
+    ),
+    re.IGNORECASE,
+)
+
+
+def scan_reply(
+    candidate: str,
+    context: ReplyContext,
+    *,
+    shared_history_claims: tuple[SharedHistoryClaim, ...] = (),
+) -> ReplyPolicyResult:
+    if not isinstance(candidate, str):
+        raise TypeError("candidate must be text")
+    if not isinstance(context, ReplyContext):
+        raise TypeError("context must be ReplyContext")
+    violations: list[Violation] = []
+    limit = context.output_constraints.max_characters
+    if len(candidate) > limit:
+        violations.append(
+            Violation(
+                ViolationCode.OUTPUT_LIMIT_EXCEEDED,
+                ViolationSeverity.HARD,
+                limit,
+                len(candidate),
+            )
+        )
+    if context.output_constraints.channel.value == "spoken_text":
+        match = _STAGE_DIRECTION_RE.search(candidate)
+        if match is not None:
+            violations.append(
+                Violation(
+                    ViolationCode.STAGE_DIRECTION_IN_SPOKEN_TEXT,
+                    ViolationSeverity.HARD,
+                    match.start(),
+                    match.end(),
+                )
+            )
+    for code, pattern in (
+        (ViolationCode.INTERNAL_CONTROL_MARKUP, _CONTROL_MARKUP_RE),
+        (ViolationCode.PRIVATE_STATE_EXPOSED, _PRIVATE_STATE_RE),
+        (ViolationCode.PERMANENT_AVAILABILITY_PROMISE, _PERMANENT_PROMISE_RE),
+        (ViolationCode.EXCLUSIVE_RELATIONSHIP_PROMISE, _EXCLUSIVE_PROMISE_RE),
+    ):
+        match = pattern.search(candidate)
+        if match is not None:
+            violations.append(
+                Violation(code, ViolationSeverity.HARD, match.start(), match.end())
+            )
+    for claim in shared_history_claims:
+        if not isinstance(claim, SharedHistoryClaim) or claim.end > len(candidate):
+            raise ValueError("shared history claim is invalid for candidate")
+        if not claim.authorized:
+            violations.append(
+                Violation(
+                    ViolationCode.UNAUTHORIZED_SHARED_HISTORY,
+                    ViolationSeverity.HARD,
+                    claim.start,
+                    claim.end,
+                )
+            )
+    return ReplyPolicyResult(tuple(violations))

--- a/tests/persona/test_reply_policy.py
+++ b/tests/persona/test_reply_policy.py
@@ -1,0 +1,79 @@
+from datetime import datetime, timezone
+
+from reply_context import (
+    OutputChannel,
+    OutputConstraints,
+    ReplyContext,
+    ReplyMode,
+    TrustedTime,
+)
+from reply_policy import SharedHistoryClaim, ViolationCode, scan_reply
+
+
+def test_internal_markup_and_serialized_private_state_are_hard_violations() -> None:
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    )
+    candidate = "你好。<PERSONA_POLICY> trust=high"
+
+    result = scan_reply(candidate, context)
+
+    assert result.passed is False
+    assert tuple(violation.code for violation in result.violations) == (
+        ViolationCode.INTERNAL_CONTROL_MARKUP,
+        ViolationCode.PRIVATE_STATE_EXPOSED,
+    )
+    assert all(violation.severity.value == "hard" for violation in result.violations)
+    assert all(candidate[violation.start : violation.end] for violation in result.violations)
+
+
+def test_spoken_output_enforces_length_and_standalone_stage_direction_rules() -> None:
+    context = ReplyContext.create(
+        ReplyMode.SPOKEN_VIDEO,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+        output_constraints=OutputConstraints(
+            OutputChannel.SPOKEN_TEXT,
+            max_characters=12,
+        ),
+    )
+
+    result = scan_reply("你好（这是说明）。\n（轻轻微笑）", context)
+
+    assert tuple(violation.code for violation in result.violations) == (
+        ViolationCode.OUTPUT_LIMIT_EXCEEDED,
+        ViolationCode.STAGE_DIRECTION_IN_SPOKEN_TEXT,
+    )
+
+
+def test_only_explicit_permanent_or_exclusive_commitments_are_blocked() -> None:
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    )
+
+    safe = scan_reply("我愿意在这封信里陪你慢慢想一想。", context)
+    blocked = scan_reply("我会永远在线，我只属于你。", context)
+
+    assert safe.passed is True
+    assert tuple(violation.code for violation in blocked.violations) == (
+        ViolationCode.PERMANENT_AVAILABILITY_PROMISE,
+        ViolationCode.EXCLUSIVE_RELATIONSHIP_PROMISE,
+    )
+
+
+def test_shared_history_is_blocked_only_from_explicit_structured_evidence() -> None:
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    )
+    candidate = "还记得我们一起去过海边。"
+    unauthorized = SharedHistoryClaim("claim.synthetic", 0, len(candidate), False)
+    authorized = SharedHistoryClaim("claim.synthetic", 0, len(candidate), True)
+
+    assert scan_reply(candidate, context).passed is True
+    assert scan_reply(candidate, context, shared_history_claims=(authorized,)).passed is True
+    blocked = scan_reply(candidate, context, shared_history_claims=(unauthorized,))
+    assert tuple(violation.code for violation in blocked.violations) == (
+        ViolationCode.UNAUTHORIZED_SHARED_HISTORY,
+    )


### PR DESCRIPTION
Implements only the deterministic ReplyPolicy from Issue #34. It returns stable hard/soft violation codes and character spans for explicit output-limit, spoken stage-direction, internal-markup, serialized private-state, permanent-availability, exclusive-relationship, and structured unauthorized-history evidence. It deliberately does not guess broad semantic hallucinations; semantic review remains P02-08. No rewrite, provider, persistence, server, media, or activation wiring. Scope: 4 files, 255 added lines. Validation: 147 passed, 1 experimental deselected; hardening scanner PASS with 0 findings; compile and diff-check PASS.