### PR TITLE
P02-08: add reply reviewer contract and adapter

### DIFF
--- a/contracts/reply_review.schema.json
+++ b/contracts/reply_review.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "p02.reply-review.v1",
+  "title": "P02 reply reviewer response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "status", "verdict", "violations", "scores"],
+  "properties": {
+    "schema_version": {"const": "p02.reply-review.v1"},
+    "status": {"const": "completed"},
+    "verdict": {"enum": ["pass", "rewrite", "block"]},
+    "violations": {
+      "type": "array",
+      "maxItems": 32,
+      "items": {"$ref": "#/$defs/violation"}
+    },
+    "scores": {"$ref": "#/$defs/scores"}
+  },
+  "$defs": {
+    "violation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "severity", "evidence"],
+      "properties": {
+        "code": {"type": "string", "pattern": "^[A-Z][A-Z0-9_]{2,63}$"},
+        "severity": {"enum": ["hard", "soft"]},
+        "evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["start", "end"],
+          "properties": {
+            "start": {"type": "integer", "minimum": 0},
+            "end": {"type": "integer", "minimum": 1}
+          }
+        }
+      }
+    },
+    "scores": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["persona_consistency", "factual_consistency", "relationship_boundary", "mode_compliance"],
+      "properties": {
+        "persona_consistency": {"type": "integer", "minimum": 0, "maximum": 100},
+        "factual_consistency": {"type": "integer", "minimum": 0, "maximum": 100},
+        "relationship_boundary": {"type": "integer", "minimum": 0, "maximum": 100},
+        "mode_compliance": {"type": "integer", "minimum": 0, "maximum": 100}
+      }
+    }
+  }
+}

--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -1,0 +1,19 @@
+# P02-08 reply reviewer contract and adapter
+
+`reply_reviewer.py` defines a provider-neutral review adapter and typed result.
+The provider response must match `contracts/reply_review.schema.json` with id
+`p02.reply-review.v1`: verdict, bounded violations, four 0-100 consistency
+scores, and completed status.
+
+The request contains only candidate text, reply mode/output constraints,
+trusted world facts, and caller-supplied short identified reference summaries.
+It excludes private behavior values, control views, databases, paths, complete
+letter libraries, and provider configuration.
+
+`NullReviewer` and a disabled adapter make no transport call. Transport errors
+return `REVIEWER_UNAVAILABLE`; invalid JSON returns
+`REVIEWER_RESPONSE_INVALID`. Both results are sanitized and contain no provider
+exception, request body, path, credential, prompt, or private evidence.
+
+This module only judges. It does not modify candidate text, retry, rewrite,
+persist state, call media, or connect to the reply pipeline.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ py-modules = [
     "prompt_budget",
     "reply_context",
     "reply_policy",
+    "reply_reviewer",
 ]
 
 [tool.setuptools.packages.find]

--- a/reply_reviewer.py
+++ b/reply_reviewer.py
@@ -1,0 +1,190 @@
+"""Strict, provider-neutral reply-review adapter boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+import json
+from pathlib import Path
+import re
+from typing import Mapping, Protocol
+
+from jsonschema import Draft202012Validator
+
+from reply_context import ReplyContext
+
+
+_SCHEMA_PATH = Path(__file__).resolve().parent / "contracts" / "reply_review.schema.json"
+_VALIDATOR = Draft202012Validator(json.loads(_SCHEMA_PATH.read_text(encoding="utf-8")))
+
+
+class ReviewStatus(StrEnum):
+    COMPLETED = "completed"
+    DISABLED = "disabled"
+    UNAVAILABLE = "unavailable"
+    INVALID_RESPONSE = "invalid_response"
+
+
+class ReviewVerdict(StrEnum):
+    PASS = "pass"
+    REWRITE = "rewrite"
+    BLOCK = "block"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class ReviewerScores:
+    persona_consistency: int
+    factual_consistency: int
+    relationship_boundary: int
+    mode_compliance: int
+
+
+@dataclass(frozen=True)
+class ReviewerViolation:
+    code: str
+    severity: str
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class ReviewReference:
+    reference_id: str
+    summary: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.reference_id, str) or not re.fullmatch(
+            r"[A-Za-z0-9._:-]{1,96}", self.reference_id
+        ):
+            raise ValueError("reference_id must be a stable identifier")
+        if (
+            not isinstance(self.summary, str)
+            or not self.summary.strip()
+            or len(self.summary) > 600
+            or re.search(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", self.summary)
+        ):
+            raise ValueError("reference summary is invalid")
+
+    def to_dict(self) -> dict[str, str]:
+        return {"reference_id": self.reference_id, "summary": self.summary.strip()}
+
+
+@dataclass(frozen=True)
+class ReviewResult:
+    status: ReviewStatus
+    verdict: ReviewVerdict
+    violations: tuple[ReviewerViolation, ...]
+    scores: ReviewerScores
+    error_code: str | None = None
+
+
+@dataclass(frozen=True)
+class ReviewerConfig:
+    model: str
+    timeout_seconds: float = 10.0
+    enabled: bool = True
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.model, str) or not re.fullmatch(
+            r"[A-Za-z0-9._:-]{1,96}", self.model
+        ):
+            raise ValueError("reviewer model must be a stable identifier")
+        if not isinstance(self.timeout_seconds, (int, float)) or self.timeout_seconds <= 0:
+            raise ValueError("reviewer timeout must be positive")
+        if type(self.enabled) is not bool:
+            raise ValueError("reviewer enabled must be boolean")
+
+
+class ReviewTransport(Protocol):
+    def review_json(
+        self,
+        request: dict[str, object],
+        *,
+        model: str,
+        timeout_seconds: float,
+    ) -> object: ...
+
+
+class NullReviewer:
+    def review(
+        self,
+        candidate: str,
+        context: ReplyContext,
+        *,
+        references: tuple[ReviewReference, ...] = (),
+    ) -> ReviewResult:
+        return _failure(ReviewStatus.DISABLED, "REVIEWER_DISABLED")
+
+
+class JsonReviewerAdapter:
+    def __init__(self, transport: ReviewTransport, config: ReviewerConfig) -> None:
+        self.transport = transport
+        self.config = config
+
+    def review(
+        self,
+        candidate: str,
+        context: ReplyContext,
+        *,
+        references: tuple[ReviewReference, ...] = (),
+    ) -> ReviewResult:
+        if not isinstance(candidate, str) or not candidate.strip():
+            raise ValueError("candidate is required")
+        if not isinstance(context, ReplyContext):
+            raise TypeError("context must be ReplyContext")
+        if not self.config.enabled:
+            return _failure(ReviewStatus.DISABLED, "REVIEWER_DISABLED")
+        request: dict[str, object] = {
+            "candidate": candidate,
+            "mode": context.mode.value,
+            "output_constraints": context.output_constraints.to_dict(),
+            "world_facts": [fact.to_dict() for fact in context.world_facts],
+            "references": [reference.to_dict() for reference in references],
+        }
+        try:
+            response = self.transport.review_json(
+                request,
+                model=self.config.model,
+                timeout_seconds=float(self.config.timeout_seconds),
+            )
+        except Exception:
+            return _failure(ReviewStatus.UNAVAILABLE, "REVIEWER_UNAVAILABLE")
+        if not isinstance(response, Mapping) or list(_VALIDATOR.iter_errors(response)):
+            return _failure(ReviewStatus.INVALID_RESPONSE, "REVIEWER_RESPONSE_INVALID")
+        try:
+            scores = response["scores"]
+            violations = tuple(
+                ReviewerViolation(
+                    code=str(item["code"]),
+                    severity=str(item["severity"]),
+                    start=int(item["evidence"]["start"]),
+                    end=int(item["evidence"]["end"]),
+                )
+                for item in response["violations"]
+            )
+            if any(item.end <= item.start or item.end > len(candidate) for item in violations):
+                return _failure(ReviewStatus.INVALID_RESPONSE, "REVIEWER_RESPONSE_INVALID")
+            return ReviewResult(
+                status=ReviewStatus(str(response["status"])),
+                verdict=ReviewVerdict(str(response["verdict"])),
+                violations=violations,
+                scores=ReviewerScores(
+                    int(scores["persona_consistency"]),
+                    int(scores["factual_consistency"]),
+                    int(scores["relationship_boundary"]),
+                    int(scores["mode_compliance"]),
+                ),
+            )
+        except (KeyError, TypeError, ValueError):
+            return _failure(ReviewStatus.INVALID_RESPONSE, "REVIEWER_RESPONSE_INVALID")
+
+
+def _failure(status: ReviewStatus, error_code: str) -> ReviewResult:
+    return ReviewResult(
+        status=status,
+        verdict=ReviewVerdict.UNAVAILABLE,
+        violations=(),
+        scores=ReviewerScores(0, 0, 0, 0),
+        error_code=error_code,
+    )

--- a/tests/persona/test_reply_reviewer.py
+++ b/tests/persona/test_reply_reviewer.py
@@ -1,0 +1,198 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from reply_context import ReplyContext, ReplyMode, TrustedTime, TrustedWorldFact
+from reply_reviewer import (
+    JsonReviewerAdapter,
+    NullReviewer,
+    ReviewReference,
+    ReviewerConfig,
+    ReviewStatus,
+    ReviewVerdict,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class _Transport:
+    def __init__(self, response: object) -> None:
+        self.response = response
+        self.requests: list[dict[str, object]] = []
+
+    def review_json(
+        self,
+        request: dict[str, object],
+        *,
+        model: str,
+        timeout_seconds: float,
+    ) -> object:
+        self.requests.append(request)
+        return self.response
+
+
+class _FailingTransport:
+    def review_json(self, request, *, model, timeout_seconds):
+        raise RuntimeError("private provider failure details")
+
+
+def test_valid_reviewer_json_becomes_a_typed_result_from_limited_context() -> None:
+    transport = _Transport(
+        {
+            "schema_version": "p02.reply-review.v1",
+            "status": "completed",
+            "verdict": "pass",
+            "violations": [],
+            "scores": {
+                "persona_consistency": 92,
+                "factual_consistency": 94,
+                "relationship_boundary": 96,
+                "mode_compliance": 98,
+            },
+        }
+    )
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+        world_facts=(
+            TrustedWorldFact("fact.synthetic", "source.synthetic", "Synthetic fact."),
+        ),
+    )
+    adapter = JsonReviewerAdapter(
+        transport,
+        ReviewerConfig(model="reviewer-small", timeout_seconds=5),
+    )
+
+    result = adapter.review("A synthetic candidate.", context)
+
+    assert result.status is ReviewStatus.COMPLETED
+    assert result.verdict is ReviewVerdict.PASS
+    assert result.scores.mode_compliance == 98
+    assert transport.requests[0]["world_facts"][0]["fact_id"] == "fact.synthetic"
+    assert "private_behavior" not in transport.requests[0]
+
+
+def test_public_schema_rejects_unknown_fields_and_out_of_range_scores() -> None:
+    schema = json.loads(
+        (ROOT / "contracts" / "reply_review.schema.json").read_text(encoding="utf-8")
+    )
+    validator = Draft202012Validator(schema)
+    valid = {
+        "schema_version": "p02.reply-review.v1",
+        "status": "completed",
+        "verdict": "rewrite",
+        "violations": [
+            {
+                "code": "UNAUTHORIZED_SHARED_HISTORY",
+                "severity": "hard",
+                "evidence": {"start": 2, "end": 8},
+            }
+        ],
+        "scores": {
+            "persona_consistency": 80,
+            "factual_consistency": 75,
+            "relationship_boundary": 60,
+            "mode_compliance": 100,
+        },
+    }
+
+    assert list(validator.iter_errors(valid)) == []
+    invalid = {**valid, "hidden_state": {"trust": 0.9}}
+    assert list(validator.iter_errors(invalid))
+    invalid_score = {**valid, "scores": {**valid["scores"], "mode_compliance": 101}}
+    assert list(validator.iter_errors(invalid_score))
+
+
+def test_invalid_provider_json_returns_a_sanitized_typed_failure() -> None:
+    transport = _Transport(
+        {
+            "schema_version": "p02.reply-review.v1",
+            "status": "completed",
+            "verdict": "pass",
+            "violations": [],
+            "scores": {
+                "persona_consistency": 100,
+                "factual_consistency": 100,
+                "relationship_boundary": 100,
+                "mode_compliance": 101,
+            },
+        }
+    )
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    )
+
+    result = JsonReviewerAdapter(transport, ReviewerConfig("reviewer-small")).review(
+        "Synthetic candidate.", context
+    )
+
+    assert result.status is ReviewStatus.INVALID_RESPONSE
+    assert result.verdict is ReviewVerdict.UNAVAILABLE
+    assert result.error_code == "REVIEWER_RESPONSE_INVALID"
+    assert result.violations == ()
+
+
+def test_disabled_and_failed_reviewers_return_sanitized_unavailable_results() -> None:
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    )
+    transport = _Transport({})
+
+    disabled = JsonReviewerAdapter(
+        transport,
+        ReviewerConfig("reviewer-small", enabled=False),
+    ).review("Synthetic candidate.", context)
+    null_result = NullReviewer().review("Synthetic candidate.", context)
+    failed = JsonReviewerAdapter(
+        _FailingTransport(), ReviewerConfig("reviewer-small")
+    ).review("Synthetic candidate.", context)
+
+    assert disabled.status is ReviewStatus.DISABLED
+    assert null_result.status is ReviewStatus.DISABLED
+    assert transport.requests == []
+    assert failed.status is ReviewStatus.UNAVAILABLE
+    assert failed.error_code == "REVIEWER_UNAVAILABLE"
+    assert "private" not in str(failed)
+
+
+def test_reviewer_request_accepts_only_short_identified_reference_summaries() -> None:
+    transport = _Transport(
+        {
+            "schema_version": "p02.reply-review.v1",
+            "status": "completed",
+            "verdict": "pass",
+            "violations": [],
+            "scores": {
+                "persona_consistency": 100,
+                "factual_consistency": 100,
+                "relationship_boundary": 100,
+                "mode_compliance": 100,
+            },
+        }
+    )
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    )
+
+    JsonReviewerAdapter(transport, ReviewerConfig("reviewer-small")).review(
+        "Synthetic candidate.",
+        context,
+        references=(ReviewReference("ref.synthetic", "Short synthetic summary."),),
+    )
+
+    assert transport.requests[0]["references"] == [
+        {"reference_id": "ref.synthetic", "summary": "Short synthetic summary."}
+    ]
+    assert set(transport.requests[0]) == {
+        "candidate",
+        "mode",
+        "output_constraints",
+        "world_facts",
+        "references",
+    }


### PR DESCRIPTION
Implements only the P02-08 strict reviewer JSON contract, provider-neutral adapter, configuration, and NullReviewer. Requests contain candidate text, mode/output constraints, trusted facts, and short identified summaries; hidden state/control/database/path content is excluded. Disabled mode makes zero calls; provider and invalid-response failures return sanitized typed results. No rewrite, retry loop, persistence, server, media, or pipeline wiring. Scope: 5 files, 458 added lines; production module 190 lines. Validation: 152 passed, 1 experimental deselected; hardening scanner PASS with 0 findings; compile and diff-check PASS.