### PR TITLE
P02-09: add one-rewrite ReplyQualityGate

### DIFF
--- a/docs/P02_REPLY_QUALITY_GATE.md
+++ b/docs/P02_REPLY_QUALITY_GATE.md
@@ -1,0 +1,17 @@
+# P02-09 bounded ReplyQualityGate
+
+`reply_quality_gate.py` runs one deterministic scan and one semantic review on
+a candidate. A hard deterministic violation or reviewer `rewrite`/`block`
+verdict may trigger exactly one rewrite by the original reply model. The
+rewritten text is scanned and reviewed once more; there is no loop.
+
+After the rewrite budget is consumed, a deterministic hard violation or
+reviewer `block` fails closed. A final reviewer `rewrite` containing only soft
+violations is accepted with warnings. Reviewer unavailability may degrade-pass
+only when deterministic checks are clean. Rewrite failure is blocked with the
+sanitized code `REWRITE_FAILED`.
+
+The result exposes deterministic, reviewer, and rewrite call counts so the
+one-rewrite bound is testable. This module does not generate the first
+candidate, persist canonical text, update private state, render media, or wire
+the server.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ py-modules = [
     "prompt_budget",
     "reply_context",
     "reply_policy",
+    "reply_quality_gate",
     "reply_reviewer",
 ]
 

--- a/reply_quality_gate.py
+++ b/reply_quality_gate.py
@@ -1,0 +1,135 @@
+"""Bounded reply quality gate with a global one-rewrite maximum."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+
+from reply_context import ReplyContext
+from reply_policy import scan_reply
+from reply_reviewer import ReviewResult, ReviewVerdict
+
+
+class QualityGateStatus(StrEnum):
+    ACCEPTED = "accepted"
+    ACCEPTED_DEGRADED = "accepted_degraded"
+    ACCEPTED_WITH_WARNINGS = "accepted_with_warnings"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class QualityGateResult:
+    status: QualityGateStatus
+    text: str
+    violation_codes: tuple[str, ...]
+    deterministic_checks: int
+    reviewer_calls: int
+    rewrite_calls: int
+    error_code: str | None = None
+
+    @property
+    def accepted(self) -> bool:
+        return self.status is not QualityGateStatus.BLOCKED
+
+
+class ReviewerPort(Protocol):
+    def review(self, candidate: str, context: ReplyContext) -> ReviewResult: ...
+
+
+class RewriterPort(Protocol):
+    def rewrite(
+        self,
+        candidate: str,
+        context: ReplyContext,
+        violation_codes: tuple[str, ...],
+    ) -> str: ...
+
+
+def run_reply_quality_gate(
+    candidate: str,
+    context: ReplyContext,
+    *,
+    reviewer: ReviewerPort,
+    rewriter: RewriterPort,
+) -> QualityGateResult:
+    deterministic = scan_reply(candidate, context)
+    review = reviewer.review(candidate, context)
+    deterministic_codes = tuple(item.code.value for item in deterministic.violations)
+    review_codes = tuple(item.code for item in review.violations)
+    if deterministic.passed and review.verdict is ReviewVerdict.UNAVAILABLE:
+        return QualityGateResult(
+            QualityGateStatus.ACCEPTED_DEGRADED,
+            candidate,
+            deterministic_codes,
+            deterministic_checks=1,
+            reviewer_calls=1,
+            rewrite_calls=0,
+            error_code=review.error_code,
+        )
+    rewrite_required = not deterministic.passed or review.verdict in {
+        ReviewVerdict.REWRITE,
+        ReviewVerdict.BLOCK,
+    }
+    if not rewrite_required:
+        return QualityGateResult(
+            QualityGateStatus.ACCEPTED,
+            candidate,
+            deterministic_codes + review_codes,
+            deterministic_checks=1,
+            reviewer_calls=1,
+            rewrite_calls=0,
+        )
+    try:
+        rewritten = rewriter.rewrite(
+            candidate,
+            context,
+            deterministic_codes + review_codes,
+        )
+    except Exception:
+        return QualityGateResult(
+            QualityGateStatus.BLOCKED,
+            candidate,
+            deterministic_codes + review_codes,
+            deterministic_checks=1,
+            reviewer_calls=1,
+            rewrite_calls=1,
+            error_code="REWRITE_FAILED",
+        )
+    if not isinstance(rewritten, str) or not rewritten.strip():
+        return QualityGateResult(
+            QualityGateStatus.BLOCKED,
+            candidate,
+            deterministic_codes + review_codes,
+            deterministic_checks=1,
+            reviewer_calls=1,
+            rewrite_calls=1,
+            error_code="REWRITE_FAILED",
+        )
+    final_deterministic = scan_reply(rewritten, context)
+    final_review = reviewer.review(rewritten, context)
+    final_codes = tuple(item.code.value for item in final_deterministic.violations) + tuple(
+        item.code for item in final_review.violations
+    )
+    if not final_deterministic.passed or final_review.verdict is ReviewVerdict.BLOCK:
+        status = QualityGateStatus.BLOCKED
+    elif final_review.verdict is ReviewVerdict.UNAVAILABLE:
+        status = QualityGateStatus.ACCEPTED_DEGRADED
+    elif final_review.verdict is ReviewVerdict.REWRITE:
+        has_hard_review = any(item.severity == "hard" for item in final_review.violations)
+        status = (
+            QualityGateStatus.BLOCKED
+            if has_hard_review
+            else QualityGateStatus.ACCEPTED_WITH_WARNINGS
+        )
+    else:
+        status = QualityGateStatus.ACCEPTED
+    return QualityGateResult(
+        status,
+        rewritten,
+        final_codes,
+        deterministic_checks=2,
+        reviewer_calls=2,
+        rewrite_calls=1,
+        error_code=final_review.error_code,
+    )

--- a/tests/persona/test_reply_quality_gate.py
+++ b/tests/persona/test_reply_quality_gate.py
@@ -1,0 +1,134 @@
+from datetime import datetime, timezone
+
+from reply_context import ReplyContext, ReplyMode, TrustedTime
+from reply_quality_gate import QualityGateStatus, run_reply_quality_gate
+from reply_reviewer import (
+    NullReviewer,
+    ReviewerScores,
+    ReviewerViolation,
+    ReviewResult,
+    ReviewStatus,
+    ReviewVerdict,
+)
+
+
+class _NeverRewrite:
+    def rewrite(self, candidate, context, violation_codes):
+        raise AssertionError("rewrite must not be called")
+
+
+class _Reviewer:
+    def __init__(self, *results: ReviewResult) -> None:
+        self.results = list(results)
+        self.calls = 0
+
+    def review(self, candidate, context):
+        result = self.results[self.calls]
+        self.calls += 1
+        return result
+
+
+class _Rewriter:
+    def __init__(self, rewritten: str) -> None:
+        self.rewritten = rewritten
+        self.calls = 0
+
+    def rewrite(self, candidate, context, violation_codes):
+        self.calls += 1
+        return self.rewritten
+
+
+def _pass_review() -> ReviewResult:
+    return ReviewResult(
+        ReviewStatus.COMPLETED,
+        ReviewVerdict.PASS,
+        (),
+        ReviewerScores(100, 100, 100, 100),
+    )
+
+
+def _context() -> ReplyContext:
+    return ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    )
+
+
+def test_clean_candidate_passes_degraded_when_reviewer_is_disabled() -> None:
+    result = run_reply_quality_gate(
+        "A clean synthetic candidate.",
+        _context(),
+        reviewer=NullReviewer(),
+        rewriter=_NeverRewrite(),
+    )
+
+    assert result.status is QualityGateStatus.ACCEPTED_DEGRADED
+    assert result.accepted is True
+    assert result.text == "A clean synthetic candidate."
+    assert result.reviewer_calls == 1
+    assert result.rewrite_calls == 0
+
+
+def test_hard_candidate_is_rewritten_once_then_rechecked_before_acceptance() -> None:
+    reviewer = _Reviewer(_pass_review(), _pass_review())
+    rewriter = _Rewriter("A clean rewritten candidate.")
+
+    result = run_reply_quality_gate(
+        "<CONTROL>bad candidate",
+        _context(),
+        reviewer=reviewer,
+        rewriter=rewriter,
+    )
+
+    assert result.status is QualityGateStatus.ACCEPTED
+    assert result.text == "A clean rewritten candidate."
+    assert result.deterministic_checks == 2
+    assert result.reviewer_calls == 2
+    assert result.rewrite_calls == 1
+    assert reviewer.calls == 2
+    assert rewriter.calls == 1
+
+
+def test_second_hard_result_is_blocked_without_a_hidden_rewrite_loop() -> None:
+    reviewer = _Reviewer(_pass_review(), _pass_review())
+    rewriter = _Rewriter("<SYSTEM>still invalid")
+
+    result = run_reply_quality_gate(
+        "<CONTROL>first invalid",
+        _context(),
+        reviewer=reviewer,
+        rewriter=rewriter,
+    )
+
+    assert result.status is QualityGateStatus.BLOCKED
+    assert result.accepted is False
+    assert result.rewrite_calls == 1
+    assert result.reviewer_calls == 2
+    assert rewriter.calls == 1
+
+
+def test_final_soft_review_issue_is_accepted_with_warnings_after_one_rewrite() -> None:
+    first = ReviewResult(
+        ReviewStatus.COMPLETED,
+        ReviewVerdict.REWRITE,
+        (),
+        ReviewerScores(80, 80, 80, 80),
+    )
+    final = ReviewResult(
+        ReviewStatus.COMPLETED,
+        ReviewVerdict.REWRITE,
+        (ReviewerViolation("STYLE_DRIFT", "soft", 0, 5),),
+        ReviewerScores(90, 90, 90, 90),
+    )
+
+    result = run_reply_quality_gate(
+        "Initial candidate.",
+        _context(),
+        reviewer=_Reviewer(first, final),
+        rewriter=_Rewriter("Final candidate."),
+    )
+
+    assert result.status is QualityGateStatus.ACCEPTED_WITH_WARNINGS
+    assert result.accepted is True
+    assert result.violation_codes == ("STYLE_DRIFT",)
+    assert result.rewrite_calls == 1


### PR DESCRIPTION
Implements only the pure bounded quality gate from Issue #34. It runs deterministic policy and semantic review, permits at most one rewrite, rechecks once, blocks final hard/block outcomes, permits final soft-only warnings, and degrades on reviewer outage only when deterministic checks are clean. Call counts prove the global one-rewrite bound. No initial generation, persistence, private-state mutation, server, media, or activation wiring. Scope: 4 files, 287 added lines. Validation: 156 passed, 1 experimental deselected; hardening scanner PASS with 0 findings; compile and diff-check PASS.