### PR TITLE
P02-10: define PrivateWorld contract

### DIFF
--- a/contracts/private_world.schema.json
+++ b/contracts/private_world.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "p02.private-world.v1",
+  "title": "P02 PrivateWorld views",
+  "oneOf": [
+    {"$ref": "#/$defs/snapshot"},
+    {"$ref": "#/$defs/control"},
+    {"$ref": "#/$defs/character"}
+  ],
+  "$defs": {
+    "token": {"type": "string", "pattern": "^[A-Za-z0-9._:-]{1,64}$"},
+    "score": {"type": "integer", "minimum": 0, "maximum": 100},
+    "home_access": {"enum": ["no_access", "visit_access", "errand_access", "domestic_access"]},
+    "awareness": {"enum": ["control_only", "character_known", "pending"]},
+    "shared": {
+      "type": "object",
+      "required": ["relationship_stage", "nickname_permissions", "home_access", "continuation_awareness"],
+      "properties": {
+        "relationship_stage": {"$ref": "#/$defs/token"},
+        "nickname_permissions": {"type": "array", "maxItems": 16, "uniqueItems": true, "items": {"$ref": "#/$defs/token"}},
+        "home_access": {"$ref": "#/$defs/home_access"},
+        "continuation_awareness": {"$ref": "#/$defs/awareness"}
+      }
+    },
+    "hidden": {
+      "type": "object",
+      "required": ["familiarity", "trust", "comfort", "closeness", "tension"],
+      "properties": {
+        "familiarity": {"$ref": "#/$defs/score"},
+        "trust": {"$ref": "#/$defs/score"},
+        "comfort": {"$ref": "#/$defs/score"},
+        "closeness": {"$ref": "#/$defs/score"},
+        "tension": {"$ref": "#/$defs/score"}
+      }
+    },
+    "control": {
+      "allOf": [
+        {"$ref": "#/$defs/shared"}, {"$ref": "#/$defs/hidden"},
+        {"type": "object", "additionalProperties": false, "required": ["view"], "properties": {
+          "view": {"const": "control"}, "familiarity": {}, "trust": {}, "comfort": {}, "closeness": {}, "tension": {},
+          "relationship_stage": {}, "nickname_permissions": {}, "home_access": {}, "continuation_awareness": {}
+        }}
+      ]
+    },
+    "character": {
+      "allOf": [
+        {"$ref": "#/$defs/shared"},
+        {"type": "object", "additionalProperties": false, "required": ["view"], "properties": {
+          "view": {"const": "character"}, "relationship_stage": {}, "nickname_permissions": {}, "home_access": {}, "continuation_awareness": {}
+        }}
+      ]
+    },
+    "snapshot": {
+      "allOf": [
+        {"$ref": "#/$defs/shared"}, {"$ref": "#/$defs/hidden"},
+        {"type": "object", "additionalProperties": false, "required": ["view", "version"], "properties": {
+          "view": {"const": "snapshot"}, "version": {"type": "integer", "minimum": 1},
+          "familiarity": {}, "trust": {}, "comfort": {}, "closeness": {}, "tension": {},
+          "relationship_stage": {}, "nickname_permissions": {}, "home_access": {}, "continuation_awareness": {}
+        }}
+      ]
+    }
+  }
+}

--- a/docs/P02_10_PRIVATE_WORLD.md
+++ b/docs/P02_10_PRIVATE_WORLD.md
@@ -1,0 +1,13 @@
+# P02-10 PrivateWorld contract
+
+`PrivateWorldPort` separates private relationship state from ordinary memory.
+Its persistent snapshot and control view may contain bounded hidden values; the
+character view omits every hidden numeric value and exposes only explicit,
+finite permissions and relationship labels.
+
+`NullPrivateWorldPort` is the disabled default. It returns an immutable empty
+snapshot, does not persist or mutate files, and does not call a provider.
+
+This slice defines contracts only. P02-11 owns the SQLite event ledger, P02-12
+owns reduction, and P02-13 owns behavioral projection. No runtime pipeline or
+model integration is included here.

--- a/private_world_port.py
+++ b/private_world_port.py
@@ -1,0 +1,190 @@
+"""Provider-free contracts for private relationship state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol, runtime_checkable
+import re
+
+
+class PrivateWorldError(ValueError):
+    code = "PRIVATE_WORLD_INVALID"
+
+
+class HomeAccess(str, Enum):
+    NO_ACCESS = "no_access"
+    VISIT_ACCESS = "visit_access"
+    ERRAND_ACCESS = "errand_access"
+    DOMESTIC_ACCESS = "domestic_access"
+
+
+class ContinuationAwareness(str, Enum):
+    CONTROL_ONLY = "control_only"
+    CHARACTER_KNOWN = "character_known"
+    PENDING = "pending"
+
+
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9._:-]{1,64}$")
+_HIDDEN_NAMES = ("familiarity", "trust", "comfort", "closeness", "tension")
+
+
+def _validate_score(name: str, value: int) -> None:
+    if type(value) is not int or not 0 <= value <= 100:
+        raise PrivateWorldError(f"{name} must be an integer from 0 to 100")
+
+
+def _validate_tokens(values: tuple[str, ...]) -> None:
+    if len(values) > 16 or len(set(values)) != len(values):
+        raise PrivateWorldError("nickname permissions must be unique and bounded")
+    if any(not isinstance(value, str) or not _TOKEN_RE.fullmatch(value) for value in values):
+        raise PrivateWorldError("nickname permission is invalid")
+
+
+def _validate_shared(
+    relationship_stage: str,
+    nickname_permissions: tuple[str, ...],
+    home_access: HomeAccess,
+    continuation_awareness: ContinuationAwareness,
+) -> None:
+    if not isinstance(relationship_stage, str) or not _TOKEN_RE.fullmatch(
+        relationship_stage
+    ):
+        raise PrivateWorldError("relationship stage is invalid")
+    _validate_tokens(nickname_permissions)
+    if not isinstance(home_access, HomeAccess):
+        raise PrivateWorldError("home access is invalid")
+    if not isinstance(continuation_awareness, ContinuationAwareness):
+        raise PrivateWorldError("continuation awareness is invalid")
+
+
+@dataclass(frozen=True)
+class PrivateWorldControlView:
+    familiarity: int
+    trust: int
+    comfort: int
+    closeness: int
+    tension: int
+    relationship_stage: str
+    nickname_permissions: tuple[str, ...]
+    home_access: HomeAccess
+    continuation_awareness: ContinuationAwareness
+
+    def __post_init__(self) -> None:
+        for name in _HIDDEN_NAMES:
+            _validate_score(name, getattr(self, name))
+        _validate_shared(
+            self.relationship_stage,
+            self.nickname_permissions,
+            self.home_access,
+            self.continuation_awareness,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "view": "control",
+            **{name: getattr(self, name) for name in _HIDDEN_NAMES},
+            "relationship_stage": self.relationship_stage,
+            "nickname_permissions": list(self.nickname_permissions),
+            "home_access": self.home_access.value,
+            "continuation_awareness": self.continuation_awareness.value,
+        }
+
+
+@dataclass(frozen=True)
+class PrivateWorldCharacterView:
+    relationship_stage: str
+    nickname_permissions: tuple[str, ...]
+    home_access: HomeAccess
+    continuation_awareness: ContinuationAwareness
+
+    def __post_init__(self) -> None:
+        _validate_shared(
+            self.relationship_stage,
+            self.nickname_permissions,
+            self.home_access,
+            self.continuation_awareness,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "view": "character",
+            "relationship_stage": self.relationship_stage,
+            "nickname_permissions": list(self.nickname_permissions),
+            "home_access": self.home_access.value,
+            "continuation_awareness": self.continuation_awareness.value,
+        }
+
+
+@dataclass(frozen=True)
+class PrivateWorldSnapshot:
+    version: int = 1
+    familiarity: int = 0
+    trust: int = 0
+    comfort: int = 0
+    closeness: int = 0
+    tension: int = 0
+    relationship_stage: str = "unknown"
+    nickname_permissions: tuple[str, ...] = ()
+    home_access: HomeAccess = HomeAccess.NO_ACCESS
+    continuation_awareness: ContinuationAwareness = ContinuationAwareness.CONTROL_ONLY
+
+    def __post_init__(self) -> None:
+        if type(self.version) is not int or self.version < 1:
+            raise PrivateWorldError("snapshot version must be positive")
+        for name in _HIDDEN_NAMES:
+            _validate_score(name, getattr(self, name))
+        if not isinstance(self.nickname_permissions, tuple):
+            object.__setattr__(self, "nickname_permissions", tuple(self.nickname_permissions))
+        _validate_shared(
+            self.relationship_stage,
+            self.nickname_permissions,
+            self.home_access,
+            self.continuation_awareness,
+        )
+
+    def control_view(self) -> PrivateWorldControlView:
+        return PrivateWorldControlView(
+            *(getattr(self, name) for name in _HIDDEN_NAMES),
+            self.relationship_stage,
+            self.nickname_permissions,
+            self.home_access,
+            self.continuation_awareness,
+        )
+
+    def character_view(self) -> PrivateWorldCharacterView:
+        return PrivateWorldCharacterView(
+            self.relationship_stage,
+            self.nickname_permissions,
+            self.home_access,
+            self.continuation_awareness,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        payload = self.control_view().to_dict()
+        payload["view"] = "snapshot"
+        return {"version": self.version, **payload}
+
+
+@runtime_checkable
+class PrivateWorldPort(Protocol):
+    def snapshot(self) -> PrivateWorldSnapshot: ...
+
+    def control_view(self) -> PrivateWorldControlView: ...
+
+    def character_view(self) -> PrivateWorldCharacterView: ...
+
+
+class NullPrivateWorldPort:
+    """Disabled adapter with no persistence, network, or mutation surface."""
+
+    _snapshot = PrivateWorldSnapshot()
+
+    def snapshot(self) -> PrivateWorldSnapshot:
+        return self._snapshot
+
+    def control_view(self) -> PrivateWorldControlView:
+        return self._snapshot.control_view()
+
+    def character_view(self) -> PrivateWorldCharacterView:
+        return self._snapshot.character_view()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ py-modules = [
     "persona_loader",
     "persona_assembly",
     "prompt_budget",
+    "private_world_port",
     "reply_context",
     "reply_policy",
     "reply_quality_gate",
@@ -44,6 +45,7 @@ include = ["asr*", "contracts*", "installer*", "linli_character*", "media_state*
 [tool.pytest.ini_options]
 testpaths = [
     "tests/persona",
+    "tests/private_world",
     "tests/http",
     "tests/installer",
     "tests/media",

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ testpaths =
     tests/http
     tests/media
     tests/persona
+    tests/private_world
     tests/test_asset_manifest.py
     tests/test_third_party_download.py
     tests/test_baseline_hardening.py

--- a/tests/private_world/test_private_world_port.py
+++ b/tests/private_world/test_private_world_port.py
@@ -1,0 +1,102 @@
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from private_world_port import (
+    ContinuationAwareness,
+    HomeAccess,
+    NullPrivateWorldPort,
+    PrivateWorldError,
+    PrivateWorldSnapshot,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_snapshot_keeps_hidden_values_out_of_character_view() -> None:
+    snapshot = PrivateWorldSnapshot(
+        familiarity=72,
+        trust=61,
+        comfort=55,
+        closeness=48,
+        tension=13,
+        relationship_stage="trusted_friend",
+        nickname_permissions=("linli",),
+        home_access=HomeAccess.VISIT_ACCESS,
+        continuation_awareness=ContinuationAwareness.CHARACTER_KNOWN,
+    )
+
+    control = snapshot.control_view().to_dict()
+    character = snapshot.character_view().to_dict()
+
+    assert control["trust"] == 61
+    assert character == {
+        "view": "character",
+        "relationship_stage": "trusted_friend",
+        "nickname_permissions": ["linli"],
+        "home_access": "visit_access",
+        "continuation_awareness": "character_known",
+    }
+    for hidden in ("familiarity", "trust", "comfort", "closeness", "tension"):
+        assert hidden not in character
+
+
+def test_contract_rejects_unbounded_or_ambiguous_values() -> None:
+    with pytest.raises(PrivateWorldError):
+        PrivateWorldSnapshot(trust=101)
+    with pytest.raises(PrivateWorldError):
+        PrivateWorldSnapshot(relationship_stage="x" * 65)
+    with pytest.raises(PrivateWorldError):
+        PrivateWorldSnapshot(nickname_permissions=("not allowed whitespace",))
+    with pytest.raises(PrivateWorldError):
+        PrivateWorldSnapshot(home_access="visit_access")  # type: ignore[arg-type]
+
+
+def test_python_and_schema_agree_on_relationship_stage_boundary() -> None:
+    schema = json.loads(
+        (ROOT / "contracts" / "private_world.schema.json").read_text(encoding="utf-8")
+    )
+    validator = Draft202012Validator(schema)
+    accepted = PrivateWorldSnapshot(relationship_stage="x" * 64).to_dict()
+
+    assert list(validator.iter_errors(accepted)) == []
+    assert list(
+        validator.iter_errors(PrivateWorldSnapshot().control_view().to_dict())
+    ) == []
+    assert list(
+        validator.iter_errors(PrivateWorldSnapshot().character_view().to_dict())
+    ) == []
+    with pytest.raises(PrivateWorldError):
+        PrivateWorldSnapshot(relationship_stage="x" * 65)
+
+
+def test_null_port_is_stable_and_has_no_mutation_surface() -> None:
+    port = NullPrivateWorldPort()
+
+    assert port.snapshot() == PrivateWorldSnapshot()
+    assert port.control_view() == PrivateWorldSnapshot().control_view()
+    assert port.character_view() == PrivateWorldSnapshot().character_view()
+    assert not hasattr(port, "append")
+    assert not hasattr(port, "commit")
+    assert not hasattr(port, "store")
+
+
+def test_public_documentation_keeps_persistence_and_projection_out_of_scope() -> None:
+    documentation = (ROOT / "docs" / "P02_10_PRIVATE_WORLD.md").read_text(
+        encoding="utf-8"
+    )
+
+    for marker in (
+        "PrivateWorldPort",
+        "NullPrivateWorldPort",
+        "control view",
+        "character view",
+        "does not persist",
+        "does not call a provider",
+        "P02-11",
+        "P02-13",
+    ):
+        assert marker in documentation


### PR DESCRIPTION
## Scope
- add bounded private-world snapshot, control view, and character view
- add provider-free PrivateWorldPort and Null adapter
- add matching public JSON Schema and contract tests

## Boundaries
- no persistence or SQLite (P02-11)
- no reducer (P02-12)
- no behavior projection or runtime wiring (P02-13+)

## Validation
- 5 focused tests passed
- 156 default tests passed, 1 experimental deselected
- baseline hardening scanner passed with 0 findings
- diff-check passed