### PR TITLE
P02-11: add PrivateWorld SQLite ledger

### DIFF
--- a/docs/P02_11_PRIVATE_WORLD_LEDGER.md
+++ b/docs/P02_11_PRIVATE_WORLD_LEDGER.md
@@ -1,0 +1,10 @@
+# P02-11 PrivateWorld SQLite ledger
+
+`SQLitePrivateWorldLedger` stores PrivateWorld data in an explicit, separate
+SQLite file. `apply_once` atomically appends one typed event and its caller-
+provided snapshot. Both `event_id` and `delivery_id` are unique, so a delivery
+retry cannot apply the same relationship change twice.
+
+The ledger does not reduce events, infer relationship changes, call a model, or
+join the ordinary memory database. P02-12 owns the pure reducer. Public health
+contains only status and row counts; it never exposes a path or private value.

--- a/private_world_ledger.py
+++ b/private_world_ledger.py
@@ -1,0 +1,192 @@
+"""SQLite event ledger for PrivateWorld state; contains no reduction policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from pathlib import Path
+import re
+import sqlite3
+
+from private_world_port import (
+    ContinuationAwareness,
+    HomeAccess,
+    PrivateWorldCharacterView,
+    PrivateWorldControlView,
+    PrivateWorldSnapshot,
+)
+
+
+class LedgerWriteError(RuntimeError):
+    code = "PRIVATE_WORLD_WRITE_FAILED"
+
+
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
+
+
+@dataclass(frozen=True)
+class LedgerEvent:
+    event_id: str
+    delivery_id: str
+    event_type: str
+    payload: dict[str, object]
+    occurred_at: str
+
+    def __post_init__(self) -> None:
+        if any(
+            not isinstance(value, str) or not _ID_RE.fullmatch(value)
+            for value in (self.event_id, self.delivery_id, self.event_type)
+        ):
+            raise ValueError("event identifiers are invalid")
+        if not isinstance(self.payload, dict):
+            raise ValueError("event payload must be an object")
+        try:
+            encoded = json.dumps(
+                self.payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError("event payload must be JSON serializable") from exc
+        if len(encoded.encode("utf-8")) > 8192:
+            raise ValueError("event payload is too large")
+        try:
+            timestamp = datetime.fromisoformat(self.occurred_at.replace("Z", "+00:00"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("event timestamp is invalid") from exc
+        if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+            raise ValueError("event timestamp must be timezone-aware")
+
+    def _payload_json(self) -> str:
+        return json.dumps(
+            self.payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+
+
+class SQLitePrivateWorldLedger:
+    def __init__(self, database_path: Path) -> None:
+        path = Path(database_path)
+        if str(path) in {"", "."} or path.exists() and path.is_dir():
+            raise ValueError("an explicit database file path is required")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._database_path = path
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._database_path, timeout=5)
+        connection.execute("PRAGMA foreign_keys = ON")
+        return connection
+
+    def _initialize(self) -> None:
+        with self._connect() as connection:
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS private_world_events (
+                    event_id TEXT PRIMARY KEY,
+                    delivery_id TEXT NOT NULL UNIQUE,
+                    event_type TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    occurred_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS private_world_snapshots (
+                    version INTEGER PRIMARY KEY,
+                    payload_json TEXT NOT NULL,
+                    event_id TEXT NOT NULL UNIQUE,
+                    FOREIGN KEY(event_id) REFERENCES private_world_events(event_id)
+                );
+                """
+            )
+
+    def apply_once(self, event: LedgerEvent, snapshot: PrivateWorldSnapshot) -> bool:
+        if not isinstance(event, LedgerEvent) or not isinstance(
+            snapshot, PrivateWorldSnapshot
+        ):
+            raise TypeError("apply_once requires a typed event and snapshot")
+        try:
+            with self._connect() as connection:
+                duplicate = connection.execute(
+                    """SELECT 1 FROM private_world_events
+                       WHERE event_id = ? OR delivery_id = ? LIMIT 1""",
+                    (event.event_id, event.delivery_id),
+                ).fetchone()
+                if duplicate:
+                    return False
+                connection.execute(
+                    """INSERT INTO private_world_events
+                       (event_id, delivery_id, event_type, payload_json, occurred_at)
+                       VALUES (?, ?, ?, ?, ?)""",
+                    (
+                        event.event_id,
+                        event.delivery_id,
+                        event.event_type,
+                        event._payload_json(),
+                        event.occurred_at,
+                    ),
+                )
+                connection.execute(
+                    """INSERT INTO private_world_snapshots
+                       (version, payload_json, event_id) VALUES (?, ?, ?)""",
+                    (
+                        snapshot.version,
+                        json.dumps(snapshot.to_dict(), sort_keys=True, separators=(",", ":")),
+                        event.event_id,
+                    ),
+                )
+        except sqlite3.Error as exc:
+            raise LedgerWriteError("private world transaction failed") from exc
+        return True
+
+    def events(self) -> tuple[LedgerEvent, ...]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                """SELECT event_id, delivery_id, event_type, payload_json, occurred_at
+                   FROM private_world_events ORDER BY rowid"""
+            ).fetchall()
+        return tuple(
+            LedgerEvent(row[0], row[1], row[2], json.loads(row[3]), row[4])
+            for row in rows
+        )
+
+    def snapshot(self) -> PrivateWorldSnapshot:
+        with self._connect() as connection:
+            row = connection.execute(
+                """SELECT payload_json FROM private_world_snapshots
+                   ORDER BY version DESC LIMIT 1"""
+            ).fetchone()
+        if row is None:
+            return PrivateWorldSnapshot()
+        payload = json.loads(row[0])
+        return PrivateWorldSnapshot(
+            version=payload["version"],
+            familiarity=payload["familiarity"],
+            trust=payload["trust"],
+            comfort=payload["comfort"],
+            closeness=payload["closeness"],
+            tension=payload["tension"],
+            relationship_stage=payload["relationship_stage"],
+            nickname_permissions=tuple(payload["nickname_permissions"]),
+            home_access=HomeAccess(payload["home_access"]),
+            continuation_awareness=ContinuationAwareness(
+                payload["continuation_awareness"]
+            ),
+        )
+
+    def control_view(self) -> PrivateWorldControlView:
+        return self.snapshot().control_view()
+
+    def character_view(self) -> PrivateWorldCharacterView:
+        return self.snapshot().character_view()
+
+    def health(self) -> dict[str, int | str]:
+        with self._connect() as connection:
+            event_count = connection.execute(
+                "SELECT COUNT(*) FROM private_world_events"
+            ).fetchone()[0]
+            snapshot_count = connection.execute(
+                "SELECT COUNT(*) FROM private_world_snapshots"
+            ).fetchone()[0]
+        return {
+            "status": "READY",
+            "event_count": event_count,
+            "snapshot_count": snapshot_count,
+        }
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ py-modules = [
     "persona_assembly",
     "prompt_budget",
     "private_world_port",
+    "private_world_ledger",
     "reply_context",
     "reply_policy",
     "reply_quality_gate",

--- a/tests/private_world/test_private_world_ledger.py
+++ b/tests/private_world/test_private_world_ledger.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+import pytest
+
+from private_world_ledger import (
+    LedgerEvent,
+    LedgerWriteError,
+    SQLitePrivateWorldLedger,
+)
+from private_world_port import HomeAccess, PrivateWorldSnapshot
+
+
+def _event(number: int, *, delivery_id: str | None = None) -> LedgerEvent:
+    return LedgerEvent(
+        event_id=f"event-{number}",
+        delivery_id=delivery_id or f"delivery-{number}",
+        event_type="reply_accepted",
+        payload={"trust_delta": number},
+        occurred_at="2026-08-22T00:00:00+00:00",
+    )
+
+
+def test_apply_once_atomically_appends_event_and_snapshot(tmp_path: Path) -> None:
+    database = tmp_path / "private-world" / "ledger.sqlite3"
+    ledger = SQLitePrivateWorldLedger(database)
+    snapshot = PrivateWorldSnapshot(
+        version=1,
+        trust=4,
+        relationship_stage="acquaintance",
+        home_access=HomeAccess.VISIT_ACCESS,
+    )
+
+    assert ledger.apply_once(_event(4), snapshot) is True
+    assert ledger.snapshot() == snapshot
+    assert ledger.events() == (_event(4),)
+    assert database.is_file()
+
+
+def test_apply_once_deduplicates_event_and_delivery_ids(tmp_path: Path) -> None:
+    ledger = SQLitePrivateWorldLedger(tmp_path / "private-world.sqlite3")
+
+    assert ledger.apply_once(_event(1), PrivateWorldSnapshot(version=1)) is True
+    assert ledger.apply_once(_event(1), PrivateWorldSnapshot(version=2)) is False
+    assert (
+        ledger.apply_once(
+            _event(2, delivery_id="delivery-1"), PrivateWorldSnapshot(version=2)
+        )
+        is False
+    )
+    assert ledger.health() == {
+        "status": "READY",
+        "event_count": 1,
+        "snapshot_count": 1,
+    }
+
+
+def test_event_insert_rolls_back_when_snapshot_version_conflicts(tmp_path: Path) -> None:
+    ledger = SQLitePrivateWorldLedger(tmp_path / "private-world.sqlite3")
+    ledger.apply_once(_event(1), PrivateWorldSnapshot(version=1))
+
+    with pytest.raises(LedgerWriteError):
+        ledger.apply_once(_event(2), PrivateWorldSnapshot(version=1))
+
+    assert ledger.events() == (_event(1),)
+    assert ledger.health()["event_count"] == 1
+
+
+def test_health_never_exposes_database_path_or_private_values(tmp_path: Path) -> None:
+    ledger = SQLitePrivateWorldLedger(tmp_path / "secret-name.sqlite3")
+    ledger.apply_once(
+        _event(1),
+        PrivateWorldSnapshot(
+            version=1,
+            trust=88,
+            nickname_permissions=("private_nickname",),
+        ),
+    )
+
+    health = ledger.health()
+    serialized = repr(health)
+    assert set(health) == {"status", "event_count", "snapshot_count"}
+    assert "secret-name" not in serialized
+    assert "private_nickname" not in serialized
+    assert "88" not in serialized
+
+
+def test_ledger_requires_explicit_local_database_path(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        SQLitePrivateWorldLedger(Path())
+    with pytest.raises(ValueError):
+        SQLitePrivateWorldLedger(tmp_path)


### PR DESCRIPTION
## Scope
- add a separate SQLite event ledger for PrivateWorld state
- atomically append typed event plus caller-provided snapshot
- deduplicate both event_id and delivery_id
- expose path-free, value-free health counts

## Boundaries
- no reducer or relationship policy (P02-12)
- no behavior projection (P02-13)
- no runtime pipeline wiring

## Validation
- 10 PrivateWorld tests passed
- 166 default tests passed, 1 experimental deselected
- baseline hardening scanner passed with 0 findings
- diff-check passed