### PR TITLE
P02-13: project private world behavior

### DIFF
--- a/docs/P02_13_PRIVATE_WORLD_PROJECTION.md
+++ b/docs/P02_13_PRIVATE_WORLD_PROJECTION.md
@@ -1,0 +1,12 @@
+# P02-13 PrivateWorld behavior projection
+
+`project_private_world` is a pure, provider-free projection. It converts hidden
+numeric state into the finite `PrivateBehaviorView` enums already accepted by
+`ReplyContext`; raw values and the complete snapshot never enter its payload.
+
+Only current nickname permissions are returned. `control_only` and `pending`
+Local Continuation awareness both project to `continuation_known=false`, without
+exposing their control labels. Home access stays outside the model payload and
+only grants the assembly layer permission to acknowledge matching trusted
+history; it does not instruct the character to mention, invent, or describe a
+home scene.

--- a/private_world_projection.py
+++ b/private_world_projection.py
@@ -1,0 +1,81 @@
+"""Pure projection from hidden PrivateWorld state to bounded model hints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from private_world_port import (
+    ContinuationAwareness,
+    HomeAccess as PrivateHomeAccess,
+    PrivateWorldSnapshot,
+)
+from reply_context import (
+    BehaviorLevel,
+    HomeAccess,
+    NicknamePermission,
+    PrivateBehaviorView,
+    RelationshipStage,
+)
+
+
+def _level(value: int) -> BehaviorLevel:
+    if value == 0:
+        return BehaviorLevel.UNKNOWN
+    if value < 35:
+        return BehaviorLevel.LOW
+    if value < 70:
+        return BehaviorLevel.MEDIUM
+    return BehaviorLevel.HIGH
+
+
+def _stage(value: str) -> RelationshipStage:
+    try:
+        return RelationshipStage(value)
+    except ValueError:
+        return RelationshipStage.UNKNOWN
+
+
+@dataclass(frozen=True)
+class ProjectedPrivateWorld:
+    behavior: PrivateBehaviorView
+    authorized_nicknames: tuple[str, ...]
+    may_acknowledge_home_history: bool
+    continuation_known: bool
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "behavior": self.behavior.to_dict(),
+            "authorized_nicknames": list(self.authorized_nicknames),
+            "continuation_known": self.continuation_known,
+        }
+
+
+def project_private_world(snapshot: PrivateWorldSnapshot) -> ProjectedPrivateWorld:
+    if not isinstance(snapshot, PrivateWorldSnapshot):
+        raise TypeError("projection requires a PrivateWorldSnapshot")
+    nicknames = tuple(snapshot.nickname_permissions)
+    behavior = PrivateBehaviorView(
+        familiarity=_level(snapshot.familiarity),
+        trust=_level(snapshot.trust),
+        comfort=_level(snapshot.comfort),
+        closeness=_level(snapshot.closeness),
+        tension=_level(snapshot.tension),
+        relationship_stage=_stage(snapshot.relationship_stage),
+        nickname_permission=(
+            NicknamePermission.ALLOWED
+            if nicknames
+            else NicknamePermission.NOT_ALLOWED
+        ),
+        home_access=HomeAccess.NO_ACCESS,
+    )
+    return ProjectedPrivateWorld(
+        behavior=behavior,
+        authorized_nicknames=nicknames,
+        may_acknowledge_home_history=(
+            snapshot.home_access is not PrivateHomeAccess.NO_ACCESS
+        ),
+        continuation_known=(
+            snapshot.continuation_awareness
+            is ContinuationAwareness.CHARACTER_KNOWN
+        ),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ py-modules = [
     "prompt_budget",
     "private_world_port",
     "private_world_ledger",
+    "private_world_projection",
     "reply_context",
     "reply_policy",
     "reply_quality_gate",

--- a/tests/private_world/test_private_world_projection.py
+++ b/tests/private_world/test_private_world_projection.py
@@ -1,0 +1,83 @@
+from private_world_port import (
+    ContinuationAwareness,
+    HomeAccess,
+    PrivateWorldSnapshot,
+)
+from private_world_projection import project_private_world
+from reply_context import BehaviorLevel, RelationshipStage
+
+
+def test_projection_converts_hidden_scores_to_finite_behavior_levels() -> None:
+    projected = project_private_world(
+        PrivateWorldSnapshot(
+            familiarity=100,
+            trust=70,
+            comfort=69,
+            closeness=35,
+            tension=34,
+            relationship_stage="close",
+        )
+    )
+
+    assert projected.behavior.familiarity is BehaviorLevel.HIGH
+    assert projected.behavior.trust is BehaviorLevel.HIGH
+    assert projected.behavior.comfort is BehaviorLevel.MEDIUM
+    assert projected.behavior.closeness is BehaviorLevel.MEDIUM
+    assert projected.behavior.tension is BehaviorLevel.LOW
+    assert projected.behavior.relationship_stage is RelationshipStage.CLOSE
+
+    payload = projected.to_dict()
+    serialized = repr(payload)
+    for raw in ("100", "70", "69", "35", "34"):
+        assert raw not in serialized
+
+
+def test_only_current_authorized_nicknames_enter_projection() -> None:
+    projected = project_private_world(
+        PrivateWorldSnapshot(nickname_permissions=("linli", "friend"))
+    )
+
+    assert projected.authorized_nicknames == ("linli", "friend")
+    assert projected.to_dict()["authorized_nicknames"] == ["linli", "friend"]
+
+
+def test_control_only_and_pending_continuation_never_enter_character_payload() -> None:
+    for awareness in (
+        ContinuationAwareness.CONTROL_ONLY,
+        ContinuationAwareness.PENDING,
+    ):
+        payload = project_private_world(
+            PrivateWorldSnapshot(continuation_awareness=awareness)
+        ).to_dict()
+
+        assert payload["continuation_known"] is False
+        assert awareness.value not in repr(payload)
+
+    known = project_private_world(
+        PrivateWorldSnapshot(
+            continuation_awareness=ContinuationAwareness.CHARACTER_KNOWN
+        )
+    )
+    assert known.continuation_known is True
+
+
+def test_home_access_only_grants_history_acknowledgement() -> None:
+    no_access = project_private_world(PrivateWorldSnapshot())
+    visit_access = project_private_world(
+        PrivateWorldSnapshot(home_access=HomeAccess.VISIT_ACCESS)
+    )
+
+    assert no_access.may_acknowledge_home_history is False
+    assert visit_access.may_acknowledge_home_history is True
+    assert "may_acknowledge_home_history" not in visit_access.to_dict()
+    assert visit_access.behavior.home_access.value == "no_access"
+    assert "mention" not in repr(visit_access.to_dict()).lower()
+    assert "describe" not in repr(visit_access.to_dict()).lower()
+
+
+def test_unknown_relationship_stage_fails_closed_to_unknown() -> None:
+    projected = project_private_world(
+        PrivateWorldSnapshot(relationship_stage="custom_future_stage")
+    )
+
+    assert projected.behavior.relationship_stage is RelationshipStage.UNKNOWN


### PR DESCRIPTION
## Scope
- project hidden scores into finite ReplyContext behavior enums
- expose only current authorized nicknames
- hide control_only and pending continuation state from the model payload
- keep home access outside the model payload and expose only an assembly-layer acknowledgement permission

## Boundaries
- no persistence or reducer changes
- no prompt assembly or runtime wiring
- no provider calls

## Validation
- 5 focused projection tests passed
- 171 default tests passed, 1 experimental deselected
- baseline hardening scanner passed with 0 findings
- diff-check passed