### PR TITLE
P02-12: add pure PrivateWorld reducer

### DIFF
--- a/docs/P02_12_PRIVATE_WORLD_REDUCER.md
+++ b/docs/P02_12_PRIVATE_WORLD_REDUCER.md
@@ -1,0 +1,12 @@
+# P02-12 PrivateWorld reducer
+
+`reduce_private_world` is a pure function from an immutable snapshot and typed
+event to a new snapshot plus an explainable field delta. Boundary respect,
+conflict, and repair use small fixed changes; score bounds are 0–100.
+
+High-frequency messages, gifts, repeated phrases, one-off confessions, and
+inactivity never upgrade or decay the relationship. A stage changes only after
+an explicit `stage_confirmed` event with evidence identifiers. Equivalent
+semantic events inside the fixed 24-hour window are no-ops.
+
+This slice has no database, clock read, model call, or runtime wiring.

--- a/private_world_reducer.py
+++ b/private_world_reducer.py
@@ -1,0 +1,170 @@
+"""Pure, deterministic PrivateWorld relationship reducer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta
+from enum import Enum
+import re
+
+from private_world_port import PrivateWorldSnapshot
+
+
+class ReducerInputError(ValueError):
+    code = "PRIVATE_WORLD_EVENT_INVALID"
+
+
+class ReducerEventKind(str, Enum):
+    BOUNDARY_RESPECTED = "boundary_respected"
+    CONFLICT = "conflict"
+    REPAIR = "repair"
+    STAGE_CONFIRMED = "stage_confirmed"
+    HIGH_FREQUENCY_MESSAGE = "high_frequency_message"
+    GIFT = "gift"
+    REPEATED_PHRASE = "repeated_phrase"
+    CONFESSION = "confession"
+    INACTIVITY = "inactivity"
+
+
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
+_STAGE_RE = re.compile(r"^[A-Za-z0-9._:-]{1,64}$")
+_DEDUPLICATION_WINDOW = timedelta(hours=24)
+_NO_EFFECT_KINDS = {
+    ReducerEventKind.HIGH_FREQUENCY_MESSAGE,
+    ReducerEventKind.GIFT,
+    ReducerEventKind.REPEATED_PHRASE,
+    ReducerEventKind.CONFESSION,
+    ReducerEventKind.INACTIVITY,
+}
+
+
+@dataclass(frozen=True)
+class ReducerEvent:
+    kind: ReducerEventKind
+    occurred_at: datetime
+    semantic_key: str
+    last_equivalent_at: datetime | None = None
+    target_stage: str | None = None
+    basis_event_ids: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, ReducerEventKind):
+            raise ReducerInputError("event kind is invalid")
+        if (
+            not isinstance(self.occurred_at, datetime)
+            or self.occurred_at.tzinfo is None
+            or self.occurred_at.utcoffset() is None
+        ):
+            raise ReducerInputError("event time must be timezone-aware")
+        if not isinstance(self.semantic_key, str) or not _TOKEN_RE.fullmatch(
+            self.semantic_key
+        ):
+            raise ReducerInputError("semantic key is invalid")
+        if self.last_equivalent_at is not None:
+            if (
+                not isinstance(self.last_equivalent_at, datetime)
+                or self.last_equivalent_at.tzinfo is None
+                or self.last_equivalent_at.utcoffset() is None
+                or self.last_equivalent_at > self.occurred_at
+            ):
+                raise ReducerInputError("previous equivalent time is invalid")
+        if not isinstance(self.basis_event_ids, tuple):
+            object.__setattr__(self, "basis_event_ids", tuple(self.basis_event_ids))
+        if self.kind is ReducerEventKind.STAGE_CONFIRMED:
+            if not isinstance(self.target_stage, str) or not _STAGE_RE.fullmatch(
+                self.target_stage
+            ):
+                raise ReducerInputError("stage confirmation requires a target stage")
+            if (
+                not self.basis_event_ids
+                or len(self.basis_event_ids) > 8
+                or len(set(self.basis_event_ids)) != len(self.basis_event_ids)
+                or any(not _TOKEN_RE.fullmatch(value) for value in self.basis_event_ids)
+            ):
+                raise ReducerInputError("stage confirmation requires explicit evidence")
+        elif self.target_stage is not None or self.basis_event_ids:
+            raise ReducerInputError("stage evidence is only valid for stage confirmation")
+
+
+@dataclass(frozen=True)
+class FieldDelta:
+    field: str
+    before: int | str
+    after: int | str
+
+
+@dataclass(frozen=True)
+class ReducerDelta:
+    applied: bool
+    reason_code: str
+    changes: tuple[FieldDelta, ...] = ()
+
+
+@dataclass(frozen=True)
+class ReducerResult:
+    snapshot: PrivateWorldSnapshot
+    delta: ReducerDelta
+
+
+def _bounded(value: int, change: int) -> int:
+    return min(100, max(0, value + change))
+
+
+def _duplicate(event: ReducerEvent) -> bool:
+    if event.last_equivalent_at is None:
+        return False
+    return event.occurred_at - event.last_equivalent_at < _DEDUPLICATION_WINDOW
+
+
+def reduce_private_world(
+    snapshot: PrivateWorldSnapshot, event: ReducerEvent
+) -> ReducerResult:
+    if not isinstance(snapshot, PrivateWorldSnapshot) or not isinstance(
+        event, ReducerEvent
+    ):
+        raise ReducerInputError("typed snapshot and event are required")
+    if event.kind in _NO_EFFECT_KINDS:
+        return ReducerResult(
+            snapshot, ReducerDelta(False, "NO_RELATIONSHIP_EFFECT")
+        )
+    if _duplicate(event):
+        return ReducerResult(snapshot, ReducerDelta(False, "SEMANTIC_DUPLICATE"))
+
+    updates: dict[str, int | str] = {}
+    if event.kind is ReducerEventKind.BOUNDARY_RESPECTED:
+        updates = {
+            "trust": _bounded(snapshot.trust, 1),
+            "comfort": _bounded(snapshot.comfort, 1),
+        }
+    elif event.kind is ReducerEventKind.CONFLICT:
+        updates = {
+            "trust": _bounded(snapshot.trust, -2),
+            "comfort": _bounded(snapshot.comfort, -2),
+            "tension": _bounded(snapshot.tension, 3),
+        }
+    elif event.kind is ReducerEventKind.REPAIR:
+        updates = {
+            "trust": _bounded(snapshot.trust, 1),
+            "comfort": _bounded(snapshot.comfort, 1),
+            "tension": _bounded(snapshot.tension, -2),
+        }
+    elif event.kind is ReducerEventKind.STAGE_CONFIRMED:
+        updates = {"relationship_stage": event.target_stage or "unknown"}
+
+    changes = tuple(
+        FieldDelta(field, getattr(snapshot, field), value)
+        for field, value in updates.items()
+        if getattr(snapshot, field) != value
+    )
+    if not changes:
+        return ReducerResult(snapshot, ReducerDelta(False, "BOUNDED_NO_CHANGE"))
+    next_snapshot = replace(
+        snapshot,
+        version=snapshot.version + 1,
+        **{change.field: change.after for change in changes},
+    )
+    return ReducerResult(
+        next_snapshot,
+        ReducerDelta(True, event.kind.value.upper(), changes),
+    )
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ py-modules = [
     "persona_assembly",
     "prompt_budget",
     "private_world_port",
+    "private_world_reducer",
     "private_world_ledger",
     "private_world_projection",
     "reply_context",

--- a/tests/private_world/test_private_world_reducer.py
+++ b/tests/private_world/test_private_world_reducer.py
@@ -1,0 +1,128 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from private_world_port import PrivateWorldSnapshot
+from private_world_reducer import (
+    ReducerEvent,
+    ReducerEventKind,
+    ReducerInputError,
+    reduce_private_world,
+)
+
+
+NOW = datetime(2026, 8, 22, tzinfo=timezone.utc)
+
+
+def _event(kind: ReducerEventKind, **changes: object) -> ReducerEvent:
+    values: dict[str, object] = {
+        "kind": kind,
+        "occurred_at": NOW,
+        "semantic_key": f"semantic.{kind.value}",
+    }
+    values.update(changes)
+    return ReducerEvent(**values)  # type: ignore[arg-type]
+
+
+def test_boundary_respect_changes_state_slowly_and_explains_delta() -> None:
+    before = PrivateWorldSnapshot(version=3, trust=10, comfort=20)
+
+    result = reduce_private_world(
+        before, _event(ReducerEventKind.BOUNDARY_RESPECTED)
+    )
+
+    assert before == PrivateWorldSnapshot(version=3, trust=10, comfort=20)
+    assert result.snapshot.version == 4
+    assert result.snapshot.trust == 11
+    assert result.snapshot.comfort == 21
+    assert result.delta.applied is True
+    assert result.delta.reason_code == "BOUNDARY_RESPECTED"
+    assert {change.field for change in result.delta.changes} == {"trust", "comfort"}
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        ReducerEventKind.HIGH_FREQUENCY_MESSAGE,
+        ReducerEventKind.GIFT,
+        ReducerEventKind.REPEATED_PHRASE,
+        ReducerEventKind.CONFESSION,
+        ReducerEventKind.INACTIVITY,
+    ],
+)
+def test_spam_gifts_confession_and_inactivity_do_not_upgrade_state(
+    kind: ReducerEventKind,
+) -> None:
+    before = PrivateWorldSnapshot(version=7, trust=30, closeness=30)
+
+    result = reduce_private_world(before, _event(kind))
+
+    assert result.snapshot == before
+    assert result.delta.applied is False
+    assert result.delta.changes == ()
+
+
+def test_conflict_and_repair_apply_bounded_explainable_changes() -> None:
+    before = PrivateWorldSnapshot(version=1, trust=1, comfort=1, tension=99)
+    conflict = reduce_private_world(before, _event(ReducerEventKind.CONFLICT))
+
+    assert conflict.snapshot.trust == 0
+    assert conflict.snapshot.comfort == 0
+    assert conflict.snapshot.tension == 100
+
+    repair = reduce_private_world(
+        conflict.snapshot, _event(ReducerEventKind.REPAIR)
+    )
+    assert repair.snapshot.trust == 1
+    assert repair.snapshot.comfort == 1
+    assert repair.snapshot.tension == 98
+
+
+def test_stage_never_changes_from_score_threshold_alone() -> None:
+    high_scores = PrivateWorldSnapshot(
+        version=1,
+        familiarity=100,
+        trust=100,
+        comfort=100,
+        closeness=100,
+        relationship_stage="acquaintance",
+    )
+
+    ordinary = reduce_private_world(
+        high_scores, _event(ReducerEventKind.BOUNDARY_RESPECTED)
+    )
+    assert ordinary.snapshot.relationship_stage == "acquaintance"
+
+    confirmed = reduce_private_world(
+        ordinary.snapshot,
+        _event(
+            ReducerEventKind.STAGE_CONFIRMED,
+            target_stage="familiar",
+            basis_event_ids=("basis-1",),
+        ),
+    )
+    assert confirmed.snapshot.relationship_stage == "familiar"
+
+    with pytest.raises(ReducerInputError):
+        reduce_private_world(
+            ordinary.snapshot,
+            _event(ReducerEventKind.STAGE_CONFIRMED, target_stage="close"),
+        )
+
+
+def test_same_semantic_event_is_deduplicated_inside_fixed_window() -> None:
+    before = PrivateWorldSnapshot(version=1, trust=10)
+    duplicate = _event(
+        ReducerEventKind.BOUNDARY_RESPECTED,
+        last_equivalent_at=NOW - timedelta(hours=2),
+    )
+
+    blocked = reduce_private_world(before, duplicate)
+    assert blocked.snapshot == before
+    assert blocked.delta.reason_code == "SEMANTIC_DUPLICATE"
+
+    outside_window = _event(
+        ReducerEventKind.BOUNDARY_RESPECTED,
+        last_equivalent_at=NOW - timedelta(hours=25),
+    )
+    assert reduce_private_world(before, outside_window).delta.applied is True


### PR DESCRIPTION
## Scope
- add a pure typed-event reducer with explainable field deltas
- apply small bounded changes for boundary respect, conflict, and repair
- require explicit evidence-backed events for relationship-stage changes
- deduplicate equivalent semantic events in a fixed 24-hour window

## Anti-abuse rules
- high-frequency messages, gifts, repeated phrases, and one-off confessions never upgrade state
- inactivity never decays state
- score thresholds never change the stage

## Boundaries
- no database or clock reads
- no model calls or runtime wiring

## Validation
- 9 focused reducer tests passed
- 180 default tests passed, 1 experimental deselected
- baseline hardening scanner passed with 0 findings
- diff-check passed