### PR TITLE
P02-14: add PrivateWorld local administration

### DIFF
--- a/docs/P02_14_PRIVATE_WORLD_ADMIN.md
+++ b/docs/P02_14_PRIVATE_WORLD_ADMIN.md
@@ -1,0 +1,10 @@
+# P02-14 PrivateWorld local administration
+
+Run `python -m private_world_admin --database <file> <command> --yes` to perform
+an explicit local operation. Commands are `export --output <file>`, `reset`, and
+`delete`. Omitting `--yes` changes nothing and returns `CONFIRMATION_REQUIRED`.
+
+Export uses a same-directory temporary file plus atomic replacement. There is no
+default export path, automatic repository write, log upload, Release attachment,
+or product-interface exposure. Reset preserves an empty database; delete removes
+the database and its SQLite sidecars. Console output contains stable codes only.

--- a/private_world_admin.py
+++ b/private_world_admin.py
@@ -1,0 +1,145 @@
+"""Explicit local administration for the PrivateWorld SQLite ledger."""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import closing
+import json
+import os
+from pathlib import Path
+import sqlite3
+import tempfile
+from typing import Sequence
+
+from private_world_ledger import SQLitePrivateWorldLedger
+
+
+class AdminConfirmationRequired(RuntimeError):
+    code = "CONFIRMATION_REQUIRED"
+
+
+class AdminOperationError(RuntimeError):
+    code = "PRIVATE_WORLD_ADMIN_FAILED"
+
+
+class PrivateWorldAdmin:
+    def __init__(self, database_path: Path) -> None:
+        path = Path(database_path)
+        if str(path) in {"", "."} or path.exists() and path.is_dir():
+            raise ValueError("an explicit database file path is required")
+        self._database_path = path
+
+    @staticmethod
+    def _confirm(confirmed: bool) -> None:
+        if confirmed is not True:
+            raise AdminConfirmationRequired("explicit confirmation is required")
+
+    def _require_database(self) -> None:
+        if not self._database_path.is_file():
+            raise AdminOperationError("private world database is unavailable")
+
+    def export(self, destination: Path, *, confirmed: bool = False) -> None:
+        self._confirm(confirmed)
+        self._require_database()
+        output = Path(destination)
+        if str(output) in {"", "."} or output.exists() and output.is_dir():
+            raise ValueError("an explicit export file is required")
+        if output.resolve() == self._database_path.resolve():
+            raise ValueError("export must not replace the database")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        ledger = SQLitePrivateWorldLedger(self._database_path)
+        payload = {
+            "schema": "p02.private-world-export.v1",
+            "snapshot": ledger.snapshot().to_dict(),
+            "events": [
+                {
+                    "event_id": event.event_id,
+                    "delivery_id": event.delivery_id,
+                    "event_type": event.event_type,
+                    "payload": event.payload,
+                    "occurred_at": event.occurred_at,
+                }
+                for event in ledger.events()
+            ],
+        }
+        temporary: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=output.parent,
+                prefix=".private-world-",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                temporary = Path(handle.name)
+                json.dump(payload, handle, ensure_ascii=False, sort_keys=True)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, output)
+        except (OSError, TypeError, ValueError) as exc:
+            if temporary is not None:
+                temporary.unlink(missing_ok=True)
+            raise AdminOperationError("private world export failed") from exc
+
+    def reset(self, *, confirmed: bool = False) -> None:
+        self._confirm(confirmed)
+        self._require_database()
+        try:
+            with closing(sqlite3.connect(self._database_path, timeout=5)) as connection, connection:
+                connection.execute("PRAGMA foreign_keys = ON")
+                connection.execute("DELETE FROM private_world_snapshots")
+                connection.execute("DELETE FROM private_world_events")
+        except sqlite3.Error as exc:
+            raise AdminOperationError("private world reset failed") from exc
+
+    def delete(self, *, confirmed: bool = False) -> None:
+        self._confirm(confirmed)
+        self._require_database()
+        try:
+            for path in (
+                self._database_path,
+                Path(f"{self._database_path}-wal"),
+                Path(f"{self._database_path}-shm"),
+            ):
+                path.unlink(missing_ok=True)
+        except OSError as exc:
+            raise AdminOperationError("private world delete failed") from exc
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="private-world-admin")
+    parser.add_argument("--database", required=True, type=Path)
+    commands = parser.add_subparsers(dest="command", required=True)
+    export = commands.add_parser("export")
+    export.add_argument("--output", required=True, type=Path)
+    export.add_argument("--yes", action="store_true")
+    for name in ("reset", "delete"):
+        command = commands.add_parser(name)
+        command.add_argument("--yes", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    admin = PrivateWorldAdmin(arguments.database)
+    try:
+        if arguments.command == "export":
+            admin.export(arguments.output, confirmed=arguments.yes)
+        elif arguments.command == "reset":
+            admin.reset(confirmed=arguments.yes)
+        else:
+            admin.delete(confirmed=arguments.yes)
+    except AdminConfirmationRequired as exc:
+        print(exc.code)
+        return 2
+    except AdminOperationError as exc:
+        print(exc.code)
+        return 1
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/private_world_ledger.py
+++ b/private_world_ledger.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from contextlib import contextmanager
 from datetime import datetime
 import json
 from pathlib import Path
 import re
 import sqlite3
+from typing import Iterator
 
 from private_world_port import (
     ContinuationAwareness,
@@ -71,13 +73,18 @@ class SQLitePrivateWorldLedger:
         self._database_path = path
         self._initialize()
 
-    def _connect(self) -> sqlite3.Connection:
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
         connection = sqlite3.connect(self._database_path, timeout=5)
         connection.execute("PRAGMA foreign_keys = ON")
-        return connection
+        try:
+            with connection:
+                yield connection
+        finally:
+            connection.close()
 
     def _initialize(self) -> None:
-        with self._connect() as connection:
+        with self._connection() as connection:
             connection.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS private_world_events (
@@ -102,7 +109,7 @@ class SQLitePrivateWorldLedger:
         ):
             raise TypeError("apply_once requires a typed event and snapshot")
         try:
-            with self._connect() as connection:
+            with self._connection() as connection:
                 duplicate = connection.execute(
                     """SELECT 1 FROM private_world_events
                        WHERE event_id = ? OR delivery_id = ? LIMIT 1""",
@@ -136,7 +143,7 @@ class SQLitePrivateWorldLedger:
         return True
 
     def events(self) -> tuple[LedgerEvent, ...]:
-        with self._connect() as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 """SELECT event_id, delivery_id, event_type, payload_json, occurred_at
                    FROM private_world_events ORDER BY rowid"""
@@ -147,7 +154,7 @@ class SQLitePrivateWorldLedger:
         )
 
     def snapshot(self) -> PrivateWorldSnapshot:
-        with self._connect() as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 """SELECT payload_json FROM private_world_snapshots
                    ORDER BY version DESC LIMIT 1"""
@@ -177,7 +184,7 @@ class SQLitePrivateWorldLedger:
         return self.snapshot().character_view()
 
     def health(self) -> dict[str, int | str]:
-        with self._connect() as connection:
+        with self._connection() as connection:
             event_count = connection.execute(
                 "SELECT COUNT(*) FROM private_world_events"
             ).fetchone()[0]
@@ -189,4 +196,3 @@ class SQLitePrivateWorldLedger:
             "event_count": event_count,
             "snapshot_count": snapshot_count,
         }
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ py-modules = [
     "private_world_port",
     "private_world_reducer",
     "private_world_ledger",
+    "private_world_admin",
     "private_world_projection",
     "reply_context",
     "reply_policy",

--- a/tests/private_world/test_private_world_admin.py
+++ b/tests/private_world/test_private_world_admin.py
@@ -1,0 +1,109 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import private_world_admin
+from private_world_admin import (
+    AdminConfirmationRequired,
+    AdminOperationError,
+    PrivateWorldAdmin,
+    main,
+)
+from private_world_ledger import LedgerEvent, SQLitePrivateWorldLedger
+from private_world_port import PrivateWorldSnapshot
+
+
+def _seed(database: Path) -> None:
+    SQLitePrivateWorldLedger(database).apply_once(
+        LedgerEvent(
+            event_id="event-1",
+            delivery_id="delivery-1",
+            event_type="reply_accepted",
+            payload={"trust_delta": 1},
+            occurred_at="2026-08-22T00:00:00+00:00",
+        ),
+        PrivateWorldSnapshot(version=1, trust=1),
+    )
+
+
+def test_export_requires_confirmation_and_writes_atomically(tmp_path: Path) -> None:
+    database = tmp_path / "private.sqlite3"
+    destination = tmp_path / "exports" / "private-world.json"
+    _seed(database)
+    admin = PrivateWorldAdmin(database)
+
+    with pytest.raises(AdminConfirmationRequired):
+        admin.export(destination)
+
+    admin.export(destination, confirmed=True)
+    payload = json.loads(destination.read_text(encoding="utf-8"))
+    assert payload["snapshot"]["trust"] == 1
+    assert payload["events"][0]["event_id"] == "event-1"
+    assert list(destination.parent.glob(".private-world-*.tmp")) == []
+
+
+def test_failed_export_preserves_existing_file_and_cleans_temp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database = tmp_path / "private.sqlite3"
+    destination = tmp_path / "private-world.json"
+    _seed(database)
+    destination.write_text("existing", encoding="utf-8")
+
+    def fail_replace(source: object, target: object) -> None:
+        raise OSError("synthetic replace failure")
+
+    monkeypatch.setattr(private_world_admin.os, "replace", fail_replace)
+    with pytest.raises(AdminOperationError):
+        PrivateWorldAdmin(database).export(destination, confirmed=True)
+
+    assert destination.read_text(encoding="utf-8") == "existing"
+    assert list(tmp_path.glob(".private-world-*.tmp")) == []
+
+
+def test_reset_requires_confirmation_and_keeps_empty_database(tmp_path: Path) -> None:
+    database = tmp_path / "private.sqlite3"
+    _seed(database)
+    admin = PrivateWorldAdmin(database)
+
+    with pytest.raises(AdminConfirmationRequired):
+        admin.reset()
+    admin.reset(confirmed=True)
+
+    ledger = SQLitePrivateWorldLedger(database)
+    assert ledger.snapshot() == PrivateWorldSnapshot()
+    assert ledger.health()["event_count"] == 0
+    assert database.is_file()
+
+
+def test_delete_removes_database_and_sidecars_only_after_confirmation(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "private.sqlite3"
+    _seed(database)
+    sidecars = [Path(f"{database}-wal"), Path(f"{database}-shm")]
+    for sidecar in sidecars:
+        sidecar.write_bytes(b"synthetic")
+    admin = PrivateWorldAdmin(database)
+
+    with pytest.raises(AdminConfirmationRequired):
+        admin.delete()
+    admin.delete(confirmed=True)
+
+    assert not database.exists()
+    assert all(not sidecar.exists() for sidecar in sidecars)
+
+
+def test_cli_returns_stable_codes_without_printing_paths(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    database = tmp_path / "private-name.sqlite3"
+    _seed(database)
+
+    assert main(["--database", str(database), "reset"]) == 2
+    assert main(["--database", str(database), "reset", "--yes"]) == 0
+    output = capsys.readouterr().out
+    assert "CONFIRMATION_REQUIRED" in output
+    assert "OK" in output
+    assert "private-name" not in output


### PR DESCRIPTION
## Scope
- add explicit confirmed export, reset, and delete operations
- atomically write user-selected exports
- return stable path-free CLI status codes
- deterministically close SQLite connections so Windows deletion succeeds

## Safety boundaries
- no default export path or product UI exposure
- no repository, log, upload, or Release integration
- reset preserves an empty database; delete removes DB plus SQLite sidecars

## Validation
- 10 ledger/admin focused tests passed
- 185 default tests passed, 1 experimental deselected
- baseline hardening scanner passed with 0 findings
- diff-check passed