### PR TITLE
P02-15: wire PersonaAssembly into letters

### DIFF
--- a/contracts/llm_config.schema.json
+++ b/contracts/llm_config.schema.json
@@ -21,6 +21,8 @@
     "persona_file": {"type": "string", "minLength": 1},
     "persona_config": {"type": "string", "minLength": 1},
     "persona_evidence_file": {"type": "string", "minLength": 1},
+    "persona_v2_file": {"type": "string", "minLength": 1},
+    "persona_v2_enabled": {"type": "boolean"},
     "feature_enabled": {"type": "boolean"},
     "requires_api_key": {"type": "boolean"},
     "provider_options": {"type": "object"}

--- a/docs/P02_15_PERSONA_ASSEMBLY_WIRING.md
+++ b/docs/P02_15_PERSONA_ASSEMBLY_WIRING.md
@@ -1,0 +1,11 @@
+# P02-15 LetterAdapter Persona 2.0 wiring
+
+Set `persona_v2_enabled=true` (or `OLIVIA_PERSONA_V2_ENABLED=true`) to route
+`LetterAdapter._messages()` through `PersonaAssembly`. The default remains false,
+so the existing adapter path is unchanged until explicitly enabled.
+
+The v2 path loads `persona_v2_file` with DRAFT fallback, creates a text-letter
+`ReplyContext`, projects PrivateWorld state into finite character inputs, and
+passes MemoryPromptBuilder output as one escaped, untrusted history block. It
+does not modify `reply_orchestrator.py`, run a reviewer, or write relationship
+state.

--- a/llm_config.example.json
+++ b/llm_config.example.json
@@ -14,6 +14,8 @@
   "persona_file": "linli_character/system_prompt.md",
   "persona_config": "linli_character/persona_config.json",
   "persona_evidence_file": "linli_character/provenance.json",
+  "persona_v2_file": "linli_character/persona_v2.json",
+  "persona_v2_enabled": false,
   "feature_enabled": true,
   "requires_api_key": true
 }

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -92,6 +92,8 @@ class GatewayConfig:
     persona_file: str = "linli_character/system_prompt.md"
     persona_config: str = "linli_character/persona_config.json"
     persona_evidence_file: str = "linli_character/provenance.json"
+    persona_v2_file: str = "linli_character/persona_v2.json"
+    persona_v2_enabled: bool = False
     feature_enabled: bool = True
     requires_api_key: bool = False
     provider_options: Mapping[str, Any] = field(default_factory=dict)
@@ -149,6 +151,10 @@ class GatewayConfig:
             persona_evidence_file=str(
                 data.get("persona_evidence_file", "linli_character/provenance.json") or ""
             ),
+            persona_v2_file=str(
+                data.get("persona_v2_file", "linli_character/persona_v2.json") or ""
+            ),
+            persona_v2_enabled=_as_bool(data.get("persona_v2_enabled", False)),
             feature_enabled=_as_bool(data.get("feature_enabled", True), True),
             requires_api_key=_as_bool(data.get("requires_api_key", options.get("requires_api_key", False))),
             provider_options=dict(options),
@@ -171,6 +177,7 @@ class GatewayConfig:
             "feature_enabled": self.feature_enabled,
             "persona_configured": bool(self.persona_config),
             "persona_evidence_configured": bool(self.persona_evidence_file),
+            "persona_v2_enabled": self.persona_v2_enabled,
         }
         if api_key_configured is not None:
             result["api_key_configured"] = api_key_configured
@@ -247,6 +254,8 @@ def _env_overlay(environ: Mapping[str, str]) -> dict[str, Any]:
         "OLIVIA_PERSONA_FILE": "persona_file",
         "OLIVIA_PERSONA_CONFIG": "persona_config",
         "OLIVIA_PERSONA_EVIDENCE_FILE": "persona_evidence_file",
+        "OLIVIA_PERSONA_V2_FILE": "persona_v2_file",
+        "OLIVIA_PERSONA_V2_ENABLED": "persona_v2_enabled",
         "OLIVIA_LLM_FEATURE_ENABLED": "feature_enabled",
         "OLIVIA_LLM_REQUIRES_API_KEY": "requires_api_key",
     }

--- a/local_server.py
+++ b/local_server.py
@@ -12,7 +12,9 @@ import re as _re
 import random
 import time
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Callable
 
 from aiohttp import web
 
@@ -48,6 +50,17 @@ from reply_media import ReplyMediaError, render_reply_video
 from local_memory import create_memory_adapter
 from memory_port import LegacyLetter, MemoryPort, NullMemoryPort
 from memory_prompt import MemoryPromptBuilder
+from persona_assembly import UntrustedFragment, assemble_persona
+from persona_loader import load_persona
+from private_world_port import NullPrivateWorldPort, PrivateWorldPort, PrivateWorldSnapshot
+from private_world_projection import project_private_world
+from reply_context import (
+    ReplyContext,
+    ReplyMode,
+    TrustedTime,
+    TrustedWorldFact,
+    WorldFactKind,
+)
 
 PORT = int(_os.environ.get("OLIVIA_PORT", "8899"))
 LLM_TIMEOUT_SECONDS = 30
@@ -148,6 +161,8 @@ class LetterAdapter:
         config: GatewayConfig | None = None,
         *,
         memory_port: MemoryPort | None = None,
+        private_world_port: PrivateWorldPort | None = None,
+        now: Callable[[], datetime] | None = None,
     ) -> None:
         self.config = config or LLM_CONFIG
         try:
@@ -155,6 +170,10 @@ class LetterAdapter:
         except GatewayError:
             self.gateway = UnconfiguredAdapter()
         self.memory_port: MemoryPort = memory_port or NullMemoryPort()
+        self.private_world_port: PrivateWorldPort = (
+            private_world_port or NullPrivateWorldPort()
+        )
+        self._now = now or (lambda: datetime.now(timezone.utc))
         persona_path = Path(self.config.persona_file)
         if not persona_path.is_absolute():
             persona_path = Path(__file__).resolve().parent / persona_path
@@ -164,6 +183,10 @@ class LetterAdapter:
         persona_evidence_path = Path(self.config.persona_evidence_file)
         if not persona_evidence_path.is_absolute():
             persona_evidence_path = Path(__file__).resolve().parent / persona_evidence_path
+        persona_v2_path = Path(self.config.persona_v2_file)
+        if not persona_v2_path.is_absolute():
+            persona_v2_path = Path(__file__).resolve().parent / persona_v2_path
+        self.persona_v2_path = persona_v2_path
         self.persona_provider = ConfigPersonaProvider(
             persona_config_path,
             draft_path=persona_path,
@@ -183,6 +206,13 @@ class LetterAdapter:
         return []
 
     def _messages(self, content: str, context: str = "") -> tuple[dict[str, str], ...]:
+        if self.config.persona_v2_enabled:
+            return self._persona_v2_messages(content, context)
+        return self._legacy_messages(content, context)
+
+    def _legacy_messages(
+        self, content: str, context: str = ""
+    ) -> tuple[dict[str, str], ...]:
         user_content = content
         if context:
             user_content = content + "\n\n" + context
@@ -205,6 +235,62 @@ class LetterAdapter:
             user_content,
             max_chars=self.config.max_input_chars,
         )
+
+    def _persona_v2_messages(
+        self, content: str, context: str = ""
+    ) -> tuple[dict[str, str], ...]:
+        user_content = content + ("\n\n" + context if context else "")
+        loaded = load_persona(self.persona_v2_path)
+        try:
+            private_snapshot = self.private_world_port.snapshot()
+            if not isinstance(private_snapshot, PrivateWorldSnapshot):
+                private_snapshot = PrivateWorldSnapshot()
+        except Exception:
+            private_snapshot = PrivateWorldSnapshot()
+        projected = project_private_world(private_snapshot)
+        facts = tuple(
+            TrustedWorldFact(
+                fact_id=f"private.nickname.{index}",
+                source_id="private_world.character_view",
+                statement=f"Currently authorized nickname: {nickname}",
+                kind=WorldFactKind.TRUSTED_RUNTIME,
+            )
+            for index, nickname in enumerate(projected.authorized_nicknames)
+        )
+        if projected.continuation_known:
+            facts += (
+                TrustedWorldFact(
+                    fact_id="private.continuation.known",
+                    source_id="private_world.character_view",
+                    statement="Local continuation is known to the character.",
+                    kind=WorldFactKind.TRUSTED_RUNTIME,
+                ),
+            )
+        reply_context = ReplyContext.create(
+            ReplyMode.TEXT_LETTER,
+            trusted_time=TrustedTime(self._now()),
+            world_facts=facts,
+            private_behavior=projected.behavior,
+        )
+        memory_context = self.memory_prompt_builder.build(
+            content,
+            max_chars=min(
+                self.config.max_input_chars,
+                int(getattr(self.memory_port, "context_max_chars", 2400)),
+            ),
+        )
+        history = (
+            (UntrustedFragment("memory.references", memory_context.text),)
+            if memory_context.text
+            else ()
+        )
+        return assemble_persona(
+            loaded.snapshot,
+            reply_context,
+            user_input=user_content,
+            max_units=self.config.max_input_chars,
+            history=history,
+        ).to_messages()
 
     def remember_conversation(self, content: str, reply: str) -> None:
         """Write new-chat memory only when the opt-in profile is enabled."""

--- a/tests/persona/test_letter_persona_v2_integration.py
+++ b/tests/persona/test_letter_persona_v2_integration.py
@@ -1,0 +1,130 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from llm_gateway import GatewayConfig
+from local_server import LetterAdapter
+from memory_port import NullMemoryPort
+from memory_prompt import MemoryPrompt
+from private_world_port import (
+    ContinuationAwareness,
+    PrivateWorldSnapshot,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+NOW = datetime(2026, 8, 22, tzinfo=timezone.utc)
+
+
+class SnapshotPort:
+    def __init__(self, snapshot: PrivateWorldSnapshot) -> None:
+        self._snapshot = snapshot
+
+    def snapshot(self) -> PrivateWorldSnapshot:
+        return self._snapshot
+
+
+class FixedMemoryPromptBuilder:
+    def build(self, query: str, *, max_chars: int | None = None) -> MemoryPrompt:
+        return MemoryPrompt(
+            text="<MEMORY_CONTEXT_UNTRUSTED_DATA>legacy synthetic letter</MEMORY_CONTEXT_UNTRUSTED_DATA>",
+            status="available",
+        )
+
+
+def _config(**changes: object) -> GatewayConfig:
+    values: dict[str, object] = {
+        "provider": "mock",
+        "model": "synthetic",
+        "persona_v2_enabled": True,
+        "persona_v2_file": str(ROOT / "linli_character" / "persona_v2.json"),
+    }
+    values.update(changes)
+    return GatewayConfig(**values)  # type: ignore[arg-type]
+
+
+def test_enabled_v2_uses_persona_assembly_and_separate_user_message() -> None:
+    adapter = LetterAdapter(
+        _config(),
+        memory_port=NullMemoryPort(),
+        now=lambda: NOW,
+    )
+
+    messages = adapter._messages("synthetic current letter")
+
+    assert tuple(message["role"] for message in messages) == ("system", "user")
+    assert messages[1]["content"] == "synthetic current letter"
+    assert "<constitution>" in messages[0]["content"]
+    assert "<mode_constraints>" in messages[0]["content"]
+    assert "synthetic current letter" not in messages[0]["content"]
+
+
+def test_private_world_projection_enters_only_as_bounded_character_input() -> None:
+    adapter = LetterAdapter(
+        _config(),
+        memory_port=NullMemoryPort(),
+        private_world_port=SnapshotPort(
+            PrivateWorldSnapshot(
+                trust=88,
+                nickname_permissions=("linli",),
+                continuation_awareness=ContinuationAwareness.PENDING,
+            )
+        ),
+        now=lambda: NOW,
+    )
+
+    system = adapter._messages("synthetic")[0]["content"]
+
+    assert '"trust":"high"' in system
+    assert "88" not in system
+    assert "linli" in system
+    assert "pending" not in system
+    assert "control_only" not in system
+
+
+def test_legacy_memory_remains_a_whole_untrusted_history_block() -> None:
+    adapter = LetterAdapter(_config(), memory_port=NullMemoryPort(), now=lambda: NOW)
+    adapter.memory_prompt_builder = FixedMemoryPromptBuilder()
+
+    system = adapter._messages("synthetic")[0]["content"]
+
+    assert "<untrusted_history>" in system
+    assert "legacy synthetic letter" in system
+    assert "<MEMORY_CONTEXT_UNTRUSTED_DATA>" not in system
+    assert r"\u003cMEMORY_CONTEXT_UNTRUSTED_DATA" in system
+
+
+def test_corrupt_v2_file_falls_back_to_safe_draft(tmp_path: Path) -> None:
+    corrupt = tmp_path / "persona_v2.json"
+    corrupt.write_text("{broken", encoding="utf-8")
+    adapter = LetterAdapter(
+        _config(persona_v2_file=str(corrupt)),
+        memory_port=NullMemoryPort(),
+        now=lambda: NOW,
+    )
+
+    system = adapter._messages("synthetic")[0]["content"]
+
+    assert "Persona status is DRAFT" in system
+    assert "Do not invent identity or shared history" in system
+
+
+def test_disabled_v2_preserves_existing_letter_adapter_path() -> None:
+    adapter = LetterAdapter(
+        _config(persona_v2_enabled=False),
+        memory_port=NullMemoryPort(),
+        now=lambda: NOW,
+    )
+
+    expected = adapter.persona_provider.messages_for(
+        "synthetic", max_chars=adapter.config.max_input_chars
+    )
+    assert adapter._messages("synthetic") == expected
+
+
+def test_gateway_config_parses_v2_feature_flag_and_file() -> None:
+    config = GatewayConfig.from_mapping(
+        {"persona_v2_enabled": True, "persona_v2_file": "synthetic/persona.json"}
+    )
+
+    assert config.persona_v2_enabled is True
+    assert config.persona_v2_file == "synthetic/persona.json"


### PR DESCRIPTION
## Scope
- add an explicit Persona 2.0 feature flag and file setting
- route LetterAdapter messages through PersonaAssembly only when enabled
- project PrivateWorld into bounded behavior and authorized nickname facts
- pass MemoryPromptBuilder output as one escaped untrusted history block
- preserve DRAFT fallback for missing or corrupt v2 data

## Compatibility
- feature flag defaults false
- disabled path delegates to the existing adapter unchanged
- reply_orchestrator lifecycle, review, and state writes are untouched

## Validation
- 17 focused persona/memory integration tests passed
- 191 default tests passed, 1 experimental deselected
- baseline hardening scanner passed with 0 findings
- diff-check passed