### PR TITLE
P02-16: gate canonical replies before persistence and media

### DIFF
--- a/docs/P02_16_REPLY_QUALITY_PIPELINE.md
+++ b/docs/P02_16_REPLY_QUALITY_PIPELINE.md
@@ -1,0 +1,12 @@
+# P02-16 Reply quality pipeline
+
+`ReplyPipeline` wraps the existing orchestrator without changing its request or
+event lifecycle. The orchestrator produces a private candidate; the bounded
+quality gate produces the only canonical text returned by the pipeline.
+
+`generate_reply` writes `reply_text`, marks `COMPLETED`, updates memory, and
+schedules text/video/music projection only after acceptance. A blocked candidate
+never reaches those sinks. Persisted review metadata is limited to quality status
+and violation codes; reviewer prompts, hidden state, and private evidence are not
+stored. The default reviewer is disabled and clean deterministic output degrades
+open; deterministic violations fail closed when no rewriter is configured.

--- a/local_server.py
+++ b/local_server.py
@@ -61,6 +61,8 @@ from reply_context import (
     TrustedWorldFact,
     WorldFactKind,
 )
+from reply_pipeline import ReplyPipeline, UnavailableRewriter
+from reply_reviewer import NullReviewer
 
 PORT = int(_os.environ.get("OLIVIA_PORT", "8899"))
 LLM_TIMEOUT_SECONDS = 30
@@ -241,6 +243,28 @@ class LetterAdapter:
     ) -> tuple[dict[str, str], ...]:
         user_content = content + ("\n\n" + context if context else "")
         loaded = load_persona(self.persona_v2_path)
+        reply_context = self.build_reply_context(ReplyMode.TEXT_LETTER)
+        memory_context = self.memory_prompt_builder.build(
+            content,
+            max_chars=min(
+                self.config.max_input_chars,
+                int(getattr(self.memory_port, "context_max_chars", 2400)),
+            ),
+        )
+        history = (
+            (UntrustedFragment("memory.references", memory_context.text),)
+            if memory_context.text
+            else ()
+        )
+        return assemble_persona(
+            loaded.snapshot,
+            reply_context,
+            user_input=user_content,
+            max_units=self.config.max_input_chars,
+            history=history,
+        ).to_messages()
+
+    def build_reply_context(self, mode: ReplyMode) -> ReplyContext:
         try:
             private_snapshot = self.private_world_port.snapshot()
             if not isinstance(private_snapshot, PrivateWorldSnapshot):
@@ -266,31 +290,12 @@ class LetterAdapter:
                     kind=WorldFactKind.TRUSTED_RUNTIME,
                 ),
             )
-        reply_context = ReplyContext.create(
-            ReplyMode.TEXT_LETTER,
+        return ReplyContext.create(
+            mode,
             trusted_time=TrustedTime(self._now()),
             world_facts=facts,
             private_behavior=projected.behavior,
         )
-        memory_context = self.memory_prompt_builder.build(
-            content,
-            max_chars=min(
-                self.config.max_input_chars,
-                int(getattr(self.memory_port, "context_max_chars", 2400)),
-            ),
-        )
-        history = (
-            (UntrustedFragment("memory.references", memory_context.text),)
-            if memory_context.text
-            else ()
-        )
-        return assemble_persona(
-            loaded.snapshot,
-            reply_context,
-            user_input=user_content,
-            max_units=self.config.max_input_chars,
-            history=history,
-        ).to_messages()
 
     def remember_conversation(self, content: str, reply: str) -> None:
         """Write new-chat memory only when the opt-in profile is enabled."""
@@ -413,6 +418,11 @@ music_adapter = MusicAdapter()
 reply_engine = ReplyOrchestrator(
     _LetterGateway(letters_adapter),
     timeout_seconds=LLM_CONFIG.timeout_seconds,
+)
+reply_pipeline = ReplyPipeline(
+    reply_engine,
+    reviewer=NullReviewer(),
+    rewriter=UnavailableRewriter(),
 )
 
 # ---------------------------------------------------------------------------
@@ -953,6 +963,8 @@ def _letter_list_payload(scope: str) -> dict:
 
 
 def _public_llm_error(code: str | None) -> tuple[str, bool]:
+    if code in {"REPLY_QUALITY_BLOCKED", "REWRITE_FAILED"}:
+        return "REPLY_QUALITY_BLOCKED", False
     if code in {"LLM_TIMEOUT", "PROVIDER_TIMEOUT"}:
         return "LLM_TIMEOUT", True
     if code in {"LLM_PROVIDER_REJECTED", "PROVIDER_REJECTED"}:
@@ -1432,8 +1444,13 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
             idempotency_key=idempotency_key,
             max_input_chars=LLM_CONFIG.max_input_chars,
         )
+        gate_mode = (
+            ReplyMode.MUSICAL_VIDEO
+            if triage.reply_mode == "video"
+            else ReplyMode.TEXT_LETTER
+        )
         result = await asyncio.wait_for(
-            reply_engine.run(request),
+            reply_pipeline.run(request, letters_adapter.build_reply_context(gate_mode)),
             timeout=LLM_TIMEOUT_SECONDS,
         )
     except asyncio.CancelledError:
@@ -1452,6 +1469,9 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
         _safe_log("letter_failed", error_code="LLM_UNAVAILABLE")
         return False
 
+    if result.quality_status is not None:
+        letter["quality_status"] = result.quality_status
+        letter["quality_violation_codes"] = list(result.violation_codes)
     if result.state is not ReplyState.COMPLETED:
         public_code, _retryable = _public_llm_error(result.error_code)
         letter["letter_status"] = "FAILED"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ py-modules = [
     "private_world_projection",
     "reply_context",
     "reply_policy",
+    "reply_pipeline",
     "reply_quality_gate",
     "reply_reviewer",
 ]

--- a/reply_pipeline.py
+++ b/reply_pipeline.py
@@ -1,0 +1,88 @@
+"""Narrow candidate-to-canonical reply pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from reply_context import ReplyContext
+from reply_orchestrator import ReplyResult, ReplyState
+from reply_quality_gate import ReviewerPort, RewriterPort, run_reply_quality_gate
+
+
+class OrchestratorPort(Protocol):
+    async def run(self, request: object) -> ReplyResult: ...
+
+
+class UnavailableRewriter:
+    def rewrite(
+        self,
+        candidate: str,
+        context: ReplyContext,
+        violation_codes: tuple[str, ...],
+    ) -> str:
+        raise RuntimeError("rewriter is unavailable")
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    request_id: str
+    state: ReplyState
+    text: str = ""
+    error_code: str | None = None
+    retryable: bool = False
+    quality_status: str | None = None
+    violation_codes: tuple[str, ...] = ()
+    reviewer_calls: int = 0
+    rewrite_calls: int = 0
+
+
+class ReplyPipeline:
+    def __init__(
+        self,
+        orchestrator: OrchestratorPort,
+        *,
+        reviewer: ReviewerPort,
+        rewriter: RewriterPort,
+    ) -> None:
+        self.orchestrator = orchestrator
+        self.reviewer = reviewer
+        self.rewriter = rewriter
+
+    async def run(self, request: object, context: ReplyContext) -> PipelineResult:
+        if not isinstance(context, ReplyContext):
+            raise TypeError("ReplyContext is required")
+        candidate = await self.orchestrator.run(request)
+        if candidate.state is not ReplyState.COMPLETED:
+            return PipelineResult(
+                candidate.request_id,
+                candidate.state,
+                error_code=candidate.error_code,
+                retryable=candidate.retryable,
+            )
+        gate = run_reply_quality_gate(
+            candidate.text,
+            context,
+            reviewer=self.reviewer,
+            rewriter=self.rewriter,
+        )
+        if not gate.accepted:
+            return PipelineResult(
+                candidate.request_id,
+                ReplyState.FAILED,
+                error_code=gate.error_code or "REPLY_QUALITY_BLOCKED",
+                quality_status=gate.status.value,
+                violation_codes=gate.violation_codes,
+                reviewer_calls=gate.reviewer_calls,
+                rewrite_calls=gate.rewrite_calls,
+            )
+        return PipelineResult(
+            candidate.request_id,
+            ReplyState.COMPLETED,
+            text=gate.text,
+            quality_status=gate.status.value,
+            violation_codes=gate.violation_codes,
+            reviewer_calls=gate.reviewer_calls,
+            rewrite_calls=gate.rewrite_calls,
+        )
+

--- a/tests/persona/test_reply_pipeline.py
+++ b/tests/persona/test_reply_pipeline.py
@@ -1,0 +1,211 @@
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from reply_context import ReplyContext, ReplyMode, TrustedTime
+from reply_orchestrator import ReplyResult, ReplyState
+from reply_pipeline import (
+    PipelineResult,
+    ReplyPipeline,
+    UnavailableRewriter,
+)
+from reply_reviewer import (
+    NullReviewer,
+    ReviewResult,
+    ReviewerScores,
+    ReviewStatus,
+    ReviewVerdict,
+)
+
+
+def _context(mode: ReplyMode = ReplyMode.TEXT_LETTER) -> ReplyContext:
+    return ReplyContext.create(
+        mode,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    )
+
+
+class CompletedOrchestrator:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+    async def run(self, request: object) -> ReplyResult:
+        return ReplyResult("request-1", ReplyState.COMPLETED, text=self.text)
+
+
+class PassingReviewer:
+    def review(self, candidate: str, context: ReplyContext) -> ReviewResult:
+        return ReviewResult(
+            ReviewStatus.COMPLETED,
+            ReviewVerdict.PASS,
+            (),
+            ReviewerScores(100, 100, 100, 100),
+        )
+
+
+class FixedRewriter:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.calls = 0
+
+    def rewrite(
+        self,
+        candidate: str,
+        context: ReplyContext,
+        violation_codes: tuple[str, ...],
+    ) -> str:
+        self.calls += 1
+        return self.text
+
+
+def test_pipeline_accepts_clean_candidate_with_disabled_reviewer() -> None:
+    pipeline = ReplyPipeline(
+        CompletedOrchestrator("clean canonical reply"),
+        reviewer=NullReviewer(),
+        rewriter=UnavailableRewriter(),
+    )
+
+    result = asyncio.run(pipeline.run(object(), _context()))
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.text == "clean canonical reply"
+    assert result.quality_status == "accepted_degraded"
+    assert result.rewrite_calls == 0
+
+
+def test_pipeline_exposes_only_rewritten_canonical_text() -> None:
+    rewriter = FixedRewriter("safe canonical reply")
+    pipeline = ReplyPipeline(
+        CompletedOrchestrator("candidate <CONTROL>private</CONTROL>"),
+        reviewer=PassingReviewer(),
+        rewriter=rewriter,
+    )
+
+    result = asyncio.run(pipeline.run(object(), _context()))
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.text == "safe canonical reply"
+    assert "candidate" not in repr(result)
+    assert rewriter.calls == 1
+
+
+def test_pipeline_blocks_candidate_when_single_rewrite_fails() -> None:
+    pipeline = ReplyPipeline(
+        CompletedOrchestrator("<CONTROL>private</CONTROL>"),
+        reviewer=PassingReviewer(),
+        rewriter=UnavailableRewriter(),
+    )
+
+    result = asyncio.run(pipeline.run(object(), _context()))
+
+    assert result.state is ReplyState.FAILED
+    assert result.text == ""
+    assert result.error_code == "REWRITE_FAILED"
+    assert result.quality_status == "blocked"
+    assert result.violation_codes == ("INTERNAL_CONTROL_MARKUP",)
+
+
+class FakeTriage:
+    reply_mode = "video"
+
+    def to_dict(self) -> dict[str, str]:
+        return {"reply_mode": self.reply_mode}
+
+
+class FakeTriageService:
+    async def classify(self, content: str) -> FakeTriage:
+        return FakeTriage()
+
+
+class FakePipeline:
+    def __init__(self, result: PipelineResult) -> None:
+        self.result = result
+
+    async def run(self, request: object, context: ReplyContext) -> PipelineResult:
+        assert context.mode is ReplyMode.MUSICAL_VIDEO
+        return self.result
+
+
+def test_generate_reply_persists_and_renders_only_canonical_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    letter = {"letter_id": "letter-1", "reply_text": "", "letter_status": "PENDING"}
+    scheduled: list[tuple[object, ...]] = []
+    remembered: list[tuple[str, str]] = []
+    monkeypatch.setattr(local_server.store, "letters", [letter])
+    monkeypatch.setattr(local_server, "emotion_triage", FakeTriageService())
+    monkeypatch.setattr(local_server, "_persist_store_state", lambda: None)
+    monkeypatch.setattr(local_server, "_schedule_text_reply_delay", lambda *args: None)
+    monkeypatch.setattr(
+        local_server, "_schedule_media_job", lambda *args: scheduled.append(args)
+    )
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "remember_conversation",
+        lambda content, reply: remembered.append((content, reply)),
+    )
+    monkeypatch.setattr(
+        local_server,
+        "reply_pipeline",
+        FakePipeline(
+            PipelineResult(
+                "letter-1",
+                ReplyState.COMPLETED,
+                text="canonical final text",
+                quality_status="accepted",
+                violation_codes=("SYNTHETIC_FIXED",),
+                reviewer_calls=2,
+                rewrite_calls=1,
+            )
+        ),
+    )
+
+    assert asyncio.run(local_server.generate_reply("letter-1", "candidate input")) is True
+    assert letter["reply_text"] == "canonical final text"
+    assert letter["letter_status"] == "COMPLETED"
+    assert letter["quality_status"] == "accepted"
+    assert letter["quality_violation_codes"] == ["SYNTHETIC_FIXED"]
+    assert scheduled[0][2] == "canonical final text"
+    assert remembered == [("candidate input", "canonical final text")]
+
+
+def test_blocked_candidate_never_reaches_storage_or_media(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    letter = {"letter_id": "letter-2", "reply_text": "", "letter_status": "PENDING"}
+    scheduled: list[tuple[object, ...]] = []
+    monkeypatch.setattr(local_server.store, "letters", [letter])
+    monkeypatch.setattr(local_server, "emotion_triage", FakeTriageService())
+    monkeypatch.setattr(local_server, "_persist_store_state", lambda: None)
+    monkeypatch.setattr(local_server, "_schedule_text_reply_delay", lambda *args: None)
+    monkeypatch.setattr(
+        local_server, "_schedule_media_job", lambda *args: scheduled.append(args)
+    )
+    monkeypatch.setattr(
+        local_server,
+        "reply_pipeline",
+        FakePipeline(
+            PipelineResult(
+                "letter-2",
+                ReplyState.FAILED,
+                error_code="REPLY_QUALITY_BLOCKED",
+                quality_status="blocked",
+                violation_codes=("INTERNAL_CONTROL_MARKUP",),
+                reviewer_calls=1,
+                rewrite_calls=1,
+            )
+        ),
+    )
+
+    assert asyncio.run(local_server.generate_reply("letter-2", "candidate input")) is False
+    assert letter["reply_text"] == ""
+    assert letter["letter_status"] == "FAILED"
+    assert letter["quality_status"] == "blocked"
+    assert scheduled == []
+    assert "review_prompt" not in letter
+    assert "private_world" not in letter


### PR DESCRIPTION
## Scope
- add a narrow ReplyPipeline around the existing orchestrator and quality gate
- expose only accepted canonical text from the pipeline
- persist quality status and violation codes only
- schedule memory and text/video/music projection only after acceptance

## Failure behavior
- clean output with disabled reviewer is accepted_degraded
- deterministic violations require at most one rewrite
- blocked candidates return no text and never reach storage or media

## Boundaries
- reply_orchestrator lifecycle is unchanged
- no private-state commit (P02-17)
- no reviewer prompt, hidden state, or private evidence persistence

## Validation
- 11 focused pipeline/integration tests passed
- 196 default tests passed, 1 experimental deselected
- baseline hardening scanner passed with 0 findings
- diff-check passed