### PR TITLE
P02-17: commit PrivateWorld state once after canonical reply

### DIFF
--- a/docs/P02_17_PRIVATE_WORLD_DELIVERY.md
+++ b/docs/P02_17_PRIVATE_WORLD_DELIVERY.md
@@ -1,0 +1,11 @@
+# P02-17 canonical reply PrivateWorld commit
+
+The only relationship delivery point is a quality-gate accepted canonical reply
+persisted with `reply_revision`. Its stable `delivery_id` is
+`letter_id:reply_revision`; the SQLite ledger applies it once.
+
+The letter is first stored with `private_world_status=PENDING`, then committed.
+Startup recovery retries pending records without changing or deleting canonical
+text. An unavailable backend leaves the reply intact and records only a stable
+error code. Generation failure, quality block, request retry, TTS/video/music
+failure, and media rerender never call the commit path.

--- a/local_server.py
+++ b/local_server.py
@@ -12,6 +12,7 @@ import re as _re
 import random
 import time
 import uuid
+import hashlib
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
@@ -53,6 +54,13 @@ from memory_prompt import MemoryPromptBuilder
 from persona_assembly import UntrustedFragment, assemble_persona
 from persona_loader import load_persona
 from private_world_port import NullPrivateWorldPort, PrivateWorldPort, PrivateWorldSnapshot
+from private_world_delivery import (
+    DeliveryEvent,
+    DeliveryStatus,
+    PrivateWorldDeliveryCommitter,
+)
+from private_world_ledger import SQLitePrivateWorldLedger
+from private_world_reducer import ReducerEventKind
 from private_world_projection import project_private_world
 from reply_context import (
     ReplyContext,
@@ -406,7 +414,20 @@ def _persist_store_state() -> None:
 
 _load_store_state()
 memory_adapter: MemoryPort = create_memory_adapter()
-letters_adapter = LetterAdapter(memory_port=memory_adapter)
+private_world_committer: PrivateWorldDeliveryCommitter | None = None
+private_world_port: PrivateWorldPort = NullPrivateWorldPort()
+_private_world_path = Path(_os.environ.get("OLIVIA_PRIVATE_WORLD_DB", ""))
+if _private_world_path.is_absolute():
+    try:
+        _private_world_ledger = SQLitePrivateWorldLedger(_private_world_path)
+        private_world_port = _private_world_ledger
+        private_world_committer = PrivateWorldDeliveryCommitter(_private_world_ledger)
+    except (OSError, ValueError, RuntimeError):
+        pass
+letters_adapter = LetterAdapter(
+    memory_port=memory_adapter,
+    private_world_port=private_world_port,
+)
 emotion_triage = LetterEmotionTriage(letters_adapter.gateway)
 media_semaphore = asyncio.Semaphore(1)
 media_tasks: set[asyncio.Task] = set()
@@ -1424,6 +1445,62 @@ def _schedule_media_job(letter_id: str, content: str, reply_text: str, reply_mod
     task.add_done_callback(media_tasks.discard)
 
 
+def _prepare_private_world_delivery(letter: dict, canonical_text: str) -> None:
+    if letter.get("reply_text") == canonical_text and letter.get(
+        "private_world_delivery_id"
+    ):
+        return
+    revision = max(0, int(letter.get("reply_revision", 0))) + 1
+    letter_id = str(letter["letter_id"])
+    delivery_id = f"{letter_id}:{revision}"
+    semantic_digest = hashlib.sha256(letter_id.encode("utf-8")).hexdigest()
+    letter["reply_revision"] = revision
+    letter["private_world_delivery_id"] = delivery_id
+    letter["private_world_status"] = "PENDING"
+    letter["private_world_occurred_at"] = datetime.now(timezone.utc).isoformat()
+    letter["private_world_event_kind"] = ReducerEventKind.CANONICAL_REPLY_DELIVERED.value
+    letter["private_world_semantic_key"] = f"canonical.{semantic_digest}"
+
+
+def _commit_private_world_letter(letter: dict) -> bool:
+    if letter.get("private_world_status") != "PENDING":
+        return False
+    if private_world_committer is None:
+        letter["private_world_error_code"] = "PRIVATE_WORLD_UNAVAILABLE"
+        return False
+    try:
+        delivery = DeliveryEvent(
+            delivery_id=str(letter["private_world_delivery_id"]),
+            kind=ReducerEventKind(str(letter["private_world_event_kind"])),
+            occurred_at=datetime.fromisoformat(str(letter["private_world_occurred_at"])),
+            semantic_key=str(letter["private_world_semantic_key"]),
+        )
+        status = private_world_committer.commit(delivery)
+    except (KeyError, TypeError, ValueError):
+        letter["private_world_error_code"] = "PRIVATE_WORLD_EVENT_INVALID"
+        return False
+    if status in {DeliveryStatus.COMMITTED, DeliveryStatus.DUPLICATE}:
+        letter["private_world_status"] = "COMMITTED"
+        letter.pop("private_world_error_code", None)
+        return True
+    letter["private_world_error_code"] = "PRIVATE_WORLD_UNAVAILABLE"
+    return False
+
+
+def recover_pending_private_world() -> int:
+    recovered = 0
+    for letter in store.letters:
+        if (
+            letter.get("letter_status") == "COMPLETED"
+            and letter.get("reply_text")
+            and _commit_private_world_letter(letter)
+        ):
+            recovered += 1
+    if recovered:
+        _persist_store_state()
+    return recovered
+
+
 async def generate_reply(letter_id, content, *, idempotency_key=None):
     """Run the narrow current-letter pipeline and record its terminal state."""
 
@@ -1479,8 +1556,11 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
         _safe_log("letter_failed", error_code=public_code)
         return False
 
+    _prepare_private_world_delivery(letter, result.text)
     letter["reply_text"] = result.text
     letter["letter_status"] = "COMPLETED"
+    _persist_store_state()
+    _commit_private_world_letter(letter)
     _persist_store_state()
     if letter.get("reply_mode") == "video":
         letter["reply_mode"] = "musical_video"
@@ -1491,6 +1571,7 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
     return True
 
 if __name__ == "__main__":
+    recover_pending_private_world()
     app = web.Application()
     app.router.add_route("*", "/{tail:.*}", handler)
     _safe_log('server_start', host='127.0.0.1', port=PORT)

--- a/private_world_delivery.py
+++ b/private_world_delivery.py
@@ -1,0 +1,86 @@
+"""Exactly-once PrivateWorld commit at canonical reply delivery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+import hashlib
+import re
+
+from private_world_ledger import LedgerEvent, LedgerWriteError, SQLitePrivateWorldLedger
+from private_world_reducer import ReducerEvent, ReducerEventKind, reduce_private_world
+
+
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
+
+
+class DeliveryStatus(StrEnum):
+    COMMITTED = "COMMITTED"
+    DUPLICATE = "DUPLICATE"
+    UNAVAILABLE = "UNAVAILABLE"
+
+
+@dataclass(frozen=True)
+class DeliveryEvent:
+    delivery_id: str
+    kind: ReducerEventKind
+    occurred_at: datetime
+    semantic_key: str
+    last_equivalent_at: datetime | None = None
+    target_stage: str | None = None
+    basis_event_ids: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.delivery_id, str) or not _ID_RE.fullmatch(
+            self.delivery_id
+        ):
+            raise ValueError("delivery_id is invalid")
+        ReducerEvent(
+            self.kind,
+            self.occurred_at,
+            self.semantic_key,
+            self.last_equivalent_at,
+            self.target_stage,
+            self.basis_event_ids,
+        )
+
+
+class PrivateWorldDeliveryCommitter:
+    def __init__(self, ledger: SQLitePrivateWorldLedger) -> None:
+        self.ledger = ledger
+
+    def commit(self, delivery: DeliveryEvent) -> DeliveryStatus:
+        if not isinstance(delivery, DeliveryEvent):
+            raise TypeError("typed delivery is required")
+        event = ReducerEvent(
+            delivery.kind,
+            delivery.occurred_at,
+            delivery.semantic_key,
+            delivery.last_equivalent_at,
+            delivery.target_stage,
+            delivery.basis_event_ids,
+        )
+        try:
+            reduced = reduce_private_world(self.ledger.snapshot(), event)
+            digest = hashlib.sha256(delivery.delivery_id.encode("utf-8")).hexdigest()
+            applied = self.ledger.apply_once(
+                LedgerEvent(
+                    event_id=f"delivery.{digest}",
+                    delivery_id=delivery.delivery_id,
+                    event_type=event.kind.value,
+                    payload={
+                        "applied": reduced.delta.applied,
+                        "reason_code": reduced.delta.reason_code,
+                        "change_fields": [
+                            change.field for change in reduced.delta.changes
+                        ],
+                    },
+                    occurred_at=delivery.occurred_at.isoformat(),
+                ),
+                reduced.snapshot,
+            )
+        except (LedgerWriteError, OSError):
+            return DeliveryStatus.UNAVAILABLE
+        return DeliveryStatus.COMMITTED if applied else DeliveryStatus.DUPLICATE
+

--- a/private_world_ledger.py
+++ b/private_world_ledger.py
@@ -117,6 +117,27 @@ class SQLitePrivateWorldLedger:
                 ).fetchone()
                 if duplicate:
                     return False
+                latest = connection.execute(
+                    """SELECT version, payload_json FROM private_world_snapshots
+                       ORDER BY version DESC LIMIT 1"""
+                ).fetchone()
+                snapshot_json = json.dumps(
+                    snapshot.to_dict(), sort_keys=True, separators=(",", ":")
+                )
+                if latest is None:
+                    write_snapshot = snapshot.version in {1, 2}
+                elif snapshot.version == latest[0]:
+                    if snapshot_json != latest[1]:
+                        raise LedgerWriteError(
+                            "unchanged snapshot version must preserve state"
+                        )
+                    write_snapshot = False
+                else:
+                    write_snapshot = snapshot.version == latest[0] + 1
+                if not write_snapshot and (
+                    latest is None or snapshot.version != latest[0]
+                ):
+                    raise LedgerWriteError("snapshot version is not contiguous")
                 connection.execute(
                     """INSERT INTO private_world_events
                        (event_id, delivery_id, event_type, payload_json, occurred_at)
@@ -129,15 +150,12 @@ class SQLitePrivateWorldLedger:
                         event.occurred_at,
                     ),
                 )
-                connection.execute(
-                    """INSERT INTO private_world_snapshots
-                       (version, payload_json, event_id) VALUES (?, ?, ?)""",
-                    (
-                        snapshot.version,
-                        json.dumps(snapshot.to_dict(), sort_keys=True, separators=(",", ":")),
-                        event.event_id,
-                    ),
-                )
+                if write_snapshot:
+                    connection.execute(
+                        """INSERT INTO private_world_snapshots
+                           (version, payload_json, event_id) VALUES (?, ?, ?)""",
+                        (snapshot.version, snapshot_json, event.event_id),
+                    )
         except sqlite3.Error as exc:
             raise LedgerWriteError("private world transaction failed") from exc
         return True

--- a/private_world_reducer.py
+++ b/private_world_reducer.py
@@ -15,6 +15,7 @@ class ReducerInputError(ValueError):
 
 
 class ReducerEventKind(str, Enum):
+    CANONICAL_REPLY_DELIVERED = "canonical_reply_delivered"
     BOUNDARY_RESPECTED = "boundary_respected"
     CONFLICT = "conflict"
     REPAIR = "repair"
@@ -30,6 +31,7 @@ _TOKEN_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
 _STAGE_RE = re.compile(r"^[A-Za-z0-9._:-]{1,64}$")
 _DEDUPLICATION_WINDOW = timedelta(hours=24)
 _NO_EFFECT_KINDS = {
+    ReducerEventKind.CANONICAL_REPLY_DELIVERED,
     ReducerEventKind.HIGH_FREQUENCY_MESSAGE,
     ReducerEventKind.GIFT,
     ReducerEventKind.REPEATED_PHRASE,
@@ -167,4 +169,3 @@ def reduce_private_world(
         next_snapshot,
         ReducerDelta(True, event.kind.value.upper(), changes),
     )
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ py-modules = [
     "private_world_reducer",
     "private_world_ledger",
     "private_world_admin",
+    "private_world_delivery",
     "private_world_projection",
     "reply_context",
     "reply_policy",

--- a/tests/private_world/test_private_world_delivery.py
+++ b/tests/private_world/test_private_world_delivery.py
@@ -1,0 +1,146 @@
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from private_world_delivery import (
+    DeliveryEvent,
+    DeliveryStatus,
+    PrivateWorldDeliveryCommitter,
+)
+from private_world_ledger import SQLitePrivateWorldLedger
+from private_world_reducer import ReducerEventKind
+from reply_orchestrator import ReplyState
+from reply_pipeline import PipelineResult
+
+
+NOW = datetime(2026, 8, 22, tzinfo=timezone.utc)
+
+
+def test_delivery_commits_once_with_stable_delivery_id(tmp_path: Path) -> None:
+    ledger = SQLitePrivateWorldLedger(tmp_path / "private.sqlite3")
+    committer = PrivateWorldDeliveryCommitter(ledger)
+    delivery = DeliveryEvent(
+        delivery_id="letter-1:1",
+        kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
+        occurred_at=NOW,
+        semantic_key="canonical.letter-1",
+    )
+
+    assert committer.commit(delivery) is DeliveryStatus.COMMITTED
+    assert committer.commit(delivery) is DeliveryStatus.DUPLICATE
+    assert ledger.health() == {
+        "status": "READY",
+        "event_count": 1,
+        "snapshot_count": 1,
+    }
+
+
+def test_explicit_relationship_event_reduces_then_persists_atomically(
+    tmp_path: Path,
+) -> None:
+    ledger = SQLitePrivateWorldLedger(tmp_path / "private.sqlite3")
+    committer = PrivateWorldDeliveryCommitter(ledger)
+
+    status = committer.commit(
+        DeliveryEvent(
+            delivery_id="letter-2:1",
+            kind=ReducerEventKind.BOUNDARY_RESPECTED,
+            occurred_at=NOW,
+            semantic_key="boundary.synthetic",
+        )
+    )
+
+    assert status is DeliveryStatus.COMMITTED
+    assert ledger.snapshot().trust == 1
+    assert ledger.snapshot().comfort == 1
+    assert ledger.snapshot().version == 2
+
+
+class AcceptedPipeline:
+    async def run(self, request: object, context: object) -> PipelineResult:
+        return PipelineResult(
+            "letter-3",
+            ReplyState.COMPLETED,
+            text="canonical reply",
+            quality_status="accepted",
+        )
+
+
+class TextTriage:
+    reply_mode = "text"
+
+    def to_dict(self) -> dict[str, str]:
+        return {"reply_mode": "text"}
+
+
+class TextTriageService:
+    async def classify(self, content: str) -> TextTriage:
+        return TextTriage()
+
+
+def test_canonical_reply_is_persisted_pending_before_private_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    letter = {"letter_id": "letter-3", "reply_text": "", "letter_status": "PENDING"}
+    sequence: list[tuple[str, str | None]] = []
+
+    class RecordingCommitter:
+        def commit(self, delivery: DeliveryEvent) -> DeliveryStatus:
+            sequence.append(("commit", letter.get("private_world_status")))
+            return DeliveryStatus.COMMITTED
+
+    monkeypatch.setattr(local_server.store, "letters", [letter])
+    monkeypatch.setattr(local_server, "emotion_triage", TextTriageService())
+    monkeypatch.setattr(local_server, "reply_pipeline", AcceptedPipeline())
+    monkeypatch.setattr(local_server, "private_world_committer", RecordingCommitter())
+    monkeypatch.setattr(local_server, "_schedule_text_reply_delay", lambda *args: None)
+    monkeypatch.setattr(
+        local_server,
+        "_persist_store_state",
+        lambda: sequence.append(("persist", letter.get("private_world_status"))),
+    )
+    monkeypatch.setattr(local_server.letters_adapter, "remember_conversation", lambda *args: None)
+
+    assert asyncio.run(local_server.generate_reply("letter-3", "input")) is True
+    assert ("persist", "PENDING") in sequence
+    pending_index = sequence.index(("persist", "PENDING"))
+    commit_index = sequence.index(("commit", "PENDING"))
+    assert pending_index < commit_index
+    assert letter["private_world_status"] == "COMMITTED"
+    assert letter["private_world_delivery_id"] == "letter-3:1"
+
+
+def test_pending_delivery_recovers_without_changing_canonical_reply(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import local_server
+
+    ledger = SQLitePrivateWorldLedger(tmp_path / "private.sqlite3")
+    letter = {
+        "letter_id": "letter-4",
+        "reply_text": "already persisted canonical reply",
+        "letter_status": "COMPLETED",
+        "reply_revision": 1,
+        "private_world_status": "PENDING",
+        "private_world_delivery_id": "letter-4:1",
+        "private_world_occurred_at": NOW.isoformat(),
+        "private_world_event_kind": "canonical_reply_delivered",
+        "private_world_semantic_key": "canonical.letter-4",
+    }
+    monkeypatch.setattr(local_server.store, "letters", [letter])
+    monkeypatch.setattr(
+        local_server,
+        "private_world_committer",
+        PrivateWorldDeliveryCommitter(ledger),
+    )
+    monkeypatch.setattr(local_server, "_persist_store_state", lambda: None)
+
+    assert local_server.recover_pending_private_world() == 1
+    assert local_server.recover_pending_private_world() == 0
+    assert letter["reply_text"] == "already persisted canonical reply"
+    assert letter["private_world_status"] == "COMMITTED"
+    assert ledger.health()["event_count"] == 1

--- a/tests/private_world/test_private_world_ledger.py
+++ b/tests/private_world/test_private_world_ledger.py
@@ -54,15 +54,27 @@ def test_apply_once_deduplicates_event_and_delivery_ids(tmp_path: Path) -> None:
     }
 
 
-def test_event_insert_rolls_back_when_snapshot_version_conflicts(tmp_path: Path) -> None:
+def test_event_insert_rolls_back_when_snapshot_version_skips_ahead(tmp_path: Path) -> None:
     ledger = SQLitePrivateWorldLedger(tmp_path / "private-world.sqlite3")
     ledger.apply_once(_event(1), PrivateWorldSnapshot(version=1))
 
     with pytest.raises(LedgerWriteError):
-        ledger.apply_once(_event(2), PrivateWorldSnapshot(version=1))
+        ledger.apply_once(_event(2), PrivateWorldSnapshot(version=3))
 
     assert ledger.events() == (_event(1),)
     assert ledger.health()["event_count"] == 1
+
+
+def test_no_effect_event_can_share_latest_snapshot_version(tmp_path: Path) -> None:
+    ledger = SQLitePrivateWorldLedger(tmp_path / "private-world.sqlite3")
+    ledger.apply_once(_event(1), PrivateWorldSnapshot(version=1))
+
+    assert ledger.apply_once(_event(2), PrivateWorldSnapshot(version=1)) is True
+    assert ledger.health() == {
+        "status": "READY",
+        "event_count": 2,
+        "snapshot_count": 1,
+    }
 
 
 def test_health_never_exposes_database_path_or_private_values(tmp_path: Path) -> None:


### PR DESCRIPTION
## Scope
- define canonical delivery events and an exactly-once committer
- derive delivery_id as letter_id:reply_revision
- persist PENDING outbox metadata before the private-state commit
- recover pending commits on startup without changing canonical text
- allow no-effect delivery events without duplicating snapshot rows

## Invariants
- generation failure and quality block never create a delivery
- request retry with the same canonical revision is idempotent
- media generation, failure, retry, and rerender never call the commit path
- backend unavailability keeps the accepted reply and leaves a retryable pending marker

## Validation
- 15 focused delivery/ledger/pipeline tests passed
- 201 default tests passed, 1 experimental deselected
- baseline hardening scanner passed with 0 findings
- diff-check passed