### PR TITLE
feat(persona): add public release boundary scan

### DIFF
--- a/baseline_hardening_scan.py
+++ b/baseline_hardening_scan.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import ast
 import io
+import json
 import re
 import subprocess
 import sys
@@ -30,7 +31,31 @@ MODES = (
     "sensitive-paths",
     "large-files",
     "evidence-ignore",
+    "persona-release",
 )
+
+PERSONA_RELEASE_PATTERNS = (
+    "private_reference_path",
+    "private_state_path",
+    "private_communication_path",
+    "control_view_instance",
+    "continuation_instance",
+    "private_nickname_instance",
+    "blocked_release_record",
+    "long_source_copy",
+    "invalid_release_asset",
+)
+PERSONA_RELEASE_ROOTS = {"linli_character", "persona", "personas", "content"}
+PERSONA_RELEASE_SUFFIXES = {".json", ".yaml", ".yml", ".toml", ".md"}
+PERSONA_RELEASE_TEXT_KEYS = {
+    "content",
+    "original_text",
+    "source_text",
+    "statement",
+    "summary",
+    "text",
+}
+MAX_PERSONA_RELEASE_TEXT_CHARS = 1_200
 
 
 COMMENT_PATTERNS = (
@@ -314,6 +339,133 @@ def scan_evidence_ignore(root: Path) -> tuple[list[str], list[str]]:
     return not_ignored, checked
 
 
+def _persona_release_files(root: Path, files: list[Path]) -> list[Path]:
+    selected: list[Path] = []
+    for path in files:
+        try:
+            parts = path.relative_to(root).parts
+        except ValueError:
+            continue
+        if (
+            not parts
+            or parts[0] not in PERSONA_RELEASE_ROOTS
+            or path.suffix.lower() not in PERSONA_RELEASE_SUFFIXES
+            or "provenance" in path.stem.lower()
+        ):
+            continue
+        selected.append(path)
+    return selected
+
+
+def _append_persona_finding(findings: list[str], name: str, label: str) -> None:
+    finding = f"{name}:{label}"
+    if finding not in findings:
+        findings.append(finding)
+
+
+def _scan_persona_json(
+    value: object,
+    name: str,
+    findings: list[str],
+    *,
+    enforce_release_flags: bool,
+) -> None:
+    if isinstance(value, list):
+        for item in value:
+            _scan_persona_json(
+                item,
+                name,
+                findings,
+                enforce_release_flags=enforce_release_flags,
+            )
+        return
+    if not isinstance(value, dict):
+        return
+
+    allowed = value.get("allowed_public_release")
+    rights = value.get("rights_status")
+    if enforce_release_flags and (
+        allowed is False
+        or (
+            isinstance(rights, str)
+            and any(marker in rights.upper() for marker in ("UNKNOWN", "BLOCK"))
+        )
+    ):
+        _append_persona_finding(findings, name, "blocked_release_record")
+    if value.get("view") == "control":
+        _append_persona_finding(findings, name, "control_view_instance")
+    if value.get("continuation_awareness") in {"control_only", "pending"}:
+        _append_persona_finding(findings, name, "continuation_instance")
+    if value.get("nickname_permissions"):
+        _append_persona_finding(findings, name, "private_nickname_instance")
+
+    for key, item in value.items():
+        if (
+            key in PERSONA_RELEASE_TEXT_KEYS
+            and isinstance(item, str)
+            and len(item) > MAX_PERSONA_RELEASE_TEXT_CHARS
+        ):
+            _append_persona_finding(findings, name, "long_source_copy")
+        _scan_persona_json(
+            item,
+            name,
+            findings,
+            enforce_release_flags=enforce_release_flags,
+        )
+
+
+def _scan_persona_text(text: str, name: str, findings: list[str]) -> None:
+    checks = (
+        (r"(?i)allowed_public_release\s*[:=]\s*false", "blocked_release_record"),
+        (r"(?i)rights_status\s*[:=]\s*[^\r\n]*(?:unknown|block)", "blocked_release_record"),
+        (r"(?i)(?:^|[,{\s])view\s*[:=]\s*[\"']?control\b", "control_view_instance"),
+        (
+            r"(?i)continuation_awareness\s*[:=]\s*[\"']?(?:control_only|pending)\b",
+            "continuation_instance",
+        ),
+        (r"(?i)nickname_permissions\s*[:=]\s*\[[^\]\s]", "private_nickname_instance"),
+    )
+    for pattern, label in checks:
+        if re.search(pattern, text):
+            _append_persona_finding(findings, name, label)
+    if any(len(line) > MAX_PERSONA_RELEASE_TEXT_CHARS for line in text.splitlines()):
+        _append_persona_finding(findings, name, "long_source_copy")
+
+
+def scan_persona_release(
+    root: Path, files: list[Path]
+) -> tuple[list[str], list[str], int]:
+    findings: list[str] = []
+    selected = _persona_release_files(root, files)
+    for path in selected:
+        name = relative(path, root)
+        lower_name = name.lower()
+        if re.search(r"(?:^|/)(?:private|reference)[^/]*\.(?:md|txt|docx?|pdf)$", lower_name):
+            _append_persona_finding(findings, name, "private_reference_path")
+        if re.search(r"(?:^|/)(?:private_world|relationship|world)[^/]*state[^/]*\.", lower_name):
+            _append_persona_finding(findings, name, "private_state_path")
+        if re.search(
+            r"(?:^|/)(?:chat|letter|message|transcript|communication)[^/]*\.",
+            lower_name,
+        ):
+            _append_persona_finding(findings, name, "private_communication_path")
+
+        try:
+            text = path.read_text(encoding="utf-8")
+            if path.suffix.lower() == ".json":
+                _scan_persona_json(
+                    json.loads(text),
+                    name,
+                    findings,
+                    enforce_release_flags=path.name != "persona_v2.json",
+                )
+            else:
+                _scan_persona_text(text, name, findings)
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            _append_persona_finding(findings, name, "invalid_release_asset")
+    return findings, list(PERSONA_RELEASE_PATTERNS), len(selected)
+
+
 def emit_section(name: str, patterns: list[str], findings: list[str]) -> None:
     print(f"[{name}]")
     print(f"patterns={','.join(patterns)}")
@@ -373,6 +525,11 @@ def main(argv: list[str] | None = None) -> int:
             emit_section("evidence_ignore_boundary", [".evidence/**"], findings)
             print(f"evidence_probe_count={len(probes)}")
             print(f"evidence_probes_checked={len(probes) - len(findings)}")
+            all_findings.extend(findings)
+        if "persona-release" in selected:
+            findings, patterns, checked = scan_persona_release(root, files)
+            emit_section("persona_public_release_boundary", patterns, findings)
+            print(f"persona_release_files_checked={checked}")
             all_findings.extend(findings)
     except (OSError, UnicodeError, subprocess.SubprocessError, tokenize.TokenError, SyntaxError) as exc:
         print(f"status=ERROR:{type(exc).__name__}")

--- a/docs/P02_18_PUBLIC_RELEASE_SCAN.md
+++ b/docs/P02_18_PUBLIC_RELEASE_SCAN.md
@@ -1,0 +1,20 @@
+# P02-18 Public Persona Release Scan
+
+`baseline_hardening_scan.py --mode persona-release` checks tracked persona and
+content assets before public distribution. Findings contain only a relative
+path and a stable label; matched text and private values are never printed.
+
+The scan rejects private reference/state/communication paths, control-view and
+Local Continuation instances, private nickname grants, blocked rights records,
+overlong copied source text, and unreadable release assets. `--mode all`
+includes this boundary.
+
+`linli_character/persona_v2.json` is an auditable source registry, not a
+release payload. It may retain explicitly quarantined
+`allowed_public_release=false` rows so the loader can fail closed. Those rows
+must not be copied into the release payload created by P02-19. All other
+persona assets are checked as release candidates and blocked rows fail the
+scan.
+
+Rollback is removal of the `persona-release` mode and its call from `all`; it
+does not modify runtime Persona assembly, state, or media behavior.

--- a/tests/test_baseline_hardening.py
+++ b/tests/test_baseline_hardening.py
@@ -239,6 +239,113 @@ def test_b00_scanner_allows_pinned_cors_metadata_but_rejects_forwarding(
     ]
 
 
+def test_persona_release_scan_allows_contracts_code_and_public_declarations(
+    tmp_path: Path,
+) -> None:
+    import json
+    import baseline_hardening_scan as scanner
+
+    contract = tmp_path / "contracts" / "private_world.schema.json"
+    runtime = tmp_path / "private_world_port.py"
+    persona = tmp_path / "linli_character" / "persona_v2.json"
+    contract.parent.mkdir()
+    persona.parent.mkdir()
+    contract.write_text('{"properties":{"view":{"const":"control"}}}', encoding="utf-8")
+    runtime.write_text('CONTROL_VIEW = "control_only"\n', encoding="utf-8")
+    persona.write_text(
+        json.dumps(
+            {
+                    "declarations": [
+                        {
+                            "allowed_public_release": True,
+                            "rights_status": "REDISTRIBUTABLE",
+                            "statement": "Synthetic public rule.",
+                        },
+                        {
+                            "allowed_public_release": False,
+                            "rights_status": "UNKNOWN_BLOCK_RELEASE",
+                            "statement": "Synthetic quarantined registry record.",
+                        }
+                    ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    findings, _, checked = scanner.scan_persona_release(
+        tmp_path, [contract, runtime, persona]
+    )
+
+    assert findings == []
+    assert checked == 1
+
+
+def test_persona_release_scan_rejects_private_instances_and_communications(
+    tmp_path: Path,
+) -> None:
+    import json
+    import baseline_hardening_scan as scanner
+
+    state = tmp_path / "linli_character" / "private_world_state.json"
+    chat = tmp_path / "linli_character" / "chat_export.json"
+    state.parent.mkdir()
+    state.write_text(
+        json.dumps(
+            {
+                "view": "control",
+                "continuation_awareness": "pending",
+                "nickname_permissions": ["synthetic_private_nickname"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    chat.write_text('{"messages":["synthetic private communication"]}', encoding="utf-8")
+
+    findings, _, _ = scanner.scan_persona_release(tmp_path, [state, chat])
+
+    assert {finding.rsplit(":", 1)[-1] for finding in findings} >= {
+        "private_state_path",
+        "control_view_instance",
+        "continuation_instance",
+        "private_nickname_instance",
+        "private_communication_path",
+    }
+    assert "synthetic_private_nickname" not in "\n".join(findings)
+    assert "synthetic private communication" not in "\n".join(findings)
+
+
+def test_persona_release_scan_fails_closed_on_blocked_rights_and_source_copy(
+    tmp_path: Path,
+) -> None:
+    import json
+    import baseline_hardening_scan as scanner
+
+    asset = tmp_path / "linli_character" / "persona_extra.json"
+    asset.parent.mkdir()
+    asset.write_text(
+        json.dumps(
+            {
+                "records": [
+                    {
+                        "allowed_public_release": False,
+                        "rights_status": "UNKNOWN_BLOCK_RELEASE",
+                        "statement": "x" * 1300,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    findings, _, _ = scanner.scan_persona_release(tmp_path, [asset])
+
+    assert {finding.rsplit(":", 1)[-1] for finding in findings} == {
+        "blocked_release_record",
+        "long_source_copy",
+    }
+    assert "x" * 20 not in "\n".join(findings)
+
+
 def test_b00_scanner_process_exit_codes_and_sanitized_findings(tmp_path: Path) -> None:
     repo = tmp_path / "synthetic-repo"
     repo.mkdir()


### PR DESCRIPTION
## Scope
- add a dedicated persona public-release scanner mode
- fail closed on private state/communications/control-view/continuation/nickname/rights/source-copy instances
- keep the auditable source registry distinct from the future release payload

## Validation
- 204 passed, 1 deselected
- baseline_hardening_scan --mode all: PASS, zero findings
- py_compile and git diff --check: PASS

## Boundary
No runtime Persona, reply pipeline, private-world persistence, or media behavior changes.