### PR TITLE
fix(http): expose original numeric letter statuses

### DIFF
--- a/local_server.py
+++ b/local_server.py
@@ -507,12 +507,30 @@ def fake_jwt():
     # 本地伪造 token（客户端不校验，服务器自己验证）
     return "toy__local." + uuid.uuid4().hex
 
+
+CLIENT_LETTER_STATUS = {
+    "PENDING": 1,
+    "AUDITING": 2,
+    "LLM_PROCESSING": 3,
+    "COMPLETED": 4,
+    "REPLIED": 4,
+    "FAILED": 5,
+    "CANCELED": 5,
+}
+
+
+def client_letter_status(value) -> int:
+    if isinstance(value, int) and value in range(1, 6):
+        return value
+    return CLIENT_LETTER_STATUS.get(str(value).upper(), 5)
+
+
 def letter_to_out(l):
     published = l.get("reply_not_before", 0.0) <= time.time()
     return {
         "letter_id": l["letter_id"],
         "summary": (l.get("reply_text") or l.get("content") or "")[:50],
-        "letter_status": l.get("letter_status", 4) if published else "PENDING",
+        "letter_status": client_letter_status(l.get("letter_status", 4)) if published else 1,
         "audit_status": l.get("audit_status", 2),
         "reply_type": 1 if published and l.get("reply_text") else 0,
         "reply_mode": l.get("reply_mode", "text") if published else "text",
@@ -1154,7 +1172,7 @@ async def route(method, path, body, query):
         reply_text = l.get("reply_text", "") if reply_published else ""
         return ok({
             "letter_id": l["letter_id"],
-            "letter_status": l.get("letter_status", 4),
+            "letter_status": client_letter_status(l.get("letter_status", 4)) if reply_published else 1,
             "audit_status": l.get("audit_status", 2),
             "content": l.get("content", ""),
             "material": l.get("material", {}),

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -95,7 +95,9 @@ def test_normal_send_list_and_detail_preserve_legacy_fields(monkeypatch: pytest.
     assert sent["code"] == 0
     assert sent["data"]["letterId"] == letter_id
     assert listed["data"]["list"][0]["letter_id"] == letter_id
+    assert listed["data"]["list"][0]["letter_status"] == 4
     assert detail["data"]["content"] == "synthetic input"
+    assert detail["data"]["letter_status"] == 4
     assert detail["data"]["reply_text"] == "synthetic reply"
     assert detail["data"]["reply_content"] == "synthetic reply"
     assert detail["data"]["read_only"] is False


### PR DESCRIPTION
修复原版客户端一直显示回信中的兼容问题。后端内部状态保持字符串，仅在公开列表和详情响应中映射为原版数值枚举（PENDING=1、REPLIED=4、FAILED=5）。\n\n验证：\n- RED：完成状态原返回 COMPLETED，前端要求 4\n- GREEN：HTTP 契约与延迟测试 17 passed\n- py_compile PASS\n- baseline_hardening_scan PASS\n- git diff --check PASS\n\n边界：不修改原版前端、不修改内部回信状态机、不修改延迟逻辑。