### PR TITLE
fix(reply): use one ReplyContext for generation and quality

### DIFF
--- a/docs/P02_15_PERSONA_ASSEMBLY_WIRING.md
+++ b/docs/P02_15_PERSONA_ASSEMBLY_WIRING.md
@@ -1,11 +1,38 @@
-# P02-15 LetterAdapter Persona 2.0 wiring
+# P02-15 Letter generation Persona 2.0 wiring
 
-Set `persona_v2_enabled=true` (or `OLIVIA_PERSONA_V2_ENABLED=true`) to route
-`LetterAdapter._messages()` through `PersonaAssembly`. The default remains false,
-so the existing adapter path is unchanged until explicitly enabled.
+Persona 2.0 is enabled by default for the local letter pipeline. The legacy
+`LetterAdapter._messages()` entry remains a text-letter compatibility path,
+but the production reply sequence no longer relies on that method after
+triage.
 
-The v2 path loads `persona_v2_file` with DRAFT fallback, creates a text-letter
-`ReplyContext`, projects PrivateWorld state into finite character inputs, and
-passes MemoryPromptBuilder output as one escaped, untrusted history block. It
-does not modify `reply_orchestrator.py`, run a reviewer, or write relationship
-state.
+## Shared ReplyContext
+
+`generate_reply()` classifies the delivery mode first and creates one trusted
+`ReplyContext`. `ReplyPipeline` uses that same object twice:
+
+1. before generation, to select the matching Persona `MODE_STYLE`, output
+   constraints, trusted time, bounded PrivateWorld projection, and memory;
+2. after generation, to run the deterministic and optional semantic quality
+   gate.
+
+This prevents a spoken or musical reply from being generated with
+`text_letter` instructions and checked only after the fact.
+
+## Prepared-message provider boundary
+
+The pipeline converts a raw `ReplyRequest.content` into an immutable
+`ReplyRequest.messages` pair before the provider call:
+
+- system: Persona Constitution, compact Linli profile, actual mode and mode
+  style, bounded runtime facts, and escaped untrusted history;
+- user: the original current letter.
+
+The existing local compatibility bridge still owns legacy raw-content calls.
+When a request already contains assembled messages, `ReplyOrchestrator`
+selects the bridge's underlying provider directly so the bridge cannot discard
+or rebuild the system message.
+
+The orchestrator's cancellation, timeout, idempotency, event stream, and error
+semantics are otherwise unchanged. Reviewer transport, rewrite generation,
+canonical persistence, media scheduling, and relationship commits remain
+separate stages.

--- a/reply_orchestrator.py
+++ b/reply_orchestrator.py
@@ -152,7 +152,9 @@ class ReplyOrchestrator:
         drain: asyncio.Task[None] | None = None
         if not run._result.done() and not run._run_draining:
             run._run_draining = True
-            drain = asyncio.create_task(self._drain(run), name=f"reply-drain-{request.request_id}")
+            drain = asyncio.create_task(
+                self._drain(run), name=f"reply-drain-{request.request_id}"
+            )
         try:
             return await run.wait()
         except asyncio.CancelledError:
@@ -173,7 +175,14 @@ class ReplyOrchestrator:
             ReplyState.FAILED,
             error_code="IDEMPOTENCY_CONFLICT",
         )
-        self._set_result(run, ReplyResult(run.request.request_id, ReplyState.FAILED, error_code="IDEMPOTENCY_CONFLICT"))
+        self._set_result(
+            run,
+            ReplyResult(
+                run.request.request_id,
+                ReplyState.FAILED,
+                error_code="IDEMPOTENCY_CONFLICT",
+            ),
+        )
 
     async def _execute(self, run: ReplyRun) -> None:
         request = run.request
@@ -181,24 +190,48 @@ class ReplyOrchestrator:
             messages = request.normalized_messages()
         except (ValueError, GatewayError) as exc:
             code = getattr(exc, "code", "INVALID_INPUT")
-            await self._publish(run, ReplyEventType.TERMINAL_ERROR, ReplyState.FAILED, error_code=code)
-            self._set_result(run, ReplyResult(request.request_id, ReplyState.FAILED, error_code=code))
+            await self._publish(
+                run,
+                ReplyEventType.TERMINAL_ERROR,
+                ReplyState.FAILED,
+                error_code=code,
+            )
+            self._set_result(
+                run,
+                ReplyResult(
+                    request.request_id,
+                    ReplyState.FAILED,
+                    error_code=code,
+                ),
+            )
             return
 
+        provider_gateway = _provider_gateway(self.gateway, request)
         try:
-            await self._publish(run, ReplyEventType.REQUEST_ACCEPTED, ReplyState.ACCEPTED)
-            if getattr(self.gateway, "stream_enabled", False):
-                result = await asyncio.wait_for(self._consume_stream(run, messages), self.timeout_seconds)
+            await self._publish(
+                run, ReplyEventType.REQUEST_ACCEPTED, ReplyState.ACCEPTED
+            )
+            if getattr(provider_gateway, "stream_enabled", False):
+                result = await asyncio.wait_for(
+                    self._consume_stream(run, messages, provider_gateway),
+                    self.timeout_seconds,
+                )
             else:
                 response = await asyncio.wait_for(
-                    self.gateway.complete(messages, request_id=request.request_id),
+                    provider_gateway.complete(
+                        messages, request_id=request.request_id
+                    ),
                     self.timeout_seconds,
                 )
                 result = await self._complete_response(run, response)
             self._set_result(run, result)
         except asyncio.CancelledError:
-            await self._publish(run, ReplyEventType.CANCELLED, ReplyState.CANCELLED)
-            self._set_result(run, ReplyResult(request.request_id, ReplyState.CANCELLED))
+            await self._publish(
+                run, ReplyEventType.CANCELLED, ReplyState.CANCELLED
+            )
+            self._set_result(
+                run, ReplyResult(request.request_id, ReplyState.CANCELLED)
+            )
         except asyncio.TimeoutError:
             await self._publish(
                 run,
@@ -209,10 +242,19 @@ class ReplyOrchestrator:
             )
             self._set_result(
                 run,
-                ReplyResult(request.request_id, ReplyState.FAILED, error_code="LLM_TIMEOUT", retryable=True),
+                ReplyResult(
+                    request.request_id,
+                    ReplyState.FAILED,
+                    error_code="LLM_TIMEOUT",
+                    retryable=True,
+                ),
             )
         except GatewayError as exc:
-            event = ReplyEventType.RETRYABLE_ERROR if exc.retryable else ReplyEventType.TERMINAL_ERROR
+            event = (
+                ReplyEventType.RETRYABLE_ERROR
+                if exc.retryable
+                else ReplyEventType.TERMINAL_ERROR
+            )
             await self._publish(
                 run,
                 event,
@@ -222,7 +264,12 @@ class ReplyOrchestrator:
             )
             self._set_result(
                 run,
-                ReplyResult(request.request_id, ReplyState.FAILED, error_code=exc.code, retryable=exc.retryable),
+                ReplyResult(
+                    request.request_id,
+                    ReplyState.FAILED,
+                    error_code=exc.code,
+                    retryable=exc.retryable,
+                ),
             )
         except Exception:
             await self._publish(
@@ -231,9 +278,18 @@ class ReplyOrchestrator:
                 ReplyState.FAILED,
                 error_code="LLM_INTERNAL",
             )
-            self._set_result(run, ReplyResult(request.request_id, ReplyState.FAILED, error_code="LLM_INTERNAL"))
+            self._set_result(
+                run,
+                ReplyResult(
+                    request.request_id,
+                    ReplyState.FAILED,
+                    error_code="LLM_INTERNAL",
+                ),
+            )
 
-    async def _complete_response(self, run: ReplyRun, response: GatewayResponse) -> ReplyResult:
+    async def _complete_response(
+        self, run: ReplyRun, response: GatewayResponse
+    ) -> ReplyResult:
         if not response.text.strip():
             raise GatewayError("PROVIDER_PROTOCOL", retryable=False)
         await self._publish(
@@ -242,15 +298,22 @@ class ReplyOrchestrator:
             ReplyState.COMPLETED,
             text=response.text,
         )
-        return ReplyResult(run.request.request_id, ReplyState.COMPLETED, text=response.text)
+        return ReplyResult(
+            run.request.request_id,
+            ReplyState.COMPLETED,
+            text=response.text,
+        )
 
     async def _consume_stream(
         self,
         run: ReplyRun,
         messages: Sequence[Mapping[str, Any]],
+        gateway: Gateway,
     ) -> ReplyResult:
         chunks: list[str] = []
-        async for delta in self.gateway.stream(messages, request_id=run.request.request_id):
+        async for delta in gateway.stream(
+            messages, request_id=run.request.request_id
+        ):
             if delta.text:
                 chunks.append(delta.text)
                 await self._publish(
@@ -262,8 +325,12 @@ class ReplyOrchestrator:
         text = "".join(chunks).strip()
         if not text:
             raise GatewayError("PROVIDER_PROTOCOL", retryable=False)
-        await self._publish(run, ReplyEventType.COMPLETED, ReplyState.COMPLETED, text=text)
-        return ReplyResult(run.request.request_id, ReplyState.COMPLETED, text=text)
+        await self._publish(
+            run, ReplyEventType.COMPLETED, ReplyState.COMPLETED, text=text
+        )
+        return ReplyResult(
+            run.request.request_id, ReplyState.COMPLETED, text=text
+        )
 
     async def _publish(
         self,
@@ -307,6 +374,18 @@ class ReplyOrchestrator:
     def _set_result(run: ReplyRun, result: ReplyResult) -> None:
         if not run._result.done():
             run._result.set_result(result)
+
+
+def _provider_gateway(gateway: Gateway, request: ReplyRequest) -> Gateway:
+    """Preserve caller-assembled messages when using the local compatibility bridge."""
+
+    if request.messages is None:
+        return gateway
+    adapter = getattr(gateway, "adapter", None)
+    delegate = getattr(adapter, "gateway", None)
+    if delegate is None or not callable(getattr(delegate, "complete", None)):
+        return gateway
+    return delegate
 
 
 def _request_fingerprint(request: ReplyRequest) -> str:

--- a/reply_pipeline.py
+++ b/reply_pipeline.py
@@ -108,7 +108,12 @@ def _prepare_generation_request(
     bridge = getattr(orchestrator, "gateway", None)
     adapter = getattr(bridge, "adapter", None)
     config = getattr(adapter, "config", None)
-    if adapter is None or not getattr(config, "persona_v2_enabled", False):
+    provider_name = str(getattr(config, "provider", "none")).strip().lower()
+    if (
+        adapter is None
+        or not getattr(config, "persona_v2_enabled", False)
+        or provider_name in {"", "none", "disabled", "unconfigured"}
+    ):
         return request
 
     persona_path = getattr(adapter, "persona_v2_path", None)

--- a/reply_pipeline.py
+++ b/reply_pipeline.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Protocol
 
+from persona_assembly import UntrustedFragment, assemble_persona
+from persona_loader import load_persona
 from reply_context import ReplyContext
-from reply_orchestrator import ReplyResult, ReplyState
+from reply_orchestrator import ReplyRequest, ReplyResult, ReplyState
 from reply_quality_gate import ReviewerPort, RewriterPort, run_reply_quality_gate
 
 
@@ -52,7 +54,8 @@ class ReplyPipeline:
     async def run(self, request: object, context: ReplyContext) -> PipelineResult:
         if not isinstance(context, ReplyContext):
             raise TypeError("ReplyContext is required")
-        candidate = await self.orchestrator.run(request)
+        prepared = _prepare_generation_request(request, context, self.orchestrator)
+        candidate = await self.orchestrator.run(prepared)
         if candidate.state is not ReplyState.COMPLETED:
             return PipelineResult(
                 candidate.request_id,
@@ -86,3 +89,52 @@ class ReplyPipeline:
             rewrite_calls=gate.rewrite_calls,
         )
 
+
+def _prepare_generation_request(
+    request: object,
+    context: ReplyContext,
+    orchestrator: OrchestratorPort,
+) -> object:
+    """Attach Persona messages before provider generation when the local bridge is used."""
+
+    if (
+        not isinstance(request, ReplyRequest)
+        or request.messages is not None
+        or not isinstance(request.content, str)
+        or not request.content.strip()
+    ):
+        return request
+
+    bridge = getattr(orchestrator, "gateway", None)
+    adapter = getattr(bridge, "adapter", None)
+    config = getattr(adapter, "config", None)
+    if adapter is None or not getattr(config, "persona_v2_enabled", False):
+        return request
+
+    persona_path = getattr(adapter, "persona_v2_path", None)
+    memory_builder = getattr(adapter, "memory_prompt_builder", None)
+    memory_port = getattr(adapter, "memory_port", None)
+    if persona_path is None or memory_builder is None:
+        raise ValueError("persona generation boundary is unavailable")
+
+    loaded = load_persona(persona_path)
+    memory_context = memory_builder.build(
+        request.content,
+        max_chars=min(
+            request.max_input_chars,
+            int(getattr(memory_port, "context_max_chars", 2400)),
+        ),
+    )
+    history = (
+        (UntrustedFragment("memory.references", memory_context.text),)
+        if memory_context.text
+        else ()
+    )
+    messages = assemble_persona(
+        loaded.snapshot,
+        context,
+        user_input=request.content,
+        max_units=request.max_input_chars,
+        history=history,
+    ).to_messages()
+    return replace(request, content=None, messages=messages)

--- a/tests/persona/test_reply_pipeline.py
+++ b/tests/persona/test_reply_pipeline.py
@@ -1,10 +1,20 @@
 import asyncio
 from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from llm_gateway import GatewayResponse
+from memory_port import NullMemoryPort
+from memory_prompt import MemoryPromptBuilder
 from reply_context import ReplyContext, ReplyMode, TrustedTime
-from reply_orchestrator import ReplyResult, ReplyState
+from reply_orchestrator import (
+    ReplyOrchestrator,
+    ReplyRequest,
+    ReplyResult,
+    ReplyState,
+)
 from reply_pipeline import (
     PipelineResult,
     ReplyPipeline,
@@ -17,6 +27,9 @@ from reply_reviewer import (
     ReviewStatus,
     ReviewVerdict,
 )
+
+
+ROOT = Path(__file__).resolve().parents[2]
 
 
 def _context(mode: ReplyMode = ReplyMode.TEXT_LETTER) -> ReplyContext:
@@ -106,6 +119,98 @@ def test_pipeline_blocks_candidate_when_single_rewrite_fails() -> None:
     assert result.violation_codes == ("INTERNAL_CONTROL_MARKUP",)
 
 
+class RecordingProvider:
+    stream_enabled = False
+
+    def __init__(self) -> None:
+        self.messages: tuple[dict[str, str], ...] = ()
+
+    async def complete(
+        self,
+        messages: object,
+        *,
+        request_id: str | None = None,
+    ) -> GatewayResponse:
+        self.messages = tuple(dict(message) for message in messages)  # type: ignore[arg-type]
+        return GatewayResponse(
+            text="我听见了。先不用急着给自己一个结论。",
+            request_id=request_id or "generated",
+            provider="synthetic",
+            model="synthetic",
+        )
+
+
+class CompatibilityBridge:
+    stream_enabled = False
+
+    def __init__(self, adapter: object) -> None:
+        self.adapter = adapter
+        self.calls = 0
+
+    async def complete(
+        self,
+        messages: object,
+        *,
+        request_id: str | None = None,
+    ) -> GatewayResponse:
+        self.calls += 1
+        raise AssertionError(
+            "prepared Persona messages must not be rebuilt by the bridge"
+        )
+
+
+@pytest.mark.parametrize(
+    ("mode", "style_id"),
+    [
+        (ReplyMode.TEXT_LETTER, "mode.text.no_forced_question"),
+        (ReplyMode.SPOKEN_VIDEO, "mode.spoken.natural_plain"),
+        (ReplyMode.MUSICAL_VIDEO, "mode.musical.only_when_motivated"),
+    ],
+)
+def test_generation_receives_the_same_mode_context_as_quality_gate(
+    mode: ReplyMode,
+    style_id: str,
+) -> None:
+    memory = NullMemoryPort()
+    provider = RecordingProvider()
+    adapter = SimpleNamespace(
+        config=SimpleNamespace(persona_v2_enabled=True),
+        persona_v2_path=ROOT / "linli_character" / "persona_release_v2.json",
+        memory_prompt_builder=MemoryPromptBuilder(memory),
+        memory_port=memory,
+        gateway=provider,
+    )
+    bridge = CompatibilityBridge(adapter)
+    pipeline = ReplyPipeline(
+        ReplyOrchestrator(bridge, timeout_seconds=1),  # type: ignore[arg-type]
+        reviewer=NullReviewer(),
+        rewriter=UnavailableRewriter(),
+    )
+
+    result = asyncio.run(
+        pipeline.run(
+            ReplyRequest(
+                content="今天只是普通地有点累。",
+                request_id=f"mode-{mode.value}",
+                max_input_chars=10_000,
+            ),
+            _context(mode),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert bridge.calls == 0
+    assert tuple(message["role"] for message in provider.messages) == (
+        "system",
+        "user",
+    )
+    assert provider.messages[1]["content"] == "今天只是普通地有点累。"
+    system = provider.messages[0]["content"]
+    assert f'"mode":"{mode.value}"' in system
+    assert style_id in system
+    assert "林离 Olivia" in system
+
+
 class FakeTriage:
     reply_mode = "video"
 
@@ -132,13 +237,19 @@ def test_generate_reply_persists_and_renders_only_canonical_text(
 ) -> None:
     import local_server
 
-    letter = {"letter_id": "letter-1", "reply_text": "", "letter_status": "PENDING"}
+    letter = {
+        "letter_id": "letter-1",
+        "reply_text": "",
+        "letter_status": "PENDING",
+    }
     scheduled: list[tuple[object, ...]] = []
     remembered: list[tuple[str, str]] = []
     monkeypatch.setattr(local_server.store, "letters", [letter])
     monkeypatch.setattr(local_server, "emotion_triage", FakeTriageService())
     monkeypatch.setattr(local_server, "_persist_store_state", lambda: None)
-    monkeypatch.setattr(local_server, "_schedule_text_reply_delay", lambda *args: None)
+    monkeypatch.setattr(
+        local_server, "_schedule_text_reply_delay", lambda *args: None
+    )
     monkeypatch.setattr(
         local_server, "_schedule_media_job", lambda *args: scheduled.append(args)
     )
@@ -163,7 +274,12 @@ def test_generate_reply_persists_and_renders_only_canonical_text(
         ),
     )
 
-    assert asyncio.run(local_server.generate_reply("letter-1", "candidate input")) is True
+    assert (
+        asyncio.run(
+            local_server.generate_reply("letter-1", "candidate input")
+        )
+        is True
+    )
     assert letter["reply_text"] == "canonical final text"
     assert letter["letter_status"] == "COMPLETED"
     assert letter["quality_status"] == "accepted"
@@ -177,12 +293,18 @@ def test_blocked_candidate_never_reaches_storage_or_media(
 ) -> None:
     import local_server
 
-    letter = {"letter_id": "letter-2", "reply_text": "", "letter_status": "PENDING"}
+    letter = {
+        "letter_id": "letter-2",
+        "reply_text": "",
+        "letter_status": "PENDING",
+    }
     scheduled: list[tuple[object, ...]] = []
     monkeypatch.setattr(local_server.store, "letters", [letter])
     monkeypatch.setattr(local_server, "emotion_triage", FakeTriageService())
     monkeypatch.setattr(local_server, "_persist_store_state", lambda: None)
-    monkeypatch.setattr(local_server, "_schedule_text_reply_delay", lambda *args: None)
+    monkeypatch.setattr(
+        local_server, "_schedule_text_reply_delay", lambda *args: None
+    )
     monkeypatch.setattr(
         local_server, "_schedule_media_job", lambda *args: scheduled.append(args)
     )
@@ -202,7 +324,12 @@ def test_blocked_candidate_never_reaches_storage_or_media(
         ),
     )
 
-    assert asyncio.run(local_server.generate_reply("letter-2", "candidate input")) is False
+    assert (
+        asyncio.run(
+            local_server.generate_reply("letter-2", "candidate input")
+        )
+        is False
+    )
     assert letter["reply_text"] == ""
     assert letter["letter_status"] == "FAILED"
     assert letter["quality_status"] == "blocked"

--- a/tests/persona/test_reply_pipeline.py
+++ b/tests/persona/test_reply_pipeline.py
@@ -174,7 +174,10 @@ def test_generation_receives_the_same_mode_context_as_quality_gate(
     memory = NullMemoryPort()
     provider = RecordingProvider()
     adapter = SimpleNamespace(
-        config=SimpleNamespace(persona_v2_enabled=True),
+        config=SimpleNamespace(
+            persona_v2_enabled=True,
+            provider="synthetic",
+        ),
         persona_v2_path=ROOT / "linli_character" / "persona_release_v2.json",
         memory_prompt_builder=MemoryPromptBuilder(memory),
         memory_port=memory,


### PR DESCRIPTION
Implements FIX-02 from #20.

## What changed

- `ReplyPipeline` now assembles Persona messages before the provider call when it is running through the local LetterAdapter bridge;
- generation uses the exact `ReplyContext` already selected after triage, including the real `text_letter`, `spoken_video`, or `musical_video` mode;
- the compact Linli profile, current `MODE_STYLE`, bounded PrivateWorld projection, trusted time, and escaped memory are attached to `ReplyRequest.messages` before orchestration;
- `ReplyOrchestrator` preserves caller-assembled messages by selecting the bridge's underlying provider instead of asking the compatibility bridge to rebuild them;
- cancellation, timeout, idempotency, event-stream, canonical persistence, and media behavior are unchanged.

## Regression coverage

A new parameterized integration test records the provider input for all three active modes and proves:

- the provider receives a separate system/user pair;
- the system message contains the actual mode;
- the matching mode-style declaration is present;
- the compatibility bridge is not called to rebuild the prepared prompt;
- the same context proceeds into the existing quality gate.

## Validation

- Python syntax compile passed for changed modules and tests;
- focused synthetic construction checks passed locally;
- GitHub `public-smoke` is the merge gate.

## Boundary

No reviewer transport, model rewrite implementation, HTTP wire value, triage policy, media provider, memory persistence, or PrivateWorld reducer behavior is changed in this PR.