### PR TITLE
feat(reply): enable configured-model review and one-shot rewrite

### DIFF
--- a/docs/P02_16_REPLY_QUALITY_PIPELINE.md
+++ b/docs/P02_16_REPLY_QUALITY_PIPELINE.md
@@ -1,12 +1,21 @@
-# P02-16 Reply quality pipeline
+# P02 Reply quality pipeline
 
 `ReplyPipeline` wraps the existing orchestrator without changing its request or
 event lifecycle. The orchestrator produces a private candidate; the bounded
 quality gate produces the only canonical text returned by the pipeline.
 
+For a configured non-mock Provider, semantic review and one-shot rewrite are
+enabled automatically unless disabled by the documented environment controls.
+An unconfigured or mock profile keeps `NullReviewer` and the deterministic
+fallback, so offline smoke tests and explicit local fallback remain truthful.
+
 `generate_reply` writes `reply_text`, marks `COMPLETED`, updates memory, and
-schedules text/video/music projection only after acceptance. A blocked candidate
-never reaches those sinks. Persisted review metadata is limited to quality status
-and violation codes; reviewer prompts, hidden state, and private evidence are not
-stored. The default reviewer is disabled and clean deterministic output degrades
-open; deterministic violations fail closed when no rewriter is configured.
+schedules text/video/music projection only after acceptance. A blocked
+candidate never reaches those sinks. Persisted review metadata is limited to
+quality status and violation codes; reviewer prompts, hidden state, user
+excerpt, model response, and private evidence are not stored.
+
+A clean deterministic reply may degrade open when the reviewer is unavailable.
+A deterministic hard violation requires the one available rewrite and fails
+closed if the rewrite is unavailable or remains invalid. The first candidate,
+review, optional rewrite, and final review all use the same `ReplyContext`.

--- a/docs/P02_REPLY_QUALITY_GATE.md
+++ b/docs/P02_REPLY_QUALITY_GATE.md
@@ -1,9 +1,21 @@
-# P02-09 bounded ReplyQualityGate
+# P02 bounded ReplyQualityGate
 
 `reply_quality_gate.py` runs one deterministic scan and one semantic review on
 a candidate. A hard deterministic violation or reviewer `rewrite`/`block`
-verdict may trigger exactly one rewrite by the original reply model. The
-rewritten text is scanned and reviewed once more; there is no loop.
+verdict may trigger exactly one rewrite by the original configured reply
+Provider. The rewritten text is scanned and reviewed once more; there is no
+loop.
+
+The extended runtime adapters receive the prepared generation messages only to
+recover a bounded current-user excerpt. The reviewer sees no raw archive or
+hidden state. The rewriter receives the current user message capped at 3000
+characters, public Persona review rules, trusted facts, candidate, mode, output
+constraints, and violation codes. It returns replacement plain text only.
+
+`ReplyPipeline` executes the synchronous gate in a worker thread. Provider
+review and rewrite calls therefore do not block the aiohttp event loop. Each
+model call has its own bounded timeout, and the outer reply timeout still owns
+the full request.
 
 After the rewrite budget is consumed, a deterministic hard violation or
 reviewer `block` fails closed. A final reviewer `rewrite` containing only soft
@@ -12,6 +24,5 @@ only when deterministic checks are clean. Rewrite failure is blocked with the
 sanitized code `REWRITE_FAILED`.
 
 The result exposes deterministic, reviewer, and rewrite call counts so the
-one-rewrite bound is testable. This module does not generate the first
-candidate, persist canonical text, update private state, render media, or wire
-the server.
+one-rewrite bound is testable. No candidate or reviewer material is persisted;
+only the canonical text, quality status, and violation codes reach storage.

--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -1,19 +1,41 @@
-# P02-08 reply reviewer contract and adapter
+# P02 reply reviewer and configured-model transport
 
-`reply_reviewer.py` defines a provider-neutral review adapter and typed result.
-The provider response must match `contracts/reply_review.schema.json` with id
+`reply_reviewer.py` keeps the provider-neutral JSON contract. The response must
+match `contracts/reply_review.schema.json` with id
 `p02.reply-review.v1`: verdict, bounded violations, four 0-100 consistency
 scores, and completed status.
 
-The request contains only candidate text, reply mode/output constraints,
-trusted world facts, and caller-supplied short identified reference summaries.
-It excludes private behavior values, control views, databases, paths, complete
-letter libraries, and provider configuration.
+`reply_model_quality.py` supplies the runtime transport. When a configured
+non-mock Provider is present, `ReplyPipeline` replaces its `NullReviewer` with
+a reviewer that calls the same configured Provider after first-generation
+completion. It requests strict JSON and validates the response through the
+existing adapter and schema.
 
-`NullReviewer` and a disabled adapter make no transport call. Transport errors
-return `REVIEWER_UNAVAILABLE`; invalid JSON returns
-`REVIEWER_RESPONSE_INVALID`. Both results are sanitized and contain no provider
-exception, request body, path, credential, prompt, or private evidence.
+## Reviewer input boundary
 
-This module only judges. It does not modify candidate text, retry, rewrite,
-persist state, call media, or connect to the reply pipeline.
+The model reviewer receives only:
+
+- candidate reply text;
+- current mode and output constraints;
+- trusted world facts already allowed in `ReplyContext`;
+- the public Persona profile and a bounded set of current-mode/personality
+  rules;
+- at most 600 characters of the current user message as an identified excerpt.
+
+It does not receive PrivateWorld numeric values, control views, database
+contents, filesystem paths, provider configuration, the complete archive, or
+stored reviewer prompts. Review prompts and responses are not persisted.
+
+## Runtime controls
+
+- `OLIVIA_REPLY_REVIEW_ENABLED=false` disables semantic review and restores the
+  existing deterministic-clean degraded path;
+- `OLIVIA_REPLY_REWRITE_ENABLED=false` leaves review enabled but disables model
+  rewrite;
+- `OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS` sets a bounded 0.1-120 second timeout;
+  the default is the smaller of 12 seconds and the configured Provider timeout.
+
+Provider absence, timeout, transport errors, non-JSON output, and schema-invalid
+output become sanitized `REVIEWER_UNAVAILABLE` or
+`REVIEWER_RESPONSE_INVALID` results. A clean deterministic reply may then pass
+as `accepted_degraded`; a hard violation cannot bypass the single-rewrite gate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ py-modules = [
     "private_world_projection",
     "reply_context",
     "reply_policy",
+    "reply_model_quality",
     "reply_pipeline",
     "reply_quality_gate",
     "reply_reviewer",

--- a/reply_model_quality.py
+++ b/reply_model_quality.py
@@ -1,0 +1,345 @@
+"""Configured-model reviewer and one-shot rewrite adapters for reply quality."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from llm_gateway import Gateway
+from persona_loader import PersonaDeclaration, load_persona
+from reply_context import ReplyContext
+from reply_reviewer import (
+    JsonReviewerAdapter,
+    ReviewReference,
+    ReviewResult,
+    ReviewerConfig,
+)
+
+
+_REVIEW_MARKER = "P02_REPLY_REVIEW_JSON"
+_REWRITE_MARKER = "P02_REPLY_REWRITE_TEXT"
+_REVIEW_FACETS = frozenset(
+    {
+        "CORE_TRAIT",
+        "AUTONOMY",
+        "KNOWLEDGE_BOUNDARY",
+        "EXPRESSION_STYLE",
+        "RELATIONSHIP_STYLE",
+        "MEMORY_CONTINUITY",
+        "UNCERTAINTY",
+    }
+)
+
+
+class GatewayReviewTransport:
+    def __init__(self, gateway: Gateway, persona_path: Path) -> None:
+        self.gateway = gateway
+        self.persona_path = persona_path
+
+    def review_json(
+        self,
+        request: dict[str, object],
+        *,
+        model: str,
+        timeout_seconds: float,
+    ) -> object:
+        payload = {
+            **request,
+            "persona": _persona_review_profile(
+                self.persona_path, str(request.get("mode", ""))
+            ),
+        }
+        messages = (
+            {
+                "role": "system",
+                "content": (
+                    f"{_REVIEW_MARKER}\n"
+                    "You are a strict reply evaluator. Return exactly one JSON object, "
+                    "without Markdown or commentary. The object must use schema_version "
+                    "p02.reply-review.v1, status completed, verdict pass/rewrite/block, "
+                    "violations with hard/soft severity and zero-based Unicode start/end "
+                    "spans into candidate, and four integer scores from 0 to 100. Check "
+                    "Linli identity and autonomy, generic-assistant or counselling drift, "
+                    "invented shared history or facts, forced music imagery, relationship "
+                    "pressure, internal-state leakage, and current channel constraints."
+                ),
+            },
+            {
+                "role": "user",
+                "content": json.dumps(
+                    payload,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ),
+            },
+        )
+        text = _complete_text(self.gateway, messages, timeout_seconds)
+        parsed = json.loads(text.strip())
+        if not isinstance(parsed, Mapping):
+            raise ValueError("review response must be an object")
+        return dict(parsed)
+
+
+class GatewayPersonaReviewer:
+    def __init__(
+        self,
+        gateway: Gateway,
+        persona_path: Path,
+        timeout_seconds: float,
+    ) -> None:
+        self.adapter = JsonReviewerAdapter(
+            GatewayReviewTransport(gateway, persona_path),
+            ReviewerConfig(
+                model="configured_model",
+                timeout_seconds=timeout_seconds,
+                enabled=True,
+            ),
+        )
+
+    def review(self, candidate: str, context: ReplyContext) -> ReviewResult:
+        return self.adapter.review(candidate, context)
+
+    def review_with_messages(
+        self,
+        candidate: str,
+        context: ReplyContext,
+        generation_messages: Sequence[Mapping[str, Any]],
+    ) -> ReviewResult:
+        user_text = _last_user_text(generation_messages)
+        excerpt = _safe_excerpt(user_text)
+        references = (
+            (ReviewReference("current.user_excerpt", excerpt),)
+            if excerpt
+            else ()
+        )
+        return self.adapter.review(candidate, context, references=references)
+
+
+class GatewayPersonaRewriter:
+    def __init__(
+        self,
+        gateway: Gateway,
+        persona_path: Path,
+        timeout_seconds: float,
+    ) -> None:
+        self.gateway = gateway
+        self.persona_path = persona_path
+        self.timeout_seconds = timeout_seconds
+
+    def rewrite(
+        self,
+        candidate: str,
+        context: ReplyContext,
+        violation_codes: tuple[str, ...],
+    ) -> str:
+        return self._rewrite(candidate, context, violation_codes, user_text="")
+
+    def rewrite_with_messages(
+        self,
+        candidate: str,
+        context: ReplyContext,
+        violation_codes: tuple[str, ...],
+        generation_messages: Sequence[Mapping[str, Any]],
+    ) -> str:
+        return self._rewrite(
+            candidate,
+            context,
+            violation_codes,
+            user_text=_last_user_text(generation_messages),
+        )
+
+    def _rewrite(
+        self,
+        candidate: str,
+        context: ReplyContext,
+        violation_codes: tuple[str, ...],
+        *,
+        user_text: str,
+    ) -> str:
+        payload = {
+            "persona": _persona_review_profile(
+                self.persona_path, context.mode.value
+            ),
+            "mode": context.mode.value,
+            "output_constraints": context.output_constraints.to_dict(),
+            "world_facts": [fact.to_dict() for fact in context.world_facts],
+            "user_message": _safe_text(user_text, 3000),
+            "candidate": candidate,
+            "violation_codes": list(violation_codes),
+        }
+        messages = (
+            {
+                "role": "system",
+                "content": (
+                    f"{_REWRITE_MARKER}\n"
+                    "Rewrite the candidate once as Linli. Preserve the user's meaning "
+                    "and the useful content, but remove every listed violation. Keep her "
+                    "autonomy, selective attention, knowledge limits, and current mode "
+                    "style. Do not invent history or facts. Return only the replacement "
+                    "plain-text reply: no analysis, JSON, Markdown heading, stage direction, "
+                    "speaker prefix, or control markup."
+                ),
+            },
+            {
+                "role": "user",
+                "content": json.dumps(
+                    payload,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ),
+            },
+        )
+        return _complete_text(
+            self.gateway,
+            messages,
+            self.timeout_seconds,
+        ).strip()
+
+
+def create_model_quality_ports(
+    orchestrator: object,
+) -> tuple[GatewayPersonaReviewer | None, GatewayPersonaRewriter | None]:
+    bridge = getattr(orchestrator, "gateway", None)
+    adapter = getattr(bridge, "adapter", None)
+    config = getattr(adapter, "config", None)
+    provider = str(getattr(config, "provider", "none")).strip().lower()
+    if provider in {"", "none", "mock", "disabled", "unconfigured"}:
+        return None, None
+    if not _env_bool("OLIVIA_REPLY_REVIEW_ENABLED", True):
+        return None, None
+
+    gateway = getattr(adapter, "gateway", None)
+    persona_path = getattr(adapter, "persona_v2_path", None)
+    if not isinstance(gateway, Gateway) or not isinstance(persona_path, Path):
+        return None, None
+
+    configured_timeout = float(getattr(config, "timeout_seconds", 30.0))
+    timeout = _env_timeout(
+        "OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS",
+        min(configured_timeout, 12.0),
+    )
+    reviewer = GatewayPersonaReviewer(gateway, persona_path, timeout)
+    rewriter = (
+        GatewayPersonaRewriter(gateway, persona_path, timeout)
+        if _env_bool("OLIVIA_REPLY_REWRITE_ENABLED", True)
+        else None
+    )
+    return reviewer, rewriter
+
+
+def _persona_review_profile(path: Path, mode: str) -> dict[str, object]:
+    snapshot = load_persona(path).snapshot
+    profile = snapshot.profile
+    selected = [
+        item
+        for item in snapshot.declarations
+        if item.facet in _REVIEW_FACETS
+        or (item.tier == "MODE_STYLE" and item.mode == mode)
+    ]
+    selected.sort(key=lambda item: _rule_priority(item, mode))
+    rules = [
+        {
+            "declaration_id": item.declaration_id,
+            "facet": item.facet,
+            "statement": item.statement,
+        }
+        for item in selected[:18]
+    ]
+    return {
+        "status": snapshot.status,
+        "display_name": profile.display_name if profile else None,
+        "summary": profile.summary if profile else None,
+        "rules": rules,
+    }
+
+
+def _rule_priority(
+    item: PersonaDeclaration,
+    mode: str,
+) -> tuple[int, str]:
+    if item.tier == "MODE_STYLE" and item.mode == mode:
+        return (0, item.declaration_id)
+    priorities = {
+        "AUTONOMY": 1,
+        "KNOWLEDGE_BOUNDARY": 2,
+        "EXPRESSION_STYLE": 3,
+        "RELATIONSHIP_STYLE": 4,
+        "MEMORY_CONTINUITY": 5,
+        "CORE_TRAIT": 6,
+        "UNCERTAINTY": 7,
+    }
+    return (priorities.get(item.facet or "", 9), item.declaration_id)
+
+
+def _last_user_text(messages: Sequence[Mapping[str, Any]]) -> str:
+    for message in reversed(tuple(messages)):
+        if (
+            message.get("role") == "user"
+            and isinstance(message.get("content"), str)
+        ):
+            return str(message["content"])
+    return ""
+
+
+def _safe_excerpt(value: str) -> str:
+    return _safe_text(value, 600)
+
+
+def _safe_text(value: str, limit: int) -> str:
+    cleaned = "".join(
+        character
+        for character in value
+        if character in {"\n", "\r", "\t"} or ord(character) >= 32
+    ).strip()
+    return cleaned[:limit]
+
+
+def _complete_text(
+    gateway: Gateway,
+    messages: Sequence[Mapping[str, Any]],
+    timeout_seconds: float,
+) -> str:
+    async def invoke() -> str:
+        response = await asyncio.wait_for(
+            gateway.complete(
+                messages,
+                request_id=f"quality-{uuid.uuid4().hex}",
+            ),
+            timeout_seconds,
+        )
+        return response.text
+
+    try:
+        text = asyncio.run(invoke())
+    except Exception:
+        raise RuntimeError("quality model unavailable") from None
+    if not isinstance(text, str) or not text.strip():
+        raise RuntimeError("quality model returned empty text")
+    return text
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_timeout(name: str, default: float) -> float:
+    try:
+        value = float(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        value = default
+    return max(0.1, min(120.0, value))
+
+
+__all__ = [
+    "GatewayPersonaReviewer",
+    "GatewayPersonaRewriter",
+    "GatewayReviewTransport",
+    "create_model_quality_ports",
+]

--- a/reply_pipeline.py
+++ b/reply_pipeline.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, replace
-from typing import Protocol
+from typing import Any, Mapping, Protocol
 
 from persona_assembly import UntrustedFragment, assemble_persona
 from persona_loader import load_persona
+from reply_model_quality import create_model_quality_ports
 from reply_context import ReplyContext
 from reply_orchestrator import ReplyRequest, ReplyResult, ReplyState
 from reply_quality_gate import ReviewerPort, RewriterPort, run_reply_quality_gate
+from reply_reviewer import NullReviewer
 
 
 class OrchestratorPort(Protocol):
@@ -48,13 +51,30 @@ class ReplyPipeline:
         rewriter: RewriterPort,
     ) -> None:
         self.orchestrator = orchestrator
-        self.reviewer = reviewer
-        self.rewriter = rewriter
+        runtime_reviewer, runtime_rewriter = create_model_quality_ports(
+            orchestrator
+        )
+        self.reviewer = (
+            runtime_reviewer
+            if isinstance(reviewer, NullReviewer)
+            and runtime_reviewer is not None
+            else reviewer
+        )
+        self.rewriter = (
+            runtime_rewriter
+            if isinstance(rewriter, UnavailableRewriter)
+            and runtime_rewriter is not None
+            else rewriter
+        )
 
     async def run(self, request: object, context: ReplyContext) -> PipelineResult:
         if not isinstance(context, ReplyContext):
             raise TypeError("ReplyContext is required")
-        prepared = _prepare_generation_request(request, context, self.orchestrator)
+        prepared = _prepare_generation_request(
+            request,
+            context,
+            self.orchestrator,
+        )
         candidate = await self.orchestrator.run(prepared)
         if candidate.state is not ReplyState.COMPLETED:
             return PipelineResult(
@@ -63,11 +83,13 @@ class ReplyPipeline:
                 error_code=candidate.error_code,
                 retryable=candidate.retryable,
             )
-        gate = run_reply_quality_gate(
+        gate = await asyncio.to_thread(
+            run_reply_quality_gate,
             candidate.text,
             context,
             reviewer=self.reviewer,
             rewriter=self.rewriter,
+            generation_messages=_generation_messages(prepared),
         )
         if not gate.accepted:
             return PipelineResult(
@@ -143,3 +165,11 @@ def _prepare_generation_request(
         history=history,
     ).to_messages()
     return replace(request, content=None, messages=messages)
+
+
+def _generation_messages(
+    request: object,
+) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(request, ReplyRequest) or request.messages is None:
+        return ()
+    return tuple(dict(message) for message in request.messages)

--- a/reply_quality_gate.py
+++ b/reply_quality_gate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Protocol
+from typing import Any, Mapping, Protocol, Sequence
 
 from reply_context import ReplyContext
 from reply_policy import scan_reply
@@ -52,10 +52,18 @@ def run_reply_quality_gate(
     *,
     reviewer: ReviewerPort,
     rewriter: RewriterPort,
+    generation_messages: Sequence[Mapping[str, Any]] = (),
 ) -> QualityGateResult:
     deterministic = scan_reply(candidate, context)
-    review = reviewer.review(candidate, context)
-    deterministic_codes = tuple(item.code.value for item in deterministic.violations)
+    review = _review_candidate(
+        reviewer,
+        candidate,
+        context,
+        generation_messages,
+    )
+    deterministic_codes = tuple(
+        item.code.value for item in deterministic.violations
+    )
     review_codes = tuple(item.code for item in review.violations)
     if deterministic.passed and review.verdict is ReviewVerdict.UNAVAILABLE:
         return QualityGateResult(
@@ -81,10 +89,12 @@ def run_reply_quality_gate(
             rewrite_calls=0,
         )
     try:
-        rewritten = rewriter.rewrite(
+        rewritten = _rewrite_candidate(
+            rewriter,
             candidate,
             context,
             deterministic_codes + review_codes,
+            generation_messages,
         )
     except Exception:
         return QualityGateResult(
@@ -107,16 +117,26 @@ def run_reply_quality_gate(
             error_code="REWRITE_FAILED",
         )
     final_deterministic = scan_reply(rewritten, context)
-    final_review = reviewer.review(rewritten, context)
-    final_codes = tuple(item.code.value for item in final_deterministic.violations) + tuple(
-        item.code for item in final_review.violations
+    final_review = _review_candidate(
+        reviewer,
+        rewritten,
+        context,
+        generation_messages,
     )
-    if not final_deterministic.passed or final_review.verdict is ReviewVerdict.BLOCK:
+    final_codes = tuple(
+        item.code.value for item in final_deterministic.violations
+    ) + tuple(item.code for item in final_review.violations)
+    if (
+        not final_deterministic.passed
+        or final_review.verdict is ReviewVerdict.BLOCK
+    ):
         status = QualityGateStatus.BLOCKED
     elif final_review.verdict is ReviewVerdict.UNAVAILABLE:
         status = QualityGateStatus.ACCEPTED_DEGRADED
     elif final_review.verdict is ReviewVerdict.REWRITE:
-        has_hard_review = any(item.severity == "hard" for item in final_review.violations)
+        has_hard_review = any(
+            item.severity == "hard" for item in final_review.violations
+        )
         status = (
             QualityGateStatus.BLOCKED
             if has_hard_review
@@ -133,3 +153,33 @@ def run_reply_quality_gate(
         rewrite_calls=1,
         error_code=final_review.error_code,
     )
+
+
+def _review_candidate(
+    reviewer: ReviewerPort,
+    candidate: str,
+    context: ReplyContext,
+    generation_messages: Sequence[Mapping[str, Any]],
+) -> ReviewResult:
+    extended = getattr(reviewer, "review_with_messages", None)
+    if callable(extended):
+        return extended(candidate, context, generation_messages)
+    return reviewer.review(candidate, context)
+
+
+def _rewrite_candidate(
+    rewriter: RewriterPort,
+    candidate: str,
+    context: ReplyContext,
+    violation_codes: tuple[str, ...],
+    generation_messages: Sequence[Mapping[str, Any]],
+) -> str:
+    extended = getattr(rewriter, "rewrite_with_messages", None)
+    if callable(extended):
+        return extended(
+            candidate,
+            context,
+            violation_codes,
+            generation_messages,
+        )
+    return rewriter.rewrite(candidate, context, violation_codes)

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Mapping, Sequence
+
+import pytest
+
+from llm_gateway import Gateway, GatewayResponse
+from memory_port import NullMemoryPort
+from memory_prompt import MemoryPromptBuilder
+from reply_context import ReplyContext, ReplyMode, TrustedTime
+from reply_orchestrator import ReplyOrchestrator, ReplyRequest, ReplyState
+from reply_pipeline import ReplyPipeline, UnavailableRewriter
+from reply_reviewer import NullReviewer
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _review_payload(verdict: str = "pass") -> str:
+    return json.dumps(
+        {
+            "schema_version": "p02.reply-review.v1",
+            "status": "completed",
+            "verdict": verdict,
+            "violations": [],
+            "scores": {
+                "persona_consistency": 95,
+                "factual_consistency": 96,
+                "relationship_boundary": 97,
+                "mode_compliance": 98,
+            },
+        }
+    )
+
+
+class SequencedQualityGateway(Gateway):
+    stream_enabled = False
+
+    def __init__(
+        self,
+        *,
+        candidate: str,
+        reviews: list[str],
+        rewritten: str = "我听见了。先不用急着给自己一个结论。",
+    ) -> None:
+        self.candidate = candidate
+        self.reviews = list(reviews)
+        self.rewritten = rewritten
+        self.call_kinds: list[str] = []
+        self.review_requests: list[dict[str, object]] = []
+        self.rewrite_requests: list[dict[str, object]] = []
+
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None = None,
+    ) -> GatewayResponse:
+        system = str(messages[0].get("content", ""))
+        user = str(messages[-1].get("content", ""))
+        if "P02_REPLY_REVIEW_JSON" in system:
+            self.call_kinds.append("review")
+            self.review_requests.append(json.loads(user))
+            text = self.reviews.pop(0)
+        elif "P02_REPLY_REWRITE_TEXT" in system:
+            self.call_kinds.append("rewrite")
+            self.rewrite_requests.append(json.loads(user))
+            text = self.rewritten
+        else:
+            self.call_kinds.append("generation")
+            text = self.candidate
+        return GatewayResponse(
+            text=text,
+            request_id=request_id or "synthetic",
+            provider="synthetic",
+            model="synthetic",
+        )
+
+
+class CompatibilityBridge(Gateway):
+    stream_enabled = False
+
+    def __init__(self, adapter: object) -> None:
+        self.adapter = adapter
+
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None = None,
+    ) -> GatewayResponse:
+        raise AssertionError(
+            "configured requests must use the underlying gateway"
+        )
+
+
+def _pipeline(
+    gateway: Gateway,
+    monkeypatch: pytest.MonkeyPatch,
+) -> ReplyPipeline:
+    monkeypatch.setenv("OLIVIA_REPLY_REVIEW_ENABLED", "true")
+    monkeypatch.setenv("OLIVIA_REPLY_REWRITE_ENABLED", "true")
+    monkeypatch.setenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", "1")
+    memory = NullMemoryPort()
+    adapter = SimpleNamespace(
+        config=SimpleNamespace(
+            provider="openai_compatible",
+            persona_v2_enabled=True,
+            timeout_seconds=3.0,
+        ),
+        persona_v2_path=(
+            ROOT / "linli_character" / "persona_release_v2.json"
+        ),
+        memory_prompt_builder=MemoryPromptBuilder(memory),
+        memory_port=memory,
+        gateway=gateway,
+    )
+    return ReplyPipeline(
+        ReplyOrchestrator(
+            CompatibilityBridge(adapter),
+            timeout_seconds=2,
+        ),
+        reviewer=NullReviewer(),
+        rewriter=UnavailableRewriter(),
+    )
+
+
+def _context() -> ReplyContext:
+    return ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(
+            datetime(2026, 8, 22, tzinfo=timezone.utc)
+        ),
+    )
+
+
+def test_configured_provider_runs_structured_persona_review(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = SequencedQualityGateway(
+        candidate="我听见了。今晚先做一件小事就好。",
+        reviews=[_review_payload()],
+    )
+    pipeline = _pipeline(gateway, monkeypatch)
+
+    result = asyncio.run(
+        pipeline.run(
+            ReplyRequest(
+                content="今天有点累。",
+                request_id="review-pass",
+            ),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.quality_status == "accepted"
+    assert result.reviewer_calls == 1
+    assert result.rewrite_calls == 0
+    assert gateway.call_kinds == ["generation", "review"]
+    request = gateway.review_requests[0]
+    assert request["candidate"] == result.text
+    assert request["mode"] == "text_letter"
+    assert request["persona"]["display_name"] == "林离 Olivia"
+    assert (
+        request["references"][0]["reference_id"]
+        == "current.user_excerpt"
+    )
+    assert "private_behavior" not in request
+
+
+def test_deterministic_violation_uses_original_model_for_one_rewrite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = SequencedQualityGateway(
+        candidate="<CONTROL>hidden</CONTROL>",
+        reviews=[_review_payload(), _review_payload()],
+        rewritten="谁让你一个人把事情都扛着的。今晚先停一下。",
+    )
+    pipeline = _pipeline(gateway, monkeypatch)
+
+    result = asyncio.run(
+        pipeline.run(
+            ReplyRequest(
+                content="我又把事情搞砸了。",
+                request_id="rewrite-once",
+            ),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.text == "谁让你一个人把事情都扛着的。今晚先停一下。"
+    assert result.reviewer_calls == 2
+    assert result.rewrite_calls == 1
+    assert gateway.call_kinds == [
+        "generation",
+        "review",
+        "rewrite",
+        "review",
+    ]
+    rewrite = gateway.rewrite_requests[0]
+    assert rewrite["user_message"] == "我又把事情搞砸了。"
+    assert rewrite["violation_codes"] == ["INTERNAL_CONTROL_MARKUP"]
+    assert rewrite["persona"]["display_name"] == "林离 Olivia"
+
+
+def test_invalid_reviewer_json_degrades_only_clean_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = SequencedQualityGateway(
+        candidate="我收到了。先去喝口水。",
+        reviews=["not-json"],
+    )
+    pipeline = _pipeline(gateway, monkeypatch)
+
+    result = asyncio.run(
+        pipeline.run(
+            ReplyRequest(
+                content="今天有点乱。",
+                request_id="review-invalid",
+            ),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.quality_status == "accepted_degraded"
+    assert result.error_code is None
+    assert result.reviewer_calls == 1
+    assert result.rewrite_calls == 0
+    assert gateway.call_kinds == ["generation", "review"]
+
+
+def test_quality_model_can_be_disabled_without_disabling_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OLIVIA_REPLY_REVIEW_ENABLED", "false")
+    memory = NullMemoryPort()
+    gateway = SequencedQualityGateway(candidate="我在。", reviews=[])
+    adapter = SimpleNamespace(
+        config=SimpleNamespace(
+            provider="openai_compatible",
+            persona_v2_enabled=True,
+            timeout_seconds=3.0,
+        ),
+        persona_v2_path=(
+            ROOT / "linli_character" / "persona_release_v2.json"
+        ),
+        memory_prompt_builder=MemoryPromptBuilder(memory),
+        memory_port=memory,
+        gateway=gateway,
+    )
+    pipeline = ReplyPipeline(
+        ReplyOrchestrator(
+            CompatibilityBridge(adapter),
+            timeout_seconds=2,
+        ),
+        reviewer=NullReviewer(),
+        rewriter=UnavailableRewriter(),
+    )
+
+    result = asyncio.run(
+        pipeline.run(
+            ReplyRequest(
+                content="在吗？",
+                request_id="review-disabled",
+            ),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.quality_status == "accepted_degraded"
+    assert gateway.call_kinds == ["generation"]


### PR DESCRIPTION
Implements FIX-03 from #20.

## What changed

- adds `reply_model_quality.py`, a configured-model reviewer transport and one-shot rewriter built on the existing Gateway;
- automatically replaces `NullReviewer` / `UnavailableRewriter` only when a configured non-mock Provider is present;
- keeps offline, mock, and unconfigured profiles on the truthful deterministic degraded path;
- executes the synchronous quality gate in a worker thread so review/rewrite calls do not block aiohttp;
- passes the prepared generation context into extended adapters without persisting it;
- enforces the existing global maximum of one rewrite and one final recheck.

## Privacy and prompt boundary

The reviewer receives candidate text, mode/output constraints, trusted world facts, public Persona profile/rules, and at most 600 characters of the current user message. It does not receive PrivateWorld numeric values, control views, database contents, paths, provider configuration, or the complete archive.

The rewriter receives a capped current-user excerpt, candidate, violation codes, public Persona review rules, trusted facts, and the same ReplyContext. It returns replacement plain text only.

## Runtime controls

- `OLIVIA_REPLY_REVIEW_ENABLED=false`
- `OLIVIA_REPLY_REWRITE_ENABLED=false`
- `OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS=<0.1..120>`

## Validation

- local focused model-quality tests: 4 passed;
- covers clean structured review, one deterministic rewrite, invalid-JSON degraded behavior, and explicit disable;
- existing quality-gate interfaces remain backward-compatible;
- GitHub `public-smoke` is the merge gate.

## Boundary

No HTTP wire values, triage policy, Persona content, memory persistence, media provider, PrivateWorld reducer, or canonical delivery semantics are changed.