### PR TITLE
feat(private-world): model character-known local continuity

### DIFF
--- a/contracts/private_world.schema.json
+++ b/contracts/private_world.schema.json
@@ -8,57 +8,193 @@
     {"$ref": "#/$defs/character"}
   ],
   "$defs": {
-    "token": {"type": "string", "pattern": "^[A-Za-z0-9._:-]{1,64}$"},
-    "score": {"type": "integer", "minimum": 0, "maximum": 100},
-    "home_access": {"enum": ["no_access", "visit_access", "errand_access", "domestic_access"]},
-    "awareness": {"enum": ["control_only", "character_known", "pending"]},
-    "shared": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._:-]{1,64}$"
+    },
+    "nickname": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32,
+      "pattern": "^[^\\s\\u0000-\\u001F\\u007F]{1,32}$"
+    },
+    "score": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "home_access": {
+      "enum": [
+        "no_access",
+        "visit_access",
+        "errand_access",
+        "domestic_access"
+      ]
+    },
+    "awareness": {
+      "enum": [
+        "control_only",
+        "character_known",
+        "pending"
+      ]
+    },
+    "continuation_fact": {
       "type": "object",
-      "required": ["relationship_stage", "nickname_permissions", "home_access", "continuation_awareness"],
+      "additionalProperties": false,
+      "required": [
+        "fact_id",
+        "statement",
+        "awareness"
+      ],
       "properties": {
-        "relationship_stage": {"$ref": "#/$defs/token"},
-        "nickname_permissions": {"type": "array", "maxItems": 16, "uniqueItems": true, "items": {"$ref": "#/$defs/token"}},
-        "home_access": {"$ref": "#/$defs/home_access"},
-        "continuation_awareness": {"$ref": "#/$defs/awareness"}
+        "fact_id": {"$ref": "#/$defs/identifier"},
+        "statement": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 600
+        },
+        "awareness": {"$ref": "#/$defs/awareness"}
       }
     },
-    "hidden": {
+    "character_fact": {
       "type": "object",
-      "required": ["familiarity", "trust", "comfort", "closeness", "tension"],
+      "additionalProperties": false,
+      "required": [
+        "fact_id",
+        "statement",
+        "awareness"
+      ],
       "properties": {
+        "fact_id": {"$ref": "#/$defs/identifier"},
+        "statement": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 600
+        },
+        "awareness": {"const": "character_known"}
+      }
+    },
+    "control": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "view",
+        "familiarity",
+        "trust",
+        "comfort",
+        "closeness",
+        "tension",
+        "relationship_stage",
+        "nickname_permissions",
+        "home_access",
+        "continuation_awareness",
+        "continuation_facts"
+      ],
+      "properties": {
+        "view": {"const": "control"},
         "familiarity": {"$ref": "#/$defs/score"},
         "trust": {"$ref": "#/$defs/score"},
         "comfort": {"$ref": "#/$defs/score"},
         "closeness": {"$ref": "#/$defs/score"},
-        "tension": {"$ref": "#/$defs/score"}
+        "tension": {"$ref": "#/$defs/score"},
+        "relationship_stage": {
+          "$ref": "#/$defs/identifier"
+        },
+        "nickname_permissions": {
+          "type": "array",
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/nickname"}
+        },
+        "home_access": {"$ref": "#/$defs/home_access"},
+        "continuation_awareness": {
+          "$ref": "#/$defs/awareness"
+        },
+        "continuation_facts": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {"$ref": "#/$defs/continuation_fact"}
+        }
       }
     },
-    "control": {
-      "allOf": [
-        {"$ref": "#/$defs/shared"}, {"$ref": "#/$defs/hidden"},
-        {"type": "object", "additionalProperties": false, "required": ["view"], "properties": {
-          "view": {"const": "control"}, "familiarity": {}, "trust": {}, "comfort": {}, "closeness": {}, "tension": {},
-          "relationship_stage": {}, "nickname_permissions": {}, "home_access": {}, "continuation_awareness": {}
-        }}
-      ]
-    },
     "character": {
-      "allOf": [
-        {"$ref": "#/$defs/shared"},
-        {"type": "object", "additionalProperties": false, "required": ["view"], "properties": {
-          "view": {"const": "character"}, "relationship_stage": {}, "nickname_permissions": {}, "home_access": {}, "continuation_awareness": {}
-        }}
-      ]
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "view",
+        "relationship_stage",
+        "nickname_permissions",
+        "home_history_allowed",
+        "continuation_known",
+        "continuation_facts"
+      ],
+      "properties": {
+        "view": {"const": "character"},
+        "relationship_stage": {
+          "$ref": "#/$defs/identifier"
+        },
+        "nickname_permissions": {
+          "type": "array",
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/nickname"}
+        },
+        "home_history_allowed": {"type": "boolean"},
+        "continuation_known": {"type": "boolean"},
+        "continuation_facts": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {"$ref": "#/$defs/character_fact"}
+        }
+      }
     },
     "snapshot": {
-      "allOf": [
-        {"$ref": "#/$defs/shared"}, {"$ref": "#/$defs/hidden"},
-        {"type": "object", "additionalProperties": false, "required": ["view", "version"], "properties": {
-          "view": {"const": "snapshot"}, "version": {"type": "integer", "minimum": 1},
-          "familiarity": {}, "trust": {}, "comfort": {}, "closeness": {}, "tension": {},
-          "relationship_stage": {}, "nickname_permissions": {}, "home_access": {}, "continuation_awareness": {}
-        }}
-      ]
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "view",
+        "version",
+        "familiarity",
+        "trust",
+        "comfort",
+        "closeness",
+        "tension",
+        "relationship_stage",
+        "nickname_permissions",
+        "home_access",
+        "continuation_awareness",
+        "continuation_facts"
+      ],
+      "properties": {
+        "view": {"const": "snapshot"},
+        "version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "familiarity": {"$ref": "#/$defs/score"},
+        "trust": {"$ref": "#/$defs/score"},
+        "comfort": {"$ref": "#/$defs/score"},
+        "closeness": {"$ref": "#/$defs/score"},
+        "tension": {"$ref": "#/$defs/score"},
+        "relationship_stage": {
+          "$ref": "#/$defs/identifier"
+        },
+        "nickname_permissions": {
+          "type": "array",
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/nickname"}
+        },
+        "home_access": {"$ref": "#/$defs/home_access"},
+        "continuation_awareness": {
+          "$ref": "#/$defs/awareness"
+        },
+        "continuation_facts": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {"$ref": "#/$defs/continuation_fact"}
+        }
+      }
     }
   }
 }

--- a/contracts/reply_context.schema.json
+++ b/contracts/reply_context.schema.json
@@ -4,27 +4,68 @@
   "title": "P02 ReplyContext contract",
   "type": "object",
   "additionalProperties": false,
-  "required": ["mode", "wire_mode", "trusted_time", "world_facts", "private_behavior", "output_constraints"],
+  "required": [
+    "mode",
+    "wire_mode",
+    "trusted_time",
+    "world_facts",
+    "private_behavior",
+    "output_constraints"
+  ],
   "properties": {
-    "mode": {"enum": ["text_letter", "spoken_video", "musical_video", "future_im"]},
-    "wire_mode": {"type": ["string", "null"], "enum": ["text", "video", null]},
+    "mode": {
+      "enum": [
+        "text_letter",
+        "spoken_video",
+        "musical_video",
+        "future_im"
+      ]
+    },
+    "wire_mode": {
+      "type": ["string", "null"],
+      "enum": ["text", "video", null]
+    },
     "trusted_time": {"$ref": "#/$defs/trusted_time"},
-    "world_facts": {"type": "array", "items": {"$ref": "#/$defs/world_fact"}},
-    "private_behavior": {"$ref": "#/$defs/private_behavior"},
-    "output_constraints": {"$ref": "#/$defs/output_constraints"}
+    "world_facts": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/world_fact"}
+    },
+    "private_behavior": {
+      "$ref": "#/$defs/private_behavior"
+    },
+    "output_constraints": {
+      "$ref": "#/$defs/output_constraints"
+    }
   },
   "allOf": [
     {
-      "if": {"properties": {"mode": {"const": "text_letter"}}},
+      "if": {
+        "properties": {
+          "mode": {"const": "text_letter"}
+        }
+      },
       "then": {
         "properties": {
           "wire_mode": {"const": "text"},
-          "output_constraints": {"properties": {"channel": {"const": "letter"}}}
+          "output_constraints": {
+            "properties": {
+              "channel": {"const": "letter"}
+            }
+          }
         }
       }
     },
     {
-      "if": {"properties": {"mode": {"enum": ["spoken_video", "musical_video"]}}},
+      "if": {
+        "properties": {
+          "mode": {
+            "enum": [
+              "spoken_video",
+              "musical_video"
+            ]
+          }
+        }
+      },
       "then": {
         "properties": {
           "wire_mode": {"const": "video"},
@@ -38,61 +79,190 @@
       }
     },
     {
-      "if": {"properties": {"mode": {"const": "future_im"}}},
+      "if": {
+        "properties": {
+          "mode": {"const": "future_im"}
+        }
+      },
       "then": {
         "properties": {
           "wire_mode": {"const": null},
-          "output_constraints": {"properties": {"channel": {"const": "instant_message"}}}
+          "output_constraints": {
+            "properties": {
+              "channel": {"const": "instant_message"}
+            }
+          }
         }
       }
     }
   ],
   "$defs": {
-    "identifier": {"type": "string", "pattern": "^[A-Za-z0-9._:-]{1,96}$"},
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._:-]{1,96}$"
+    },
     "trusted_time": {
       "type": "object",
       "additionalProperties": false,
       "required": ["instant", "source"],
       "properties": {
-        "instant": {"type": "string", "format": "date-time"},
+        "instant": {
+          "type": "string",
+          "format": "date-time"
+        },
         "source": {"$ref": "#/$defs/identifier"}
       }
     },
     "world_fact": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["fact_id", "source_id", "statement", "kind"],
+      "required": [
+        "fact_id",
+        "source_id",
+        "statement",
+        "kind"
+      ],
       "properties": {
         "fact_id": {"$ref": "#/$defs/identifier"},
         "source_id": {"$ref": "#/$defs/identifier"},
-        "statement": {"type": "string", "minLength": 1, "maxLength": 600},
-        "kind": {"enum": ["public_canon", "trusted_runtime"]}
+        "statement": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 600
+        },
+        "kind": {
+          "enum": [
+            "public_canon",
+            "trusted_runtime"
+          ]
+        }
+      }
+    },
+    "known_continuation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fact_id", "statement"],
+      "properties": {
+        "fact_id": {"$ref": "#/$defs/identifier"},
+        "statement": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 600
+        }
       }
     },
     "private_behavior": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["familiarity", "trust", "comfort", "closeness", "tension", "relationship_stage", "nickname_permission", "home_access"],
+      "required": [
+        "familiarity",
+        "trust",
+        "comfort",
+        "closeness",
+        "tension",
+        "relationship_stage",
+        "nickname_permission",
+        "home_access",
+        "known_continuations"
+      ],
       "properties": {
-        "familiarity": {"enum": ["unknown", "low", "medium", "high"]},
-        "trust": {"enum": ["unknown", "low", "medium", "high"]},
-        "comfort": {"enum": ["unknown", "low", "medium", "high"]},
-        "closeness": {"enum": ["unknown", "low", "medium", "high"]},
-        "tension": {"enum": ["unknown", "low", "medium", "high"]},
-        "relationship_stage": {"enum": ["unknown", "acquaintance", "familiar", "close"]},
-        "nickname_permission": {"enum": ["not_allowed", "allowed"]},
-        "home_access": {"enum": ["no_access", "visit_access", "errand_access", "domestic_access"]}
+        "familiarity": {
+          "enum": [
+            "unknown",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "trust": {
+          "enum": [
+            "unknown",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "comfort": {
+          "enum": [
+            "unknown",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "closeness": {
+          "enum": [
+            "unknown",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "tension": {
+          "enum": [
+            "unknown",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "relationship_stage": {
+          "enum": [
+            "unknown",
+            "acquaintance",
+            "familiar",
+            "close"
+          ]
+        },
+        "nickname_permission": {
+          "enum": [
+            "not_allowed",
+            "allowed"
+          ]
+        },
+        "home_access": {
+          "enum": [
+            "no_access",
+            "visit_access",
+            "errand_access",
+            "domestic_access"
+          ]
+        },
+        "known_continuations": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/known_continuation"
+          }
+        }
       }
     },
     "output_constraints": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["channel", "max_characters", "plain_text_only", "allow_stage_directions", "allow_control_markup"],
+      "required": [
+        "channel",
+        "max_characters",
+        "plain_text_only",
+        "allow_stage_directions",
+        "allow_control_markup"
+      ],
       "properties": {
-        "channel": {"enum": ["letter", "spoken_text", "instant_message"]},
-        "max_characters": {"type": "integer", "minimum": 1},
+        "channel": {
+          "enum": [
+            "letter",
+            "spoken_text",
+            "instant_message"
+          ]
+        },
+        "max_characters": {
+          "type": "integer",
+          "minimum": 1
+        },
         "plain_text_only": {"const": true},
-        "allow_stage_directions": {"type": "boolean"},
+        "allow_stage_directions": {
+          "type": "boolean"
+        },
         "allow_control_markup": {"const": false}
       }
     }

--- a/docs/P02_10_PRIVATE_WORLD.md
+++ b/docs/P02_10_PRIVATE_WORLD.md
@@ -1,13 +1,28 @@
 # P02-10 PrivateWorld contract
 
-`PrivateWorldPort` separates private relationship state from ordinary memory.
-Its persistent snapshot and control view may contain bounded hidden values; the
-character view omits every hidden numeric value and exposes only explicit,
-finite permissions and relationship labels.
+`private_world_port.py` defines the provider-free `PrivateWorldPort`,
+`PrivateWorldSnapshot`, `PrivateWorldControlView`,
+`PrivateWorldCharacterView`, and disabled `NullPrivateWorldPort`.
 
-`NullPrivateWorldPort` is the disabled default. It returns an immutable empty
-snapshot, does not persist or mutate files, and does not call a provider.
+The snapshot stores bounded relationship scores, relationship stage, current
+nickname permissions, home access, legacy continuation awareness, and typed
+`LocalContinuationFact` records. A continuation fact has a stable identifier,
+a short local statement, and one awareness state:
 
-This slice defines contracts only. P02-11 owns the SQLite event ledger, P02-12
-owns reduction, and P02-13 owns behavioral projection. No runtime pipeline or
-model integration is included here.
+- `control_only`: only the local maintenance layer may read it;
+- `pending`: recorded, but the character does not know it yet;
+- `character_known`: eligible for the bounded character projection.
+
+Nickname permissions accept short Unicode labels such as Chinese private
+nicknames, while rejecting whitespace, controls, duplicates, and unbounded
+values. Concrete nickname instances and continuation statements remain local
+data and are never committed as fixtures.
+
+The control view can expose all local state to an explicitly authorized local
+administrator. The character view removes hidden scores, raw home-access
+levels, and every pending/control-only continuation. It exposes only a boolean
+home-history permission and character-known facts.
+
+This module does not persist, call a provider, infer events, render prompts, or
+update relationship values. P02-11 owns persistence and P02-13 owns the
+model-facing projection.

--- a/docs/P02_10_PRIVATE_WORLD.md
+++ b/docs/P02_10_PRIVATE_WORLD.md
@@ -23,6 +23,6 @@ administrator. The character view removes hidden scores, raw home-access
 levels, and every pending/control-only continuation. It exposes only a boolean
 home-history permission and character-known facts.
 
-This module does not persist, call a provider, infer events, render prompts, or
-update relationship values. P02-11 owns persistence and P02-13 owns the
-model-facing projection.
+This module does not persist and does not call a provider. It also does not
+infer events, render prompts, or update relationship values. P02-11 owns
+persistence and P02-13 owns the model-facing projection.

--- a/docs/P02_11_PRIVATE_WORLD_LEDGER.md
+++ b/docs/P02_11_PRIVATE_WORLD_LEDGER.md
@@ -5,6 +5,11 @@ SQLite file. `apply_once` atomically appends one typed event and its caller-
 provided snapshot. Both `event_id` and `delivery_id` are unique, so a delivery
 retry cannot apply the same relationship change twice.
 
+Snapshots include Unicode nickname permissions and typed Local Continuation
+facts. Older databases that predate the continuation-fact field load with an
+empty fact list; no history rewrite or destructive migration is required.
+
 The ledger does not reduce events, infer relationship changes, call a model, or
 join the ordinary memory database. P02-12 owns the pure reducer. Public health
-contains only status and row counts; it never exposes a path or private value.
+contains only status and row counts; it never exposes a path, score, nickname,
+continuation statement, or other private value.

--- a/docs/P02_13_PRIVATE_WORLD_PROJECTION.md
+++ b/docs/P02_13_PRIVATE_WORLD_PROJECTION.md
@@ -1,12 +1,20 @@
 # P02-13 PrivateWorld behavior projection
 
 `project_private_world` is a pure, provider-free projection. It converts hidden
-numeric state into the finite `PrivateBehaviorView` enums already accepted by
-`ReplyContext`; raw values and the complete snapshot never enter its payload.
+numeric state into the finite `PrivateBehaviorView` enums accepted by
+`ReplyContext`; raw scores and the complete snapshot never enter the prompt.
 
-Only current nickname permissions are returned. `control_only` and `pending`
-Local Continuation awareness both project to `continuation_known=false`, without
-exposing their control labels. Home access stays outside the model payload and
-only grants the assembly layer permission to acknowledge matching trusted
-history; it does not instruct the character to mention, invent, or describe a
+Current nickname permissions are returned as bounded labels. Home access is
+projected only as the finite permission enum used to decide whether already
+retrieved home history may be acknowledged; it does not create or describe a
 home scene.
+
+Local Continuation is filtered per fact. `control_only` and `pending`
+statements, identifiers, and awareness labels never enter the model payload.
+Only `character_known` facts become typed `KnownContinuationFact` values in
+`PrivateBehaviorView`. The reviewer and one-shot rewriter receive the same
+known-fact subset, but never hidden scores or control state.
+
+The projection does not persist, change awareness, infer relationship events,
+or promote a fact from pending to known. Those changes require the explicit
+local administration boundary.

--- a/docs/P02_REPLY_CONTEXT.md
+++ b/docs/P02_REPLY_CONTEXT.md
@@ -1,24 +1,27 @@
 # P02-04 ReplyContext contract
 
-`reply_context.py` defines the immutable, provider-free input passed between
-future reply-pipeline stages. It does not call a provider, render media, load a
-persona, review a reply, or commit private state. The matching JSON Schema is
+`reply_context.py` defines the immutable, provider-free input shared by reply
+pipeline stages. It does not call a provider, render media, load a persona,
+review a reply, or commit private state. The matching JSON Schema is
 `contracts/reply_context.schema.json` with id `p02.reply-context.v1`.
 
 ## Public API
 
 - `ReplyContext.create(...)` accepts a `ReplyMode`, timezone-aware
-  `TrustedTime`, identified `TrustedWorldFact` values, a finite
+  `TrustedTime`, identified `TrustedWorldFact` values, a bounded
   `PrivateBehaviorView`, and explicit `OutputConstraints`.
+- `PrivateBehaviorView` contains only finite relationship/home enums plus
+  typed `KnownContinuationFact` values already marked character-known. It
+  rejects raw scores, control awareness, arbitrary dictionaries, duplicates,
+  and unbounded statements.
 - `ReplyModeAdapter` preserves the legacy wire values: `text` maps to
   `text_letter`, while `video` maps to `spoken_video`. Both spoken and musical
   video serialize back to `video`.
 - `future_im` has no legacy wire value and is rejected unless application
   state explicitly passes `future_im_enabled=True`.
 
-Private behavior crosses this boundary only as finite enums. Raw scores,
-private history, letters, prompts, local paths, credentials, and provider state
-are not accepted by the contract.
+Private history, letters, prompts, local paths, credentials, provider state,
+pending plans, and control-only facts are not accepted by the contract.
 
 ## Output invariants
 

--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -18,13 +18,16 @@ The model reviewer receives only:
 - candidate reply text;
 - current mode and output constraints;
 - trusted world facts already allowed in `ReplyContext`;
+- character-known Local Continuation facts already filtered by
+  `PrivateWorld` projection;
 - the public Persona profile and a bounded set of current-mode/personality
   rules;
 - at most 600 characters of the current user message as an identified excerpt.
 
-It does not receive PrivateWorld numeric values, control views, database
-contents, filesystem paths, provider configuration, the complete archive, or
-stored reviewer prompts. Review prompts and responses are not persisted.
+It does not receive PrivateWorld numeric values, raw home-access records,
+pending/control-only continuation facts, databases, filesystem paths, provider
+configuration, or the complete archive. Review prompts and responses are not
+persisted.
 
 ## Runtime controls
 
@@ -35,7 +38,7 @@ stored reviewer prompts. Review prompts and responses are not persisted.
 - `OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS` sets a bounded 0.1-120 second timeout;
   the default is the smaller of 12 seconds and the configured Provider timeout.
 
-Provider absence, timeout, transport errors, non-JSON output, and schema-invalid
-output become sanitized `REVIEWER_UNAVAILABLE` or
+Provider absence, timeout, transport errors, non-JSON output, and
+schema-invalid output become sanitized `REVIEWER_UNAVAILABLE` or
 `REVIEWER_RESPONSE_INVALID` results. A clean deterministic reply may then pass
 as `accepted_degraded`; a hard violation cannot bypass the single-rewrite gate.

--- a/private_world_ledger.py
+++ b/private_world_ledger.py
@@ -14,6 +14,7 @@ from typing import Iterator
 from private_world_port import (
     ContinuationAwareness,
     HomeAccess,
+    LocalContinuationFact,
     PrivateWorldCharacterView,
     PrivateWorldControlView,
     PrivateWorldSnapshot,
@@ -37,45 +38,74 @@ class LedgerEvent:
 
     def __post_init__(self) -> None:
         if any(
-            not isinstance(value, str) or not _ID_RE.fullmatch(value)
-            for value in (self.event_id, self.delivery_id, self.event_type)
+            not isinstance(value, str)
+            or not _ID_RE.fullmatch(value)
+            for value in (
+                self.event_id,
+                self.delivery_id,
+                self.event_type,
+            )
         ):
             raise ValueError("event identifiers are invalid")
         if not isinstance(self.payload, dict):
             raise ValueError("event payload must be an object")
         try:
             encoded = json.dumps(
-                self.payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+                self.payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
             )
         except (TypeError, ValueError) as exc:
-            raise ValueError("event payload must be JSON serializable") from exc
+            raise ValueError(
+                "event payload must be JSON serializable"
+            ) from exc
         if len(encoded.encode("utf-8")) > 8192:
             raise ValueError("event payload is too large")
         try:
-            timestamp = datetime.fromisoformat(self.occurred_at.replace("Z", "+00:00"))
+            timestamp = datetime.fromisoformat(
+                self.occurred_at.replace("Z", "+00:00")
+            )
         except (TypeError, ValueError) as exc:
             raise ValueError("event timestamp is invalid") from exc
-        if timestamp.tzinfo is None or timestamp.utcoffset() is None:
-            raise ValueError("event timestamp must be timezone-aware")
+        if (
+            timestamp.tzinfo is None
+            or timestamp.utcoffset() is None
+        ):
+            raise ValueError(
+                "event timestamp must be timezone-aware"
+            )
 
     def _payload_json(self) -> str:
         return json.dumps(
-            self.payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+            self.payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
         )
 
 
 class SQLitePrivateWorldLedger:
     def __init__(self, database_path: Path) -> None:
         path = Path(database_path)
-        if str(path) in {"", "."} or path.exists() and path.is_dir():
-            raise ValueError("an explicit database file path is required")
+        if (
+            str(path) in {"", "."}
+            or path.exists()
+            and path.is_dir()
+        ):
+            raise ValueError(
+                "an explicit database file path is required"
+            )
         path.parent.mkdir(parents=True, exist_ok=True)
         self._database_path = path
         self._initialize()
 
     @contextmanager
     def _connection(self) -> Iterator[sqlite3.Connection]:
-        connection = sqlite3.connect(self._database_path, timeout=5)
+        connection = sqlite3.connect(
+            self._database_path,
+            timeout=5,
+        )
         connection.execute("PRAGMA foreign_keys = ON")
         try:
             with connection:
@@ -103,17 +133,27 @@ class SQLitePrivateWorldLedger:
                 """
             )
 
-    def apply_once(self, event: LedgerEvent, snapshot: PrivateWorldSnapshot) -> bool:
+    def apply_once(
+        self,
+        event: LedgerEvent,
+        snapshot: PrivateWorldSnapshot,
+    ) -> bool:
         if not isinstance(event, LedgerEvent) or not isinstance(
-            snapshot, PrivateWorldSnapshot
+            snapshot,
+            PrivateWorldSnapshot,
         ):
-            raise TypeError("apply_once requires a typed event and snapshot")
+            raise TypeError(
+                "apply_once requires a typed event and snapshot"
+            )
         try:
             with self._connection() as connection:
                 duplicate = connection.execute(
                     """SELECT 1 FROM private_world_events
                        WHERE event_id = ? OR delivery_id = ? LIMIT 1""",
-                    (event.event_id, event.delivery_id),
+                    (
+                        event.event_id,
+                        event.delivery_id,
+                    ),
                 ).fetchone()
                 if duplicate:
                     return False
@@ -122,7 +162,10 @@ class SQLitePrivateWorldLedger:
                        ORDER BY version DESC LIMIT 1"""
                 ).fetchone()
                 snapshot_json = json.dumps(
-                    snapshot.to_dict(), sort_keys=True, separators=(",", ":")
+                    snapshot.to_dict(),
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
                 )
                 if latest is None:
                     write_snapshot = snapshot.version in {1, 2}
@@ -133,11 +176,16 @@ class SQLitePrivateWorldLedger:
                         )
                     write_snapshot = False
                 else:
-                    write_snapshot = snapshot.version == latest[0] + 1
+                    write_snapshot = (
+                        snapshot.version == latest[0] + 1
+                    )
                 if not write_snapshot and (
-                    latest is None or snapshot.version != latest[0]
+                    latest is None
+                    or snapshot.version != latest[0]
                 ):
-                    raise LedgerWriteError("snapshot version is not contiguous")
+                    raise LedgerWriteError(
+                        "snapshot version is not contiguous"
+                    )
                 connection.execute(
                     """INSERT INTO private_world_events
                        (event_id, delivery_id, event_type, payload_json, occurred_at)
@@ -154,10 +202,16 @@ class SQLitePrivateWorldLedger:
                     connection.execute(
                         """INSERT INTO private_world_snapshots
                            (version, payload_json, event_id) VALUES (?, ?, ?)""",
-                        (snapshot.version, snapshot_json, event.event_id),
+                        (
+                            snapshot.version,
+                            snapshot_json,
+                            event.event_id,
+                        ),
                     )
         except sqlite3.Error as exc:
-            raise LedgerWriteError("private world transaction failed") from exc
+            raise LedgerWriteError(
+                "private world transaction failed"
+            ) from exc
         return True
 
     def events(self) -> tuple[LedgerEvent, ...]:
@@ -167,7 +221,13 @@ class SQLitePrivateWorldLedger:
                    FROM private_world_events ORDER BY rowid"""
             ).fetchall()
         return tuple(
-            LedgerEvent(row[0], row[1], row[2], json.loads(row[3]), row[4])
+            LedgerEvent(
+                row[0],
+                row[1],
+                row[2],
+                json.loads(row[3]),
+                row[4],
+            )
             for row in rows
         )
 
@@ -180,6 +240,19 @@ class SQLitePrivateWorldLedger:
         if row is None:
             return PrivateWorldSnapshot()
         payload = json.loads(row[0])
+        continuation_facts = tuple(
+            LocalContinuationFact(
+                fact_id=item["fact_id"],
+                statement=item["statement"],
+                awareness=ContinuationAwareness(
+                    item["awareness"]
+                ),
+            )
+            for item in payload.get(
+                "continuation_facts",
+                (),
+            )
+        )
         return PrivateWorldSnapshot(
             version=payload["version"],
             familiarity=payload["familiarity"],
@@ -187,12 +260,19 @@ class SQLitePrivateWorldLedger:
             comfort=payload["comfort"],
             closeness=payload["closeness"],
             tension=payload["tension"],
-            relationship_stage=payload["relationship_stage"],
-            nickname_permissions=tuple(payload["nickname_permissions"]),
-            home_access=HomeAccess(payload["home_access"]),
+            relationship_stage=payload[
+                "relationship_stage"
+            ],
+            nickname_permissions=tuple(
+                payload["nickname_permissions"]
+            ),
+            home_access=HomeAccess(
+                payload["home_access"]
+            ),
             continuation_awareness=ContinuationAwareness(
                 payload["continuation_awareness"]
             ),
+            continuation_facts=continuation_facts,
         )
 
     def control_view(self) -> PrivateWorldControlView:

--- a/private_world_port.py
+++ b/private_world_port.py
@@ -1,4 +1,4 @@
-"""Provider-free contracts for private relationship state."""
+"""Provider-free contracts for private relationship and local-continuation state."""
 
 from __future__ import annotations
 
@@ -34,11 +34,78 @@ def _validate_score(name: str, value: int) -> None:
         raise PrivateWorldError(f"{name} must be an integer from 0 to 100")
 
 
-def _validate_tokens(values: tuple[str, ...]) -> None:
-    if len(values) > 16 or len(set(values)) != len(values):
+def _plain_text(value: object, *, field_name: str, max_length: int) -> str:
+    if not isinstance(value, str):
+        raise PrivateWorldError(f"{field_name} must be text")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > max_length
+        or any(ord(character) < 32 or ord(character) == 127 for character in normalized)
+    ):
+        raise PrivateWorldError(f"{field_name} is invalid")
+    return normalized
+
+
+def _validate_nicknames(values: tuple[str, ...]) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise PrivateWorldError("nickname permissions must be a sequence")
+    if not isinstance(values, tuple):
+        values = tuple(values)
+    normalized = tuple(
+        _plain_text(value, field_name="nickname", max_length=32) for value in values
+    )
+    if any(any(character.isspace() for character in value) for value in normalized):
+        raise PrivateWorldError("nickname permissions cannot contain whitespace")
+    if len(normalized) > 16 or len(set(normalized)) != len(normalized):
         raise PrivateWorldError("nickname permissions must be unique and bounded")
-    if any(not isinstance(value, str) or not _TOKEN_RE.fullmatch(value) for value in values):
-        raise PrivateWorldError("nickname permission is invalid")
+    return normalized
+
+
+@dataclass(frozen=True)
+class LocalContinuationFact:
+    fact_id: str
+    statement: str
+    awareness: ContinuationAwareness = ContinuationAwareness.PENDING
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.fact_id, str) or not _TOKEN_RE.fullmatch(self.fact_id):
+            raise PrivateWorldError("continuation fact id is invalid")
+        object.__setattr__(
+            self,
+            "statement",
+            _plain_text(
+                self.statement,
+                field_name="continuation statement",
+                max_length=600,
+            ),
+        )
+        if not isinstance(self.awareness, ContinuationAwareness):
+            raise PrivateWorldError("continuation awareness is invalid")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "fact_id": self.fact_id,
+            "statement": self.statement,
+            "awareness": self.awareness.value,
+        }
+
+
+def _validate_facts(
+    values: tuple[LocalContinuationFact, ...],
+) -> tuple[LocalContinuationFact, ...]:
+    if isinstance(values, (str, bytes)):
+        raise PrivateWorldError("continuation facts must be a sequence")
+    if not isinstance(values, tuple):
+        values = tuple(values)
+    if len(values) > 32 or any(
+        not isinstance(value, LocalContinuationFact) for value in values
+    ):
+        raise PrivateWorldError("continuation facts must be typed and bounded")
+    identifiers = tuple(value.fact_id for value in values)
+    if len(set(identifiers)) != len(identifiers):
+        raise PrivateWorldError("continuation fact ids must be unique")
+    return values
 
 
 def _validate_shared(
@@ -46,16 +113,19 @@ def _validate_shared(
     nickname_permissions: tuple[str, ...],
     home_access: HomeAccess,
     continuation_awareness: ContinuationAwareness,
-) -> None:
+    continuation_facts: tuple[LocalContinuationFact, ...],
+) -> tuple[tuple[str, ...], tuple[LocalContinuationFact, ...]]:
     if not isinstance(relationship_stage, str) or not _TOKEN_RE.fullmatch(
         relationship_stage
     ):
         raise PrivateWorldError("relationship stage is invalid")
-    _validate_tokens(nickname_permissions)
+    nicknames = _validate_nicknames(nickname_permissions)
+    facts = _validate_facts(continuation_facts)
     if not isinstance(home_access, HomeAccess):
         raise PrivateWorldError("home access is invalid")
     if not isinstance(continuation_awareness, ContinuationAwareness):
         raise PrivateWorldError("continuation awareness is invalid")
+    return nicknames, facts
 
 
 @dataclass(frozen=True)
@@ -69,16 +139,20 @@ class PrivateWorldControlView:
     nickname_permissions: tuple[str, ...]
     home_access: HomeAccess
     continuation_awareness: ContinuationAwareness
+    continuation_facts: tuple[LocalContinuationFact, ...] = ()
 
     def __post_init__(self) -> None:
         for name in _HIDDEN_NAMES:
             _validate_score(name, getattr(self, name))
-        _validate_shared(
+        nicknames, facts = _validate_shared(
             self.relationship_stage,
             self.nickname_permissions,
             self.home_access,
             self.continuation_awareness,
+            self.continuation_facts,
         )
+        object.__setattr__(self, "nickname_permissions", nicknames)
+        object.__setattr__(self, "continuation_facts", facts)
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -88,6 +162,9 @@ class PrivateWorldControlView:
             "nickname_permissions": list(self.nickname_permissions),
             "home_access": self.home_access.value,
             "continuation_awareness": self.continuation_awareness.value,
+            "continuation_facts": [
+                fact.to_dict() for fact in self.continuation_facts
+            ],
         }
 
 
@@ -95,24 +172,44 @@ class PrivateWorldControlView:
 class PrivateWorldCharacterView:
     relationship_stage: str
     nickname_permissions: tuple[str, ...]
-    home_access: HomeAccess
-    continuation_awareness: ContinuationAwareness
+    home_history_allowed: bool
+    continuation_known: bool
+    continuation_facts: tuple[LocalContinuationFact, ...] = ()
 
     def __post_init__(self) -> None:
-        _validate_shared(
-            self.relationship_stage,
-            self.nickname_permissions,
-            self.home_access,
-            self.continuation_awareness,
+        if not isinstance(self.relationship_stage, str) or not _TOKEN_RE.fullmatch(
+            self.relationship_stage
+        ):
+            raise PrivateWorldError("relationship stage is invalid")
+        object.__setattr__(
+            self,
+            "nickname_permissions",
+            _validate_nicknames(self.nickname_permissions),
         )
+        if type(self.home_history_allowed) is not bool:
+            raise PrivateWorldError("home history permission must be boolean")
+        if type(self.continuation_known) is not bool:
+            raise PrivateWorldError("continuation known must be boolean")
+        facts = _validate_facts(self.continuation_facts)
+        if any(
+            fact.awareness is not ContinuationAwareness.CHARACTER_KNOWN
+            for fact in facts
+        ):
+            raise PrivateWorldError(
+                "character view may contain only character-known continuation facts"
+            )
+        object.__setattr__(self, "continuation_facts", facts)
 
     def to_dict(self) -> dict[str, object]:
         return {
             "view": "character",
             "relationship_stage": self.relationship_stage,
             "nickname_permissions": list(self.nickname_permissions),
-            "home_access": self.home_access.value,
-            "continuation_awareness": self.continuation_awareness.value,
+            "home_history_allowed": self.home_history_allowed,
+            "continuation_known": self.continuation_known,
+            "continuation_facts": [
+                fact.to_dict() for fact in self.continuation_facts
+            ],
         }
 
 
@@ -128,20 +225,22 @@ class PrivateWorldSnapshot:
     nickname_permissions: tuple[str, ...] = ()
     home_access: HomeAccess = HomeAccess.NO_ACCESS
     continuation_awareness: ContinuationAwareness = ContinuationAwareness.CONTROL_ONLY
+    continuation_facts: tuple[LocalContinuationFact, ...] = ()
 
     def __post_init__(self) -> None:
         if type(self.version) is not int or self.version < 1:
             raise PrivateWorldError("snapshot version must be positive")
         for name in _HIDDEN_NAMES:
             _validate_score(name, getattr(self, name))
-        if not isinstance(self.nickname_permissions, tuple):
-            object.__setattr__(self, "nickname_permissions", tuple(self.nickname_permissions))
-        _validate_shared(
+        nicknames, facts = _validate_shared(
             self.relationship_stage,
             self.nickname_permissions,
             self.home_access,
             self.continuation_awareness,
+            self.continuation_facts,
         )
+        object.__setattr__(self, "nickname_permissions", nicknames)
+        object.__setattr__(self, "continuation_facts", facts)
 
     def control_view(self) -> PrivateWorldControlView:
         return PrivateWorldControlView(
@@ -150,14 +249,26 @@ class PrivateWorldSnapshot:
             self.nickname_permissions,
             self.home_access,
             self.continuation_awareness,
+            self.continuation_facts,
         )
 
     def character_view(self) -> PrivateWorldCharacterView:
+        known_facts = tuple(
+            fact
+            for fact in self.continuation_facts
+            if fact.awareness is ContinuationAwareness.CHARACTER_KNOWN
+        )
+        continuation_known = (
+            self.continuation_awareness
+            is ContinuationAwareness.CHARACTER_KNOWN
+            or bool(known_facts)
+        )
         return PrivateWorldCharacterView(
             self.relationship_stage,
             self.nickname_permissions,
-            self.home_access,
-            self.continuation_awareness,
+            self.home_access is not HomeAccess.NO_ACCESS,
+            continuation_known,
+            known_facts,
         )
 
     def to_dict(self) -> dict[str, object]:

--- a/private_world_projection.py
+++ b/private_world_projection.py
@@ -6,12 +6,13 @@ from dataclasses import dataclass
 
 from private_world_port import (
     ContinuationAwareness,
-    HomeAccess as PrivateHomeAccess,
+    LocalContinuationFact,
     PrivateWorldSnapshot,
 )
 from reply_context import (
     BehaviorLevel,
     HomeAccess,
+    KnownContinuationFact,
     NicknamePermission,
     PrivateBehaviorView,
     RelationshipStage,
@@ -35,47 +36,71 @@ def _stage(value: str) -> RelationshipStage:
         return RelationshipStage.UNKNOWN
 
 
+def _known_fact(value: LocalContinuationFact) -> KnownContinuationFact:
+    return KnownContinuationFact(value.fact_id, value.statement)
+
+
 @dataclass(frozen=True)
 class ProjectedPrivateWorld:
     behavior: PrivateBehaviorView
     authorized_nicknames: tuple[str, ...]
     may_acknowledge_home_history: bool
     continuation_known: bool
+    known_continuation_facts: tuple[KnownContinuationFact, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         return {
             "behavior": self.behavior.to_dict(),
             "authorized_nicknames": list(self.authorized_nicknames),
             "continuation_known": self.continuation_known,
+            "known_continuations": [
+                fact.to_dict() for fact in self.known_continuation_facts
+            ],
         }
 
 
-def project_private_world(snapshot: PrivateWorldSnapshot) -> ProjectedPrivateWorld:
+def project_private_world(
+    snapshot: PrivateWorldSnapshot,
+) -> ProjectedPrivateWorld:
     if not isinstance(snapshot, PrivateWorldSnapshot):
-        raise TypeError("projection requires a PrivateWorldSnapshot")
+        raise TypeError(
+            "projection requires a PrivateWorldSnapshot"
+        )
     nicknames = tuple(snapshot.nickname_permissions)
+    known_facts = tuple(
+        _known_fact(fact)
+        for fact in snapshot.continuation_facts
+        if fact.awareness
+        is ContinuationAwareness.CHARACTER_KNOWN
+    )
+    continuation_known = (
+        snapshot.continuation_awareness
+        is ContinuationAwareness.CHARACTER_KNOWN
+        or bool(known_facts)
+    )
     behavior = PrivateBehaviorView(
         familiarity=_level(snapshot.familiarity),
         trust=_level(snapshot.trust),
         comfort=_level(snapshot.comfort),
         closeness=_level(snapshot.closeness),
         tension=_level(snapshot.tension),
-        relationship_stage=_stage(snapshot.relationship_stage),
+        relationship_stage=_stage(
+            snapshot.relationship_stage
+        ),
         nickname_permission=(
             NicknamePermission.ALLOWED
             if nicknames
             else NicknamePermission.NOT_ALLOWED
         ),
-        home_access=HomeAccess.NO_ACCESS,
+        home_access=HomeAccess(snapshot.home_access.value),
+        known_continuations=known_facts,
     )
     return ProjectedPrivateWorld(
         behavior=behavior,
         authorized_nicknames=nicknames,
         may_acknowledge_home_history=(
-            snapshot.home_access is not PrivateHomeAccess.NO_ACCESS
+            snapshot.home_access.value != "no_access"
         ),
-        continuation_known=(
-            snapshot.continuation_awareness
-            is ContinuationAwareness.CHARACTER_KNOWN
-        ),
+        continuation_known=continuation_known,
+        known_continuation_facts=known_facts,
     )

--- a/reply_context.py
+++ b/reply_context.py
@@ -72,9 +72,17 @@ class TrustedTime:
     def __post_init__(self) -> None:
         if self.instant.tzinfo is None or self.instant.utcoffset() is None:
             raise ReplyContextError("trusted time must be timezone-aware")
-        if not isinstance(self.source, str) or not _ID_RE.fullmatch(self.source.strip()):
-            raise ReplyContextError("trusted time source must be a stable identifier")
-        object.__setattr__(self, "instant", self.instant.astimezone(timezone.utc))
+        if not isinstance(self.source, str) or not _ID_RE.fullmatch(
+            self.source.strip()
+        ):
+            raise ReplyContextError(
+                "trusted time source must be a stable identifier"
+            )
+        object.__setattr__(
+            self,
+            "instant",
+            self.instant.astimezone(timezone.utc),
+        )
         object.__setattr__(self, "source", self.source.strip())
 
 
@@ -88,7 +96,9 @@ class TrustedWorldFact:
     def __post_init__(self) -> None:
         for value in (self.fact_id, self.source_id):
             if not isinstance(value, str) or not _ID_RE.fullmatch(value):
-                raise ReplyContextError("world fact identifiers must be stable")
+                raise ReplyContextError(
+                    "world fact identifiers must be stable"
+                )
         if (
             not isinstance(self.statement, str)
             or not self.statement.strip()
@@ -109,6 +119,36 @@ class TrustedWorldFact:
 
 
 @dataclass(frozen=True)
+class KnownContinuationFact:
+    fact_id: str
+    statement: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.fact_id, str) or not _ID_RE.fullmatch(
+            self.fact_id
+        ):
+            raise ReplyContextError(
+                "continuation fact identifier must be stable"
+            )
+        if (
+            not isinstance(self.statement, str)
+            or not self.statement.strip()
+            or len(self.statement) > 600
+            or _CONTROL_RE.search(self.statement)
+        ):
+            raise ReplyContextError(
+                "continuation fact statement is invalid"
+            )
+        object.__setattr__(self, "statement", self.statement.strip())
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "fact_id": self.fact_id,
+            "statement": self.statement,
+        }
+
+
+@dataclass(frozen=True)
 class PrivateBehaviorView:
     familiarity: BehaviorLevel = BehaviorLevel.UNKNOWN
     trust: BehaviorLevel = BehaviorLevel.UNKNOWN
@@ -118,6 +158,7 @@ class PrivateBehaviorView:
     relationship_stage: RelationshipStage = RelationshipStage.UNKNOWN
     nickname_permission: NicknamePermission = NicknamePermission.NOT_ALLOWED
     home_access: HomeAccess = HomeAccess.NO_ACCESS
+    known_continuations: tuple[KnownContinuationFact, ...] = ()
 
     def __post_init__(self) -> None:
         expected_types = (
@@ -130,10 +171,32 @@ class PrivateBehaviorView:
             (self.nickname_permission, NicknamePermission),
             (self.home_access, HomeAccess),
         )
-        if any(not isinstance(value, expected) for value, expected in expected_types):
-            raise ReplyContextError("private behavior is outside the bounded view")
+        if any(
+            not isinstance(value, expected)
+            for value, expected in expected_types
+        ):
+            raise ReplyContextError(
+                "private behavior is outside the bounded view"
+            )
+        if isinstance(self.known_continuations, (str, bytes)):
+            raise ReplyContextError(
+                "known continuations must be a typed sequence"
+            )
+        facts = tuple(self.known_continuations)
+        if (
+            len(facts) > 32
+            or any(
+                not isinstance(fact, KnownContinuationFact)
+                for fact in facts
+            )
+            or len({fact.fact_id for fact in facts}) != len(facts)
+        ):
+            raise ReplyContextError(
+                "known continuations must be typed, unique, and bounded"
+            )
+        object.__setattr__(self, "known_continuations", facts)
 
-    def to_dict(self) -> dict[str, str]:
+    def to_dict(self) -> dict[str, object]:
         return {
             "familiarity": self.familiarity.value,
             "trust": self.trust.value,
@@ -143,6 +206,9 @@ class PrivateBehaviorView:
             "relationship_stage": self.relationship_stage.value,
             "nickname_permission": self.nickname_permission.value,
             "home_access": self.home_access.value,
+            "known_continuations": [
+                fact.to_dict() for fact in self.known_continuations
+            ],
         }
 
 
@@ -159,14 +225,27 @@ class OutputConstraints:
             raise ReplyContextError("output channel is invalid")
         if type(self.max_characters) is not int or self.max_characters < 1:
             raise ReplyContextError("max_characters must be positive")
-        if type(self.plain_text_only) is not bool or not self.plain_text_only:
+        if (
+            type(self.plain_text_only) is not bool
+            or not self.plain_text_only
+        ):
             raise ReplyContextError("reply output must be plain text")
         if type(self.allow_stage_directions) is not bool:
-            raise ReplyContextError("allow_stage_directions must be boolean")
-        if type(self.allow_control_markup) is not bool or self.allow_control_markup:
+            raise ReplyContextError(
+                "allow_stage_directions must be boolean"
+            )
+        if (
+            type(self.allow_control_markup) is not bool
+            or self.allow_control_markup
+        ):
             raise ReplyContextError("control markup is not allowed")
-        if self.channel is OutputChannel.SPOKEN_TEXT and self.allow_stage_directions:
-            raise ReplyContextError("spoken text cannot contain stage directions")
+        if (
+            self.channel is OutputChannel.SPOKEN_TEXT
+            and self.allow_stage_directions
+        ):
+            raise ReplyContextError(
+                "spoken text cannot contain stage directions"
+            )
 
     @classmethod
     def for_mode(cls, mode: ReplyMode) -> "OutputConstraints":
@@ -209,9 +288,13 @@ class ReplyContext:
     mode: ReplyMode
     trusted_time: TrustedTime
     world_facts: tuple[TrustedWorldFact, ...] = ()
-    private_behavior: PrivateBehaviorView = field(default_factory=PrivateBehaviorView)
+    private_behavior: PrivateBehaviorView = field(
+        default_factory=PrivateBehaviorView
+    )
     output_constraints: OutputConstraints = field(
-        default_factory=lambda: OutputConstraints.for_mode(ReplyMode.TEXT_LETTER)
+        default_factory=lambda: OutputConstraints.for_mode(
+            ReplyMode.TEXT_LETTER
+        )
     )
     future_im_enabled: bool = False
 
@@ -229,13 +312,24 @@ class ReplyContext:
         if mode is ReplyMode.FUTURE_IM and not future_im_enabled:
             raise UnsupportedReplyMode()
         constraints = output_constraints or OutputConstraints.for_mode(mode)
-        if constraints.channel is not OutputConstraints.for_mode(mode).channel:
-            raise ReplyContextError("output channel does not match reply mode")
+        if (
+            constraints.channel
+            is not OutputConstraints.for_mode(mode).channel
+        ):
+            raise ReplyContextError(
+                "output channel does not match reply mode"
+            )
         facts = tuple(world_facts)
-        if any(not isinstance(fact, TrustedWorldFact) for fact in facts):
-            raise ReplyContextError("world facts must use the trusted fact type")
+        if any(
+            not isinstance(fact, TrustedWorldFact) for fact in facts
+        ):
+            raise ReplyContextError(
+                "world facts must use the trusted fact type"
+            )
         if len({fact.fact_id for fact in facts}) != len(facts):
-            raise ReplyContextError("world fact identifiers must be unique")
+            raise ReplyContextError(
+                "world fact identifiers must be unique"
+            )
         return cls(
             mode,
             trusted_time,
@@ -251,26 +345,61 @@ class ReplyContext:
         if not isinstance(self.trusted_time, TrustedTime):
             raise ReplyContextError("trusted time is required")
         if type(self.future_im_enabled) is not bool:
-            raise ReplyContextError("future_im_enabled must be boolean")
-        if self.mode is ReplyMode.FUTURE_IM and not self.future_im_enabled:
+            raise ReplyContextError(
+                "future_im_enabled must be boolean"
+            )
+        if (
+            self.mode is ReplyMode.FUTURE_IM
+            and not self.future_im_enabled
+        ):
             raise UnsupportedReplyMode()
         if not isinstance(self.world_facts, tuple):
-            object.__setattr__(self, "world_facts", tuple(self.world_facts))
-        if any(not isinstance(fact, TrustedWorldFact) for fact in self.world_facts):
-            raise ReplyContextError("world facts must use the trusted fact type")
-        if len({fact.fact_id for fact in self.world_facts}) != len(self.world_facts):
-            raise ReplyContextError("world fact identifiers must be unique")
-        if not isinstance(self.private_behavior, PrivateBehaviorView):
-            raise ReplyContextError("private behavior view is invalid")
-        if not isinstance(self.output_constraints, OutputConstraints):
-            raise ReplyContextError("output constraints are invalid")
-        expected_channel = OutputConstraints.for_mode(self.mode).channel
+            object.__setattr__(
+                self,
+                "world_facts",
+                tuple(self.world_facts),
+            )
+        if any(
+            not isinstance(fact, TrustedWorldFact)
+            for fact in self.world_facts
+        ):
+            raise ReplyContextError(
+                "world facts must use the trusted fact type"
+            )
+        if (
+            len({fact.fact_id for fact in self.world_facts})
+            != len(self.world_facts)
+        ):
+            raise ReplyContextError(
+                "world fact identifiers must be unique"
+            )
+        if not isinstance(
+            self.private_behavior,
+            PrivateBehaviorView,
+        ):
+            raise ReplyContextError(
+                "private behavior view is invalid"
+            )
+        if not isinstance(
+            self.output_constraints,
+            OutputConstraints,
+        ):
+            raise ReplyContextError(
+                "output constraints are invalid"
+            )
+        expected_channel = OutputConstraints.for_mode(
+            self.mode
+        ).channel
         if self.output_constraints.channel is not expected_channel:
-            raise ReplyContextError("output channel does not match reply mode")
+            raise ReplyContextError(
+                "output channel does not match reply mode"
+            )
 
     def to_dict(self) -> dict[str, object]:
         try:
-            wire_mode: str | None = ReplyModeAdapter().to_wire(self.mode)
+            wire_mode: str | None = ReplyModeAdapter().to_wire(
+                self.mode
+            )
         except UnsupportedReplyMode:
             wire_mode = None
         return {
@@ -280,7 +409,11 @@ class ReplyContext:
                 "instant": self.trusted_time.instant.isoformat(),
                 "source": self.trusted_time.source,
             },
-            "world_facts": [fact.to_dict() for fact in self.world_facts],
+            "world_facts": [
+                fact.to_dict() for fact in self.world_facts
+            ],
             "private_behavior": self.private_behavior.to_dict(),
-            "output_constraints": self.output_constraints.to_dict(),
+            "output_constraints": (
+                self.output_constraints.to_dict()
+            ),
         }

--- a/reply_model_quality.py
+++ b/reply_model_quality.py
@@ -36,7 +36,11 @@ _REVIEW_FACETS = frozenset(
 
 
 class GatewayReviewTransport:
-    def __init__(self, gateway: Gateway, persona_path: Path) -> None:
+    def __init__(
+        self,
+        gateway: Gateway,
+        persona_path: Path,
+    ) -> None:
         self.gateway = gateway
         self.persona_path = persona_path
 
@@ -50,7 +54,8 @@ class GatewayReviewTransport:
         payload = {
             **request,
             "persona": _persona_review_profile(
-                self.persona_path, str(request.get("mode", ""))
+                self.persona_path,
+                str(request.get("mode", "")),
             ),
         }
         messages = (
@@ -77,10 +82,16 @@ class GatewayReviewTransport:
                 ),
             },
         )
-        text = _complete_text(self.gateway, messages, timeout_seconds)
+        text = _complete_text(
+            self.gateway,
+            messages,
+            timeout_seconds,
+        )
         parsed = json.loads(text.strip())
         if not isinstance(parsed, Mapping):
-            raise ValueError("review response must be an object")
+            raise ValueError(
+                "review response must be an object"
+            )
         return dict(parsed)
 
 
@@ -92,7 +103,10 @@ class GatewayPersonaReviewer:
         timeout_seconds: float,
     ) -> None:
         self.adapter = JsonReviewerAdapter(
-            GatewayReviewTransport(gateway, persona_path),
+            GatewayReviewTransport(
+                gateway,
+                persona_path,
+            ),
             ReviewerConfig(
                 model="configured_model",
                 timeout_seconds=timeout_seconds,
@@ -100,23 +114,43 @@ class GatewayPersonaReviewer:
             ),
         )
 
-    def review(self, candidate: str, context: ReplyContext) -> ReviewResult:
-        return self.adapter.review(candidate, context)
+    def review(
+        self,
+        candidate: str,
+        context: ReplyContext,
+    ) -> ReviewResult:
+        return self.adapter.review(
+            candidate,
+            context,
+        )
 
     def review_with_messages(
         self,
         candidate: str,
         context: ReplyContext,
-        generation_messages: Sequence[Mapping[str, Any]],
+        generation_messages: Sequence[
+            Mapping[str, Any]
+        ],
     ) -> ReviewResult:
-        user_text = _last_user_text(generation_messages)
+        user_text = _last_user_text(
+            generation_messages
+        )
         excerpt = _safe_excerpt(user_text)
         references = (
-            (ReviewReference("current.user_excerpt", excerpt),)
+            (
+                ReviewReference(
+                    "current.user_excerpt",
+                    excerpt,
+                ),
+            )
             if excerpt
             else ()
         )
-        return self.adapter.review(candidate, context, references=references)
+        return self.adapter.review(
+            candidate,
+            context,
+            references=references,
+        )
 
 
 class GatewayPersonaRewriter:
@@ -136,20 +170,29 @@ class GatewayPersonaRewriter:
         context: ReplyContext,
         violation_codes: tuple[str, ...],
     ) -> str:
-        return self._rewrite(candidate, context, violation_codes, user_text="")
+        return self._rewrite(
+            candidate,
+            context,
+            violation_codes,
+            user_text="",
+        )
 
     def rewrite_with_messages(
         self,
         candidate: str,
         context: ReplyContext,
         violation_codes: tuple[str, ...],
-        generation_messages: Sequence[Mapping[str, Any]],
+        generation_messages: Sequence[
+            Mapping[str, Any]
+        ],
     ) -> str:
         return self._rewrite(
             candidate,
             context,
             violation_codes,
-            user_text=_last_user_text(generation_messages),
+            user_text=_last_user_text(
+                generation_messages
+            ),
         )
 
     def _rewrite(
@@ -162,14 +205,31 @@ class GatewayPersonaRewriter:
     ) -> str:
         payload = {
             "persona": _persona_review_profile(
-                self.persona_path, context.mode.value
+                self.persona_path,
+                context.mode.value,
             ),
             "mode": context.mode.value,
-            "output_constraints": context.output_constraints.to_dict(),
-            "world_facts": [fact.to_dict() for fact in context.world_facts],
-            "user_message": _safe_text(user_text, 3000),
+            "output_constraints": (
+                context.output_constraints.to_dict()
+            ),
+            "world_facts": [
+                fact.to_dict()
+                for fact in context.world_facts
+            ],
+            "known_continuations": [
+                fact.to_dict()
+                for fact in (
+                    context.private_behavior.known_continuations
+                )
+            ],
+            "user_message": _safe_text(
+                user_text,
+                3000,
+            ),
             "candidate": candidate,
-            "violation_codes": list(violation_codes),
+            "violation_codes": list(
+                violation_codes
+            ),
         }
         messages = (
             {
@@ -202,48 +262,118 @@ class GatewayPersonaRewriter:
 
 def create_model_quality_ports(
     orchestrator: object,
-) -> tuple[GatewayPersonaReviewer | None, GatewayPersonaRewriter | None]:
-    bridge = getattr(orchestrator, "gateway", None)
-    adapter = getattr(bridge, "adapter", None)
-    config = getattr(adapter, "config", None)
-    provider = str(getattr(config, "provider", "none")).strip().lower()
-    if provider in {"", "none", "mock", "disabled", "unconfigured"}:
+) -> tuple[
+    GatewayPersonaReviewer | None,
+    GatewayPersonaRewriter | None,
+]:
+    bridge = getattr(
+        orchestrator,
+        "gateway",
+        None,
+    )
+    adapter = getattr(
+        bridge,
+        "adapter",
+        None,
+    )
+    config = getattr(
+        adapter,
+        "config",
+        None,
+    )
+    provider = str(
+        getattr(config, "provider", "none")
+    ).strip().lower()
+    if provider in {
+        "",
+        "none",
+        "mock",
+        "disabled",
+        "unconfigured",
+    }:
         return None, None
-    if not _env_bool("OLIVIA_REPLY_REVIEW_ENABLED", True):
+    if not _env_bool(
+        "OLIVIA_REPLY_REVIEW_ENABLED",
+        True,
+    ):
         return None, None
 
-    gateway = getattr(adapter, "gateway", None)
-    persona_path = getattr(adapter, "persona_v2_path", None)
-    if not isinstance(gateway, Gateway) or not isinstance(persona_path, Path):
+    gateway = getattr(
+        adapter,
+        "gateway",
+        None,
+    )
+    persona_path = getattr(
+        adapter,
+        "persona_v2_path",
+        None,
+    )
+    if not isinstance(
+        gateway,
+        Gateway,
+    ) or not isinstance(
+        persona_path,
+        Path,
+    ):
         return None, None
 
-    configured_timeout = float(getattr(config, "timeout_seconds", 30.0))
+    configured_timeout = float(
+        getattr(
+            config,
+            "timeout_seconds",
+            30.0,
+        )
+    )
     timeout = _env_timeout(
         "OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS",
         min(configured_timeout, 12.0),
     )
-    reviewer = GatewayPersonaReviewer(gateway, persona_path, timeout)
+    reviewer = GatewayPersonaReviewer(
+        gateway,
+        persona_path,
+        timeout,
+    )
     rewriter = (
-        GatewayPersonaRewriter(gateway, persona_path, timeout)
-        if _env_bool("OLIVIA_REPLY_REWRITE_ENABLED", True)
+        GatewayPersonaRewriter(
+            gateway,
+            persona_path,
+            timeout,
+        )
+        if _env_bool(
+            "OLIVIA_REPLY_REWRITE_ENABLED",
+            True,
+        )
         else None
     )
     return reviewer, rewriter
 
 
-def _persona_review_profile(path: Path, mode: str) -> dict[str, object]:
+def _persona_review_profile(
+    path: Path,
+    mode: str,
+) -> dict[str, object]:
     snapshot = load_persona(path).snapshot
     profile = snapshot.profile
     selected = [
         item
         for item in snapshot.declarations
         if item.facet in _REVIEW_FACETS
-        or (item.tier == "MODE_STYLE" and item.mode == mode)
+        or (
+            item.tier == "MODE_STYLE"
+            and item.mode == mode
+        )
     ]
-    selected.sort(key=lambda item: _rule_priority(item, mode))
+    selected.sort(
+        key=lambda item: _rule_priority(
+            item,
+            mode,
+        )
+    )
     rules = [
         {
-            "declaration_id": item.declaration_id,
+            "declaration_id": (
+                item.declaration_id
+            ),
             "facet": item.facet,
             "statement": item.statement,
         }
@@ -251,8 +381,16 @@ def _persona_review_profile(path: Path, mode: str) -> dict[str, object]:
     ]
     return {
         "status": snapshot.status,
-        "display_name": profile.display_name if profile else None,
-        "summary": profile.summary if profile else None,
+        "display_name": (
+            profile.display_name
+            if profile
+            else None
+        ),
+        "summary": (
+            profile.summary
+            if profile
+            else None
+        ),
         "rules": rules,
     }
 
@@ -261,8 +399,14 @@ def _rule_priority(
     item: PersonaDeclaration,
     mode: str,
 ) -> tuple[int, str]:
-    if item.tier == "MODE_STYLE" and item.mode == mode:
-        return (0, item.declaration_id)
+    if (
+        item.tier == "MODE_STYLE"
+        and item.mode == mode
+    ):
+        return (
+            0,
+            item.declaration_id,
+        )
     priorities = {
         "AUTONOMY": 1,
         "KNOWLEDGE_BOUNDARY": 2,
@@ -272,16 +416,31 @@ def _rule_priority(
         "CORE_TRAIT": 6,
         "UNCERTAINTY": 7,
     }
-    return (priorities.get(item.facet or "", 9), item.declaration_id)
+    return (
+        priorities.get(
+            item.facet or "",
+            9,
+        ),
+        item.declaration_id,
+    )
 
 
-def _last_user_text(messages: Sequence[Mapping[str, Any]]) -> str:
-    for message in reversed(tuple(messages)):
+def _last_user_text(
+    messages: Sequence[Mapping[str, Any]],
+) -> str:
+    for message in reversed(
+        tuple(messages)
+    ):
         if (
             message.get("role") == "user"
-            and isinstance(message.get("content"), str)
+            and isinstance(
+                message.get("content"),
+                str,
+            )
         ):
-            return str(message["content"])
+            return str(
+                message["content"]
+            )
     return ""
 
 
@@ -289,25 +448,37 @@ def _safe_excerpt(value: str) -> str:
     return _safe_text(value, 600)
 
 
-def _safe_text(value: str, limit: int) -> str:
+def _safe_text(
+    value: str,
+    limit: int,
+) -> str:
     cleaned = "".join(
         character
         for character in value
-        if character in {"\n", "\r", "\t"} or ord(character) >= 32
+        if character in {
+            "\n",
+            "\r",
+            "\t",
+        }
+        or ord(character) >= 32
     ).strip()
     return cleaned[:limit]
 
 
 def _complete_text(
     gateway: Gateway,
-    messages: Sequence[Mapping[str, Any]],
+    messages: Sequence[
+        Mapping[str, Any]
+    ],
     timeout_seconds: float,
 ) -> str:
     async def invoke() -> str:
         response = await asyncio.wait_for(
             gateway.complete(
                 messages,
-                request_id=f"quality-{uuid.uuid4().hex}",
+                request_id=(
+                    f"quality-{uuid.uuid4().hex}"
+                ),
             ),
             timeout_seconds,
         )
@@ -316,25 +487,54 @@ def _complete_text(
     try:
         text = asyncio.run(invoke())
     except Exception:
-        raise RuntimeError("quality model unavailable") from None
-    if not isinstance(text, str) or not text.strip():
-        raise RuntimeError("quality model returned empty text")
+        raise RuntimeError(
+            "quality model unavailable"
+        ) from None
+    if (
+        not isinstance(text, str)
+        or not text.strip()
+    ):
+        raise RuntimeError(
+            "quality model returned empty text"
+        )
     return text
 
 
-def _env_bool(name: str, default: bool) -> bool:
+def _env_bool(
+    name: str,
+    default: bool,
+) -> bool:
     value = os.environ.get(name)
     if value is None:
         return default
-    return value.strip().lower() in {"1", "true", "yes", "on"}
+    return value.strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
-def _env_timeout(name: str, default: float) -> float:
+def _env_timeout(
+    name: str,
+    default: float,
+) -> float:
     try:
-        value = float(os.environ.get(name, default))
+        value = float(
+            os.environ.get(
+                name,
+                default,
+            )
+        )
     except (TypeError, ValueError):
         value = default
-    return max(0.1, min(120.0, value))
+    return max(
+        0.1,
+        min(
+            120.0,
+            value,
+        ),
+    )
 
 
 __all__ = [

--- a/reply_reviewer.py
+++ b/reply_reviewer.py
@@ -15,7 +15,9 @@ from reply_context import ReplyContext
 
 
 _SCHEMA_PATH = Path(__file__).resolve().parent / "contracts" / "reply_review.schema.json"
-_VALIDATOR = Draft202012Validator(json.loads(_SCHEMA_PATH.read_text(encoding="utf-8")))
+_VALIDATOR = Draft202012Validator(
+    json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+)
 
 
 class ReviewStatus(StrEnum):
@@ -55,19 +57,28 @@ class ReviewReference:
 
     def __post_init__(self) -> None:
         if not isinstance(self.reference_id, str) or not re.fullmatch(
-            r"[A-Za-z0-9._:-]{1,96}", self.reference_id
+            r"[A-Za-z0-9._:-]{1,96}",
+            self.reference_id,
         ):
-            raise ValueError("reference_id must be a stable identifier")
+            raise ValueError(
+                "reference_id must be a stable identifier"
+            )
         if (
             not isinstance(self.summary, str)
             or not self.summary.strip()
             or len(self.summary) > 600
-            or re.search(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", self.summary)
+            or re.search(
+                r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]",
+                self.summary,
+            )
         ):
             raise ValueError("reference summary is invalid")
 
     def to_dict(self) -> dict[str, str]:
-        return {"reference_id": self.reference_id, "summary": self.summary.strip()}
+        return {
+            "reference_id": self.reference_id,
+            "summary": self.summary.strip(),
+        }
 
 
 @dataclass(frozen=True)
@@ -87,13 +98,23 @@ class ReviewerConfig:
 
     def __post_init__(self) -> None:
         if not isinstance(self.model, str) or not re.fullmatch(
-            r"[A-Za-z0-9._:-]{1,96}", self.model
+            r"[A-Za-z0-9._:-]{1,96}",
+            self.model,
         ):
-            raise ValueError("reviewer model must be a stable identifier")
-        if not isinstance(self.timeout_seconds, (int, float)) or self.timeout_seconds <= 0:
-            raise ValueError("reviewer timeout must be positive")
+            raise ValueError(
+                "reviewer model must be a stable identifier"
+            )
+        if (
+            not isinstance(self.timeout_seconds, (int, float))
+            or self.timeout_seconds <= 0
+        ):
+            raise ValueError(
+                "reviewer timeout must be positive"
+            )
         if type(self.enabled) is not bool:
-            raise ValueError("reviewer enabled must be boolean")
+            raise ValueError(
+                "reviewer enabled must be boolean"
+            )
 
 
 class ReviewTransport(Protocol):
@@ -114,11 +135,18 @@ class NullReviewer:
         *,
         references: tuple[ReviewReference, ...] = (),
     ) -> ReviewResult:
-        return _failure(ReviewStatus.DISABLED, "REVIEWER_DISABLED")
+        return _failure(
+            ReviewStatus.DISABLED,
+            "REVIEWER_DISABLED",
+        )
 
 
 class JsonReviewerAdapter:
-    def __init__(self, transport: ReviewTransport, config: ReviewerConfig) -> None:
+    def __init__(
+        self,
+        transport: ReviewTransport,
+        config: ReviewerConfig,
+    ) -> None:
         self.transport = transport
         self.config = config
 
@@ -134,24 +162,52 @@ class JsonReviewerAdapter:
         if not isinstance(context, ReplyContext):
             raise TypeError("context must be ReplyContext")
         if not self.config.enabled:
-            return _failure(ReviewStatus.DISABLED, "REVIEWER_DISABLED")
+            return _failure(
+                ReviewStatus.DISABLED,
+                "REVIEWER_DISABLED",
+            )
         request: dict[str, object] = {
             "candidate": candidate,
             "mode": context.mode.value,
-            "output_constraints": context.output_constraints.to_dict(),
-            "world_facts": [fact.to_dict() for fact in context.world_facts],
-            "references": [reference.to_dict() for reference in references],
+            "output_constraints": (
+                context.output_constraints.to_dict()
+            ),
+            "world_facts": [
+                fact.to_dict()
+                for fact in context.world_facts
+            ],
+            "known_continuations": [
+                fact.to_dict()
+                for fact in (
+                    context.private_behavior.known_continuations
+                )
+            ],
+            "references": [
+                reference.to_dict()
+                for reference in references
+            ],
         }
         try:
             response = self.transport.review_json(
                 request,
                 model=self.config.model,
-                timeout_seconds=float(self.config.timeout_seconds),
+                timeout_seconds=float(
+                    self.config.timeout_seconds
+                ),
             )
         except Exception:
-            return _failure(ReviewStatus.UNAVAILABLE, "REVIEWER_UNAVAILABLE")
-        if not isinstance(response, Mapping) or list(_VALIDATOR.iter_errors(response)):
-            return _failure(ReviewStatus.INVALID_RESPONSE, "REVIEWER_RESPONSE_INVALID")
+            return _failure(
+                ReviewStatus.UNAVAILABLE,
+                "REVIEWER_UNAVAILABLE",
+            )
+        if (
+            not isinstance(response, Mapping)
+            or list(_VALIDATOR.iter_errors(response))
+        ):
+            return _failure(
+                ReviewStatus.INVALID_RESPONSE,
+                "REVIEWER_RESPONSE_INVALID",
+            )
         try:
             scores = response["scores"]
             violations = tuple(
@@ -163,11 +219,22 @@ class JsonReviewerAdapter:
                 )
                 for item in response["violations"]
             )
-            if any(item.end <= item.start or item.end > len(candidate) for item in violations):
-                return _failure(ReviewStatus.INVALID_RESPONSE, "REVIEWER_RESPONSE_INVALID")
+            if any(
+                item.end <= item.start
+                or item.end > len(candidate)
+                for item in violations
+            ):
+                return _failure(
+                    ReviewStatus.INVALID_RESPONSE,
+                    "REVIEWER_RESPONSE_INVALID",
+                )
             return ReviewResult(
-                status=ReviewStatus(str(response["status"])),
-                verdict=ReviewVerdict(str(response["verdict"])),
+                status=ReviewStatus(
+                    str(response["status"])
+                ),
+                verdict=ReviewVerdict(
+                    str(response["verdict"])
+                ),
                 violations=violations,
                 scores=ReviewerScores(
                     int(scores["persona_consistency"]),
@@ -177,10 +244,16 @@ class JsonReviewerAdapter:
                 ),
             )
         except (KeyError, TypeError, ValueError):
-            return _failure(ReviewStatus.INVALID_RESPONSE, "REVIEWER_RESPONSE_INVALID")
+            return _failure(
+                ReviewStatus.INVALID_RESPONSE,
+                "REVIEWER_RESPONSE_INVALID",
+            )
 
 
-def _failure(status: ReviewStatus, error_code: str) -> ReviewResult:
+def _failure(
+    status: ReviewStatus,
+    error_code: str,
+) -> ReviewResult:
     return ReviewResult(
         status=status,
         verdict=ReviewVerdict.UNAVAILABLE,

--- a/tests/persona/test_private_continuity_persona_integration.py
+++ b/tests/persona/test_private_continuity_persona_integration.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from llm_gateway import GatewayConfig
+from local_server import LetterAdapter
+from memory_port import NullMemoryPort
+from private_world_port import (
+    ContinuationAwareness,
+    HomeAccess,
+    LocalContinuationFact,
+    PrivateWorldSnapshot,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+NOW = datetime(2026, 8, 22, tzinfo=timezone.utc)
+
+
+class SnapshotPort:
+    def __init__(self, snapshot: PrivateWorldSnapshot) -> None:
+        self._snapshot = snapshot
+
+    def snapshot(self) -> PrivateWorldSnapshot:
+        return self._snapshot
+
+
+def test_private_continuity_reaches_persona_without_control_only_state() -> None:
+    adapter = LetterAdapter(
+        GatewayConfig(
+            provider="mock",
+            model="synthetic",
+            persona_v2_enabled=True,
+            persona_v2_file=str(
+                ROOT / "linli_character" / "persona_release_v2.json"
+            ),
+        ),
+        memory_port=NullMemoryPort(),
+        private_world_port=SnapshotPort(
+            PrivateWorldSnapshot(
+                trust=81,
+                relationship_stage="close",
+                nickname_permissions=("小河豚",),
+                home_access=HomeAccess.VISIT_ACCESS,
+                continuation_facts=(
+                    LocalContinuationFact(
+                        "class.known",
+                        "林离已经知道下周课程时间会调整。",
+                        ContinuationAwareness.CHARACTER_KNOWN,
+                    ),
+                    LocalContinuationFact(
+                        "trip.pending",
+                        "角色尚未知道的旅行安排。",
+                        ContinuationAwareness.PENDING,
+                    ),
+                    LocalContinuationFact(
+                        "plan.control",
+                        "控制层保存的未来计划。",
+                        ContinuationAwareness.CONTROL_ONLY,
+                    ),
+                ),
+            )
+        ),
+        now=lambda: NOW,
+    )
+
+    system = adapter._messages("今天普通地有点累。")[0]["content"]
+
+    assert "小河豚" in system
+    assert '"trust":"high"' in system
+    assert '"home_access":"visit_access"' in system
+    assert "林离已经知道下周课程时间会调整。" in system
+    assert "81" not in system
+    assert "trip.pending" not in system
+    assert "plan.control" not in system
+    assert "角色尚未知道的旅行安排" not in system
+    assert "控制层保存的未来计划" not in system
+    assert "control_only" not in system
+    assert '"awareness":"pending"' not in system

--- a/tests/persona/test_private_continuity_quality.py
+++ b/tests/persona/test_private_continuity_quality.py
@@ -1,0 +1,77 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from llm_gateway import Gateway, GatewayResponse
+from reply_context import (
+    KnownContinuationFact,
+    PrivateBehaviorView,
+    ReplyContext,
+    ReplyMode,
+    TrustedTime,
+)
+from reply_model_quality import GatewayPersonaRewriter
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class RecordingGateway(Gateway):
+    stream_enabled = False
+
+    def __init__(self) -> None:
+        self.payload: dict[str, object] = {}
+
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None = None,
+    ) -> GatewayResponse:
+        self.payload = json.loads(str(messages[-1]["content"]))
+        return GatewayResponse(
+            text="改写后的合成回复。",
+            request_id=request_id or "synthetic",
+            provider="synthetic",
+            model="synthetic",
+        )
+
+
+def test_one_shot_rewriter_receives_only_character_known_continuations() -> None:
+    gateway = RecordingGateway()
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+        private_behavior=PrivateBehaviorView(
+            known_continuations=(
+                KnownContinuationFact(
+                    "class.known",
+                    "她已经知道下周课程会调整。",
+                ),
+            )
+        ),
+    )
+    rewriter = GatewayPersonaRewriter(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        timeout_seconds=1,
+    )
+
+    result = rewriter.rewrite(
+        "候选回复。",
+        context,
+        ("SYNTHETIC_VIOLATION",),
+    )
+
+    assert result == "改写后的合成回复。"
+    assert gateway.payload["known_continuations"] == [
+        {
+            "fact_id": "class.known",
+            "statement": "她已经知道下周课程会调整。",
+        }
+    ]
+    serialized = repr(gateway.payload)
+    assert "control_only" not in serialized
+    assert "pending" not in serialized
+    assert "trust" not in serialized

--- a/tests/persona/test_reply_reviewer.py
+++ b/tests/persona/test_reply_reviewer.py
@@ -4,7 +4,14 @@ from pathlib import Path
 
 from jsonschema import Draft202012Validator
 
-from reply_context import ReplyContext, ReplyMode, TrustedTime, TrustedWorldFact
+from reply_context import (
+    KnownContinuationFact,
+    PrivateBehaviorView,
+    ReplyContext,
+    ReplyMode,
+    TrustedTime,
+    TrustedWorldFact,
+)
 from reply_reviewer import (
     JsonReviewerAdapter,
     NullReviewer,
@@ -39,26 +46,40 @@ class _FailingTransport:
         raise RuntimeError("private provider failure details")
 
 
+def _valid_response() -> dict[str, object]:
+    return {
+        "schema_version": "p02.reply-review.v1",
+        "status": "completed",
+        "verdict": "pass",
+        "violations": [],
+        "scores": {
+            "persona_consistency": 92,
+            "factual_consistency": 94,
+            "relationship_boundary": 96,
+            "mode_compliance": 98,
+        },
+    }
+
+
 def test_valid_reviewer_json_becomes_a_typed_result_from_limited_context() -> None:
-    transport = _Transport(
-        {
-            "schema_version": "p02.reply-review.v1",
-            "status": "completed",
-            "verdict": "pass",
-            "violations": [],
-            "scores": {
-                "persona_consistency": 92,
-                "factual_consistency": 94,
-                "relationship_boundary": 96,
-                "mode_compliance": 98,
-            },
-        }
-    )
+    transport = _Transport(_valid_response())
     context = ReplyContext.create(
         ReplyMode.TEXT_LETTER,
         trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
         world_facts=(
-            TrustedWorldFact("fact.synthetic", "source.synthetic", "Synthetic fact."),
+            TrustedWorldFact(
+                "fact.synthetic",
+                "source.synthetic",
+                "Synthetic fact.",
+            ),
+        ),
+        private_behavior=PrivateBehaviorView(
+            known_continuations=(
+                KnownContinuationFact(
+                    "class.known",
+                    "她已经知道下周课程会调整。",
+                ),
+            )
         ),
     )
     adapter = JsonReviewerAdapter(
@@ -71,8 +92,16 @@ def test_valid_reviewer_json_becomes_a_typed_result_from_limited_context() -> No
     assert result.status is ReviewStatus.COMPLETED
     assert result.verdict is ReviewVerdict.PASS
     assert result.scores.mode_compliance == 98
-    assert transport.requests[0]["world_facts"][0]["fact_id"] == "fact.synthetic"
-    assert "private_behavior" not in transport.requests[0]
+    request = transport.requests[0]
+    assert request["world_facts"][0]["fact_id"] == "fact.synthetic"
+    assert request["known_continuations"] == [
+        {
+            "fact_id": "class.known",
+            "statement": "她已经知道下周课程会调整。",
+        }
+    ]
+    assert "private_behavior" not in request
+    assert "trust" not in repr(request)
 
 
 def test_public_schema_rejects_unknown_fields_and_out_of_range_scores() -> None:
@@ -102,33 +131,29 @@ def test_public_schema_rejects_unknown_fields_and_out_of_range_scores() -> None:
     assert list(validator.iter_errors(valid)) == []
     invalid = {**valid, "hidden_state": {"trust": 0.9}}
     assert list(validator.iter_errors(invalid))
-    invalid_score = {**valid, "scores": {**valid["scores"], "mode_compliance": 101}}
+    invalid_score = {
+        **valid,
+        "scores": {**valid["scores"], "mode_compliance": 101},
+    }
     assert list(validator.iter_errors(invalid_score))
 
 
 def test_invalid_provider_json_returns_a_sanitized_typed_failure() -> None:
-    transport = _Transport(
-        {
-            "schema_version": "p02.reply-review.v1",
-            "status": "completed",
-            "verdict": "pass",
-            "violations": [],
-            "scores": {
-                "persona_consistency": 100,
-                "factual_consistency": 100,
-                "relationship_boundary": 100,
-                "mode_compliance": 101,
-            },
-        }
-    )
+    invalid = _valid_response()
+    invalid["scores"] = {
+        **invalid["scores"],
+        "mode_compliance": 101,
+    }
+    transport = _Transport(invalid)
     context = ReplyContext.create(
         ReplyMode.TEXT_LETTER,
         trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
     )
 
-    result = JsonReviewerAdapter(transport, ReviewerConfig("reviewer-small")).review(
-        "Synthetic candidate.", context
-    )
+    result = JsonReviewerAdapter(
+        transport,
+        ReviewerConfig("reviewer-small"),
+    ).review("Synthetic candidate.", context)
 
     assert result.status is ReviewStatus.INVALID_RESPONSE
     assert result.verdict is ReviewVerdict.UNAVAILABLE
@@ -149,7 +174,8 @@ def test_disabled_and_failed_reviewers_return_sanitized_unavailable_results() ->
     ).review("Synthetic candidate.", context)
     null_result = NullReviewer().review("Synthetic candidate.", context)
     failed = JsonReviewerAdapter(
-        _FailingTransport(), ReviewerConfig("reviewer-small")
+        _FailingTransport(),
+        ReviewerConfig("reviewer-small"),
     ).review("Synthetic candidate.", context)
 
     assert disabled.status is ReviewStatus.DISABLED
@@ -161,38 +187,37 @@ def test_disabled_and_failed_reviewers_return_sanitized_unavailable_results() ->
 
 
 def test_reviewer_request_accepts_only_short_identified_reference_summaries() -> None:
-    transport = _Transport(
-        {
-            "schema_version": "p02.reply-review.v1",
-            "status": "completed",
-            "verdict": "pass",
-            "violations": [],
-            "scores": {
-                "persona_consistency": 100,
-                "factual_consistency": 100,
-                "relationship_boundary": 100,
-                "mode_compliance": 100,
-            },
-        }
-    )
+    transport = _Transport(_valid_response())
     context = ReplyContext.create(
         ReplyMode.TEXT_LETTER,
         trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
     )
 
-    JsonReviewerAdapter(transport, ReviewerConfig("reviewer-small")).review(
+    JsonReviewerAdapter(
+        transport,
+        ReviewerConfig("reviewer-small"),
+    ).review(
         "Synthetic candidate.",
         context,
-        references=(ReviewReference("ref.synthetic", "Short synthetic summary."),),
+        references=(
+            ReviewReference(
+                "ref.synthetic",
+                "Short synthetic summary.",
+            ),
+        ),
     )
 
     assert transport.requests[0]["references"] == [
-        {"reference_id": "ref.synthetic", "summary": "Short synthetic summary."}
+        {
+            "reference_id": "ref.synthetic",
+            "summary": "Short synthetic summary.",
+        }
     ]
     assert set(transport.requests[0]) == {
         "candidate",
         "mode",
         "output_constraints",
         "world_facts",
+        "known_continuations",
         "references",
     }

--- a/tests/private_world/test_private_world_continuity.py
+++ b/tests/private_world/test_private_world_continuity.py
@@ -1,0 +1,78 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from private_world_ledger import LedgerEvent, SQLitePrivateWorldLedger
+from private_world_port import (
+    ContinuationAwareness,
+    LocalContinuationFact,
+    PrivateWorldSnapshot,
+)
+
+
+def _event(number: int) -> LedgerEvent:
+    return LedgerEvent(
+        event_id=f"event-{number}",
+        delivery_id=f"delivery-{number}",
+        event_type="continuation_updated",
+        payload={"changed_fields": ["continuation_facts"]},
+        occurred_at="2026-08-22T00:00:00+00:00",
+    )
+
+
+def test_ledger_round_trips_unicode_nickname_and_continuation_facts(
+    tmp_path: Path,
+) -> None:
+    ledger = SQLitePrivateWorldLedger(tmp_path / "private.sqlite3")
+    snapshot = PrivateWorldSnapshot(
+        nickname_permissions=("小河豚",),
+        continuation_facts=(
+            LocalContinuationFact(
+                "trip.pending",
+                "下个月可能有一段旅行安排。",
+                ContinuationAwareness.PENDING,
+            ),
+            LocalContinuationFact(
+                "class.known",
+                "她已经知道下周课程会调整。",
+                ContinuationAwareness.CHARACTER_KNOWN,
+            ),
+        ),
+    )
+
+    assert ledger.apply_once(_event(1), snapshot)
+    assert ledger.snapshot() == snapshot
+    assert ledger.events()[0].payload == {
+        "changed_fields": ["continuation_facts"]
+    }
+
+
+def test_ledger_loads_legacy_snapshot_without_continuation_facts(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "legacy.sqlite3"
+    ledger = SQLitePrivateWorldLedger(database)
+    legacy = PrivateWorldSnapshot(trust=3).to_dict()
+    legacy.pop("continuation_facts")
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            """INSERT INTO private_world_events
+               (event_id, delivery_id, event_type, payload_json, occurred_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (
+                "legacy-event",
+                "legacy-delivery",
+                "legacy",
+                "{}",
+                "2026-08-22T00:00:00+00:00",
+            ),
+        )
+        connection.execute(
+            """INSERT INTO private_world_snapshots
+               (version, payload_json, event_id) VALUES (?, ?, ?)""",
+            (1, json.dumps(legacy), "legacy-event"),
+        )
+
+    loaded = ledger.snapshot()
+    assert loaded.trust == 3
+    assert loaded.continuation_facts == ()

--- a/tests/private_world/test_private_world_port.py
+++ b/tests/private_world/test_private_world_port.py
@@ -7,6 +7,7 @@ from jsonschema import Draft202012Validator
 from private_world_port import (
     ContinuationAwareness,
     HomeAccess,
+    LocalContinuationFact,
     NullPrivateWorldPort,
     PrivateWorldError,
     PrivateWorldSnapshot,
@@ -16,30 +17,63 @@ from private_world_port import (
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_snapshot_keeps_hidden_values_out_of_character_view() -> None:
+def _continuations() -> tuple[LocalContinuationFact, ...]:
+    return (
+        LocalContinuationFact(
+            "trip.pending",
+            "下个月可能有一段旅行安排。",
+            ContinuationAwareness.PENDING,
+        ),
+        LocalContinuationFact(
+            "class.known",
+            "她已经知道下周课程时间会调整。",
+            ContinuationAwareness.CHARACTER_KNOWN,
+        ),
+        LocalContinuationFact(
+            "plan.control",
+            "控制层保存的未来计划。",
+            ContinuationAwareness.CONTROL_ONLY,
+        ),
+    )
+
+
+def test_snapshot_keeps_hidden_and_control_only_values_out_of_character_view() -> None:
     snapshot = PrivateWorldSnapshot(
         familiarity=72,
         trust=61,
         comfort=55,
         closeness=48,
         tension=13,
-        relationship_stage="trusted_friend",
-        nickname_permissions=("linli",),
+        relationship_stage="close",
+        nickname_permissions=("小河豚", "旅行者"),
         home_access=HomeAccess.VISIT_ACCESS,
-        continuation_awareness=ContinuationAwareness.CHARACTER_KNOWN,
+        continuation_facts=_continuations(),
     )
 
     control = snapshot.control_view().to_dict()
     character = snapshot.character_view().to_dict()
 
     assert control["trust"] == 61
+    assert control["nickname_permissions"] == ["小河豚", "旅行者"]
+    assert len(control["continuation_facts"]) == 3
     assert character == {
         "view": "character",
-        "relationship_stage": "trusted_friend",
-        "nickname_permissions": ["linli"],
-        "home_access": "visit_access",
-        "continuation_awareness": "character_known",
+        "relationship_stage": "close",
+        "nickname_permissions": ["小河豚", "旅行者"],
+        "home_history_allowed": True,
+        "continuation_known": True,
+        "continuation_facts": [
+            {
+                "fact_id": "class.known",
+                "statement": "她已经知道下周课程时间会调整。",
+                "awareness": "character_known",
+            }
+        ],
     }
+    serialized = repr(character)
+    assert "pending" not in serialized
+    assert "control_only" not in serialized
+    assert "未来计划" not in serialized
     for hidden in ("familiarity", "trust", "comfort", "closeness", "tension"):
         assert hidden not in character
 
@@ -52,23 +86,41 @@ def test_contract_rejects_unbounded_or_ambiguous_values() -> None:
     with pytest.raises(PrivateWorldError):
         PrivateWorldSnapshot(nickname_permissions=("not allowed whitespace",))
     with pytest.raises(PrivateWorldError):
+        PrivateWorldSnapshot(nickname_permissions=("重复", "重复"))
+    with pytest.raises(PrivateWorldError):
         PrivateWorldSnapshot(home_access="visit_access")  # type: ignore[arg-type]
+    with pytest.raises(PrivateWorldError):
+        LocalContinuationFact("not allowed", "fact")
+    with pytest.raises(PrivateWorldError):
+        LocalContinuationFact("fact", "bad\nstatement")
 
 
-def test_python_and_schema_agree_on_relationship_stage_boundary() -> None:
+def test_python_and_schema_agree_on_unicode_nicknames_and_continuation_views() -> None:
     schema = json.loads(
         (ROOT / "contracts" / "private_world.schema.json").read_text(encoding="utf-8")
     )
     validator = Draft202012Validator(schema)
-    accepted = PrivateWorldSnapshot(relationship_stage="x" * 64).to_dict()
+    snapshot = PrivateWorldSnapshot(
+        relationship_stage="x" * 64,
+        nickname_permissions=("小河豚",),
+        home_access=HomeAccess.DOMESTIC_ACCESS,
+        continuation_facts=_continuations(),
+    )
 
-    assert list(validator.iter_errors(accepted)) == []
-    assert list(
-        validator.iter_errors(PrivateWorldSnapshot().control_view().to_dict())
-    ) == []
-    assert list(
-        validator.iter_errors(PrivateWorldSnapshot().character_view().to_dict())
-    ) == []
+    assert list(validator.iter_errors(snapshot.to_dict())) == []
+    assert list(validator.iter_errors(snapshot.control_view().to_dict())) == []
+    assert list(validator.iter_errors(snapshot.character_view().to_dict())) == []
+
+    unsafe = snapshot.character_view().to_dict()
+    unsafe["continuation_facts"].append(
+        {
+            "fact_id": "unsafe.pending",
+            "statement": "角色还不应该知道。",
+            "awareness": "pending",
+        }
+    )
+    assert list(validator.iter_errors(unsafe))
+
     with pytest.raises(PrivateWorldError):
         PrivateWorldSnapshot(relationship_stage="x" * 65)
 
@@ -94,6 +146,7 @@ def test_public_documentation_keeps_persistence_and_projection_out_of_scope() ->
         "NullPrivateWorldPort",
         "control view",
         "character view",
+        "LocalContinuationFact",
         "does not persist",
         "does not call a provider",
         "P02-11",

--- a/tests/private_world/test_private_world_projection.py
+++ b/tests/private_world/test_private_world_projection.py
@@ -1,6 +1,7 @@
 from private_world_port import (
     ContinuationAwareness,
     HomeAccess,
+    LocalContinuationFact,
     PrivateWorldSnapshot,
 )
 from private_world_projection import project_private_world
@@ -32,16 +33,63 @@ def test_projection_converts_hidden_scores_to_finite_behavior_levels() -> None:
         assert raw not in serialized
 
 
-def test_only_current_authorized_nicknames_enter_projection() -> None:
+def test_current_unicode_nicknames_and_home_permission_enter_finite_projection() -> None:
     projected = project_private_world(
-        PrivateWorldSnapshot(nickname_permissions=("linli", "friend"))
+        PrivateWorldSnapshot(
+            nickname_permissions=("小河豚", "旅行者"),
+            home_access=HomeAccess.VISIT_ACCESS,
+        )
     )
 
-    assert projected.authorized_nicknames == ("linli", "friend")
-    assert projected.to_dict()["authorized_nicknames"] == ["linli", "friend"]
+    assert projected.authorized_nicknames == ("小河豚", "旅行者")
+    assert projected.to_dict()["authorized_nicknames"] == ["小河豚", "旅行者"]
+    assert projected.behavior.nickname_permission.value == "allowed"
+    assert projected.behavior.home_access.value == "visit_access"
+    assert projected.may_acknowledge_home_history is True
 
 
-def test_control_only_and_pending_continuation_never_enter_character_payload() -> None:
+def test_control_only_and_pending_continuation_facts_never_enter_model_payload() -> None:
+    projected = project_private_world(
+        PrivateWorldSnapshot(
+            continuation_facts=(
+                LocalContinuationFact(
+                    "known.class",
+                    "她已经知道下周课程会调整。",
+                    ContinuationAwareness.CHARACTER_KNOWN,
+                ),
+                LocalContinuationFact(
+                    "pending.trip",
+                    "角色尚未知道的旅行安排。",
+                    ContinuationAwareness.PENDING,
+                ),
+                LocalContinuationFact(
+                    "control.plan",
+                    "仅控制层可见的未来计划。",
+                    ContinuationAwareness.CONTROL_ONLY,
+                ),
+            )
+        )
+    )
+    payload = projected.to_dict()
+
+    assert projected.continuation_known is True
+    assert payload["known_continuations"] == [
+        {
+            "fact_id": "known.class",
+            "statement": "她已经知道下周课程会调整。",
+        }
+    ]
+    assert payload["behavior"]["known_continuations"] == payload["known_continuations"]
+    serialized = repr(payload)
+    assert "pending.trip" not in serialized
+    assert "control.plan" not in serialized
+    assert "旅行安排" not in serialized
+    assert "未来计划" not in serialized
+    assert "pending" not in serialized
+    assert "control_only" not in serialized
+
+
+def test_legacy_global_awareness_projects_only_a_boolean_not_control_label() -> None:
     for awareness in (
         ContinuationAwareness.CONTROL_ONLY,
         ContinuationAwareness.PENDING,
@@ -59,20 +107,7 @@ def test_control_only_and_pending_continuation_never_enter_character_payload() -
         )
     )
     assert known.continuation_known is True
-
-
-def test_home_access_only_grants_history_acknowledgement() -> None:
-    no_access = project_private_world(PrivateWorldSnapshot())
-    visit_access = project_private_world(
-        PrivateWorldSnapshot(home_access=HomeAccess.VISIT_ACCESS)
-    )
-
-    assert no_access.may_acknowledge_home_history is False
-    assert visit_access.may_acknowledge_home_history is True
-    assert "may_acknowledge_home_history" not in visit_access.to_dict()
-    assert visit_access.behavior.home_access.value == "no_access"
-    assert "mention" not in repr(visit_access.to_dict()).lower()
-    assert "describe" not in repr(visit_access.to_dict()).lower()
+    assert known.known_continuation_facts == ()
 
 
 def test_unknown_relationship_stage_fails_closed_to_unknown() -> None:


### PR DESCRIPTION
Implements the data-model/projection half of FIX-04 from #20.

## What changed

- adds typed `LocalContinuationFact` records with per-fact `control_only`, `pending`, or `character_known` awareness;
- accepts bounded Unicode nickname permissions, including Chinese labels, while rejecting controls, whitespace, duplicates, and unbounded values;
- changes the character view to expose no hidden scores, raw home-access level, or control awareness;
- filters Local Continuation per fact so only `character_known` statements cross into `PrivateBehaviorView` as typed `KnownContinuationFact` values;
- projects home access as a finite acknowledgement permission rather than inventing a home scene;
- round-trips the new state through the separate SQLite ledger and loads older snapshots with an empty fact list;
- supplies the same character-known fact subset to configured semantic review and one-shot rewrite, without hidden values.

## Privacy boundary

Pending/control-only statements, identifiers, and awareness labels never enter PersonaAssembly, reviewer, or rewriter requests. Tests prove they are absent from the assembled system prompt. Concrete local facts and nickname instances remain private database values; committed tests use synthetic data only.

## Compatibility

- existing score and relationship-stage reducer semantics remain unchanged;
- existing snapshots without `continuation_facts` load without destructive migration;
- legacy global continuation awareness is retained for compatibility but projects only a boolean, never its control label;
- no HTTP wire value, provider selection, media behavior, installer path, or automatic relationship inference changes.

## Validation

- local focused contract/schema/ledger/projection tests: 12 passed;
- Python syntax compile passed for all changed production modules;
- GitHub `public-smoke` is the merge gate.

## Follow-up

The next FIX-04 PR will add explicit local maintenance commands and configure the installed runtime to use its private SQLite database by default. No chat keyword will mutate this state.