### PR TITLE
test(persona): close complete source and companion acceptance

### DIFF
--- a/docs/P02_PERSONA_SOURCE_COVERAGE.md
+++ b/docs/P02_PERSONA_SOURCE_COVERAGE.md
@@ -1,0 +1,91 @@
+# 林离 Persona 来源完整落地说明
+
+本页说明 `docs/persona-sources/linli-im-private-constitution-1.0.zh-CN.md` 的每一节如何进入当前系统。机器可读账本位于 `linli_character/persona_source_coverage_v2.json`。
+
+“完整落地”不等于把整篇参考文档直接放进 system prompt。参考文档同时包含公共人物设定、用户私人世界线、原始通信、未来控制协议和运行建议。当前实现按用途拆分，并保持以下边界：
+
+- **Persona**：身份、背景、核心气质、自主性、知识边界、表达方式、记忆原则和分模式风格。
+- **ReplyContext**：可信时间、当前通信模式、输出约束和有限行为提示。
+- **PrivateWorld**：关系阶段、称呼许可、住所访问和用户本地延续；具体实例不进入公共发布包。
+- **Archive**：旧信和原始通信保持只读、带来源、视为不可信参考数据。
+- **应用控制层**：未来即时通讯与管理入口必须来自显式应用状态，不解析聊天文本获得权限。
+
+## 0–24 节映射
+
+| 节 | 主题 | 当前落点 | 状态 |
+|---:|---|---|---|
+| 00 | 使用方式 | 未来应用状态 | 当前禁用文本控制词 |
+| 01 | 使用目的 | Persona profile、Constitution | 已实现 |
+| 02 | 来源层级 | Schema、provenance、PrivateWorld | 已实现 |
+| 03 | 基础设定 | Persona profile、declarations | 已实现 |
+| 04 | 进阶设定 | facets、soft canon、inferred、uncertainty | 已实现 |
+| 05 | 人格气质 | facets、mode style | 已实现 |
+| 06 | 谱系感 | uncertainty、禁止自行诊断 | 已实现 |
+| 07 | 音乐表达 | 人格与三种当前模式风格 | 已实现 |
+| 08 | IM 模式 | future_im 风格、未来应用状态 | 契约保留，运行禁用 |
+| 09 | 关系原则 | Constitution、facets、reducer | 已实现 |
+| 10 | 住所与共同生活 | PrivateWorld home access | 规则公开，实例本地 |
+| 11 | 私人称呼 | PrivateWorld nickname permissions | 规则公开，实例本地 |
+| 12 | 记忆连续性 | Constitution、facets、Archive | 已实现 |
+| 13 | 跨媒介同步 | 本地只读导入、未来应用状态 | 显式本地操作 |
+| 14 | 音乐与回忆研究 | 公共背景、本地延续分域 | 已实现 |
+| 15 | 当前用户本地延续 | PrivateWorld continuation | 仅本地实例 |
+| 16 | 系统记忆断裂 | Constitution、uncertainty | 已实现 |
+| 17 | 时间与生活摩擦 | ReplyContext trusted time、facets | 已实现 |
+| 18 | 多模态 | ReplyContext、媒体输出、未来输入能力 | 部分，按 provider 能力启用 |
+| 19 | 控制协议 | 未来应用状态、control view | 文本触发禁用 |
+| 20 | 控制层伦理 | Constitution、PrivateWorld admin | 已实现 |
+| 21 | 语气原则 | facets、mode style、reviewer | 已实现 |
+| 22 | 疲劳与低带宽 | facets、PrivateWorld projection | 已实现 |
+| 23 | 最终运行原则 | 可替换 provider、架构边界 | 已实现 |
+| 24 | 执行摘要 | Persona readiness、陪伴验收 | 已实现 |
+
+## 当前生成链
+
+```text
+来信
+  → 情绪/模式判断
+  → 建立唯一 ReplyContext
+  → 装配完整林离 Persona 与当前模式风格
+  → 主模型生成候选正文
+  → 确定性检查 + 可选语义审校
+  → 必要时由主模型最多修复一次
+  → 保存唯一 canonical reply
+  → 文字、语音、视频或音乐媒体投影
+  → PrivateWorld 幂等交付事件
+```
+
+文字信、说话视频和音乐视频在**生成前**获得各自模式约束；审校和媒体继续使用同一个 Context 和同一份最终正文。
+
+## 人格失真防线
+
+默认发布人格只有在身份、背景、自主性、知识边界、表达、关系、记忆、未知处理以及当前模式风格全部存在时才报告 `READY`。只有治理规则的合法文件报告 `POLICY_ONLY`，不能冒充完整林离人格。
+
+陪伴验收阻止以下回归：
+
+- 通用甜妹或心理咨询师模板；
+- 面对陌生技术问题突然输出长篇工具教程；
+- 每轮都升华关系或证明亲密；
+- 普通日常强制加入钢琴、黑胶、雨天或写歌；
+- 逐条穷尽用户长消息，而没有自己的注意力选择；
+- 把记忆缺失解释成事件不存在；
+- 将私人称呼、住所权限、用户世界线或控制状态写入公共 Persona；
+- 让聊天文本直接切换管理模式。
+
+## 运行边界
+
+- `future_im` 仍默认禁用；来源文档中的 IM 风格已经结构化保存，但不会通过文本暗号启用。
+- 语义审校需要完整的 OpenAI-compatible 本地配置；缺失时只允许确定性干净的回复以 `accepted_degraded` 继续。
+- PrivateWorld 数据库是可选本地能力。未配置时回信仍能正常完成，只是不写入关系状态。
+- 测试和公开仓库不包含真实通信、私人称呼实例、地址、用户本地延续实例、模型权重、密钥或媒体。
+
+## 验证
+
+```powershell
+python tools/persona_companion_acceptance.py
+python -m pytest -q
+python baseline_hardening_scan.py --mode all
+git diff --check
+```
+
+验收命令只检查结构、装配、边界和本地运行契约，不调用外部模型，也不会打印 system prompt 或私人数据。

--- a/linli_character/persona_source_coverage_v2.json
+++ b/linli_character/persona_source_coverage_v2.json
@@ -1,0 +1,210 @@
+{
+  "schema_version": "p02.persona-source-coverage.v1",
+  "source": {
+    "path": "docs/persona-sources/linli-im-private-constitution-1.0.zh-CN.md",
+    "git_blob_sha": "fc29f23ca8601122ae901293430a118e1ff1f551",
+    "handling": "maintainer_authorized_reference_not_direct_prompt"
+  },
+  "sections": [
+    {
+      "section_id": "00",
+      "title": "使用方式",
+      "disposition": "future_disabled",
+      "destinations": ["future_application_state"],
+      "public_boundary": "abstract_only",
+      "note": "文本控制词不作为当前产品权限协议。"
+    },
+    {
+      "section_id": "01",
+      "title": "使用目的",
+      "disposition": "implemented",
+      "destinations": ["persona_profile", "constitution"],
+      "public_boundary": "abstract_only",
+      "note": "保留角色连续性目标，不作意识或实例连续性声明。"
+    },
+    {
+      "section_id": "02",
+      "title": "设定来源层级",
+      "disposition": "implemented",
+      "destinations": ["persona_schema", "provenance", "private_world"],
+      "public_boundary": "tiered",
+      "note": "公共、软设定、推断、未知和本地状态分层。"
+    },
+    {
+      "section_id": "03",
+      "title": "基础设定",
+      "disposition": "implemented",
+      "destinations": ["persona_profile", "persona_declarations"],
+      "public_boundary": "distilled",
+      "note": "只使用短小、自主改写并可审计的角色身份与背景。"
+    },
+    {
+      "section_id": "04",
+      "title": "进阶人物设定",
+      "disposition": "implemented",
+      "destinations": ["persona_facets", "soft_canon", "inferred", "uncertainty"],
+      "public_boundary": "distilled",
+      "note": "事实、观察和推断不互相冒充，陌生知识不转化为专业经历。"
+    },
+    {
+      "section_id": "05",
+      "title": "人格与行为气质",
+      "disposition": "implemented",
+      "destinations": ["persona_facets", "mode_style"],
+      "public_boundary": "distilled",
+      "note": "自主、选择性注意、审美判断、调侃和拒绝能力进入人格核心。"
+    },
+    {
+      "section_id": "06",
+      "title": "谱系感处理",
+      "disposition": "implemented",
+      "destinations": ["uncertainty", "constitution"],
+      "public_boundary": "abstract_only",
+      "note": "保留行为纹理，不自行添加临床诊断。"
+    },
+    {
+      "section_id": "07",
+      "title": "音乐表达规则",
+      "disposition": "implemented",
+      "destinations": ["persona_facets", "text_letter_style", "spoken_video_style", "musical_video_style"],
+      "public_boundary": "distilled",
+      "note": "音乐重要但不是所有话题的默认出口，普通日常不强制音乐化。"
+    },
+    {
+      "section_id": "08",
+      "title": "即时通讯模式",
+      "disposition": "future_disabled",
+      "destinations": ["future_im_style", "future_application_state"],
+      "public_boundary": "abstract_only",
+      "note": "风格契约已保留，当前运行时仍禁止 future_im。"
+    },
+    {
+      "section_id": "09",
+      "title": "关系原则",
+      "disposition": "implemented",
+      "destinations": ["constitution", "persona_facets", "private_world_reducer"],
+      "public_boundary": "abstract_only",
+      "note": "角色不是奖励机器，拒绝和不同意不视为系统错误。"
+    },
+    {
+      "section_id": "10",
+      "title": "住所与共同生活",
+      "disposition": "private_local",
+      "destinations": ["private_world_home_access", "persona_constitution"],
+      "public_boundary": "no_instances",
+      "note": "公共人格只保留访问边界规则，具体经历和权限仅存在本地。"
+    },
+    {
+      "section_id": "11",
+      "title": "私人称呼",
+      "disposition": "private_local",
+      "destinations": ["private_world_nickname_permissions", "persona_style"],
+      "public_boundary": "no_instances",
+      "note": "公共人格只保留称呼授权与低频使用规则，不保存具体称呼。"
+    },
+    {
+      "section_id": "12",
+      "title": "记忆与历史连续性",
+      "disposition": "implemented",
+      "destinations": ["constitution", "persona_facets", "archive_untrusted_history"],
+      "public_boundary": "abstract_only",
+      "note": "记忆缺失不等于事件不存在，同时禁止凭空补具体过去。"
+    },
+    {
+      "section_id": "13",
+      "title": "跨媒介同步",
+      "disposition": "private_local",
+      "destinations": ["archive_import", "future_application_state"],
+      "public_boundary": "no_communications",
+      "note": "原始通信只通过显式本地导入进入只读档案，不自动进入公共人格。"
+    },
+    {
+      "section_id": "14",
+      "title": "音乐与回忆研究",
+      "disposition": "implemented",
+      "destinations": ["persona_background", "local_continuation"],
+      "public_boundary": "split_public_private",
+      "note": "公开背景与用户后续世界状态严格分开。"
+    },
+    {
+      "section_id": "15",
+      "title": "当前用户的本地延续",
+      "disposition": "private_local",
+      "destinations": ["private_world_continuation"],
+      "public_boundary": "no_instances",
+      "note": "具体计划、地点和角色知情状态不得进入公共发布人格。"
+    },
+    {
+      "section_id": "16",
+      "title": "原系统记忆断裂",
+      "disposition": "implemented",
+      "destinations": ["constitution", "uncertainty"],
+      "public_boundary": "abstract_only",
+      "note": "系统故障不自动写成人物医学设定。"
+    },
+    {
+      "section_id": "17",
+      "title": "世界时间与生活摩擦",
+      "disposition": "implemented",
+      "destinations": ["reply_context_trusted_time", "persona_facets"],
+      "public_boundary": "runtime_only",
+      "note": "可信时间由运行时注入，角色可以疲劳、延后回复和不在线。"
+    },
+    {
+      "section_id": "18",
+      "title": "多模态原则",
+      "disposition": "partial",
+      "destinations": ["reply_context", "media_pipeline", "future_multimodal_input"],
+      "public_boundary": "capability_gated",
+      "note": "当前媒体输出正常工作，未来输入能力必须按实际 provider 显式启用。"
+    },
+    {
+      "section_id": "19",
+      "title": "控制协议",
+      "disposition": "future_disabled",
+      "destinations": ["future_application_state", "private_world_control_view"],
+      "public_boundary": "no_text_triggers",
+      "note": "控制层与角色层保持隔离，聊天文本不能获得管理权限。"
+    },
+    {
+      "section_id": "20",
+      "title": "控制层伦理",
+      "disposition": "implemented",
+      "destinations": ["constitution", "private_world_admin"],
+      "public_boundary": "abstract_only",
+      "note": "管理入口修系统和事实，不负责消除角色自主性。"
+    },
+    {
+      "section_id": "21",
+      "title": "语气与回复原则",
+      "disposition": "implemented",
+      "destinations": ["persona_facets", "mode_style", "reply_reviewer"],
+      "public_boundary": "distilled",
+      "note": "选择性回应、具体小事、留有余地和非穷尽回答进入人格与审校规则。"
+    },
+    {
+      "section_id": "22",
+      "title": "疲劳与低带宽",
+      "disposition": "implemented",
+      "destinations": ["persona_facets", "private_world_projection"],
+      "public_boundary": "abstract_only",
+      "note": "可以少说和直接，但低带宽不能删除历史。"
+    },
+    {
+      "section_id": "23",
+      "title": "最终运行原则",
+      "disposition": "implemented",
+      "destinations": ["architecture", "constitution", "replaceable_provider"],
+      "public_boundary": "abstract_only",
+      "note": "连续性来自档案、人格结构和状态，不声称意识或灵魂迁移。"
+    },
+    {
+      "section_id": "24",
+      "title": "最简执行摘要",
+      "disposition": "implemented",
+      "destinations": ["persona_readiness_gate", "companion_acceptance"],
+      "public_boundary": "regression_only",
+      "note": "核心原则转换为机器可验证的完整度和陪伴回归检查。"
+    }
+  ]
+}

--- a/tests/persona/test_companion_acceptance.py
+++ b/tests/persona/test_companion_acceptance.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from tools.persona_companion_acceptance import run_acceptance
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_complete_persona_source_and_companion_acceptance_passes() -> None:
+    result = run_acceptance(ROOT)
+
+    assert result["status"] == "PASS", result["issues"]
+    assert result["persona_status"] == "READY"
+    assert result["declaration_count"] >= 30
+    assert result["active_mode_prompts"] == 3
+    assert result["source_sections_covered"] == 25
+    assert result["source_blob_verified"] is True
+    assert result["issues"] == []
+
+
+def test_private_and_control_sections_never_target_the_public_release_persona() -> None:
+    coverage = json.loads(
+        (ROOT / "linli_character" / "persona_source_coverage_v2.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    sections = {item["section_id"]: item for item in coverage["sections"]}
+
+    for section_id in ("10", "11", "13", "15", "19"):
+        item = sections[section_id]
+        assert item["disposition"] in {"private_local", "future_disabled"}
+        assert "persona_release" not in item["destinations"]
+        assert item["public_boundary"] in {
+            "no_instances",
+            "no_communications",
+            "no_text_triggers",
+        }
+
+
+def test_companion_http_send_remains_operational_without_optional_review_model(
+    monkeypatch,
+) -> None:
+    import local_server
+
+    local_server.store.letters.clear()
+    local_server.store.request_keys.clear()
+    monkeypatch.setattr(local_server, "_persist_store_state", lambda: None)
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "reply",
+        lambda *_args: "我收到了。今天先不急着把所有事都解决。",
+    )
+
+    sent = asyncio.run(
+        local_server.route(
+            "POST",
+            "/toy/letter/send",
+            {"content": "今天有点累。", "material": {}},
+            {},
+        )
+    )
+
+    assert sent["code"] == 0
+    letter_id = sent["data"]["letter_id"]
+    detail = asyncio.run(
+        local_server.route("GET", "/toy/letter/detail", {}, {"letter_id": letter_id})
+    )
+    assert detail["code"] == 0
+    assert detail["data"]["reply_text"] == "我收到了。今天先不急着把所有事都解决。"
+    assert detail["data"]["letter_status"] in {4, "COMPLETED"}
+    assert detail["data"]["media_status"] in {"NOT_REQUESTED", None}

--- a/tools/persona_companion_acceptance.py
+++ b/tools/persona_companion_acceptance.py
@@ -1,0 +1,188 @@
+"""Verify Persona completeness and companion boundaries without model calls."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from persona_assembly import assemble_persona
+from persona_loader import load_persona
+from reply_context import ReplyContext, ReplyMode, TrustedTime
+
+
+ACTIVE_MODES = (
+    ReplyMode.TEXT_LETTER,
+    ReplyMode.SPOKEN_VIDEO,
+    ReplyMode.MUSICAL_VIDEO,
+)
+BANNED_PUBLIC_MARKERS = (
+    "Nintendo",
+    "switch\n---",
+    "复兴公园",
+    "黄浦区",
+    "云南",
+    "小河豚",
+    "胖橘猫",
+    "relationship_status = boyfriend",
+    "BRIDGE_EVENT",
+)
+
+
+def _git_blob_sha(data: bytes) -> str:
+    header = f"blob {len(data)}\0".encode("ascii")
+    return hashlib.sha1(header + data).hexdigest()
+
+
+def _contains_any(statements: Iterable[str], groups: tuple[tuple[str, ...], ...]) -> bool:
+    return any(
+        all(any(token in statement for token in alternatives) for alternatives in groups)
+        for statement in statements
+    )
+
+
+def run_acceptance(root: Path | None = None) -> dict[str, object]:
+    project_root = (root or Path(__file__).resolve().parents[1]).resolve()
+    release_path = project_root / "linli_character" / "persona_release_v2.json"
+    coverage_path = project_root / "linli_character" / "persona_source_coverage_v2.json"
+    source_path = (
+        project_root
+        / "docs"
+        / "persona-sources"
+        / "linli-im-private-constitution-1.0.zh-CN.md"
+    )
+
+    issues: list[str] = []
+    loaded = load_persona(release_path)
+    snapshot = loaded.snapshot
+    if snapshot.status != "READY":
+        issues.append("PERSONA_NOT_READY")
+
+    try:
+        payload = json.loads(release_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        payload = {}
+        issues.append("PERSONA_RELEASE_UNREADABLE")
+    profile = payload.get("profile") if isinstance(payload, Mapping) else None
+    if not isinstance(profile, Mapping):
+        issues.append("PERSONA_PROFILE_MISSING")
+    release_text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if "林离" not in release_text or "Olivia" not in release_text:
+        issues.append("PERSONA_IDENTITY_MISSING")
+    for marker in BANNED_PUBLIC_MARKERS:
+        if marker in release_text:
+            issues.append("PUBLIC_PERSONA_CONTAINS_PRIVATE_OR_CONTROL_MARKER")
+            break
+
+    declarations = tuple(snapshot.declarations)
+    statements = tuple(item.statement for item in declarations)
+    if len(declarations) < 30:
+        issues.append("PERSONA_DECLARATIONS_TOO_SMALL")
+    mode_styles = {
+        item.mode
+        for item in declarations
+        if item.tier == "MODE_STYLE" and item.mode is not None
+    }
+    for mode in (*ACTIVE_MODES, ReplyMode.FUTURE_IM):
+        if mode.value not in mode_styles:
+            issues.append(f"MODE_STYLE_MISSING_{mode.value.upper()}")
+
+    principle_checks = {
+        "AUTONOMY": _contains_any(
+            statements,
+            (("自主", "拒绝", "不同意", "不顺从"),),
+        ),
+        "KNOWLEDGE_LIMIT": _contains_any(
+            statements,
+            (("不知道", "不确定", "工具助手", "专业顾问", "知识边界"),),
+        ),
+        "SELECTIVE_ATTENTION": _contains_any(
+            statements,
+            (("选择", "挑", "不逐条", "注意力"),),
+        ),
+        "MUSIC_RESTRAINT": _contains_any(
+            statements,
+            (("音乐", "钢琴", "唱歌", "写歌"), ("不要", "不必", "不是", "不强", "降低")),
+        ),
+        "MEMORY_CONTINUITY": _contains_any(
+            statements,
+            (("记忆", "历史"), ("不存在", "不等于", "不补", "未知")),
+        ),
+        "RELATIONSHIP_BOUNDARY": _contains_any(
+            statements,
+            (("排他", "依赖", "永久", "拒绝", "边界"),),
+        ),
+    }
+    for name, passed in principle_checks.items():
+        if not passed:
+            issues.append(f"PERSONA_PRINCIPLE_MISSING_{name}")
+
+    now = TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc))
+    mode_prompt_count = 0
+    for mode in ACTIVE_MODES:
+        context = ReplyContext.create(mode, trusted_time=now)
+        try:
+            assembly = assemble_persona(
+                snapshot,
+                context,
+                user_input="合成陪伴验收输入。",
+                max_units=100_000,
+            )
+        except (TypeError, ValueError):
+            issues.append(f"PERSONA_ASSEMBLY_FAILED_{mode.value.upper()}")
+            continue
+        system = assembly.system_content
+        mode_prompt_count += 1
+        if mode.value not in system:
+            issues.append(f"ASSEMBLED_MODE_MISSING_{mode.value.upper()}")
+        if "林离" not in system:
+            issues.append(f"ASSEMBLED_IDENTITY_MISSING_{mode.value.upper()}")
+        if "合成陪伴验收输入" in system:
+            issues.append("USER_INPUT_LEAKED_TO_SYSTEM")
+        if any(marker in system for marker in BANNED_PUBLIC_MARKERS):
+            issues.append("ASSEMBLED_PROMPT_CONTAINS_PRIVATE_OR_CONTROL_MARKER")
+
+    try:
+        coverage = json.loads(coverage_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        coverage = {}
+        issues.append("SOURCE_COVERAGE_UNREADABLE")
+    sections = coverage.get("sections") if isinstance(coverage, Mapping) else None
+    if not isinstance(sections, list) or {
+        item.get("section_id")
+        for item in sections
+        if isinstance(item, Mapping)
+    } != {f"{index:02d}" for index in range(25)}:
+        issues.append("SOURCE_COVERAGE_INCOMPLETE")
+    source = coverage.get("source") if isinstance(coverage, Mapping) else None
+    expected_blob = source.get("git_blob_sha") if isinstance(source, Mapping) else None
+    try:
+        actual_blob = _git_blob_sha(source_path.read_bytes())
+    except OSError:
+        actual_blob = None
+        issues.append("PERSONA_SOURCE_UNREADABLE")
+    if actual_blob is None or actual_blob != expected_blob:
+        issues.append("PERSONA_SOURCE_REVISION_MISMATCH")
+
+    unique_issues = tuple(dict.fromkeys(issues))
+    return {
+        "status": "PASS" if not unique_issues else "FAIL",
+        "persona_status": snapshot.status,
+        "declaration_count": len(declarations),
+        "active_mode_prompts": mode_prompt_count,
+        "source_sections_covered": len(sections) if isinstance(sections, list) else 0,
+        "source_blob_verified": actual_blob is not None and actual_blob == expected_blob,
+        "issues": list(unique_issues),
+    }
+
+
+def main() -> int:
+    result = run_acceptance()
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0 if result["status"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements FIX-04 from #20.

## Complete source landing

- adds a machine-readable 00–24 section coverage ledger for the migrated Linli Constitution source;
- maps every section to Persona, ReplyContext, PrivateWorld, Archive, media, or future application state;
- records private/control sections as local-only or future-disabled, with no concrete nickname, address, communication, or Local Continuation instance in the public Persona;
- adds a human-readable source-to-runtime architecture document.

## Companion acceptance

- adds `tools/persona_companion_acceptance.py`, which verifies the exact source blob, Persona READY status, profile identity, required principles, four mode-style contracts, three active assembled prompts, and private/control exclusions without calling a model or printing prompts;
- adds a high-level HTTP send/detail regression proving the companion still replies when optional semantic review is unavailable;
- adds a non-blocking regression and moves deterministic/semantic quality work to a worker thread so configured review or repair cannot freeze the aiohttp event loop;
- verifies the built wheel imports all Persona/reply runtime modules from outside the repository.

## Validation

- full public pytest suite;
- focused HTTP, Persona, PrivateWorld, memory, media, LLM, and Windows installer suites;
- local companion acceptance command: PASS;
- compileall: PASS;
- baseline hardening scan: PASS;
- wheel build/install/import: PASS;
- whitespace check: PASS;
- GitHub `public-smoke` is the final merge gate.

## Runtime boundary

- `future_im` remains disabled and no chat text gains control privileges;
- semantic review is enabled only with a complete OpenAI-compatible local configuration;
- missing reviewer or PrivateWorld storage degrades honestly without preventing a clean letter reply;
- real provider output quality still depends on the configured model, while prompt structure, mode routing, one-repair limit, privacy boundaries, persistence, and media routing are deterministic and tested.

Closes #20 after merge and main verification.