### PR TITLE
feat(music): define strict semantic song plan contract

### DIFF
--- a/song_content.py
+++ b/song_content.py
@@ -6,10 +6,98 @@ import asyncio
 import json
 import re
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
+from typing import Mapping
 
 from llm_gateway import Gateway, create_gateway, load_gateway_config
 from music_duration import normalize_music_duration
+
+
+SONG_SEMANTIC_PLAN_SCHEMA_VERSION = "p03.song-semantic-plan.v1"
+
+
+class SongEmotionArc(StrEnum):
+    QUIET_LONGING = "quiet_longing"
+    GENTLE_REASSURANCE = "gentle_reassurance"
+    RESTRAINED_SADNESS = "restrained_sadness"
+    WARM_GRATITUDE = "warm_gratitude"
+    SOFT_RECONCILIATION = "soft_reconciliation"
+    CALM_AFFECTION = "calm_affection"
+
+
+class PianoTexture(StrEnum):
+    TRANSPARENT_BROKEN_CHORDS = "transparent_broken_chords"
+    LYRICAL_ARPEGGIOS = "lyrical_arpeggios"
+    MEASURED_CHORDAL_VOICING = "measured_chordal_voicing"
+    SPARSE_COUNTERLINE = "sparse_counterline"
+
+
+class VocalDelivery(StrEnum):
+    CLEAR_LEGATO = "clear_legato"
+    GENTLE_NARRATIVE = "gentle_narrative"
+    QUIET_SONGFUL = "quiet_songful"
+    CONTAINED_INTIMATE = "contained_intimate"
+
+
+class SongDynamicArc(StrEnum):
+    SOFT_GENTLE_RISE_SETTLE = "soft_gentle_rise_settle"
+    SOFT_STEADY_SETTLE = "soft_steady_settle"
+    QUIET_GRADUAL_WARMTH = "quiet_gradual_warmth"
+
+
+class SongEnding(StrEnum):
+    COMPLETE_SOFT_CADENCE = "complete_soft_cadence"
+    LINGERING_PIANO_CADENCE = "lingering_piano_cadence"
+    SHORT_SETTLED_CADENCE = "short_settled_cadence"
+
+
+@dataclass(frozen=True)
+class SongSemanticPlan:
+    """Typed, caption-free musical intent accepted from the planning model."""
+
+    emotion_arc: SongEmotionArc
+    piano_texture: PianoTexture
+    vocal_delivery: VocalDelivery
+    dynamic_arc: SongDynamicArc
+    ending: SongEnding
+    lyrics: str
+    duration_seconds: int
+    schema_version: str = SONG_SEMANTIC_PLAN_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        duration = normalize_music_duration(self.duration_seconds)
+        if self.schema_version != SONG_SEMANTIC_PLAN_SCHEMA_VERSION:
+            raise ValueError("SONG_SEMANTIC_PLAN_SCHEMA_UNSUPPORTED")
+        for field_name, enum_type in (
+            ("emotion_arc", SongEmotionArc),
+            ("piano_texture", PianoTexture),
+            ("vocal_delivery", VocalDelivery),
+            ("dynamic_arc", SongDynamicArc),
+            ("ending", SongEnding),
+        ):
+            if not isinstance(getattr(self, field_name), enum_type):
+                raise TypeError(
+                    f"SONG_SEMANTIC_PLAN_{field_name.upper()}_TYPE_INVALID"
+                )
+        object.__setattr__(self, "duration_seconds", duration)
+        object.__setattr__(
+            self,
+            "lyrics",
+            _validate_semantic_lyrics(self.lyrics, duration),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "emotion_arc": self.emotion_arc.value,
+            "piano_texture": self.piano_texture.value,
+            "vocal_delivery": self.vocal_delivery.value,
+            "dynamic_arc": self.dynamic_arc.value,
+            "ending": self.ending.value,
+            "lyrics": self.lyrics,
+            "duration_seconds": self.duration_seconds,
+        }
 
 
 @dataclass(frozen=True)
@@ -25,6 +113,126 @@ _TIMELINES = {
     118: "0-8 piano introduction; 8-50 first Verse; 50-56 piano Interlude; 56-104 second Verse; 104-118 resolved Outro",
 }
 _LINE_COUNTS = {90: 12, 118: 16}
+_SEMANTIC_PLAN_FIELDS = frozenset(
+    {
+        "schema_version",
+        "emotion_arc",
+        "piano_texture",
+        "vocal_delivery",
+        "dynamic_arc",
+        "ending",
+        "lyrics",
+    }
+)
+_SONG_TAGS = ("[Intro]", "[Verse]", "[Interlude]", "[Verse]", "[Outro]")
+_TAG_LINE = re.compile(r"^\[[A-Za-z][A-Za-z0-9_-]{0,31}\]$")
+_CJK = re.compile(r"[\u3400-\u9fff]")
+
+
+def _semantic_json_object(text: str) -> Mapping[str, object]:
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("SONG_SEMANTIC_PLAN_JSON_MISSING")
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        match = re.fullmatch(
+            r"```(?:json)?\s*(\{.*\})\s*```",
+            cleaned,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        if match is None:
+            raise ValueError("SONG_SEMANTIC_PLAN_JSON_INVALID")
+        cleaned = match.group(1).strip()
+    try:
+        value = json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        raise ValueError("SONG_SEMANTIC_PLAN_JSON_INVALID") from exc
+    if not isinstance(value, dict):
+        raise ValueError("SONG_SEMANTIC_PLAN_JSON_INVALID")
+    return value
+
+
+def _validate_semantic_lyrics(lyrics: str, duration_seconds: int) -> str:
+    if not isinstance(lyrics, str) or not lyrics.strip():
+        raise ValueError("SONG_SEMANTIC_PLAN_LYRICS_EMPTY")
+    if len(lyrics.encode("utf-8")) > 4096:
+        raise ValueError("SONG_SEMANTIC_PLAN_LYRICS_TOO_LARGE")
+    if any(
+        ord(character) < 32 and character not in {"\r", "\n"}
+        for character in lyrics
+    ):
+        raise ValueError("SONG_SEMANTIC_PLAN_LYRICS_CONTROL_CHARACTER")
+
+    normalized = lyrics.replace("\r\n", "\n").replace("\r", "\n")
+    lines = tuple(line.strip() for line in normalized.split("\n") if line.strip())
+    tags = tuple(line for line in lines if _TAG_LINE.fullmatch(line))
+    if tags != _SONG_TAGS:
+        raise ValueError("SONG_SEMANTIC_PLAN_LYRICS_TAGS_INVALID")
+
+    sections: list[tuple[str, list[str]]] = []
+    current_lines: list[str] | None = None
+    for line in lines:
+        if _TAG_LINE.fullmatch(line):
+            current_lines = []
+            sections.append((line, current_lines))
+            continue
+        if current_lines is None:
+            raise ValueError("SONG_SEMANTIC_PLAN_LYRICS_TAGS_INVALID")
+        current_lines.append(line)
+
+    if tuple(tag for tag, _section in sections) != _SONG_TAGS:
+        raise ValueError("SONG_SEMANTIC_PLAN_LYRICS_TAGS_INVALID")
+    if sections[0][1] or sections[2][1] or sections[4][1]:
+        raise ValueError("SONG_SEMANTIC_PLAN_LYRICS_NONVERSE_CONTENT")
+
+    expected_per_verse = _LINE_COUNTS[duration_seconds] // 2
+    verse_sections = (sections[1][1], sections[3][1])
+    if any(len(section) != expected_per_verse for section in verse_sections):
+        raise ValueError("SONG_SEMANTIC_PLAN_LYRICS_LINE_COUNT_INVALID")
+
+    for line in (*verse_sections[0], *verse_sections[1]):
+        compact = "".join(line.split())
+        if not 4 <= len(compact) <= 24:
+            raise ValueError("SONG_SEMANTIC_PLAN_LYRIC_LINE_LENGTH_INVALID")
+        if _CJK.search(line) is None:
+            raise ValueError("SONG_SEMANTIC_PLAN_LYRIC_LINE_LANGUAGE_INVALID")
+        if "[" in line or "]" in line:
+            raise ValueError("SONG_SEMANTIC_PLAN_LYRIC_LINE_INVALID")
+
+    canonical_lines: list[str] = []
+    for tag, section in sections:
+        canonical_lines.append(tag)
+        canonical_lines.extend(section)
+    return "\n".join(canonical_lines)
+
+
+def parse_song_semantic_plan(
+    text: str,
+    duration_seconds: int,
+) -> SongSemanticPlan:
+    """Parse one strict model JSON response into a typed semantic plan."""
+
+    duration = normalize_music_duration(duration_seconds)
+    value = _semantic_json_object(text)
+    if set(value) != _SEMANTIC_PLAN_FIELDS:
+        raise ValueError("SONG_SEMANTIC_PLAN_FIELDS_INVALID")
+    if any(not isinstance(value[field], str) for field in _SEMANTIC_PLAN_FIELDS):
+        raise ValueError("SONG_SEMANTIC_PLAN_FIELD_TYPE_INVALID")
+    if value["schema_version"] != SONG_SEMANTIC_PLAN_SCHEMA_VERSION:
+        raise ValueError("SONG_SEMANTIC_PLAN_SCHEMA_UNSUPPORTED")
+    try:
+        return SongSemanticPlan(
+            emotion_arc=SongEmotionArc(value["emotion_arc"]),
+            piano_texture=PianoTexture(value["piano_texture"]),
+            vocal_delivery=VocalDelivery(value["vocal_delivery"]),
+            dynamic_arc=SongDynamicArc(value["dynamic_arc"]),
+            ending=SongEnding(value["ending"]),
+            lyrics=value["lyrics"],
+            duration_seconds=duration,
+        )
+    except ValueError as exc:
+        if str(exc).startswith("SONG_SEMANTIC_PLAN_"):
+            raise
+        raise ValueError("SONG_SEMANTIC_PLAN_ENUM_INVALID") from exc
 
 
 def _system_prompt(duration_seconds: int) -> str:
@@ -130,4 +338,15 @@ def plan_song_content(
     return SongContentPlan(duration_seconds=duration_seconds, **raw)
 
 
-__all__ = ["SongContentPlan", "plan_song_content"]
+__all__ = [
+    "PianoTexture",
+    "SONG_SEMANTIC_PLAN_SCHEMA_VERSION",
+    "SongContentPlan",
+    "SongDynamicArc",
+    "SongEmotionArc",
+    "SongEnding",
+    "SongSemanticPlan",
+    "VocalDelivery",
+    "parse_song_semantic_plan",
+    "plan_song_content",
+]

--- a/tests/media/test_song_semantic_plan.py
+++ b/tests/media/test_song_semantic_plan.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from song_content import (
+    PianoTexture,
+    SONG_SEMANTIC_PLAN_SCHEMA_VERSION,
+    SongDynamicArc,
+    SongEmotionArc,
+    SongEnding,
+    SongSemanticPlan,
+    VocalDelivery,
+    parse_song_semantic_plan,
+)
+
+
+def _lyrics(duration: int) -> str:
+    per_verse = 6 if duration == 90 else 8
+    first = [f"第一段第{index}句轻轻落下" for index in range(1, per_verse + 1)]
+    second = [f"第二段第{index}句慢慢收好" for index in range(1, per_verse + 1)]
+    return "\n".join(
+        (
+            "[Intro]",
+            "[Verse]",
+            *first,
+            "[Interlude]",
+            "[Verse]",
+            *second,
+            "[Outro]",
+        )
+    )
+
+
+def _payload(duration: int = 90) -> dict[str, str]:
+    return {
+        "schema_version": SONG_SEMANTIC_PLAN_SCHEMA_VERSION,
+        "emotion_arc": "gentle_reassurance",
+        "piano_texture": "transparent_broken_chords",
+        "vocal_delivery": "clear_legato",
+        "dynamic_arc": "soft_gentle_rise_settle",
+        "ending": "complete_soft_cadence",
+        "lyrics": _lyrics(duration),
+    }
+
+
+@pytest.mark.parametrize("duration", [90, 118])
+def test_parse_song_semantic_plan_accepts_strict_plain_and_fenced_json(
+    duration: int,
+) -> None:
+    payload = _payload(duration)
+    plain = parse_song_semantic_plan(
+        json.dumps(payload, ensure_ascii=False),
+        duration,
+    )
+    fenced = parse_song_semantic_plan(
+        "```json\n" + json.dumps(payload, ensure_ascii=False) + "\n```",
+        duration,
+    )
+
+    assert plain == fenced
+    assert plain.duration_seconds == duration
+    assert plain.emotion_arc is SongEmotionArc.GENTLE_REASSURANCE
+    assert plain.piano_texture is PianoTexture.TRANSPARENT_BROKEN_CHORDS
+    assert plain.vocal_delivery is VocalDelivery.CLEAR_LEGATO
+    assert plain.dynamic_arc is SongDynamicArc.SOFT_GENTLE_RISE_SETTLE
+    assert plain.ending is SongEnding.COMPLETE_SOFT_CADENCE
+    assert plain.to_dict() == {**payload, "duration_seconds": duration}
+
+
+@pytest.mark.parametrize(
+    ("mutate", "error_code"),
+    [
+        (lambda value: value.pop("ending"), "SONG_SEMANTIC_PLAN_FIELDS_INVALID"),
+        (
+            lambda value: value.__setitem__("caption", "not allowed"),
+            "SONG_SEMANTIC_PLAN_FIELDS_INVALID",
+        ),
+        (
+            lambda value: value.__setitem__("emotion_arc", 7),
+            "SONG_SEMANTIC_PLAN_FIELD_TYPE_INVALID",
+        ),
+        (
+            lambda value: value.__setitem__("schema_version", "future"),
+            "SONG_SEMANTIC_PLAN_SCHEMA_UNSUPPORTED",
+        ),
+        (
+            lambda value: value.__setitem__("emotion_arc", "dramatic"),
+            "SONG_SEMANTIC_PLAN_ENUM_INVALID",
+        ),
+        (
+            lambda value: value.__setitem__("piano_texture", "full_orchestra"),
+            "SONG_SEMANTIC_PLAN_ENUM_INVALID",
+        ),
+    ],
+)
+def test_parse_song_semantic_plan_rejects_invalid_contract(
+    mutate,
+    error_code: str,
+) -> None:
+    payload = _payload()
+    mutate(payload)
+
+    with pytest.raises(ValueError, match=error_code):
+        parse_song_semantic_plan(json.dumps(payload, ensure_ascii=False), 90)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "[]",
+        "before " + json.dumps(_payload(), ensure_ascii=False),
+        json.dumps(_payload(), ensure_ascii=False) + " after",
+        "```json\n{}\n```\nextra",
+        "```python\n{}\n```",
+    ],
+)
+def test_parse_song_semantic_plan_rejects_missing_or_wrapped_non_json(
+    text: str,
+) -> None:
+    with pytest.raises(ValueError, match="SONG_SEMANTIC_PLAN_JSON_"):
+        parse_song_semantic_plan(text, 90)
+
+
+@pytest.mark.parametrize("duration", [0, 89, 91, 118.0, True])
+def test_parse_song_semantic_plan_reuses_product_duration_contract(duration) -> None:
+    with pytest.raises(ValueError, match="MUSIC_DURATION_INVALID"):
+        parse_song_semantic_plan(json.dumps(_payload(), ensure_ascii=False), duration)
+
+
+def test_semantic_lyrics_require_exact_empty_nonverse_sections() -> None:
+    payload = _payload()
+    payload["lyrics"] = payload["lyrics"].replace(
+        "[Intro]\n[Verse]",
+        "[Intro]\n钢琴先说一句\n[Verse]",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="SONG_SEMANTIC_PLAN_LYRICS_NONVERSE_CONTENT",
+    ):
+        parse_song_semantic_plan(json.dumps(payload, ensure_ascii=False), 90)
+
+
+def test_semantic_lyrics_require_balanced_verse_line_counts() -> None:
+    payload = _payload()
+    lines = payload["lyrics"].splitlines()
+    first_interlude = lines.index("[Interlude]")
+    moved = lines.pop(first_interlude - 1)
+    second_verse = lines.index("[Verse]", 2)
+    lines.insert(second_verse + 1, moved)
+    payload["lyrics"] = "\n".join(lines)
+
+    with pytest.raises(
+        ValueError,
+        match="SONG_SEMANTIC_PLAN_LYRICS_LINE_COUNT_INVALID",
+    ):
+        parse_song_semantic_plan(json.dumps(payload, ensure_ascii=False), 90)
+
+
+@pytest.mark.parametrize(
+    ("replacement", "error_code"),
+    [
+        ("啊", "SONG_SEMANTIC_PLAN_LYRIC_LINE_LENGTH_INVALID"),
+        ("plain english line", "SONG_SEMANTIC_PLAN_LYRIC_LINE_LANGUAGE_INVALID"),
+        ("这句[Bridge]不合法", "SONG_SEMANTIC_PLAN_LYRIC_LINE_INVALID"),
+        ("这句含有\t控制符", "SONG_SEMANTIC_PLAN_LYRICS_CONTROL_CHARACTER"),
+    ],
+)
+def test_semantic_lyrics_reject_invalid_line_content(
+    replacement: str,
+    error_code: str,
+) -> None:
+    payload = _payload()
+    payload["lyrics"] = payload["lyrics"].replace(
+        "第一段第1句轻轻落下",
+        replacement,
+    )
+
+    with pytest.raises(ValueError, match=error_code):
+        parse_song_semantic_plan(json.dumps(payload, ensure_ascii=False), 90)
+
+
+def test_song_semantic_plan_is_typed_and_caption_free() -> None:
+    plan = SongSemanticPlan(
+        emotion_arc=SongEmotionArc.CALM_AFFECTION,
+        piano_texture=PianoTexture.LYRICAL_ARPEGGIOS,
+        vocal_delivery=VocalDelivery.CONTAINED_INTIMATE,
+        dynamic_arc=SongDynamicArc.QUIET_GRADUAL_WARMTH,
+        ending=SongEnding.LINGERING_PIANO_CADENCE,
+        lyrics=_lyrics(118),
+        duration_seconds=118,
+    )
+
+    assert "caption" not in plan.to_dict()
+    with pytest.raises(TypeError, match="EMOTION_ARC_TYPE_INVALID"):
+        SongSemanticPlan(
+            emotion_arc="calm_affection",  # type: ignore[arg-type]
+            piano_texture=PianoTexture.LYRICAL_ARPEGGIOS,
+            vocal_delivery=VocalDelivery.CONTAINED_INTIMATE,
+            dynamic_arc=SongDynamicArc.QUIET_GRADUAL_WARMTH,
+            ending=SongEnding.LINGERING_PIANO_CADENCE,
+            lyrics=_lyrics(118),
+            duration_seconds=118,
+        )


### PR DESCRIPTION
Implements MUSIC-01 from #32.

## Changes

- adds a caption-free `SongSemanticPlan` contract with fixed schema version;
- constrains emotion arc, piano texture, vocal delivery, dynamic arc, and ending to audited enums;
- strictly parses one JSON object and rejects prose wrappers, missing/extra fields, implicit type coercion, unsupported schema versions, and unknown enum values;
- validates the 90/118-second lyric structure:
  - exact `[Intro] -> [Verse] -> [Interlude] -> [Verse] -> [Outro]` order;
  - non-verse sections remain empty;
  - both verses receive the exact balanced line count;
  - bounded, Chinese-containing lyric lines with no hidden control characters or embedded section tags;
- leaves the current production `SongContentPlan` and free-caption route unchanged. Production switches only in later MUSIC-03 after the positive caption renderer exists.

## Validation

- 26 focused contract tests passed locally;
- GitHub `Public smoke (Windows / Python 3.12)` is the required merge gate.

## Boundary

No MiniMax prompt, worker parameter, seed, video renderer, RoFormer, LatentSync, transition, or FFmpeg behavior changes in this PR.

Part of #32.