### PR TITLE
feat(music): render deterministic positive MiniMax captions

### DIFF
--- a/music_caption.py
+++ b/music_caption.py
@@ -1,0 +1,202 @@
+"""Deterministic positive-only MiniMax Music 3 caption rendering."""
+
+from __future__ import annotations
+
+import re
+
+from music_duration import normalize_music_duration
+from song_content import (
+    PianoTexture,
+    SongDynamicArc,
+    SongEmotionArc,
+    SongEnding,
+    SongSemanticPlan,
+    VocalDelivery,
+)
+
+
+MINIMAX_CAPTION_VERSION = "p03.minimax-caption.v1"
+
+_EMOTION = {
+    SongEmotionArc.QUIET_LONGING: (
+        "The emotional motion begins in quiet longing, opens slightly around "
+        "the middle, and settles with composure."
+    ),
+    SongEmotionArc.GENTLE_REASSURANCE: (
+        "The emotional motion begins with attentive tenderness, gains gentle "
+        "reassurance through the middle, and settles calmly."
+    ),
+    SongEmotionArc.RESTRAINED_SADNESS: (
+        "The emotional motion holds restrained sadness, gathers a little "
+        "weight through the middle, and returns to a settled close."
+    ),
+    SongEmotionArc.WARM_GRATITUDE: (
+        "The emotional motion begins with quiet appreciation, grows into warm "
+        "gratitude, and resolves with an unhurried sense of closeness."
+    ),
+    SongEmotionArc.SOFT_RECONCILIATION: (
+        "The emotional motion begins with careful distance, softens through "
+        "reconciliation, and reaches a calm, complete resolution."
+    ),
+    SongEmotionArc.CALM_AFFECTION: (
+        "The emotional motion carries calm affection from the opening, gains "
+        "gentle warmth in the middle, and settles into a tender close."
+    ),
+}
+
+_PIANO_TEXTURE = {
+    PianoTexture.TRANSPARENT_BROKEN_CHORDS: (
+        "The left hand establishes a simple low-register tonal foundation "
+        "while the right hand shapes transparent broken chords and brief "
+        "lyrical answers."
+    ),
+    PianoTexture.LYRICAL_ARPEGGIOS: (
+        "The left hand establishes measured tonal support while the right hand "
+        "unfolds lyrical arpeggios with clear phrase direction and open space."
+    ),
+    PianoTexture.MEASURED_CHORDAL_VOICING: (
+        "The piano uses measured chordal voicings, clear inner movement, and "
+        "well-spaced phrase endings to support the vocal melody."
+    ),
+    PianoTexture.SPARSE_COUNTERLINE: (
+        "The piano combines sustained voicings with a sparse lyrical "
+        "counterline, leaving deliberate space around each vocal phrase."
+    ),
+}
+
+_VOCAL = {
+    VocalDelivery.CLEAR_LEGATO: (
+        "One adult female Mandarin lead carries a clear centered melody with "
+        "natural diction, mostly syllabic legato phrasing, a moderate range, "
+        "and measured phrase endings."
+    ),
+    VocalDelivery.GENTLE_NARRATIVE: (
+        "One adult female Mandarin lead delivers a gentle narrative melody "
+        "with clear consonants, restrained sustained notes, conversational "
+        "pacing, and precise phrase endings."
+    ),
+    VocalDelivery.QUIET_SONGFUL: (
+        "One adult female Mandarin lead sings a quiet songful line with rounded "
+        "vowels, smooth sustained notes, steady melodic focus, and controlled "
+        "dynamic shaping."
+    ),
+    VocalDelivery.CONTAINED_INTIMATE: (
+        "One adult female Mandarin lead uses a contained intimate tone, close "
+        "phrasing, controlled dynamics, calm projection, and precise natural "
+        "diction."
+    ),
+}
+
+_DYNAMIC = {
+    SongDynamicArc.SOFT_GENTLE_RISE_SETTLE: (
+        "The performance begins softly, broadens through slightly fuller "
+        "voicing and note density near the middle, then returns to a soft "
+        "settled profile."
+    ),
+    SongDynamicArc.SOFT_STEADY_SETTLE: (
+        "The performance maintains a soft steady profile, using small changes "
+        "in register and voicing before easing into the closing phrase."
+    ),
+    SongDynamicArc.QUIET_GRADUAL_WARMTH: (
+        "The performance begins quietly, gains gradual warmth through fuller "
+        "voicing and longer resonance, then settles with restraint."
+    ),
+}
+
+_ENDING = {
+    SongEnding.COMPLETE_SOFT_CADENCE: (
+        "The final phrase resolves through a complete soft piano cadence."
+    ),
+    SongEnding.LINGERING_PIANO_CADENCE: (
+        "The final phrase resolves through a lingering piano cadence with "
+        "natural decay."
+    ),
+    SongEnding.SHORT_SETTLED_CADENCE: (
+        "The final phrase resolves through a short settled piano cadence."
+    ),
+}
+
+_TIMELINE = {
+    90: (
+        "0-8 seconds piano opening; 8-38 seconds first verse; 38-44 seconds "
+        "piano interlude; 44-78 seconds second verse; 78-90 seconds closing "
+        "cadence."
+    ),
+    118: (
+        "0-8 seconds piano opening; 8-50 seconds first verse; 50-56 seconds "
+        "piano interlude; 56-104 seconds second verse; 104-118 seconds closing "
+        "cadence."
+    ),
+}
+
+_HEADINGS = ("### Global Metadata", "### Vocal Details", "### Arrangement")
+_NEGATIVE_SYNTAX = re.compile(
+    r"\b(?:no|not|without|avoid|exclude|excluding|never|absence|lack)\b",
+    flags=re.IGNORECASE,
+)
+_DISALLOWED_TERMS = re.compile(
+    r"\b(?:"
+    r"r&b|rnb|neo[- ]?soul|soul|jazz|gospel|cinematic|heritage|folk|pop|"
+    r"electronic|ambient|orchestral|orchestra|groove|swing|syncopated|"
+    r"backbeat|melisma|riff|ad[- ]?lib|drums?|percussion|bass|guitars?|"
+    r"strings?|cello|violins?|synth(?:esizer)?s?|pads?|choir|guzheng|"
+    r"erhu|pipa|dizi|flute"
+    r")\b",
+    flags=re.IGNORECASE,
+)
+
+
+def validate_minimax_caption(caption: str, duration_seconds: int) -> str:
+    """Validate the rendered positive caption before it reaches MiniMax."""
+
+    duration = normalize_music_duration(duration_seconds)
+    if not isinstance(caption, str) or not caption.strip():
+        raise ValueError("MINIMAX_CAPTION_EMPTY")
+    normalized = caption.strip()
+    if len(normalized.encode("utf-8")) > 4096:
+        raise ValueError("MINIMAX_CAPTION_TOO_LARGE")
+    headings = tuple(re.findall(r"^### .+$", normalized, flags=re.MULTILINE))
+    if headings != _HEADINGS:
+        raise ValueError("MINIMAX_CAPTION_HEADINGS_INVALID")
+    required = (
+        f"{duration} seconds",
+        "68 BPM",
+        "B-flat major",
+        "straight 4/4",
+        "adult female Mandarin lead",
+        "one acoustic grand piano",
+    )
+    if any(token.casefold() not in normalized.casefold() for token in required):
+        raise ValueError("MINIMAX_CAPTION_REQUIRED_CONTENT_MISSING")
+    if _NEGATIVE_SYNTAX.search(normalized):
+        raise ValueError("MINIMAX_CAPTION_NEGATIVE_SYNTAX")
+    if _DISALLOWED_TERMS.search(normalized):
+        raise ValueError("MINIMAX_CAPTION_DISALLOWED_TERM")
+    if "[" in normalized or "]" in normalized:
+        raise ValueError("MINIMAX_CAPTION_LYRIC_TAG_LEAK")
+    if len(normalized.split()) > 300:
+        raise ValueError("MINIMAX_CAPTION_WORD_LIMIT")
+    return normalized
+
+
+def render_minimax_caption(plan: SongSemanticPlan) -> str:
+    """Render one deterministic caption from audited semantic enums."""
+
+    if not isinstance(plan, SongSemanticPlan):
+        raise TypeError("MINIMAX_CAPTION_PLAN_TYPE_INVALID")
+    caption = f"""### Global Metadata
+An intimate Mandarin vocal-and-acoustic-grand-piano lyrical song lasting {plan.duration_seconds} seconds at 68 BPM in B-flat major, straight 4/4. {_EMOTION[plan.emotion_arc]} The recording presents close, natural small-room acoustics, a transparent tonal balance, and a complete long-form shape.
+
+### Vocal Details
+{_VOCAL[plan.vocal_delivery]} The melodic delivery remains personal, restrained, and consistent across both verses.
+
+### Arrangement
+The complete instrumental arrangement is performed by one acoustic grand piano from the opening through the final cadence. {_PIANO_TEXTURE[plan.piano_texture]} {_DYNAMIC[plan.dynamic_arc]} Section timing: {_TIMELINE[plan.duration_seconds]} {_ENDING[plan.ending]}"""
+    return validate_minimax_caption(caption, plan.duration_seconds)
+
+
+__all__ = [
+    "MINIMAX_CAPTION_VERSION",
+    "render_minimax_caption",
+    "validate_minimax_caption",
+]

--- a/tests/media/test_music_caption.py
+++ b/tests/media/test_music_caption.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from itertools import product
+
+import pytest
+
+from music_caption import (
+    MINIMAX_CAPTION_VERSION,
+    render_minimax_caption,
+    validate_minimax_caption,
+)
+from song_content import (
+    PianoTexture,
+    SongDynamicArc,
+    SongEmotionArc,
+    SongEnding,
+    SongSemanticPlan,
+    VocalDelivery,
+)
+
+
+def _lyrics(duration: int, marker: str = "不会进入音乐描述") -> str:
+    per_verse = 6 if duration == 90 else 8
+    first = [f"第一段第{index}句轻轻落下" for index in range(1, per_verse + 1)]
+    first[0] = marker
+    second = [f"第二段第{index}句慢慢收好" for index in range(1, per_verse + 1)]
+    return "\n".join(
+        (
+            "[Intro]",
+            "[Verse]",
+            *first,
+            "[Interlude]",
+            "[Verse]",
+            *second,
+            "[Outro]",
+        )
+    )
+
+
+def _plan(
+    *,
+    duration: int = 90,
+    emotion: SongEmotionArc = SongEmotionArc.GENTLE_REASSURANCE,
+    texture: PianoTexture = PianoTexture.TRANSPARENT_BROKEN_CHORDS,
+    vocal: VocalDelivery = VocalDelivery.CLEAR_LEGATO,
+    dynamic: SongDynamicArc = SongDynamicArc.SOFT_GENTLE_RISE_SETTLE,
+    ending: SongEnding = SongEnding.COMPLETE_SOFT_CADENCE,
+) -> SongSemanticPlan:
+    return SongSemanticPlan(
+        emotion_arc=emotion,
+        piano_texture=texture,
+        vocal_delivery=vocal,
+        dynamic_arc=dynamic,
+        ending=ending,
+        lyrics=_lyrics(duration),
+        duration_seconds=duration,
+    )
+
+
+def test_caption_version_is_explicit() -> None:
+    assert MINIMAX_CAPTION_VERSION == "p03.minimax-caption.v1"
+
+
+@pytest.mark.parametrize("duration", [90, 118])
+def test_render_minimax_caption_is_deterministic_positive_and_caption_only(
+    duration: int,
+) -> None:
+    plan = _plan(duration=duration)
+    first = render_minimax_caption(plan)
+    second = render_minimax_caption(plan)
+
+    assert first == second
+    assert "### Global Metadata" in first
+    assert "### Vocal Details" in first
+    assert "### Arrangement" in first
+    assert f"{duration} seconds" in first
+    assert "one acoustic grand piano" in first.casefold()
+    assert "adult female Mandarin lead" in first
+    assert "不会进入音乐描述" not in first
+    assert "[Verse]" not in first
+    assert len(first.split()) <= 300
+
+
+def test_render_minimax_caption_snapshot() -> None:
+    caption = render_minimax_caption(_plan())
+    assert caption == """### Global Metadata
+An intimate Mandarin vocal-and-acoustic-grand-piano lyrical song lasting 90 seconds at 68 BPM in B-flat major, straight 4/4. The emotional motion begins with attentive tenderness, gains gentle reassurance through the middle, and settles calmly. The recording presents close, natural small-room acoustics, a transparent tonal balance, and a complete long-form shape.
+
+### Vocal Details
+One adult female Mandarin lead carries a clear centered melody with natural diction, mostly syllabic legato phrasing, a moderate range, and measured phrase endings. The melodic delivery remains personal, restrained, and consistent across both verses.
+
+### Arrangement
+The complete instrumental arrangement is performed by one acoustic grand piano from the opening through the final cadence. The left hand establishes a simple low-register tonal foundation while the right hand shapes transparent broken chords and brief lyrical answers. The performance begins softly, broadens through slightly fuller voicing and note density near the middle, then returns to a soft settled profile. Section timing: 0-8 seconds piano opening; 8-38 seconds first verse; 38-44 seconds piano interlude; 44-78 seconds second verse; 78-90 seconds closing cadence. The final phrase resolves through a complete soft piano cadence."""
+
+
+def test_all_audited_enum_combinations_render_and_validate() -> None:
+    for duration, emotion, texture, vocal, dynamic, ending in product(
+        (90, 118),
+        SongEmotionArc,
+        PianoTexture,
+        VocalDelivery,
+        SongDynamicArc,
+        SongEnding,
+    ):
+        caption = render_minimax_caption(
+            _plan(
+                duration=duration,
+                emotion=emotion,
+                texture=texture,
+                vocal=vocal,
+                dynamic=dynamic,
+                ending=ending,
+            )
+        )
+        assert validate_minimax_caption(caption, duration) == caption
+
+
+@pytest.mark.parametrize(
+    ("mutate", "error_code"),
+    [
+        (
+            lambda caption: caption.replace("### Arrangement", "### Production"),
+            "MINIMAX_CAPTION_HEADINGS_INVALID",
+        ),
+        (
+            lambda caption: caption.replace("68 BPM", "72 BPM"),
+            "MINIMAX_CAPTION_REQUIRED_CONTENT_MISSING",
+        ),
+        (
+            lambda caption: caption + "\nNo drums.",
+            "MINIMAX_CAPTION_NEGATIVE_SYNTAX",
+        ),
+        (
+            lambda caption: caption + "\nSoft strings enter.",
+            "MINIMAX_CAPTION_DISALLOWED_TERM",
+        ),
+        (
+            lambda caption: caption + "\n[Verse]",
+            "MINIMAX_CAPTION_LYRIC_TAG_LEAK",
+        ),
+    ],
+)
+def test_validate_minimax_caption_rejects_tampered_output(
+    mutate,
+    error_code: str,
+) -> None:
+    caption = render_minimax_caption(_plan())
+    with pytest.raises(ValueError, match=error_code):
+        validate_minimax_caption(mutate(caption), 90)
+
+
+def test_render_minimax_caption_requires_typed_plan() -> None:
+    with pytest.raises(TypeError, match="MINIMAX_CAPTION_PLAN_TYPE_INVALID"):
+        render_minimax_caption({})  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("duration", [0, 89, 91, 118.0, True])
+def test_validate_minimax_caption_reuses_product_duration_contract(duration) -> None:
+    with pytest.raises(ValueError, match="MUSIC_DURATION_INVALID"):
+        validate_minimax_caption(render_minimax_caption(_plan()), duration)


### PR DESCRIPTION
Implements MUSIC-02 from #32.

## Changes

- adds `music_caption.py`, a deterministic renderer from typed `SongSemanticPlan` enums;
- produces exactly the official three-section shape:
  - `### Global Metadata`
  - `### Vocal Details`
  - `### Arrangement`
- fixes the musical identity to one adult female Mandarin lead and one acoustic grand piano;
- expresses emotional, piano-texture, vocal-delivery, dynamic, timing, and cadence changes only through audited positive fragments;
- never reads or paraphrases the plan's lyric text when creating the music description;
- validates the final caption before use:
  - exact headings and required positive content;
  - product duration contract;
  - no natural-language negative syntax;
  - no audited drift terms for R&B/Soul, broad genre routing, groove, extra voices, or extra instruments;
  - no lyric section-tag leakage;
  - bounded length.

## Validation

- all 1,728 enum/duration combinations render and validate;
- deterministic snapshot and tamper-rejection coverage;
- 42 focused MUSIC-01/MUSIC-02 tests passed locally;
- GitHub `Public smoke (Windows / Python 3.12)` is the required merge gate.

## Boundary

The production `plan_song_content()` path still uses the legacy free-caption plan. This PR only creates the fixed renderer; MUSIC-03 performs the explicit production switch. No worker parameters or video stages change.

Part of #32.