### PR TITLE
feat(music): add blind scoring and profile recommendations

### DIFF
--- a/music_calibration_scores.py
+++ b/music_calibration_scores.py
@@ -1,0 +1,368 @@
+"""Blind score capture, reveal, and recommendation for local music calibration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Mapping
+
+from music_calibration import MUSIC_CALIBRATION_SCHEMA_VERSION
+
+
+MUSIC_CALIBRATION_SCORE_SCHEMA_VERSION = "p03.music-calibration-score.v1"
+_BLIND_ID = re.compile(r"^sample-[0-9]{4}$")
+_VARIANT_SUFFIX = re.compile(r"-v[0-9]+$")
+_GOOD_FIELDS = (
+    "piano_carries_arrangement",
+    "mandarin_clarity",
+    "restrained_lyricism",
+    "emotion_match",
+    "lyrics_complete_and_singable",
+    "ending_complete",
+)
+_BAD_FIELDS = (
+    "extra_instruments_severity",
+    "rnb_soul_groove_severity",
+    "vocal_ornament_severity",
+)
+_SCORE_FIELDS = (*_GOOD_FIELDS, *_BAD_FIELDS)
+_HARD_FAIL_FIELDS = (
+    "lyrics_incomplete",
+    "abrupt_cut",
+    "file_corrupt",
+)
+
+
+class MusicCalibrationScoreError(RuntimeError):
+    """Stable local calibration state error."""
+
+
+@dataclass(frozen=True)
+class MusicCalibrationScore:
+    blind_id: str
+    piano_carries_arrangement: int
+    extra_instruments_severity: int
+    rnb_soul_groove_severity: int
+    vocal_ornament_severity: int
+    mandarin_clarity: int
+    restrained_lyricism: int
+    emotion_match: int
+    lyrics_complete_and_singable: int
+    ending_complete: int
+    lyrics_incomplete: bool = False
+    abrupt_cut: bool = False
+    file_corrupt: bool = False
+    notes: str = ""
+    schema_version: str = MUSIC_CALIBRATION_SCORE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != MUSIC_CALIBRATION_SCORE_SCHEMA_VERSION:
+            raise ValueError("MUSIC_CALIBRATION_SCORE_SCHEMA_UNSUPPORTED")
+        if not isinstance(self.blind_id, str) or not _BLIND_ID.fullmatch(self.blind_id):
+            raise ValueError("MUSIC_CALIBRATION_BLIND_ID_INVALID")
+        for field in _SCORE_FIELDS:
+            value = getattr(self, field)
+            if type(value) is not int or not 0 <= value <= 2:
+                raise ValueError("MUSIC_CALIBRATION_SCORE_VALUE_INVALID")
+        for field in _HARD_FAIL_FIELDS:
+            if type(getattr(self, field)) is not bool:
+                raise ValueError("MUSIC_CALIBRATION_HARD_FAIL_VALUE_INVALID")
+        if not isinstance(self.notes, str) or len(self.notes) > 500 or any(
+            ord(character) < 32 and character not in {"\n", "\t"}
+            for character in self.notes
+        ):
+            raise ValueError("MUSIC_CALIBRATION_SCORE_NOTES_INVALID")
+
+    @property
+    def hard_failed(self) -> bool:
+        return any(getattr(self, field) for field in _HARD_FAIL_FIELDS)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "blind_id": self.blind_id,
+            **{field: getattr(self, field) for field in _SCORE_FIELDS},
+            **{field: getattr(self, field) for field in _HARD_FAIL_FIELDS},
+            "notes": self.notes,
+        }
+
+
+def _load_json(path: Path, code: str) -> dict[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise MusicCalibrationScoreError(code) from exc
+    if not isinstance(value, dict):
+        raise MusicCalibrationScoreError(code)
+    return value
+
+
+def _atomic_json(path: Path, payload: object) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def _run_root(path: Path) -> Path:
+    root = Path(path).expanduser().resolve()
+    if not root.is_dir():
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_RUN_NOT_FOUND")
+    return root
+
+
+def _manifest(root: Path) -> dict[str, object]:
+    manifest = _load_json(
+        root / "manifest.json",
+        "MUSIC_CALIBRATION_MANIFEST_INVALID",
+    )
+    if manifest.get("schema_version") != MUSIC_CALIBRATION_SCHEMA_VERSION:
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_MANIFEST_INVALID")
+    jobs = manifest.get("jobs")
+    if not isinstance(jobs, list) or not jobs:
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_MANIFEST_INVALID")
+    return manifest
+
+
+def _job_index(manifest: Mapping[str, object]) -> dict[str, dict[str, object]]:
+    jobs = manifest.get("jobs")
+    if not isinstance(jobs, list):
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_MANIFEST_INVALID")
+    index: dict[str, dict[str, object]] = {}
+    for job in jobs:
+        if not isinstance(job, dict):
+            raise MusicCalibrationScoreError("MUSIC_CALIBRATION_MANIFEST_INVALID")
+        blind_id = job.get("blind_id")
+        if not isinstance(blind_id, str) or not _BLIND_ID.fullmatch(blind_id):
+            raise MusicCalibrationScoreError("MUSIC_CALIBRATION_MANIFEST_INVALID")
+        if blind_id in index:
+            raise MusicCalibrationScoreError("MUSIC_CALIBRATION_MANIFEST_INVALID")
+        index[blind_id] = job
+    return index
+
+
+def _load_scores(root: Path) -> dict[str, dict[str, object]]:
+    path = root / "scores.json"
+    if not path.exists():
+        return {}
+    payload = _load_json(path, "MUSIC_CALIBRATION_SCORES_INVALID")
+    if payload.get("schema_version") != MUSIC_CALIBRATION_SCORE_SCHEMA_VERSION:
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_SCORES_INVALID")
+    scores = payload.get("scores")
+    if not isinstance(scores, dict):
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_SCORES_INVALID")
+    return {str(key): value for key, value in scores.items() if isinstance(value, dict)}
+
+
+def submit_music_calibration_score(
+    run_root: Path,
+    score: MusicCalibrationScore,
+) -> bool:
+    """Store one blind score; identical retries are idempotent."""
+
+    if not isinstance(score, MusicCalibrationScore):
+        raise TypeError("MUSIC_CALIBRATION_TYPED_SCORE_REQUIRED")
+    root = _run_root(run_root)
+    if (root / "results.json").exists():
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_ALREADY_REVEALED")
+    manifest = _manifest(root)
+    jobs = _job_index(manifest)
+    job = jobs.get(score.blind_id)
+    if job is None:
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_SAMPLE_NOT_FOUND")
+    audio = job.get("audio")
+    if not isinstance(audio, str):
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_MANIFEST_INVALID")
+    audio_path = (root / audio).resolve()
+    if not audio_path.is_relative_to(root) or not audio_path.is_file() or audio_path.stat().st_size == 0:
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_AUDIO_NOT_READY")
+
+    scores = _load_scores(root)
+    encoded = score.to_dict()
+    current = scores.get(score.blind_id)
+    if current == encoded:
+        return False
+    scores[score.blind_id] = encoded
+    _atomic_json(
+        root / "scores.json",
+        {
+            "schema_version": MUSIC_CALIBRATION_SCORE_SCHEMA_VERSION,
+            "run_id": manifest.get("run_id"),
+            "scores": scores,
+        },
+    )
+    return True
+
+
+def music_calibration_progress(run_root: Path) -> dict[str, int | bool]:
+    root = _run_root(run_root)
+    jobs = _job_index(_manifest(root))
+    scores = _load_scores(root)
+    scored = sum(1 for blind_id in jobs if blind_id in scores)
+    return {
+        "total": len(jobs),
+        "scored": scored,
+        "remaining": len(jobs) - scored,
+        "ready_to_reveal": scored == len(jobs),
+    }
+
+
+def _request_digest(root: Path, job: Mapping[str, object]) -> str:
+    blind_id = job.get("blind_id")
+    request_path = (root / "requests" / f"{blind_id}.json").resolve()
+    if not request_path.is_relative_to(root) or not request_path.is_file():
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_REQUEST_TAMPERED")
+    try:
+        payload = json.loads(request_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_REQUEST_TAMPERED") from exc
+    return hashlib.sha256(
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _mean(rows: list[dict[str, object]], field: str) -> float:
+    return round(sum(int(row[field]) for row in rows) / len(rows), 4)
+
+
+def _summary(rows: list[dict[str, object]]) -> dict[str, object]:
+    means = {field: _mean(rows, field) for field in _SCORE_FIELDS}
+    hard_fail_count = sum(
+        1
+        for row in rows
+        if any(bool(row[field]) for field in _HARD_FAIL_FIELDS)
+    )
+    eligible = (
+        hard_fail_count == 0
+        and means["extra_instruments_severity"] <= 0.5
+        and means["rnb_soul_groove_severity"] <= 0.5
+        and all(means[field] >= 1.5 for field in _GOOD_FIELDS)
+    )
+    quality = round(
+        sum(means[field] for field in _GOOD_FIELDS)
+        - sum(means[field] for field in _BAD_FIELDS),
+        4,
+    )
+    return {
+        "sample_count": len(rows),
+        "means": means,
+        "hard_fail_count": hard_fail_count,
+        "eligible": eligible,
+        "quality_score": quality,
+    }
+
+
+def reveal_music_calibration_results(run_root: Path) -> dict[str, object]:
+    """Reveal profiles only after every blind sample has a score."""
+
+    root = _run_root(run_root)
+    existing = root / "results.json"
+    if existing.exists():
+        return _load_json(existing, "MUSIC_CALIBRATION_RESULTS_INVALID")
+    manifest = _manifest(root)
+    jobs = _job_index(manifest)
+    scores = _load_scores(root)
+    if set(scores) != set(jobs):
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_SCORING_INCOMPLETE")
+    private = _load_json(
+        root / "private-mapping.json",
+        "MUSIC_CALIBRATION_MAPPING_INVALID",
+    )
+    mapping = private.get("mapping")
+    if not isinstance(mapping, dict) or set(mapping) != set(jobs):
+        raise MusicCalibrationScoreError("MUSIC_CALIBRATION_MAPPING_INVALID")
+
+    revealed_rows: list[dict[str, object]] = []
+    by_profile: dict[str, list[dict[str, object]]] = {}
+    by_profile_seed: dict[str, list[dict[str, object]]] = {}
+    for blind_id, job in jobs.items():
+        mapped = mapping.get(blind_id)
+        if not isinstance(mapped, dict):
+            raise MusicCalibrationScoreError("MUSIC_CALIBRATION_MAPPING_INVALID")
+        if mapped.get("request_sha256") != _request_digest(root, job):
+            raise MusicCalibrationScoreError("MUSIC_CALIBRATION_REQUEST_TAMPERED")
+        profile = mapped.get("profile")
+        if not isinstance(profile, dict):
+            raise MusicCalibrationScoreError("MUSIC_CALIBRATION_MAPPING_INVALID")
+        name = profile.get("name")
+        seed = profile.get("seed")
+        if not isinstance(name, str) or type(seed) is not int:
+            raise MusicCalibrationScoreError("MUSIC_CALIBRATION_MAPPING_INVALID")
+        base_profile = _VARIANT_SUFFIX.sub("", name)
+        row = {
+            **scores[blind_id],
+            "case_id": job.get("case_id"),
+            "base_profile": base_profile,
+            "seed": seed,
+        }
+        revealed_rows.append(row)
+        by_profile.setdefault(base_profile, []).append(row)
+        by_profile_seed.setdefault(f"{base_profile}:{seed}", []).append(row)
+
+    profile_summary = {
+        key: _summary(rows)
+        for key, rows in sorted(by_profile.items())
+    }
+    seed_summary = {
+        key: _summary(rows)
+        for key, rows in sorted(by_profile_seed.items())
+    }
+    eligible_profiles = [
+        (name, data)
+        for name, data in profile_summary.items()
+        if data["eligible"]
+    ]
+    eligible_profiles.sort(
+        key=lambda item: (-float(item[1]["quality_score"]), item[0])
+    )
+    recommended_profile = eligible_profiles[0][0] if eligible_profiles else None
+    recommended_seeds: list[int] = []
+    if recommended_profile is not None:
+        candidates = [
+            (key, data)
+            for key, data in seed_summary.items()
+            if key.startswith(recommended_profile + ":") and data["eligible"]
+        ]
+        candidates.sort(
+            key=lambda item: (-float(item[1]["quality_score"]), item[0])
+        )
+        recommended_seeds = [int(key.rsplit(":", 1)[1]) for key, _ in candidates]
+
+    result = {
+        "schema_version": MUSIC_CALIBRATION_SCORE_SCHEMA_VERSION,
+        "run_id": manifest.get("run_id"),
+        "blinded": False,
+        "scored_count": len(revealed_rows),
+        "samples": revealed_rows,
+        "profile_summary": profile_summary,
+        "seed_summary": seed_summary,
+        "recommendation": {
+            "profile": recommended_profile,
+            "seeds": recommended_seeds,
+            "production_change_allowed": bool(
+                recommended_profile and recommended_seeds
+            ),
+        },
+    }
+    _atomic_json(existing, result)
+    return result
+
+
+__all__ = [
+    "MUSIC_CALIBRATION_SCORE_SCHEMA_VERSION",
+    "MusicCalibrationScore",
+    "MusicCalibrationScoreError",
+    "music_calibration_progress",
+    "reveal_music_calibration_results",
+    "submit_music_calibration_score",
+]

--- a/tests/media/test_music_calibration_scores.py
+++ b/tests/media/test_music_calibration_scores.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import music_calibration
+from music_calibration_scores import (
+    MusicCalibrationScore,
+    MusicCalibrationScoreError,
+    music_calibration_progress,
+    reveal_music_calibration_results,
+    submit_music_calibration_score,
+)
+
+
+def _score(
+    blind_id: str,
+    *,
+    good: bool = True,
+    hard_fail: bool = False,
+) -> MusicCalibrationScore:
+    return MusicCalibrationScore(
+        blind_id=blind_id,
+        piano_carries_arrangement=2 if good else 1,
+        extra_instruments_severity=0 if good else 2,
+        rnb_soul_groove_severity=0 if good else 2,
+        vocal_ornament_severity=0 if good else 2,
+        mandarin_clarity=2 if good else 1,
+        restrained_lyricism=2 if good else 1,
+        emotion_match=2 if good else 1,
+        lyrics_complete_and_singable=2 if good else 1,
+        ending_complete=2 if good else 1,
+        lyrics_incomplete=hard_fail,
+        notes="synthetic blind score",
+    )
+
+
+def _prepared_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(music_calibration, "_run_id", lambda: "music-score-run")
+    manifest = music_calibration.create_music_calibration_run(
+        tmp_path,
+        mode="quick",
+        seeds=(101,),
+    )
+    root = tmp_path / "music-score-run"
+    for job in manifest["jobs"]:
+        audio = root / job["audio"]
+        audio.parent.mkdir(parents=True, exist_ok=True)
+        audio.write_bytes(b"synthetic flac fixture")
+    return root
+
+
+def test_score_submission_is_idempotent_and_progress_is_blind(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _prepared_run(tmp_path, monkeypatch)
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    blind_id = manifest["jobs"][0]["blind_id"]
+    score = _score(blind_id)
+
+    assert submit_music_calibration_score(root, score) is True
+    assert submit_music_calibration_score(root, score) is False
+    progress = music_calibration_progress(root)
+    assert progress == {
+        "total": 4,
+        "scored": 1,
+        "remaining": 3,
+        "ready_to_reveal": False,
+    }
+    scores = json.loads((root / "scores.json").read_text(encoding="utf-8"))
+    assert "profile" not in json.dumps(scores).casefold()
+    assert "seed" not in json.dumps(scores).casefold()
+
+
+def test_score_requires_generated_audio(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(music_calibration, "_run_id", lambda: "music-no-audio")
+    manifest = music_calibration.create_music_calibration_run(
+        tmp_path,
+        mode="quick",
+        seeds=(101,),
+    )
+    root = tmp_path / "music-no-audio"
+    with pytest.raises(
+        MusicCalibrationScoreError,
+        match="MUSIC_CALIBRATION_AUDIO_NOT_READY",
+    ):
+        submit_music_calibration_score(
+            root,
+            _score(manifest["jobs"][0]["blind_id"]),
+        )
+
+
+def test_results_reveal_only_after_all_scores_and_recommend_eligible_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _prepared_run(tmp_path, monkeypatch)
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    mapping = json.loads(
+        (root / "private-mapping.json").read_text(encoding="utf-8")
+    )["mapping"]
+
+    first = manifest["jobs"][0]["blind_id"]
+    submit_music_calibration_score(root, _score(first))
+    with pytest.raises(
+        MusicCalibrationScoreError,
+        match="MUSIC_CALIBRATION_SCORING_INCOMPLETE",
+    ):
+        reveal_music_calibration_results(root)
+
+    for job in manifest["jobs"][1:]:
+        blind_id = job["blind_id"]
+        profile_name = mapping[blind_id]["profile"]["name"]
+        good = profile_name.startswith("official-comfy-1.7")
+        submit_music_calibration_score(root, _score(blind_id, good=good))
+    first_profile = mapping[first]["profile"]["name"]
+    replacement = _score(
+        first,
+        good=first_profile.startswith("official-comfy-1.7"),
+    )
+    submit_music_calibration_score(root, replacement)
+
+    result = reveal_music_calibration_results(root)
+    assert result["blinded"] is False
+    assert result["scored_count"] == 4
+    assert len(result["samples"]) == 4
+    assert result["recommendation"]["profile"] == "official-comfy-1.7"
+    assert result["recommendation"]["seeds"] == [101]
+    assert result["recommendation"]["production_change_allowed"] is True
+    assert reveal_music_calibration_results(root) == result
+
+
+def test_hard_failure_blocks_affected_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _prepared_run(tmp_path, monkeypatch)
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    for index, job in enumerate(manifest["jobs"]):
+        submit_music_calibration_score(
+            root,
+            _score(job["blind_id"], hard_fail=index == 0),
+        )
+    result = reveal_music_calibration_results(root)
+    assert any(
+        summary["hard_fail_count"] > 0
+        for summary in result["profile_summary"].values()
+    )
+
+
+def test_tampered_request_is_detected_before_reveal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _prepared_run(tmp_path, monkeypatch)
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    for job in manifest["jobs"]:
+        submit_music_calibration_score(root, _score(job["blind_id"]))
+    target = root / "requests" / f"{manifest['jobs'][0]['blind_id']}.json"
+    target.write_text("{}", encoding="utf-8")
+    with pytest.raises(
+        MusicCalibrationScoreError,
+        match="MUSIC_CALIBRATION_REQUEST_TAMPERED",
+    ):
+        reveal_music_calibration_results(root)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error_code"),
+    [
+        ("piano_carries_arrangement", 3, "MUSIC_CALIBRATION_SCORE_VALUE_INVALID"),
+        ("extra_instruments_severity", True, "MUSIC_CALIBRATION_SCORE_VALUE_INVALID"),
+        ("lyrics_incomplete", 1, "MUSIC_CALIBRATION_HARD_FAIL_VALUE_INVALID"),
+        ("notes", "x" * 501, "MUSIC_CALIBRATION_SCORE_NOTES_INVALID"),
+    ],
+)
+def test_score_contract_rejects_invalid_fields(
+    field: str,
+    value: object,
+    error_code: str,
+) -> None:
+    kwargs = _score("sample-0001").to_dict()
+    kwargs.pop("schema_version")
+    kwargs[field] = value
+    with pytest.raises(ValueError, match=error_code):
+        MusicCalibrationScore(**kwargs)


### PR DESCRIPTION
Completes the backend scoring half of MUSIC-05 from #32.

## Changes

- adds a strict 0–2 blind-listening score contract for piano coverage, extra instruments, R&B/Soul/groove drift, vocal ornamentation, Mandarin clarity, restrained lyricism, emotion fit, lyric completion, and ending completion;
- records explicit hard failures for incomplete lyrics, abrupt cuts, and corrupt files;
- requires a non-empty generated audio artifact before accepting a score;
- makes identical score retries idempotent while allowing corrections before reveal;
- keeps scores blind: profile names and seeds remain absent from `scores.json`;
- reveals mappings only after every sample is scored;
- verifies every request hash before reveal to detect modified captions, lyrics, or sampling parameters;
- aggregates by base profile and by profile/seed;
- applies the documented eligibility thresholds and emits a recommendation without mutating production configuration;
- persists sample-level revealed results and sanitized profile summaries for the future Control Center UI.

## Validation

- 84 focused MUSIC-01 through MUSIC-05B tests passed locally;
- covers incomplete scoring, idempotency, replacement before reveal, missing audio, tamper detection, hard failures, thresholds, and deterministic recommendations;
- GitHub `Public smoke (Windows / Python 3.12)` is the required merge gate.

## Boundary

This is a service layer, not an end-user CLI. CONTROL-05 will expose run creation, generation progress, audio playback, blind scoring, reveal, and selection through the local Companion Control Center. A recommendation does not become production configuration until MUSIC-07 and real local evidence.

Part of #32 and #35.