### PR TITLE
feat(private-world): default local storage and versioned ledger

### DIFF
--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -105,6 +105,10 @@ def main(argv: list[str] | None = None) -> int:
             "OLIVIA_PROJECT_ROOT": str(root / "app"),
             "OLIVIA_LOCAL_DATA_ROOT": str(data_root),
             "OLIVIA_MEMORY_ROOT": str(data_root / "memory"),
+            "OLIVIA_PRIVATE_WORLD_ENABLED": "1",
+            "OLIVIA_PRIVATE_WORLD_DB": str(
+                data_root / "private_world" / "private_world.sqlite3"
+            ),
             "OLIVIA_REPLY_DELAY_ENABLED": "1",
             "OLIVIA_REPLY_DELAY_MINUTES_MIN": "5",
             "OLIVIA_REPLY_DELAY_MINUTES_MAX": "10",

--- a/private_world_ledger.py
+++ b/private_world_ledger.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
@@ -136,9 +136,11 @@ class SQLitePrivateWorldLedger:
         ):
             return 0
         try:
-            with sqlite3.connect(
-                self._database_path,
-                timeout=5,
+            with closing(
+                sqlite3.connect(
+                    self._database_path,
+                    timeout=5,
+                )
             ) as connection:
                 rows = connection.execute(
                     "SELECT name FROM sqlite_master WHERE type = 'table'"
@@ -179,14 +181,19 @@ class SQLitePrivateWorldLedger:
             f"{self._database_path.name}.pre-v2-{stamp}.bak"
         )
         try:
-            with sqlite3.connect(
-                self._database_path,
-                timeout=5,
-            ) as source, sqlite3.connect(
-                backup,
-                timeout=5,
+            with closing(
+                sqlite3.connect(
+                    self._database_path,
+                    timeout=5,
+                )
+            ) as source, closing(
+                sqlite3.connect(
+                    backup,
+                    timeout=5,
+                )
             ) as destination:
                 source.backup(destination)
+                destination.commit()
         except sqlite3.Error as exc:
             backup.unlink(missing_ok=True)
             raise LedgerWriteError(

--- a/private_world_ledger.py
+++ b/private_world_ledger.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from contextlib import contextmanager
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import datetime, timezone
 import json
 from pathlib import Path
 import re
@@ -18,6 +18,13 @@ from private_world_port import (
     PrivateWorldCharacterView,
     PrivateWorldControlView,
     PrivateWorldSnapshot,
+)
+
+
+PRIVATE_WORLD_LEDGER_SCHEMA_VERSION = 2
+_METADATA_KEY = "schema_version"
+_LEGACY_TABLES = frozenset(
+    {"private_world_events", "private_world_snapshots"}
 )
 
 
@@ -98,7 +105,16 @@ class SQLitePrivateWorldLedger:
             )
         path.parent.mkdir(parents=True, exist_ok=True)
         self._database_path = path
+        self._migration_status = "unknown"
         self._initialize()
+
+    @property
+    def schema_version(self) -> int:
+        return PRIVATE_WORLD_LEDGER_SCHEMA_VERSION
+
+    @property
+    def migration_status(self) -> str:
+        return self._migration_status
 
     @contextmanager
     def _connection(self) -> Iterator[sqlite3.Connection]:
@@ -113,25 +129,120 @@ class SQLitePrivateWorldLedger:
         finally:
             connection.close()
 
+    def _existing_schema_version(self) -> int:
+        if (
+            not self._database_path.is_file()
+            or self._database_path.stat().st_size == 0
+        ):
+            return 0
+        try:
+            with sqlite3.connect(
+                self._database_path,
+                timeout=5,
+            ) as connection:
+                rows = connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                ).fetchall()
+                tables = {str(row[0]) for row in rows}
+                if not tables:
+                    return 0
+                if "private_world_metadata" in tables:
+                    row = connection.execute(
+                        "SELECT value FROM private_world_metadata WHERE key = ?",
+                        (_METADATA_KEY,),
+                    ).fetchone()
+                    if row is None:
+                        raise LedgerWriteError(
+                            "private world schema metadata is incomplete"
+                        )
+                    try:
+                        return int(row[0])
+                    except (TypeError, ValueError) as exc:
+                        raise LedgerWriteError(
+                            "private world schema metadata is invalid"
+                        ) from exc
+                if _LEGACY_TABLES.issubset(tables):
+                    return 1
+                raise LedgerWriteError(
+                    "private world schema is unrecognized"
+                )
+        except sqlite3.Error as exc:
+            raise LedgerWriteError(
+                "private world schema inspection failed"
+            ) from exc
+
+    def _backup_legacy_database(self) -> None:
+        stamp = datetime.now(timezone.utc).strftime(
+            "%Y%m%dT%H%M%S%fZ"
+        )
+        backup = self._database_path.with_name(
+            f"{self._database_path.name}.pre-v2-{stamp}.bak"
+        )
+        try:
+            with sqlite3.connect(
+                self._database_path,
+                timeout=5,
+            ) as source, sqlite3.connect(
+                backup,
+                timeout=5,
+            ) as destination:
+                source.backup(destination)
+        except sqlite3.Error as exc:
+            backup.unlink(missing_ok=True)
+            raise LedgerWriteError(
+                "private world migration backup failed"
+            ) from exc
+
     def _initialize(self) -> None:
-        with self._connection() as connection:
-            connection.executescript(
-                """
-                CREATE TABLE IF NOT EXISTS private_world_events (
-                    event_id TEXT PRIMARY KEY,
-                    delivery_id TEXT NOT NULL UNIQUE,
-                    event_type TEXT NOT NULL,
-                    payload_json TEXT NOT NULL,
-                    occurred_at TEXT NOT NULL
-                );
-                CREATE TABLE IF NOT EXISTS private_world_snapshots (
-                    version INTEGER PRIMARY KEY,
-                    payload_json TEXT NOT NULL,
-                    event_id TEXT NOT NULL UNIQUE,
-                    FOREIGN KEY(event_id) REFERENCES private_world_events(event_id)
-                );
-                """
+        previous = self._existing_schema_version()
+        if previous > PRIVATE_WORLD_LEDGER_SCHEMA_VERSION:
+            raise LedgerWriteError(
+                "private world schema is newer than this runtime"
             )
+        if previous == 1:
+            self._backup_legacy_database()
+            self._migration_status = "migrated_v1_to_v2"
+        elif previous == 0:
+            self._migration_status = "created_v2"
+        else:
+            self._migration_status = "current_v2"
+
+        try:
+            with self._connection() as connection:
+                connection.executescript(
+                    """
+                    CREATE TABLE IF NOT EXISTS private_world_events (
+                        event_id TEXT PRIMARY KEY,
+                        delivery_id TEXT NOT NULL UNIQUE,
+                        event_type TEXT NOT NULL,
+                        payload_json TEXT NOT NULL,
+                        occurred_at TEXT NOT NULL
+                    );
+                    CREATE TABLE IF NOT EXISTS private_world_snapshots (
+                        version INTEGER PRIMARY KEY,
+                        payload_json TEXT NOT NULL,
+                        event_id TEXT NOT NULL UNIQUE,
+                        FOREIGN KEY(event_id) REFERENCES private_world_events(event_id)
+                    );
+                    CREATE TABLE IF NOT EXISTS private_world_metadata (
+                        key TEXT PRIMARY KEY,
+                        value TEXT NOT NULL
+                    );
+                    """
+                )
+                connection.execute(
+                    """INSERT INTO private_world_metadata (key, value)
+                       VALUES (?, ?)
+                       ON CONFLICT(key) DO UPDATE SET value = excluded.value""",
+                    (
+                        _METADATA_KEY,
+                        str(PRIVATE_WORLD_LEDGER_SCHEMA_VERSION),
+                    ),
+                )
+        except sqlite3.Error as exc:
+            raise LedgerWriteError(
+                "private world schema initialization failed"
+            ) from exc
 
     def apply_once(
         self,

--- a/private_world_runtime.py
+++ b/private_world_runtime.py
@@ -36,16 +36,31 @@ class PrivateWorldRuntime:
     def public_status(self) -> dict[str, object]:
         """Return status without paths, scores, names, or continuation text."""
 
+        event_count = self.event_count
+        snapshot_count = self.snapshot_count
+        status = self.status
+        reason_code = self.reason_code
+        if status == "available" and isinstance(
+            self.port,
+            SQLitePrivateWorldLedger,
+        ):
+            try:
+                counts = self.port.health()
+                event_count = int(counts["event_count"])
+                snapshot_count = int(counts["snapshot_count"])
+            except (OSError, RuntimeError, ValueError):
+                status = "unavailable"
+                reason_code = "PRIVATE_WORLD_STORAGE_UNAVAILABLE"
         return {
-            "status": self.status,
-            "provider": self.provider,
-            "reason_code": self.reason_code,
+            "status": status,
+            "provider": self.provider if status == "available" else "none",
+            "reason_code": reason_code,
             "enabled": self.enabled,
             "schema_version": self.schema_version,
             "migration_status": self.migration_status,
-            "event_count": self.event_count,
-            "snapshot_count": self.snapshot_count,
-            "probe": "in-process" if self.status == "available" else "not-run",
+            "event_count": event_count,
+            "snapshot_count": snapshot_count,
+            "probe": "in-process" if status == "available" else "not-run",
             "network_called": False,
         }
 

--- a/private_world_runtime.py
+++ b/private_world_runtime.py
@@ -1,0 +1,149 @@
+"""Default local PrivateWorld runtime construction and sanitized status."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from typing import Mapping
+
+from private_world_delivery import PrivateWorldDeliveryCommitter
+from private_world_ledger import (
+    LedgerWriteError,
+    SQLitePrivateWorldLedger,
+)
+from private_world_port import NullPrivateWorldPort, PrivateWorldPort
+
+
+PRIVATE_WORLD_DEFAULT_RELATIVE_PATH = Path(
+    "private_world/private_world.sqlite3"
+)
+
+
+@dataclass(frozen=True)
+class PrivateWorldRuntime:
+    port: PrivateWorldPort
+    committer: PrivateWorldDeliveryCommitter | None
+    status: str
+    provider: str
+    reason_code: str | None
+    enabled: bool
+    schema_version: int | None = None
+    migration_status: str | None = None
+    event_count: int = 0
+    snapshot_count: int = 0
+
+    def public_status(self) -> dict[str, object]:
+        """Return status without paths, scores, names, or continuation text."""
+
+        return {
+            "status": self.status,
+            "provider": self.provider,
+            "reason_code": self.reason_code,
+            "enabled": self.enabled,
+            "schema_version": self.schema_version,
+            "migration_status": self.migration_status,
+            "event_count": self.event_count,
+            "snapshot_count": self.snapshot_count,
+            "probe": "in-process" if self.status == "available" else "not-run",
+            "network_called": False,
+        }
+
+
+def _enabled(value: object, *, default: bool) -> bool | None:
+    if value is None:
+        return default
+    normalized = str(value).strip().casefold()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
+def resolve_private_world_database(
+    environ: Mapping[str, str] | None = None,
+) -> tuple[Path | None, str | None, bool]:
+    """Resolve an explicit DB or the data-root default without creating it."""
+
+    values = os.environ if environ is None else environ
+    enabled = _enabled(
+        values.get("OLIVIA_PRIVATE_WORLD_ENABLED"),
+        default=True,
+    )
+    if enabled is None:
+        return None, "PRIVATE_WORLD_ENABLED_INVALID", False
+    if not enabled:
+        return None, "PRIVATE_WORLD_DISABLED", False
+
+    explicit = str(values.get("OLIVIA_PRIVATE_WORLD_DB", "")).strip()
+    if explicit:
+        path = Path(explicit).expanduser()
+        if not path.is_absolute():
+            return None, "PRIVATE_WORLD_DB_MUST_BE_ABSOLUTE", True
+        return path.resolve(), None, True
+
+    root_value = str(values.get("OLIVIA_LOCAL_DATA_ROOT", "")).strip()
+    if not root_value:
+        return None, "PRIVATE_WORLD_DATA_ROOT_NOT_CONFIGURED", True
+    root = Path(root_value).expanduser().resolve()
+    return (root / PRIVATE_WORLD_DEFAULT_RELATIVE_PATH), None, True
+
+
+def create_private_world_runtime(
+    environ: Mapping[str, str] | None = None,
+) -> PrivateWorldRuntime:
+    """Create the optional local ledger without blocking the reply runtime."""
+
+    path, reason, enabled = resolve_private_world_database(environ)
+    if not enabled:
+        return PrivateWorldRuntime(
+            NullPrivateWorldPort(),
+            None,
+            "disabled",
+            "none",
+            reason,
+            False,
+        )
+    if path is None:
+        return PrivateWorldRuntime(
+            NullPrivateWorldPort(),
+            None,
+            "unavailable",
+            "none",
+            reason or "PRIVATE_WORLD_STORAGE_UNAVAILABLE",
+            True,
+        )
+
+    try:
+        ledger = SQLitePrivateWorldLedger(path)
+        counts = ledger.health()
+        return PrivateWorldRuntime(
+            ledger,
+            PrivateWorldDeliveryCommitter(ledger),
+            "available",
+            "sqlite",
+            None,
+            True,
+            schema_version=ledger.schema_version,
+            migration_status=ledger.migration_status,
+            event_count=int(counts["event_count"]),
+            snapshot_count=int(counts["snapshot_count"]),
+        )
+    except (OSError, ValueError, RuntimeError, LedgerWriteError):
+        return PrivateWorldRuntime(
+            NullPrivateWorldPort(),
+            None,
+            "unavailable",
+            "none",
+            "PRIVATE_WORLD_STORAGE_UNAVAILABLE",
+            True,
+        )
+
+
+__all__ = [
+    "PRIVATE_WORLD_DEFAULT_RELATIVE_PATH",
+    "PrivateWorldRuntime",
+    "create_private_world_runtime",
+    "resolve_private_world_database",
+]

--- a/tests/installer/test_private_world_default.py
+++ b/tests/installer/test_private_world_default.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer import start_local
+
+
+def test_start_local_configures_private_world_under_install_data(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "Olivia Local"
+    backend = root / "local_backend"
+    backend.mkdir(parents=True)
+    (backend / "local_server.py").write_text("# synthetic", encoding="utf-8")
+    client = root / "app" / "synthetic" / "Olivia.exe"
+    client.parent.mkdir(parents=True)
+    client.write_bytes(b"synthetic")
+    observed: dict[str, object] = {}
+
+    monkeypatch.setattr(start_local, "_health", lambda _port: True)
+    monkeypatch.setattr(start_local, "_load_dpapi_key", lambda _path: "")
+    monkeypatch.setattr(start_local, "_client_executable", lambda _root: client)
+
+    def fake_call(command, *, cwd, env):
+        observed.update({"command": command, "cwd": cwd, "env": env})
+        return 0
+
+    monkeypatch.setattr(start_local.subprocess, "call", fake_call)
+
+    assert start_local.main(["--install-root", str(root)]) == 0
+
+    environment = observed["env"]
+    data_root = root.resolve() / "data"
+    assert environment["OLIVIA_LOCAL_DATA_ROOT"] == str(data_root)
+    assert environment["OLIVIA_PRIVATE_WORLD_ENABLED"] == "1"
+    assert environment["OLIVIA_PRIVATE_WORLD_DB"] == str(
+        data_root / "private_world" / "private_world.sqlite3"
+    )
+    assert Path(environment["OLIVIA_PRIVATE_WORLD_DB"]).is_absolute()

--- a/tests/private_world/test_private_world_runtime.py
+++ b/tests/private_world/test_private_world_runtime.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+from private_world_ledger import (
+    PRIVATE_WORLD_LEDGER_SCHEMA_VERSION,
+    LedgerEvent,
+    LedgerWriteError,
+    SQLitePrivateWorldLedger,
+)
+from private_world_port import NullPrivateWorldPort, PrivateWorldSnapshot
+from private_world_runtime import (
+    PRIVATE_WORLD_DEFAULT_RELATIVE_PATH,
+    create_private_world_runtime,
+    resolve_private_world_database,
+)
+
+
+def _legacy_v1_database(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE private_world_events (
+                event_id TEXT PRIMARY KEY,
+                delivery_id TEXT NOT NULL UNIQUE,
+                event_type TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                occurred_at TEXT NOT NULL
+            );
+            CREATE TABLE private_world_snapshots (
+                version INTEGER PRIMARY KEY,
+                payload_json TEXT NOT NULL,
+                event_id TEXT NOT NULL UNIQUE,
+                FOREIGN KEY(event_id) REFERENCES private_world_events(event_id)
+            );
+            """
+        )
+        connection.execute(
+            """INSERT INTO private_world_events
+               (event_id, delivery_id, event_type, payload_json, occurred_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (
+                "legacy-event",
+                "legacy-delivery",
+                "canonical_reply_delivered",
+                json.dumps({"applied": False}),
+                "2026-08-22T00:00:00+00:00",
+            ),
+        )
+        snapshot = PrivateWorldSnapshot(version=1).to_dict()
+        connection.execute(
+            """INSERT INTO private_world_snapshots
+               (version, payload_json, event_id) VALUES (?, ?, ?)""",
+            (1, json.dumps(snapshot, ensure_ascii=False, sort_keys=True, separators=(",", ":")), "legacy-event"),
+        )
+
+
+def test_legacy_ledger_is_backed_up_and_migrated_once(tmp_path: Path) -> None:
+    database = tmp_path / "private_world.sqlite3"
+    _legacy_v1_database(database)
+
+    ledger = SQLitePrivateWorldLedger(database)
+
+    assert ledger.schema_version == PRIVATE_WORLD_LEDGER_SCHEMA_VERSION == 2
+    assert ledger.migration_status == "migrated_v1_to_v2"
+    assert ledger.snapshot() == PrivateWorldSnapshot(version=1)
+    backups = tuple(tmp_path.glob("private_world.sqlite3.pre-v2-*.bak"))
+    assert len(backups) == 1
+    assert backups[0].is_file() and backups[0].stat().st_size > 0
+    with sqlite3.connect(database) as connection:
+        assert connection.execute(
+            "SELECT value FROM private_world_metadata WHERE key = 'schema_version'"
+        ).fetchone() == ("2",)
+
+    reopened = SQLitePrivateWorldLedger(database)
+    assert reopened.migration_status == "current_v2"
+    assert tuple(tmp_path.glob("private_world.sqlite3.pre-v2-*.bak")) == backups
+
+
+def test_new_ledger_records_v2_metadata_without_backup(tmp_path: Path) -> None:
+    database = tmp_path / "private_world.sqlite3"
+    ledger = SQLitePrivateWorldLedger(database)
+
+    assert ledger.migration_status == "created_v2"
+    assert not tuple(tmp_path.glob("*.pre-v2-*.bak"))
+    with sqlite3.connect(database) as connection:
+        assert connection.execute(
+            "SELECT value FROM private_world_metadata WHERE key = 'schema_version'"
+        ).fetchone() == ("2",)
+
+
+def test_newer_schema_is_rejected_without_modification(tmp_path: Path) -> None:
+    database = tmp_path / "private_world.sqlite3"
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "CREATE TABLE private_world_metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        connection.execute(
+            "INSERT INTO private_world_metadata (key, value) VALUES ('schema_version', '99')"
+        )
+
+    with pytest.raises(LedgerWriteError, match="newer than this runtime"):
+        SQLitePrivateWorldLedger(database)
+    with sqlite3.connect(database) as connection:
+        assert connection.execute(
+            "SELECT value FROM private_world_metadata WHERE key = 'schema_version'"
+        ).fetchone() == ("99",)
+
+
+def test_default_runtime_uses_local_data_root_and_reports_sanitized_health(
+    tmp_path: Path,
+) -> None:
+    runtime = create_private_world_runtime(
+        {"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path)}
+    )
+    database = tmp_path / PRIVATE_WORLD_DEFAULT_RELATIVE_PATH
+
+    assert database.is_file()
+    assert isinstance(runtime.port, SQLitePrivateWorldLedger)
+    assert runtime.committer is not None
+    assert runtime.public_status() == {
+        "status": "available",
+        "provider": "sqlite",
+        "reason_code": None,
+        "enabled": True,
+        "schema_version": 2,
+        "migration_status": "created_v2",
+        "event_count": 0,
+        "snapshot_count": 0,
+        "probe": "in-process",
+        "network_called": False,
+    }
+
+    runtime.port.apply_once(
+        LedgerEvent(
+            event_id="event-1",
+            delivery_id="delivery-1",
+            event_type="canonical_reply_delivered",
+            payload={"applied": False},
+            occurred_at="2026-08-22T00:00:00+00:00",
+        ),
+        PrivateWorldSnapshot(version=1, trust=88, nickname_permissions=("secret_name",)),
+    )
+    status = runtime.public_status()
+    serialized = json.dumps(status, ensure_ascii=False)
+    assert status["event_count"] == 1
+    assert status["snapshot_count"] == 1
+    assert str(tmp_path) not in serialized
+    assert "secret_name" not in serialized
+    assert "88" not in serialized
+
+
+def test_explicit_absolute_database_overrides_default(tmp_path: Path) -> None:
+    explicit = tmp_path / "custom" / "world.sqlite3"
+    path, reason, enabled = resolve_private_world_database(
+        {
+            "OLIVIA_LOCAL_DATA_ROOT": str(tmp_path / "data"),
+            "OLIVIA_PRIVATE_WORLD_DB": str(explicit),
+        }
+    )
+    assert (path, reason, enabled) == (explicit.resolve(), None, True)
+
+    runtime = create_private_world_runtime(
+        {"OLIVIA_PRIVATE_WORLD_DB": str(explicit)}
+    )
+    assert runtime.status == "available"
+    assert explicit.is_file()
+
+
+@pytest.mark.parametrize(
+    ("environ", "status", "reason", "enabled"),
+    [
+        (
+            {"OLIVIA_PRIVATE_WORLD_ENABLED": "0"},
+            "disabled",
+            "PRIVATE_WORLD_DISABLED",
+            False,
+        ),
+        (
+            {},
+            "unavailable",
+            "PRIVATE_WORLD_DATA_ROOT_NOT_CONFIGURED",
+            True,
+        ),
+        (
+            {"OLIVIA_PRIVATE_WORLD_ENABLED": "maybe"},
+            "disabled",
+            "PRIVATE_WORLD_ENABLED_INVALID",
+            False,
+        ),
+        (
+            {"OLIVIA_PRIVATE_WORLD_DB": "relative.sqlite3"},
+            "unavailable",
+            "PRIVATE_WORLD_DB_MUST_BE_ABSOLUTE",
+            True,
+        ),
+    ],
+)
+def test_disabled_and_invalid_runtime_states_are_explicit(
+    environ: dict[str, str],
+    status: str,
+    reason: str,
+    enabled: bool,
+) -> None:
+    runtime = create_private_world_runtime(environ)
+    assert isinstance(runtime.port, NullPrivateWorldPort)
+    assert runtime.committer is None
+    public = runtime.public_status()
+    assert public["status"] == status
+    assert public["reason_code"] == reason
+    assert public["enabled"] is enabled
+    assert public["network_called"] is False


### PR DESCRIPTION
Implements PW-01 from #33.

## Changes

- versions the PrivateWorld SQLite ledger at schema v2;
- detects legacy v1 ledgers, creates an SQLite-consistent local backup, then adds schema metadata without rewriting existing events or snapshots;
- refuses newer or unrecognized schemas instead of mutating them;
- records explicit `created_v2`, `migrated_v1_to_v2`, or `current_v2` migration state;
- adds `private_world_runtime.py` to resolve either:
  - an explicit absolute `OLIVIA_PRIVATE_WORLD_DB`; or
  - the default `<OLIVIA_LOCAL_DATA_ROOT>/private_world/private_world.sqlite3`;
- provides sanitized dynamic status with provider, schema/migration state, event/snapshot counts, and no paths or hidden relationship values;
- keeps missing/disabled/invalid storage honest through `NullPrivateWorldPort`, without blocking replies;
- makes the Windows launcher explicitly enable the installed ledger under `data/private_world/private_world.sqlite3`.

## Validation

- legacy migration and exactly-once backup;
- new database metadata;
- newer-schema refusal;
- default and explicit path resolution;
- disabled/invalid/unavailable status;
- dynamic sanitized counts;
- installed launcher environment on paths containing spaces;
- existing ledger behavior remains covered by the full suite.

GitHub `Public smoke (Windows / Python 3.12)` is the required merge gate.

## Boundary

This PR does not add mutation commands, candidates, relationship changes, management API, or UI. Canonical reply delivery remains the only current runtime write and still has no relationship effect.

Part of #33 and #37.