### PR TITLE
feat(private-world): add typed mutation commands and reducer support

### DIFF
--- a/private_world_commands.py
+++ b/private_world_commands.py
@@ -1,0 +1,385 @@
+"""Typed commands for controlled PrivateWorld state changes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+import re
+from typing import ClassVar, TypeAlias
+
+from reply_context import RelationshipStage
+
+from private_world_port import (
+    ContinuationAwareness,
+    HomeAccess,
+    LocalContinuationFact,
+    PrivateWorldError,
+)
+
+
+class PrivateWorldCommandError(ValueError):
+    code = "PRIVATE_WORLD_COMMAND_INVALID"
+
+
+class PrivateWorldActor(StrEnum):
+    LOCAL_USER = "local_user"
+    SYSTEM_CANDIDATE = "system_candidate"
+    MIGRATION = "migration"
+
+
+class PrivateWorldCommandSource(StrEnum):
+    CONTROL_CENTER = "control_center"
+    APPROVED_CANDIDATE = "approved_candidate"
+    IMPORT = "import"
+    MIGRATION = "migration"
+
+
+class PrivateWorldCommandKind(StrEnum):
+    RECORD_BOUNDARY_RESPECTED = "record_boundary_respected"
+    RECORD_CONFLICT = "record_conflict"
+    RECORD_REPAIR = "record_repair"
+    CONFIRM_RELATIONSHIP_STAGE = "confirm_relationship_stage"
+    GRANT_NICKNAME = "grant_nickname"
+    REVOKE_NICKNAME = "revoke_nickname"
+    SET_HOME_ACCESS = "set_home_access"
+    UPSERT_CONTINUATION_FACT = "upsert_continuation_fact"
+    SET_CONTINUATION_AWARENESS = "set_continuation_awareness"
+    DELETE_CONTINUATION_FACT = "delete_continuation_fact"
+
+
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
+_MAX_REASON_LENGTH = 280
+_MAX_EVIDENCE_REFS = 8
+
+
+def _identifier(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str) or not _ID_RE.fullmatch(value):
+        raise PrivateWorldCommandError(f"{field_name} is invalid")
+    return value
+
+
+def _plain_text(value: object, *, field_name: str, max_length: int) -> str:
+    if not isinstance(value, str):
+        raise PrivateWorldCommandError(f"{field_name} must be text")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > max_length
+        or any(
+            ord(character) < 32 or ord(character) == 127
+            for character in normalized
+        )
+    ):
+        raise PrivateWorldCommandError(f"{field_name} is invalid")
+    return normalized
+
+
+def _evidence_refs(values: tuple[str, ...]) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise PrivateWorldCommandError("evidence refs must be a sequence")
+    if not isinstance(values, tuple):
+        values = tuple(values)
+    if (
+        len(values) > _MAX_EVIDENCE_REFS
+        or len(values) != len(set(values))
+        or any(
+            not isinstance(value, str) or not _ID_RE.fullmatch(value)
+            for value in values
+        )
+    ):
+        raise PrivateWorldCommandError("evidence refs are invalid")
+    return values
+
+
+def _nickname(value: object) -> str:
+    normalized = _plain_text(value, field_name="nickname", max_length=32)
+    if any(character.isspace() for character in normalized):
+        raise PrivateWorldCommandError("nickname cannot contain whitespace")
+    return normalized
+
+
+@dataclass(frozen=True, kw_only=True)
+class PrivateWorldCommand:
+    command_id: str
+    idempotency_key: str
+    actor: PrivateWorldActor
+    source: PrivateWorldCommandSource
+    occurred_at: datetime
+    reason: str
+    evidence_refs: tuple[str, ...] = ()
+
+    kind: ClassVar[PrivateWorldCommandKind]
+
+    def __post_init__(self) -> None:
+        if self.__class__ is PrivateWorldCommand:
+            raise TypeError("a concrete PrivateWorld command is required")
+        object.__setattr__(
+            self,
+            "command_id",
+            _identifier(self.command_id, field_name="command id"),
+        )
+        object.__setattr__(
+            self,
+            "idempotency_key",
+            _identifier(self.idempotency_key, field_name="idempotency key"),
+        )
+        if not isinstance(self.actor, PrivateWorldActor):
+            raise PrivateWorldCommandError("actor is invalid")
+        if not isinstance(self.source, PrivateWorldCommandSource):
+            raise PrivateWorldCommandError("source is invalid")
+        if (
+            not isinstance(self.occurred_at, datetime)
+            or self.occurred_at.tzinfo is None
+            or self.occurred_at.utcoffset() is None
+        ):
+            raise PrivateWorldCommandError(
+                "occurred_at must be timezone-aware"
+            )
+        object.__setattr__(
+            self,
+            "reason",
+            _plain_text(
+                self.reason,
+                field_name="reason",
+                max_length=_MAX_REASON_LENGTH,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "evidence_refs",
+            _evidence_refs(self.evidence_refs),
+        )
+
+    def payload(self) -> dict[str, object]:
+        return {}
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "command_id": self.command_id,
+            "idempotency_key": self.idempotency_key,
+            "kind": self.kind.value,
+            "actor": self.actor.value,
+            "source": self.source.value,
+            "occurred_at": self.occurred_at.isoformat(),
+            "reason": self.reason,
+            "evidence_refs": list(self.evidence_refs),
+            "payload": self.payload(),
+        }
+
+
+@dataclass(frozen=True, kw_only=True)
+class RecordBoundaryRespected(PrivateWorldCommand):
+    kind: ClassVar[PrivateWorldCommandKind] = (
+        PrivateWorldCommandKind.RECORD_BOUNDARY_RESPECTED
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class RecordConflict(PrivateWorldCommand):
+    kind: ClassVar[PrivateWorldCommandKind] = (
+        PrivateWorldCommandKind.RECORD_CONFLICT
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class RecordRepair(PrivateWorldCommand):
+    kind: ClassVar[PrivateWorldCommandKind] = (
+        PrivateWorldCommandKind.RECORD_REPAIR
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class ConfirmRelationshipStage(PrivateWorldCommand):
+    target_stage: RelationshipStage
+    basis_event_ids: tuple[str, ...]
+
+    kind: ClassVar[PrivateWorldCommandKind] = (
+        PrivateWorldCommandKind.CONFIRM_RELATIONSHIP_STAGE
+    )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if not isinstance(self.target_stage, RelationshipStage):
+            raise PrivateWorldCommandError("target stage is invalid")
+        basis = _evidence_refs(self.basis_event_ids)
+        if not basis:
+            raise PrivateWorldCommandError(
+                "stage confirmation requires evidence"
+            )
+        object.__setattr__(self, "basis_event_ids", basis)
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "target_stage": self.target_stage.value,
+            "basis_event_ids": list(self.basis_event_ids),
+        }
+
+
+@dataclass(frozen=True, kw_only=True)
+class GrantNickname(PrivateWorldCommand):
+    nickname: str
+
+    kind: ClassVar[PrivateWorldCommandKind] = (
+        PrivateWorldCommandKind.GRANT_NICKNAME
+    )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "nickname", _nickname(self.nickname))
+
+    def payload(self) -> dict[str, object]:
+        return {"nickname": self.nickname}
+
+
+@dataclass(frozen=True, kw_only=True)
+class RevokeNickname(PrivateWorldCommand):
+    nickname: str
+
+    kind: ClassVar[PrivateWorldCommandKind] = (
+        PrivateWorldCommandKind.REVOKE_NICKNAME
+    )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "nickname", _nickname(self.nickname))
+
+    def payload(self) -> dict[str, object]:
+        return {"nickname": self.nickname}
+
+
+@dataclass(frozen=True, kw_only=True)
+class SetHomeAccess(PrivateWorldCommand):
+    home_access: HomeAccess
+
+    kind: ClassVar[PrivateWorldCommandKind] = (
+        PrivateWorldCommandKind.SET_HOME_ACCESS
+    )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if not isinstance(self.home_access, HomeAccess):
+            raise PrivateWorldCommandError("home access is invalid")
+
+    def payload(self) -> dict[str, object]:
+        return {"home_access": self.home_access.value}
+
+
+@dataclass(frozen=True, kw_only=True)
+class UpsertContinuationFact(PrivateWorldCommand):
+    fact_id: str
+    statement: str
+    awareness: ContinuationAwareness
+
+    kind: ClassVar[PrivateWorldCommandKind] = (
+        PrivateWorldCommandKind.UPSERT_CONTINUATION_FACT
+    )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        try:
+            fact = LocalContinuationFact(
+                self.fact_id,
+                self.statement,
+                self.awareness,
+            )
+        except PrivateWorldError as exc:
+            raise PrivateWorldCommandError(str(exc)) from exc
+        object.__setattr__(self, "fact_id", fact.fact_id)
+        object.__setattr__(self, "statement", fact.statement)
+        object.__setattr__(self, "awareness", fact.awareness)
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "fact_id": self.fact_id,
+            "statement": self.statement,
+            "awareness": self.awareness.value,
+        }
+
+
+@dataclass(frozen=True, kw_only=True)
+class SetContinuationAwareness(PrivateWorldCommand):
+    fact_id: str
+    awareness: ContinuationAwareness
+
+    kind: ClassVar[PrivateWorldCommandKind] = (
+        PrivateWorldCommandKind.SET_CONTINUATION_AWARENESS
+    )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(
+            self,
+            "fact_id",
+            _identifier(
+                self.fact_id,
+                field_name="continuation fact id",
+            ),
+        )
+        if not isinstance(self.awareness, ContinuationAwareness):
+            raise PrivateWorldCommandError(
+                "continuation awareness is invalid"
+            )
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "fact_id": self.fact_id,
+            "awareness": self.awareness.value,
+        }
+
+
+@dataclass(frozen=True, kw_only=True)
+class DeleteContinuationFact(PrivateWorldCommand):
+    fact_id: str
+
+    kind: ClassVar[PrivateWorldCommandKind] = (
+        PrivateWorldCommandKind.DELETE_CONTINUATION_FACT
+    )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(
+            self,
+            "fact_id",
+            _identifier(
+                self.fact_id,
+                field_name="continuation fact id",
+            ),
+        )
+
+    def payload(self) -> dict[str, object]:
+        return {"fact_id": self.fact_id}
+
+
+PrivateWorldMutation: TypeAlias = (
+    RecordBoundaryRespected
+    | RecordConflict
+    | RecordRepair
+    | ConfirmRelationshipStage
+    | GrantNickname
+    | RevokeNickname
+    | SetHomeAccess
+    | UpsertContinuationFact
+    | SetContinuationAwareness
+    | DeleteContinuationFact
+)
+
+
+__all__ = [
+    "ConfirmRelationshipStage",
+    "DeleteContinuationFact",
+    "GrantNickname",
+    "PrivateWorldActor",
+    "PrivateWorldCommand",
+    "PrivateWorldCommandError",
+    "PrivateWorldCommandKind",
+    "PrivateWorldCommandSource",
+    "PrivateWorldMutation",
+    "RecordBoundaryRespected",
+    "RecordConflict",
+    "RecordRepair",
+    "RevokeNickname",
+    "SetContinuationAwareness",
+    "SetHomeAccess",
+    "UpsertContinuationFact",
+]

--- a/private_world_reducer.py
+++ b/private_world_reducer.py
@@ -1,4 +1,4 @@
-"""Pure, deterministic PrivateWorld relationship reducer."""
+"""Pure, deterministic PrivateWorld relationship and command reducer."""
 
 from __future__ import annotations
 
@@ -7,7 +7,23 @@ from datetime import datetime, timedelta
 from enum import Enum
 import re
 
-from private_world_port import PrivateWorldSnapshot
+from private_world_commands import (
+    ConfirmRelationshipStage,
+    DeleteContinuationFact,
+    GrantNickname,
+    PrivateWorldCommand,
+    RecordBoundaryRespected,
+    RecordConflict,
+    RecordRepair,
+    RevokeNickname,
+    SetContinuationAwareness,
+    SetHomeAccess,
+    UpsertContinuationFact,
+)
+from private_world_port import (
+    LocalContinuationFact,
+    PrivateWorldSnapshot,
+)
 
 
 class ReducerInputError(ValueError):
@@ -69,30 +85,45 @@ class ReducerEvent:
                 or self.last_equivalent_at.utcoffset() is None
                 or self.last_equivalent_at > self.occurred_at
             ):
-                raise ReducerInputError("previous equivalent time is invalid")
+                raise ReducerInputError(
+                    "previous equivalent time is invalid"
+                )
         if not isinstance(self.basis_event_ids, tuple):
-            object.__setattr__(self, "basis_event_ids", tuple(self.basis_event_ids))
+            object.__setattr__(
+                self,
+                "basis_event_ids",
+                tuple(self.basis_event_ids),
+            )
         if self.kind is ReducerEventKind.STAGE_CONFIRMED:
             if not isinstance(self.target_stage, str) or not _STAGE_RE.fullmatch(
                 self.target_stage
             ):
-                raise ReducerInputError("stage confirmation requires a target stage")
+                raise ReducerInputError(
+                    "stage confirmation requires a target stage"
+                )
             if (
                 not self.basis_event_ids
                 or len(self.basis_event_ids) > 8
                 or len(set(self.basis_event_ids)) != len(self.basis_event_ids)
-                or any(not _TOKEN_RE.fullmatch(value) for value in self.basis_event_ids)
+                or any(
+                    not _TOKEN_RE.fullmatch(value)
+                    for value in self.basis_event_ids
+                )
             ):
-                raise ReducerInputError("stage confirmation requires explicit evidence")
+                raise ReducerInputError(
+                    "stage confirmation requires explicit evidence"
+                )
         elif self.target_stage is not None or self.basis_event_ids:
-            raise ReducerInputError("stage evidence is only valid for stage confirmation")
+            raise ReducerInputError(
+                "stage evidence is only valid for stage confirmation"
+            )
 
 
 @dataclass(frozen=True)
 class FieldDelta:
     field: str
-    before: int | str
-    after: int | str
+    before: object
+    after: object
 
 
 @dataclass(frozen=True)
@@ -115,24 +146,62 @@ def _bounded(value: int, change: int) -> int:
 def _duplicate(event: ReducerEvent) -> bool:
     if event.last_equivalent_at is None:
         return False
-    return event.occurred_at - event.last_equivalent_at < _DEDUPLICATION_WINDOW
+    return (
+        event.occurred_at - event.last_equivalent_at
+        < _DEDUPLICATION_WINDOW
+    )
+
+
+def _no_change(
+    snapshot: PrivateWorldSnapshot,
+    reason_code: str,
+) -> ReducerResult:
+    return ReducerResult(
+        snapshot,
+        ReducerDelta(False, reason_code),
+    )
+
+
+def _apply_updates(
+    snapshot: PrivateWorldSnapshot,
+    updates: dict[str, object],
+    *,
+    reason_code: str,
+    unchanged_reason: str = "BOUNDED_NO_CHANGE",
+) -> ReducerResult:
+    changes = tuple(
+        FieldDelta(field, getattr(snapshot, field), value)
+        for field, value in updates.items()
+        if getattr(snapshot, field) != value
+    )
+    if not changes:
+        return _no_change(snapshot, unchanged_reason)
+    next_snapshot = replace(
+        snapshot,
+        version=snapshot.version + 1,
+        **{change.field: change.after for change in changes},
+    )
+    return ReducerResult(
+        next_snapshot,
+        ReducerDelta(True, reason_code, changes),
+    )
 
 
 def reduce_private_world(
-    snapshot: PrivateWorldSnapshot, event: ReducerEvent
+    snapshot: PrivateWorldSnapshot,
+    event: ReducerEvent,
 ) -> ReducerResult:
     if not isinstance(snapshot, PrivateWorldSnapshot) or not isinstance(
-        event, ReducerEvent
+        event,
+        ReducerEvent,
     ):
         raise ReducerInputError("typed snapshot and event are required")
     if event.kind in _NO_EFFECT_KINDS:
-        return ReducerResult(
-            snapshot, ReducerDelta(False, "NO_RELATIONSHIP_EFFECT")
-        )
+        return _no_change(snapshot, "NO_RELATIONSHIP_EFFECT")
     if _duplicate(event):
-        return ReducerResult(snapshot, ReducerDelta(False, "SEMANTIC_DUPLICATE"))
+        return _no_change(snapshot, "SEMANTIC_DUPLICATE")
 
-    updates: dict[str, int | str] = {}
+    updates: dict[str, object] = {}
     if event.kind is ReducerEventKind.BOUNDARY_RESPECTED:
         updates = {
             "trust": _bounded(snapshot.trust, 1),
@@ -151,21 +220,164 @@ def reduce_private_world(
             "tension": _bounded(snapshot.tension, -2),
         }
     elif event.kind is ReducerEventKind.STAGE_CONFIRMED:
-        updates = {"relationship_stage": event.target_stage or "unknown"}
+        updates = {
+            "relationship_stage": event.target_stage or "unknown",
+        }
 
-    changes = tuple(
-        FieldDelta(field, getattr(snapshot, field), value)
-        for field, value in updates.items()
-        if getattr(snapshot, field) != value
-    )
-    if not changes:
-        return ReducerResult(snapshot, ReducerDelta(False, "BOUNDED_NO_CHANGE"))
-    next_snapshot = replace(
+    return _apply_updates(
         snapshot,
-        version=snapshot.version + 1,
-        **{change.field: change.after for change in changes},
+        updates,
+        reason_code=event.kind.value.upper(),
     )
-    return ReducerResult(
-        next_snapshot,
-        ReducerDelta(True, event.kind.value.upper(), changes),
+
+
+def _relationship_command_event(
+    command: PrivateWorldCommand,
+) -> ReducerEvent | None:
+    if isinstance(command, RecordBoundaryRespected):
+        kind = ReducerEventKind.BOUNDARY_RESPECTED
+    elif isinstance(command, RecordConflict):
+        kind = ReducerEventKind.CONFLICT
+    elif isinstance(command, RecordRepair):
+        kind = ReducerEventKind.REPAIR
+    elif isinstance(command, ConfirmRelationshipStage):
+        return ReducerEvent(
+            kind=ReducerEventKind.STAGE_CONFIRMED,
+            occurred_at=command.occurred_at,
+            semantic_key=command.idempotency_key,
+            target_stage=command.target_stage.value,
+            basis_event_ids=command.basis_event_ids,
+        )
+    else:
+        return None
+    return ReducerEvent(
+        kind=kind,
+        occurred_at=command.occurred_at,
+        semantic_key=command.idempotency_key,
     )
+
+
+def reduce_private_world_command(
+    snapshot: PrivateWorldSnapshot,
+    command: PrivateWorldCommand,
+) -> ReducerResult:
+    """Apply one validated control command without persistence or I/O."""
+
+    if not isinstance(snapshot, PrivateWorldSnapshot) or not isinstance(
+        command,
+        PrivateWorldCommand,
+    ):
+        raise ReducerInputError(
+            "typed snapshot and command are required"
+        )
+
+    relationship_event = _relationship_command_event(command)
+    if relationship_event is not None:
+        return reduce_private_world(snapshot, relationship_event)
+
+    if isinstance(command, GrantNickname):
+        if command.nickname in snapshot.nickname_permissions:
+            return _no_change(snapshot, "NICKNAME_ALREADY_GRANTED")
+        if len(snapshot.nickname_permissions) >= 16:
+            return _no_change(snapshot, "NICKNAME_LIMIT_REACHED")
+        return _apply_updates(
+            snapshot,
+            {
+                "nickname_permissions": (
+                    *snapshot.nickname_permissions,
+                    command.nickname,
+                ),
+            },
+            reason_code=command.kind.value.upper(),
+        )
+
+    if isinstance(command, RevokeNickname):
+        if command.nickname not in snapshot.nickname_permissions:
+            return _no_change(snapshot, "NICKNAME_NOT_GRANTED")
+        return _apply_updates(
+            snapshot,
+            {
+                "nickname_permissions": tuple(
+                    value
+                    for value in snapshot.nickname_permissions
+                    if value != command.nickname
+                ),
+            },
+            reason_code=command.kind.value.upper(),
+        )
+
+    if isinstance(command, SetHomeAccess):
+        return _apply_updates(
+            snapshot,
+            {"home_access": command.home_access},
+            reason_code=command.kind.value.upper(),
+            unchanged_reason="HOME_ACCESS_UNCHANGED",
+        )
+
+    if isinstance(command, UpsertContinuationFact):
+        facts = list(snapshot.continuation_facts)
+        replacement = LocalContinuationFact(
+            command.fact_id,
+            command.statement,
+            command.awareness,
+        )
+        for index, fact in enumerate(facts):
+            if fact.fact_id == command.fact_id:
+                if fact == replacement:
+                    return _no_change(
+                        snapshot,
+                        "CONTINUATION_UNCHANGED",
+                    )
+                facts[index] = replacement
+                break
+        else:
+            if len(facts) >= 32:
+                return _no_change(
+                    snapshot,
+                    "CONTINUATION_LIMIT_REACHED",
+                )
+            facts.append(replacement)
+        return _apply_updates(
+            snapshot,
+            {"continuation_facts": tuple(facts)},
+            reason_code=command.kind.value.upper(),
+        )
+
+    if isinstance(command, SetContinuationAwareness):
+        facts = list(snapshot.continuation_facts)
+        for index, fact in enumerate(facts):
+            if fact.fact_id == command.fact_id:
+                if fact.awareness is command.awareness:
+                    return _no_change(
+                        snapshot,
+                        "CONTINUATION_UNCHANGED",
+                    )
+                facts[index] = replace(
+                    fact,
+                    awareness=command.awareness,
+                )
+                return _apply_updates(
+                    snapshot,
+                    {"continuation_facts": tuple(facts)},
+                    reason_code=command.kind.value.upper(),
+                )
+        return _no_change(snapshot, "CONTINUATION_NOT_FOUND")
+
+    if isinstance(command, DeleteContinuationFact):
+        remaining = tuple(
+            fact
+            for fact in snapshot.continuation_facts
+            if fact.fact_id != command.fact_id
+        )
+        if len(remaining) == len(snapshot.continuation_facts):
+            return _no_change(
+                snapshot,
+                "CONTINUATION_NOT_FOUND",
+            )
+        return _apply_updates(
+            snapshot,
+            {"continuation_facts": remaining},
+            reason_code=command.kind.value.upper(),
+        )
+
+    raise ReducerInputError("unsupported PrivateWorld command")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ py-modules = [
     "persona_assembly",
     "prompt_budget",
     "private_world_port",
+    "private_world_commands",
     "private_world_reducer",
     "private_world_ledger",
     "private_world_admin",

--- a/tests/private_world/test_private_world_command_reducer.py
+++ b/tests/private_world/test_private_world_command_reducer.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from private_world_commands import (
+    ConfirmRelationshipStage,
+    DeleteContinuationFact,
+    GrantNickname,
+    PrivateWorldActor,
+    PrivateWorldCommandSource,
+    RecordBoundaryRespected,
+    RecordConflict,
+    RecordRepair,
+    RevokeNickname,
+    SetContinuationAwareness,
+    SetHomeAccess,
+    UpsertContinuationFact,
+)
+from private_world_port import (
+    ContinuationAwareness,
+    HomeAccess,
+    LocalContinuationFact,
+    PrivateWorldSnapshot,
+)
+from private_world_reducer import (
+    ReducerInputError,
+    reduce_private_world_command,
+)
+from reply_context import RelationshipStage
+
+
+NOW = datetime(2026, 8, 22, 20, 0, tzinfo=timezone.utc)
+
+
+def _common(sequence: int = 1) -> dict[str, object]:
+    return {
+        "command_id": f"command.synthetic-{sequence}",
+        "idempotency_key": f"idempotency.synthetic-{sequence}",
+        "actor": PrivateWorldActor.LOCAL_USER,
+        "source": PrivateWorldCommandSource.CONTROL_CENTER,
+        "occurred_at": NOW,
+        "reason": "synthetic confirmed change",
+        "evidence_refs": (f"letter:synthetic-{sequence}",),
+    }
+
+
+def test_relationship_commands_reuse_slow_bounded_reducer_policy() -> None:
+    before = PrivateWorldSnapshot(
+        version=4,
+        trust=99,
+        comfort=100,
+        tension=1,
+    )
+
+    boundary = reduce_private_world_command(
+        before,
+        RecordBoundaryRespected(**_common(1)),
+    )
+    assert before == PrivateWorldSnapshot(
+        version=4,
+        trust=99,
+        comfort=100,
+        tension=1,
+    )
+    assert boundary.snapshot.version == 5
+    assert boundary.snapshot.trust == 100
+    assert boundary.snapshot.comfort == 100
+    assert boundary.delta.reason_code == "BOUNDARY_RESPECTED"
+    assert tuple(
+        change.field for change in boundary.delta.changes
+    ) == ("trust",)
+
+    conflict = reduce_private_world_command(
+        boundary.snapshot,
+        RecordConflict(**_common(2)),
+    )
+    assert conflict.snapshot.trust == 98
+    assert conflict.snapshot.comfort == 98
+    assert conflict.snapshot.tension == 4
+
+    repair = reduce_private_world_command(
+        conflict.snapshot,
+        RecordRepair(**_common(3)),
+    )
+    assert repair.snapshot.trust == 99
+    assert repair.snapshot.comfort == 99
+    assert repair.snapshot.tension == 2
+
+
+def test_stage_confirmation_uses_typed_bounded_stage() -> None:
+    before = PrivateWorldSnapshot(
+        version=2,
+        relationship_stage="acquaintance",
+    )
+    command = ConfirmRelationshipStage(
+        **_common(),
+        target_stage=RelationshipStage.FAMILIAR,
+        basis_event_ids=("event.synthetic-1",),
+    )
+
+    result = reduce_private_world_command(before, command)
+
+    assert result.snapshot.version == 3
+    assert result.snapshot.relationship_stage == "familiar"
+    assert result.delta.reason_code == "STAGE_CONFIRMED"
+    assert result.delta.changes[0].before == "acquaintance"
+    assert result.delta.changes[0].after == "familiar"
+
+    repeated = reduce_private_world_command(result.snapshot, command)
+    assert repeated.snapshot == result.snapshot
+    assert repeated.delta.applied is False
+    assert repeated.delta.reason_code == "BOUNDED_NO_CHANGE"
+
+
+def test_nickname_grant_revoke_preserve_order_and_are_idempotent() -> None:
+    before = PrivateWorldSnapshot(
+        version=1,
+        nickname_permissions=("旅行者",),
+    )
+    grant = GrantNickname(**_common(1), nickname="小河豚")
+
+    added = reduce_private_world_command(before, grant)
+    assert added.snapshot.version == 2
+    assert added.snapshot.nickname_permissions == (
+        "旅行者",
+        "小河豚",
+    )
+    assert added.delta.reason_code == "GRANT_NICKNAME"
+
+    duplicate = reduce_private_world_command(added.snapshot, grant)
+    assert duplicate.snapshot == added.snapshot
+    assert duplicate.delta.reason_code == "NICKNAME_ALREADY_GRANTED"
+
+    revoked = reduce_private_world_command(
+        added.snapshot,
+        RevokeNickname(**_common(2), nickname="旅行者"),
+    )
+    assert revoked.snapshot.nickname_permissions == ("小河豚",)
+    assert revoked.delta.reason_code == "REVOKE_NICKNAME"
+
+    absent = reduce_private_world_command(
+        revoked.snapshot,
+        RevokeNickname(**_common(3), nickname="旅行者"),
+    )
+    assert absent.snapshot == revoked.snapshot
+    assert absent.delta.reason_code == "NICKNAME_NOT_GRANTED"
+
+
+def test_nickname_limit_is_a_noop_without_version_change() -> None:
+    before = PrivateWorldSnapshot(
+        version=9,
+        nickname_permissions=tuple(
+            f"称呼{index}" for index in range(16)
+        ),
+    )
+
+    result = reduce_private_world_command(
+        before,
+        GrantNickname(**_common(), nickname="新称呼"),
+    )
+
+    assert result.snapshot == before
+    assert result.delta.reason_code == "NICKNAME_LIMIT_REACHED"
+
+
+def test_home_access_uses_enum_and_noop_does_not_bump_version() -> None:
+    before = PrivateWorldSnapshot(
+        version=5,
+        home_access=HomeAccess.NO_ACCESS,
+    )
+    command = SetHomeAccess(
+        **_common(),
+        home_access=HomeAccess.VISIT_ACCESS,
+    )
+
+    changed = reduce_private_world_command(before, command)
+    assert changed.snapshot.version == 6
+    assert changed.snapshot.home_access is HomeAccess.VISIT_ACCESS
+    assert changed.delta.reason_code == "SET_HOME_ACCESS"
+
+    unchanged = reduce_private_world_command(changed.snapshot, command)
+    assert unchanged.snapshot == changed.snapshot
+    assert unchanged.delta.reason_code == "HOME_ACCESS_UNCHANGED"
+
+
+def test_continuation_upsert_updates_in_place_and_preserves_order() -> None:
+    before = PrivateWorldSnapshot(
+        version=1,
+        continuation_facts=(
+            LocalContinuationFact(
+                "continuation.first",
+                "第一条合成测试事实。",
+                ContinuationAwareness.CONTROL_ONLY,
+            ),
+            LocalContinuationFact(
+                "continuation.second",
+                "第二条合成测试事实。",
+                ContinuationAwareness.PENDING,
+            ),
+        ),
+    )
+
+    updated = reduce_private_world_command(
+        before,
+        UpsertContinuationFact(
+            **_common(1),
+            fact_id="continuation.first",
+            statement="第一条合成测试事实已经更新。",
+            awareness=ContinuationAwareness.CHARACTER_KNOWN,
+        ),
+    )
+    assert updated.snapshot.version == 2
+    assert tuple(
+        fact.fact_id for fact in updated.snapshot.continuation_facts
+    ) == ("continuation.first", "continuation.second")
+    assert updated.snapshot.continuation_facts[0].statement.endswith(
+        "已经更新。"
+    )
+    assert (
+        updated.snapshot.continuation_facts[0].awareness
+        is ContinuationAwareness.CHARACTER_KNOWN
+    )
+
+    added = reduce_private_world_command(
+        updated.snapshot,
+        UpsertContinuationFact(
+            **_common(2),
+            fact_id="continuation.third",
+            statement="第三条合成测试事实。",
+            awareness=ContinuationAwareness.CONTROL_ONLY,
+        ),
+    )
+    assert tuple(
+        fact.fact_id for fact in added.snapshot.continuation_facts
+    ) == (
+        "continuation.first",
+        "continuation.second",
+        "continuation.third",
+    )
+
+    duplicate = reduce_private_world_command(
+        added.snapshot,
+        UpsertContinuationFact(
+            **_common(3),
+            fact_id="continuation.third",
+            statement="第三条合成测试事实。",
+            awareness=ContinuationAwareness.CONTROL_ONLY,
+        ),
+    )
+    assert duplicate.snapshot == added.snapshot
+    assert duplicate.delta.reason_code == "CONTINUATION_UNCHANGED"
+
+
+def test_continuation_limit_is_a_noop() -> None:
+    facts = tuple(
+        LocalContinuationFact(
+            f"continuation.synthetic-{index}",
+            f"第{index}条合成事实。",
+            ContinuationAwareness.CONTROL_ONLY,
+        )
+        for index in range(32)
+    )
+    before = PrivateWorldSnapshot(
+        version=7,
+        continuation_facts=facts,
+    )
+
+    result = reduce_private_world_command(
+        before,
+        UpsertContinuationFact(
+            **_common(),
+            fact_id="continuation.overflow",
+            statement="超出上限的合成事实。",
+            awareness=ContinuationAwareness.PENDING,
+        ),
+    )
+
+    assert result.snapshot == before
+    assert result.delta.reason_code == "CONTINUATION_LIMIT_REACHED"
+
+
+def test_continuation_awareness_and_delete_require_existing_fact() -> None:
+    fact = LocalContinuationFact(
+        "continuation.synthetic",
+        "一条合成测试事实。",
+        ContinuationAwareness.CONTROL_ONLY,
+    )
+    before = PrivateWorldSnapshot(
+        version=3,
+        continuation_facts=(fact,),
+    )
+
+    known = reduce_private_world_command(
+        before,
+        SetContinuationAwareness(
+            **_common(1),
+            fact_id=fact.fact_id,
+            awareness=ContinuationAwareness.CHARACTER_KNOWN,
+        ),
+    )
+    assert known.snapshot.version == 4
+    assert (
+        known.snapshot.continuation_facts[0].awareness
+        is ContinuationAwareness.CHARACTER_KNOWN
+    )
+
+    missing_awareness = reduce_private_world_command(
+        known.snapshot,
+        SetContinuationAwareness(
+            **_common(2),
+            fact_id="continuation.missing",
+            awareness=ContinuationAwareness.PENDING,
+        ),
+    )
+    assert missing_awareness.snapshot == known.snapshot
+    assert (
+        missing_awareness.delta.reason_code
+        == "CONTINUATION_NOT_FOUND"
+    )
+
+    deleted = reduce_private_world_command(
+        known.snapshot,
+        DeleteContinuationFact(
+            **_common(3),
+            fact_id=fact.fact_id,
+        ),
+    )
+    assert deleted.snapshot.version == 5
+    assert deleted.snapshot.continuation_facts == ()
+
+    missing_delete = reduce_private_world_command(
+        deleted.snapshot,
+        DeleteContinuationFact(
+            **_common(4),
+            fact_id=fact.fact_id,
+        ),
+    )
+    assert missing_delete.snapshot == deleted.snapshot
+    assert missing_delete.delta.reason_code == "CONTINUATION_NOT_FOUND"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        GrantNickname(**_common(1), nickname="合成称呼"),
+        SetHomeAccess(
+            **_common(2),
+            home_access=HomeAccess.ERRAND_ACCESS,
+        ),
+        UpsertContinuationFact(
+            **_common(3),
+            fact_id="continuation.synthetic",
+            statement="一条合成测试事实。",
+            awareness=ContinuationAwareness.CONTROL_ONLY,
+        ),
+    ],
+)
+def test_nonrelationship_commands_do_not_change_hidden_scores(
+    command,
+) -> None:
+    before = PrivateWorldSnapshot(
+        version=11,
+        familiarity=12,
+        trust=23,
+        comfort=34,
+        closeness=45,
+        tension=56,
+    )
+
+    result = reduce_private_world_command(before, command)
+
+    assert (
+        result.snapshot.familiarity,
+        result.snapshot.trust,
+        result.snapshot.comfort,
+        result.snapshot.closeness,
+        result.snapshot.tension,
+    ) == (12, 23, 34, 45, 56)
+
+
+def test_command_reducer_requires_typed_inputs() -> None:
+    with pytest.raises(
+        ReducerInputError,
+        match="typed snapshot and command",
+    ):
+        reduce_private_world_command(  # type: ignore[arg-type]
+            {},
+            RecordConflict(**_common()),
+        )
+    with pytest.raises(
+        ReducerInputError,
+        match="typed snapshot and command",
+    ):
+        reduce_private_world_command(  # type: ignore[arg-type]
+            PrivateWorldSnapshot(),
+            object(),
+        )

--- a/tests/private_world/test_private_world_commands.py
+++ b/tests/private_world/test_private_world_commands.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from private_world_commands import (
+    ConfirmRelationshipStage,
+    DeleteContinuationFact,
+    GrantNickname,
+    PrivateWorldActor,
+    PrivateWorldCommand,
+    PrivateWorldCommandError,
+    PrivateWorldCommandSource,
+    RecordBoundaryRespected,
+    RecordConflict,
+    RecordRepair,
+    RevokeNickname,
+    SetContinuationAwareness,
+    SetHomeAccess,
+    UpsertContinuationFact,
+)
+from private_world_port import ContinuationAwareness, HomeAccess
+from reply_context import RelationshipStage
+
+
+NOW = datetime(2026, 8, 22, 20, 0, tzinfo=timezone.utc)
+
+
+def _common(**changes: object) -> dict[str, object]:
+    values: dict[str, object] = {
+        "command_id": "command.synthetic-1",
+        "idempotency_key": "idempotency.synthetic-1",
+        "actor": PrivateWorldActor.LOCAL_USER,
+        "source": PrivateWorldCommandSource.CONTROL_CENTER,
+        "occurred_at": NOW,
+        "reason": "synthetic confirmed change",
+        "evidence_refs": (
+            "letter:synthetic-1",
+            "reply:synthetic-1:1",
+        ),
+    }
+    values.update(changes)
+    return values
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        RecordBoundaryRespected(**_common()),
+        RecordConflict(**_common()),
+        RecordRepair(**_common()),
+        ConfirmRelationshipStage(
+            **_common(),
+            target_stage=RelationshipStage.FAMILIAR,
+            basis_event_ids=("event.synthetic-1",),
+        ),
+        GrantNickname(**_common(), nickname="小河豚"),
+        RevokeNickname(**_common(), nickname="小河豚"),
+        SetHomeAccess(
+            **_common(),
+            home_access=HomeAccess.VISIT_ACCESS,
+        ),
+        UpsertContinuationFact(
+            **_common(),
+            fact_id="continuation.synthetic-1",
+            statement="一项只用于合成测试的未来安排。",
+            awareness=ContinuationAwareness.CONTROL_ONLY,
+        ),
+        SetContinuationAwareness(
+            **_common(),
+            fact_id="continuation.synthetic-1",
+            awareness=ContinuationAwareness.CHARACTER_KNOWN,
+        ),
+        DeleteContinuationFact(
+            **_common(),
+            fact_id="continuation.synthetic-1",
+        ),
+    ],
+)
+def test_commands_are_typed_serializable_and_hide_relationship_scores(
+    command: PrivateWorldCommand,
+) -> None:
+    payload = command.to_dict()
+
+    assert payload["command_id"] == "command.synthetic-1"
+    assert payload["idempotency_key"] == "idempotency.synthetic-1"
+    assert payload["actor"] == "local_user"
+    assert payload["source"] == "control_center"
+    assert payload["occurred_at"] == NOW.isoformat()
+    assert payload["evidence_refs"] == [
+        "letter:synthetic-1",
+        "reply:synthetic-1:1",
+    ]
+    serialized = repr(payload)
+    for hidden in (
+        "familiarity",
+        "trust",
+        "comfort",
+        "closeness",
+        "tension",
+    ):
+        assert hidden not in serialized
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"command_id": ""}, "command id is invalid"),
+        (
+            {"idempotency_key": "contains whitespace"},
+            "idempotency key is invalid",
+        ),
+        ({"actor": "local_user"}, "actor is invalid"),
+        ({"source": "control_center"}, "source is invalid"),
+        (
+            {"occurred_at": datetime(2026, 8, 22, 20, 0)},
+            "occurred_at must be timezone-aware",
+        ),
+        ({"reason": ""}, "reason is invalid"),
+        ({"reason": "x" * 281}, "reason is invalid"),
+        ({"reason": "bad\nreason"}, "reason is invalid"),
+        (
+            {"evidence_refs": ("same", "same")},
+            "evidence refs are invalid",
+        ),
+        (
+            {
+                "evidence_refs": tuple(
+                    f"e:{index}" for index in range(9)
+                )
+            },
+            "evidence refs are invalid",
+        ),
+    ],
+)
+def test_common_command_metadata_is_strict(
+    changes: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(PrivateWorldCommandError, match=message):
+        RecordConflict(**_common(**changes))  # type: ignore[arg-type]
+
+
+def test_base_command_cannot_be_instantiated() -> None:
+    with pytest.raises(TypeError, match="concrete"):
+        PrivateWorldCommand(**_common())  # type: ignore[abstract]
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"target_stage": "familiar"},
+        {"basis_event_ids": ()},
+        {"basis_event_ids": ("same", "same")},
+    ],
+)
+def test_stage_confirmation_requires_valid_explicit_basis(
+    changes: dict[str, object],
+) -> None:
+    values = {
+        **_common(),
+        "target_stage": RelationshipStage.FAMILIAR,
+        "basis_event_ids": ("event.synthetic-1",),
+        **changes,
+    }
+    with pytest.raises(PrivateWorldCommandError):
+        ConfirmRelationshipStage(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "nickname",
+    ["", "two words", "x" * 33, "bad\tname"],
+)
+def test_nickname_commands_reject_unbounded_or_spaced_values(
+    nickname: str,
+) -> None:
+    with pytest.raises(PrivateWorldCommandError):
+        GrantNickname(**_common(), nickname=nickname)
+
+
+def test_home_access_requires_typed_enum() -> None:
+    with pytest.raises(PrivateWorldCommandError, match="home access"):
+        SetHomeAccess(
+            **_common(),
+            home_access="visit_access",  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    ("fact_id", "statement", "awareness"),
+    [
+        (
+            "invalid id",
+            "synthetic",
+            ContinuationAwareness.PENDING,
+        ),
+        ("valid", "", ContinuationAwareness.PENDING),
+        ("valid", "synthetic", "pending"),
+    ],
+)
+def test_continuation_upsert_reuses_port_validation(
+    fact_id: str,
+    statement: str,
+    awareness: object,
+) -> None:
+    with pytest.raises(PrivateWorldCommandError):
+        UpsertContinuationFact(
+            **_common(),
+            fact_id=fact_id,
+            statement=statement,
+            awareness=awareness,  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
Implements PW-02 from #33.

## Changes

- adds provider-free typed PrivateWorld commands with bounded identifiers, reasons, evidence references, actors, sources, and payloads;
- restricts relationship stage changes to the existing `RelationshipStage` enum;
- adds explicit commands for:
  - boundary respected, conflict, repair, and stage confirmation;
  - nickname grant/revoke;
  - home-access changes;
  - Local Continuation upsert, awareness changes, and deletion;
- extends the pure reducer to apply those commands without persistence or I/O;
- preserves the existing slow relationship deltas and canonical-delivery no-effect policy;
- keeps non-relationship commands from changing hidden relationship scores;
- makes duplicate/no-op/limit outcomes explicit without incrementing snapshot versions;
- packages the new command module because the existing packaged reducer imports it.

## Validation

- 53 focused command, reducer, and legacy reducer tests passed locally;
- GitHub `Public smoke (Windows / Python 3.12)` is the required merge gate.

## Boundary

This PR does not add persistence, command idempotency storage, evidence lookup, audit tables, management APIs, candidates, or UI. Those belong to PW-03 and later work.

Part of #33.