### PR TITLE
feat(private-world): add atomic command service and audit

### DIFF
--- a/private_world_service.py
+++ b/private_world_service.py
@@ -1,0 +1,436 @@
+"""Atomic, auditable execution for typed PrivateWorld commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+import hashlib
+import json
+from threading import RLock
+from typing import Protocol, runtime_checkable
+
+from private_world_commands import (
+    ConfirmRelationshipStage,
+    PrivateWorldActor,
+    PrivateWorldCommand,
+    PrivateWorldCommandKind,
+    PrivateWorldCommandSource,
+    RecordBoundaryRespected,
+    RecordConflict,
+    RecordRepair,
+)
+from private_world_ledger import LedgerEvent, LedgerWriteError
+from private_world_port import PrivateWorldSnapshot
+from private_world_reducer import reduce_private_world_command
+
+
+PRIVATE_WORLD_COMMAND_AUDIT_SCHEMA = (
+    "p03.private-world-command-audit.v1"
+)
+
+
+class PrivateWorldCommandServiceError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+class CommandExecutionStatus(StrEnum):
+    APPLIED = "APPLIED"
+    NOOP = "NOOP"
+    DUPLICATE = "DUPLICATE"
+
+
+@dataclass(frozen=True)
+class CommandExecutionResult:
+    status: CommandExecutionStatus
+    command_id: str
+    event_id: str
+    reason_code: str
+    snapshot_version: int
+    change_fields: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status.value,
+            "command_id": self.command_id,
+            "event_id": self.event_id,
+            "reason_code": self.reason_code,
+            "snapshot_version": self.snapshot_version,
+            "change_fields": list(self.change_fields),
+        }
+
+
+@runtime_checkable
+class PrivateWorldCommandLedger(Protocol):
+    def snapshot(self) -> PrivateWorldSnapshot: ...
+
+    def events(self) -> tuple[LedgerEvent, ...]: ...
+
+    def apply_once(
+        self,
+        event: LedgerEvent,
+        snapshot: PrivateWorldSnapshot,
+    ) -> bool: ...
+
+
+_RELATIONSHIP_CANDIDATE_COMMANDS = (
+    RecordBoundaryRespected,
+    RecordConflict,
+    RecordRepair,
+)
+_STAGE_BASIS_EVENT_TYPES = frozenset(
+    {
+        "boundary_respected",
+        "conflict",
+        "repair",
+        PrivateWorldCommandKind.RECORD_BOUNDARY_RESPECTED.value,
+        PrivateWorldCommandKind.RECORD_CONFLICT.value,
+        PrivateWorldCommandKind.RECORD_REPAIR.value,
+    }
+)
+
+
+def _digest(prefix: str, value: str) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    return f"{prefix}.{digest}"
+
+
+def _fingerprint(command: PrivateWorldCommand) -> str:
+    encoded = json.dumps(
+        command.to_dict(),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _event_identity(
+    command: PrivateWorldCommand,
+) -> tuple[str, str]:
+    return (
+        _digest("command", command.command_id),
+        _digest("idempotency", command.idempotency_key),
+    )
+
+
+def _result_from_audit(
+    event: LedgerEvent,
+    *,
+    duplicate: bool,
+) -> CommandExecutionResult:
+    payload = event.payload
+    try:
+        status = (
+            CommandExecutionStatus.DUPLICATE
+            if duplicate
+            else (
+                CommandExecutionStatus.APPLIED
+                if payload["applied"] is True
+                else CommandExecutionStatus.NOOP
+            )
+        )
+        command_id = str(payload["command_id"])
+        reason_code = str(payload["reason_code"])
+        snapshot_version = int(payload["snapshot_version"])
+        raw_fields = payload.get("change_fields", ())
+        if not isinstance(raw_fields, list) or any(
+            not isinstance(field, str) for field in raw_fields
+        ):
+            raise ValueError
+    except (KeyError, TypeError, ValueError) as exc:
+        raise PrivateWorldCommandServiceError(
+            "PRIVATE_WORLD_COMMAND_AUDIT_INVALID"
+        ) from exc
+    return CommandExecutionResult(
+        status,
+        command_id,
+        event.event_id,
+        reason_code,
+        snapshot_version,
+        tuple(raw_fields),
+    )
+
+
+class PrivateWorldCommandService:
+    """Serialize, authorize, reduce, and atomically audit commands."""
+
+    def __init__(self, ledger: PrivateWorldCommandLedger) -> None:
+        if not isinstance(ledger, PrivateWorldCommandLedger):
+            raise TypeError("a PrivateWorld command ledger is required")
+        self._ledger = ledger
+        self._lock = RLock()
+
+    @staticmethod
+    def _authorize(command: PrivateWorldCommand) -> None:
+        if command.actor is PrivateWorldActor.SYSTEM_CANDIDATE:
+            raise PrivateWorldCommandServiceError(
+                "PRIVATE_WORLD_COMMAND_APPROVAL_REQUIRED"
+            )
+        if command.actor is PrivateWorldActor.MIGRATION:
+            if command.source not in {
+                PrivateWorldCommandSource.MIGRATION,
+                PrivateWorldCommandSource.IMPORT,
+            }:
+                raise PrivateWorldCommandServiceError(
+                    "PRIVATE_WORLD_COMMAND_SOURCE_FORBIDDEN"
+                )
+            return
+        if command.actor is not PrivateWorldActor.LOCAL_USER:
+            raise PrivateWorldCommandServiceError(
+                "PRIVATE_WORLD_COMMAND_SOURCE_FORBIDDEN"
+            )
+        if command.source not in {
+            PrivateWorldCommandSource.CONTROL_CENTER,
+            PrivateWorldCommandSource.APPROVED_CANDIDATE,
+        }:
+            raise PrivateWorldCommandServiceError(
+                "PRIVATE_WORLD_COMMAND_SOURCE_FORBIDDEN"
+            )
+        if command.source is PrivateWorldCommandSource.APPROVED_CANDIDATE:
+            if not isinstance(
+                command,
+                _RELATIONSHIP_CANDIDATE_COMMANDS,
+            ):
+                raise PrivateWorldCommandServiceError(
+                    "PRIVATE_WORLD_COMMAND_SOURCE_FORBIDDEN"
+                )
+            if not command.evidence_refs:
+                raise PrivateWorldCommandServiceError(
+                    "PRIVATE_WORLD_COMMAND_EVIDENCE_REQUIRED"
+                )
+
+    def _ledger_events(self) -> tuple[LedgerEvent, ...]:
+        try:
+            return self._ledger.events()
+        except (
+            LedgerWriteError,
+            OSError,
+            RuntimeError,
+            ValueError,
+            KeyError,
+            TypeError,
+        ) as exc:
+            raise PrivateWorldCommandServiceError(
+                "PRIVATE_WORLD_COMMAND_STORAGE_UNAVAILABLE"
+            ) from exc
+
+    def _ledger_snapshot(self) -> PrivateWorldSnapshot:
+        try:
+            snapshot = self._ledger.snapshot()
+        except (
+            LedgerWriteError,
+            OSError,
+            RuntimeError,
+            ValueError,
+            KeyError,
+            TypeError,
+        ) as exc:
+            raise PrivateWorldCommandServiceError(
+                "PRIVATE_WORLD_COMMAND_STORAGE_UNAVAILABLE"
+            ) from exc
+        if not isinstance(snapshot, PrivateWorldSnapshot):
+            raise PrivateWorldCommandServiceError(
+                "PRIVATE_WORLD_COMMAND_STORAGE_UNAVAILABLE"
+            )
+        return snapshot
+
+    def _matching_identity_events(
+        self,
+        event_id: str,
+        delivery_id: str,
+    ) -> tuple[LedgerEvent, ...]:
+        return tuple(
+            event
+            for event in self._ledger_events()
+            if event.event_id == event_id
+            or event.delivery_id == delivery_id
+        )
+
+    @staticmethod
+    def _same_command(
+        event: LedgerEvent,
+        command: PrivateWorldCommand,
+        fingerprint: str,
+    ) -> bool:
+        payload = event.payload
+        return (
+            payload.get("schema_version")
+            == PRIVATE_WORLD_COMMAND_AUDIT_SCHEMA
+            and payload.get("command_id") == command.command_id
+            and payload.get("idempotency_key")
+            == command.idempotency_key
+            and payload.get("command_fingerprint") == fingerprint
+        )
+
+    def _resolve_existing(
+        self,
+        command: PrivateWorldCommand,
+        event_id: str,
+        delivery_id: str,
+        fingerprint: str,
+    ) -> CommandExecutionResult | None:
+        matches = self._matching_identity_events(
+            event_id,
+            delivery_id,
+        )
+        if not matches:
+            return None
+        if len(matches) == 1 and self._same_command(
+            matches[0],
+            command,
+            fingerprint,
+        ):
+            return _result_from_audit(
+                matches[0],
+                duplicate=True,
+            )
+        raise PrivateWorldCommandServiceError(
+            "PRIVATE_WORLD_COMMAND_IDENTITY_CONFLICT"
+        )
+
+    def _validate_stage_basis(
+        self,
+        command: PrivateWorldCommand,
+    ) -> None:
+        if not isinstance(command, ConfirmRelationshipStage):
+            return
+        events = {
+            event.event_id: event
+            for event in self._ledger_events()
+            if event.event_id in command.basis_event_ids
+        }
+        if set(events) != set(command.basis_event_ids):
+            raise PrivateWorldCommandServiceError(
+                "PRIVATE_WORLD_COMMAND_EVIDENCE_INVALID"
+            )
+        if any(
+            event.event_type not in _STAGE_BASIS_EVENT_TYPES
+            for event in events.values()
+        ):
+            raise PrivateWorldCommandServiceError(
+                "PRIVATE_WORLD_COMMAND_EVIDENCE_INVALID"
+            )
+
+    @staticmethod
+    def _audit_payload(
+        command: PrivateWorldCommand,
+        fingerprint: str,
+        *,
+        applied: bool,
+        reason_code: str,
+        change_fields: tuple[str, ...],
+        snapshot_version: int,
+    ) -> dict[str, object]:
+        return {
+            "schema_version": PRIVATE_WORLD_COMMAND_AUDIT_SCHEMA,
+            "command_id": command.command_id,
+            "idempotency_key": command.idempotency_key,
+            "command_kind": command.kind.value,
+            "actor": command.actor.value,
+            "source": command.source.value,
+            "reason": command.reason,
+            "evidence_refs": list(command.evidence_refs),
+            "payload_fields": sorted(command.payload()),
+            "command_fingerprint": fingerprint,
+            "applied": applied,
+            "reason_code": reason_code,
+            "change_fields": list(change_fields),
+            "snapshot_version": snapshot_version,
+        }
+
+    def execute(
+        self,
+        command: PrivateWorldCommand,
+    ) -> CommandExecutionResult:
+        if not isinstance(command, PrivateWorldCommand):
+            raise TypeError(
+                "a typed PrivateWorld command is required"
+            )
+        self._authorize(command)
+        event_id, delivery_id = _event_identity(command)
+        fingerprint = _fingerprint(command)
+
+        with self._lock:
+            existing = self._resolve_existing(
+                command,
+                event_id,
+                delivery_id,
+                fingerprint,
+            )
+            if existing is not None:
+                return existing
+            self._validate_stage_basis(command)
+            reduced = reduce_private_world_command(
+                self._ledger_snapshot(),
+                command,
+            )
+            change_fields = tuple(
+                change.field for change in reduced.delta.changes
+            )
+            audit = self._audit_payload(
+                command,
+                fingerprint,
+                applied=reduced.delta.applied,
+                reason_code=reduced.delta.reason_code,
+                change_fields=change_fields,
+                snapshot_version=reduced.snapshot.version,
+            )
+            event = LedgerEvent(
+                event_id=event_id,
+                delivery_id=delivery_id,
+                event_type=command.kind.value,
+                payload=audit,
+                occurred_at=command.occurred_at.isoformat(),
+            )
+            try:
+                applied = self._ledger.apply_once(
+                    event,
+                    reduced.snapshot,
+                )
+            except (
+                LedgerWriteError,
+                OSError,
+                RuntimeError,
+                ValueError,
+                KeyError,
+                TypeError,
+            ) as exc:
+                raise PrivateWorldCommandServiceError(
+                    "PRIVATE_WORLD_COMMAND_STORAGE_UNAVAILABLE"
+                ) from exc
+            if not applied:
+                duplicate = self._resolve_existing(
+                    command,
+                    event_id,
+                    delivery_id,
+                    fingerprint,
+                )
+                if duplicate is not None:
+                    return duplicate
+                raise PrivateWorldCommandServiceError(
+                    "PRIVATE_WORLD_COMMAND_IDENTITY_CONFLICT"
+                )
+            return CommandExecutionResult(
+                (
+                    CommandExecutionStatus.APPLIED
+                    if reduced.delta.applied
+                    else CommandExecutionStatus.NOOP
+                ),
+                command.command_id,
+                event_id,
+                reduced.delta.reason_code,
+                reduced.snapshot.version,
+                change_fields,
+            )
+
+
+__all__ = [
+    "CommandExecutionResult",
+    "CommandExecutionStatus",
+    "PRIVATE_WORLD_COMMAND_AUDIT_SCHEMA",
+    "PrivateWorldCommandLedger",
+    "PrivateWorldCommandService",
+    "PrivateWorldCommandServiceError",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ py-modules = [
     "prompt_budget",
     "private_world_port",
     "private_world_commands",
+    "private_world_service",
     "private_world_reducer",
     "private_world_ledger",
     "private_world_admin",

--- a/tests/private_world/test_private_world_service.py
+++ b/tests/private_world/test_private_world_service.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from threading import Lock
+
+import pytest
+
+from private_world_commands import (
+    ConfirmRelationshipStage,
+    GrantNickname,
+    PrivateWorldActor,
+    PrivateWorldCommandSource,
+    RecordConflict,
+    RecordRepair,
+    SetHomeAccess,
+    UpsertContinuationFact,
+)
+from private_world_ledger import LedgerEvent, LedgerWriteError
+from private_world_port import (
+    ContinuationAwareness,
+    HomeAccess,
+    PrivateWorldSnapshot,
+)
+from private_world_service import (
+    CommandExecutionStatus,
+    PRIVATE_WORLD_COMMAND_AUDIT_SCHEMA,
+    PrivateWorldCommandService,
+    PrivateWorldCommandServiceError,
+)
+from reply_context import RelationshipStage
+
+
+NOW = datetime(2026, 8, 22, 20, 0, tzinfo=timezone.utc)
+
+
+class FakeLedger:
+    def __init__(self) -> None:
+        self.current = PrivateWorldSnapshot()
+        self.items: list[LedgerEvent] = []
+        self.fail_writes = False
+        self.fail_reads = False
+        self._lock = Lock()
+
+    def snapshot(self) -> PrivateWorldSnapshot:
+        if self.fail_reads:
+            raise LedgerWriteError("synthetic read failure")
+        return self.current
+
+    def events(self) -> tuple[LedgerEvent, ...]:
+        if self.fail_reads:
+            raise LedgerWriteError("synthetic read failure")
+        return tuple(self.items)
+
+    def apply_once(
+        self,
+        event: LedgerEvent,
+        snapshot: PrivateWorldSnapshot,
+    ) -> bool:
+        if self.fail_writes:
+            raise LedgerWriteError("synthetic write failure")
+        with self._lock:
+            if any(
+                item.event_id == event.event_id
+                or item.delivery_id == event.delivery_id
+                for item in self.items
+            ):
+                return False
+            self.items.append(event)
+            self.current = snapshot
+            return True
+
+
+def _common(
+    sequence: int = 1,
+    **changes: object,
+) -> dict[str, object]:
+    values: dict[str, object] = {
+        "command_id": f"command.synthetic-{sequence}",
+        "idempotency_key": f"idempotency.synthetic-{sequence}",
+        "actor": PrivateWorldActor.LOCAL_USER,
+        "source": PrivateWorldCommandSource.CONTROL_CENTER,
+        "occurred_at": NOW,
+        "reason": "synthetic confirmed change",
+        "evidence_refs": (f"letter:synthetic-{sequence}",),
+    }
+    values.update(changes)
+    return values
+
+
+def test_service_applies_and_audits_without_payload_values() -> None:
+    ledger = FakeLedger()
+    service = PrivateWorldCommandService(ledger)
+    command = UpsertContinuationFact(
+        **_common(),
+        fact_id="continuation.synthetic",
+        statement="一条只用于合成测试的私人世界事实。",
+        awareness=ContinuationAwareness.CONTROL_ONLY,
+    )
+
+    result = service.execute(command)
+
+    assert result.status is CommandExecutionStatus.APPLIED
+    assert result.snapshot_version == 2
+    assert result.change_fields == ("continuation_facts",)
+    assert ledger.current.continuation_facts[0].statement.endswith("事实。")
+    assert len(ledger.items) == 1
+    audit = ledger.items[0].payload
+    assert audit["schema_version"] == PRIVATE_WORLD_COMMAND_AUDIT_SCHEMA
+    assert audit["command_kind"] == "upsert_continuation_fact"
+    assert audit["actor"] == "local_user"
+    assert audit["source"] == "control_center"
+    assert audit["reason"] == "synthetic confirmed change"
+    assert audit["evidence_refs"] == ["letter:synthetic-1"]
+    assert audit["payload_fields"] == [
+        "awareness",
+        "fact_id",
+        "statement",
+    ]
+    serialized = repr(audit)
+    assert command.statement not in serialized
+    assert command.fact_id not in serialized
+    assert "control_only" not in serialized
+    for value in (
+        "familiarity",
+        "trust",
+        "comfort",
+        "closeness",
+        "tension",
+    ):
+        assert f"'{value}':" not in serialized
+
+
+def test_exact_retry_returns_duplicate_without_second_write() -> None:
+    ledger = FakeLedger()
+    service = PrivateWorldCommandService(ledger)
+    command = SetHomeAccess(
+        **_common(),
+        home_access=HomeAccess.VISIT_ACCESS,
+    )
+
+    first = service.execute(command)
+    duplicate = service.execute(command)
+
+    assert first.status is CommandExecutionStatus.APPLIED
+    assert duplicate.status is CommandExecutionStatus.DUPLICATE
+    assert duplicate.event_id == first.event_id
+    assert duplicate.snapshot_version == first.snapshot_version
+    assert len(ledger.items) == 1
+    assert ledger.current.version == 2
+
+
+@pytest.mark.parametrize("reuse", ["command_id", "idempotency_key"])
+def test_identity_reuse_with_different_command_is_rejected(
+    reuse: str,
+) -> None:
+    ledger = FakeLedger()
+    service = PrivateWorldCommandService(ledger)
+    original = SetHomeAccess(
+        **_common(1),
+        home_access=HomeAccess.VISIT_ACCESS,
+    )
+    service.execute(original)
+    changes: dict[str, object] = {}
+    if reuse == "command_id":
+        changes["command_id"] = original.command_id
+    else:
+        changes["idempotency_key"] = original.idempotency_key
+    conflicting = GrantNickname(
+        **_common(2, **changes),
+        nickname="合成称呼",
+    )
+
+    with pytest.raises(
+        PrivateWorldCommandServiceError,
+        match="PRIVATE_WORLD_COMMAND_IDENTITY_CONFLICT",
+    ):
+        service.execute(conflicting)
+    assert len(ledger.items) == 1
+
+
+def test_noop_is_audited_without_incrementing_snapshot() -> None:
+    ledger = FakeLedger()
+    service = PrivateWorldCommandService(ledger)
+    first = SetHomeAccess(
+        **_common(1),
+        home_access=HomeAccess.VISIT_ACCESS,
+    )
+    repeated_with_new_identity = SetHomeAccess(
+        **_common(2),
+        home_access=HomeAccess.VISIT_ACCESS,
+    )
+
+    applied = service.execute(first)
+    noop = service.execute(repeated_with_new_identity)
+
+    assert applied.snapshot_version == 2
+    assert noop.status is CommandExecutionStatus.NOOP
+    assert noop.reason_code == "HOME_ACCESS_UNCHANGED"
+    assert noop.snapshot_version == 2
+    assert len(ledger.items) == 2
+    assert ledger.items[1].payload["applied"] is False
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        RecordConflict(
+            **_common(
+                actor=PrivateWorldActor.SYSTEM_CANDIDATE,
+                source=PrivateWorldCommandSource.APPROVED_CANDIDATE,
+            )
+        ),
+        SetHomeAccess(
+            **_common(
+                source=PrivateWorldCommandSource.APPROVED_CANDIDATE,
+            ),
+            home_access=HomeAccess.DOMESTIC_ACCESS,
+        ),
+        GrantNickname(
+            **_common(source=PrivateWorldCommandSource.IMPORT),
+            nickname="合成称呼",
+        ),
+        RecordRepair(
+            **_common(
+                actor=PrivateWorldActor.MIGRATION,
+                source=PrivateWorldCommandSource.CONTROL_CENTER,
+            )
+        ),
+    ],
+)
+def test_service_rejects_unapproved_or_mismatched_authority(
+    command,
+) -> None:
+    with pytest.raises(PrivateWorldCommandServiceError):
+        PrivateWorldCommandService(FakeLedger()).execute(command)
+
+
+def test_approved_candidate_requires_relationship_command_and_evidence() -> None:
+    service = PrivateWorldCommandService(FakeLedger())
+    missing_evidence = RecordConflict(
+        **_common(
+            source=PrivateWorldCommandSource.APPROVED_CANDIDATE,
+            evidence_refs=(),
+        )
+    )
+    with pytest.raises(
+        PrivateWorldCommandServiceError,
+        match="PRIVATE_WORLD_COMMAND_EVIDENCE_REQUIRED",
+    ):
+        service.execute(missing_evidence)
+
+    approved = RecordConflict(
+        **_common(
+            source=PrivateWorldCommandSource.APPROVED_CANDIDATE,
+        )
+    )
+    assert (
+        service.execute(approved).status
+        is CommandExecutionStatus.APPLIED
+    )
+
+
+def test_stage_confirmation_requires_existing_relationship_evidence() -> None:
+    ledger = FakeLedger()
+    service = PrivateWorldCommandService(ledger)
+    conflict = RecordConflict(**_common(1))
+    conflict_result = service.execute(conflict)
+    stage = ConfirmRelationshipStage(
+        **_common(2),
+        target_stage=RelationshipStage.FAMILIAR,
+        basis_event_ids=(conflict_result.event_id,),
+    )
+
+    confirmed = service.execute(stage)
+
+    assert confirmed.status is CommandExecutionStatus.APPLIED
+    assert ledger.current.relationship_stage == "familiar"
+
+    missing = ConfirmRelationshipStage(
+        **_common(3),
+        target_stage=RelationshipStage.CLOSE,
+        basis_event_ids=("event.missing",),
+    )
+    with pytest.raises(
+        PrivateWorldCommandServiceError,
+        match="PRIVATE_WORLD_COMMAND_EVIDENCE_INVALID",
+    ):
+        service.execute(missing)
+
+    canonical = LedgerEvent(
+        event_id="delivery.synthetic",
+        delivery_id="delivery.synthetic",
+        event_type="canonical_reply_delivered",
+        payload={},
+        occurred_at=NOW.isoformat(),
+    )
+    ledger.items.append(canonical)
+    invalid = ConfirmRelationshipStage(
+        **_common(4),
+        target_stage=RelationshipStage.CLOSE,
+        basis_event_ids=(canonical.event_id,),
+    )
+    with pytest.raises(
+        PrivateWorldCommandServiceError,
+        match="PRIVATE_WORLD_COMMAND_EVIDENCE_INVALID",
+    ):
+        service.execute(invalid)
+
+
+def test_migration_actor_can_use_only_migration_or_import_sources() -> None:
+    service = PrivateWorldCommandService(FakeLedger())
+    imported = GrantNickname(
+        **_common(
+            actor=PrivateWorldActor.MIGRATION,
+            source=PrivateWorldCommandSource.IMPORT,
+        ),
+        nickname="迁移称呼",
+    )
+    assert (
+        service.execute(imported).status
+        is CommandExecutionStatus.APPLIED
+    )
+
+
+@pytest.mark.parametrize("failure", ["read", "write"])
+def test_storage_failure_is_wrapped_in_stable_error(
+    failure: str,
+) -> None:
+    ledger = FakeLedger()
+    if failure == "read":
+        ledger.fail_reads = True
+    else:
+        ledger.fail_writes = True
+    service = PrivateWorldCommandService(ledger)
+
+    with pytest.raises(
+        PrivateWorldCommandServiceError,
+        match="PRIVATE_WORLD_COMMAND_STORAGE_UNAVAILABLE",
+    ):
+        service.execute(RecordConflict(**_common()))
+
+
+def test_service_serializes_concurrent_commands() -> None:
+    ledger = FakeLedger()
+    service = PrivateWorldCommandService(ledger)
+    commands = tuple(
+        GrantNickname(
+            **_common(index),
+            nickname=f"称呼{index}",
+        )
+        for index in range(1, 11)
+    )
+
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        results = tuple(executor.map(service.execute, commands))
+
+    assert all(
+        result.status is CommandExecutionStatus.APPLIED
+        for result in results
+    )
+    assert ledger.current.version == 11
+    assert len(ledger.items) == 10
+    assert len(ledger.current.nickname_permissions) == 10
+
+
+def test_execution_result_is_bounded_and_serializable() -> None:
+    service = PrivateWorldCommandService(FakeLedger())
+    result = service.execute(RecordConflict(**_common()))
+
+    assert result.to_dict() == {
+        "status": "APPLIED",
+        "command_id": "command.synthetic-1",
+        "event_id": result.event_id,
+        "reason_code": "CONFLICT",
+        "snapshot_version": 2,
+        "change_fields": ["tension"],
+    }
+
+
+def test_service_requires_typed_ledger_and_command() -> None:
+    with pytest.raises(TypeError, match="command ledger"):
+        PrivateWorldCommandService(object())  # type: ignore[arg-type]
+    service = PrivateWorldCommandService(FakeLedger())
+    with pytest.raises(TypeError, match="typed PrivateWorld command"):
+        service.execute(object())  # type: ignore[arg-type]

--- a/tests/private_world/test_private_world_service_sqlite.py
+++ b/tests/private_world/test_private_world_service_sqlite.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from private_world_commands import (
+    GrantNickname,
+    PrivateWorldActor,
+    PrivateWorldCommandSource,
+    RecordConflict,
+    SetHomeAccess,
+)
+from private_world_ledger import SQLitePrivateWorldLedger
+from private_world_port import HomeAccess
+from private_world_service import (
+    CommandExecutionStatus,
+    PrivateWorldCommandService,
+)
+
+
+NOW = datetime(2026, 8, 22, 20, 0, tzinfo=timezone.utc)
+
+
+def _common(sequence: int = 1) -> dict[str, object]:
+    return {
+        "command_id": f"command.sqlite-{sequence}",
+        "idempotency_key": f"idempotency.sqlite-{sequence}",
+        "actor": PrivateWorldActor.LOCAL_USER,
+        "source": PrivateWorldCommandSource.CONTROL_CENTER,
+        "occurred_at": NOW,
+        "reason": "synthetic SQLite integration",
+        "evidence_refs": (f"letter:sqlite-{sequence}",),
+    }
+
+
+def test_sqlite_service_persists_and_deduplicates_across_reopen(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "private-world.sqlite3"
+    command = RecordConflict(**_common(1))
+
+    first_ledger = SQLitePrivateWorldLedger(database)
+    first = PrivateWorldCommandService(first_ledger).execute(command)
+
+    assert first.status is CommandExecutionStatus.APPLIED
+    assert first_ledger.snapshot().tension == 3
+    assert first_ledger.health()["event_count"] == 1
+    assert first_ledger.health()["snapshot_count"] == 1
+
+    reopened = SQLitePrivateWorldLedger(database)
+    service = PrivateWorldCommandService(reopened)
+    duplicate = service.execute(command)
+
+    assert duplicate.status is CommandExecutionStatus.DUPLICATE
+    assert duplicate.event_id == first.event_id
+    assert reopened.health()["event_count"] == 1
+    assert reopened.snapshot().version == 2
+
+    nickname = GrantNickname(
+        **_common(2),
+        nickname="合成称呼",
+    )
+    applied = service.execute(nickname)
+    assert applied.status is CommandExecutionStatus.APPLIED
+    assert reopened.snapshot().nickname_permissions == ("合成称呼",)
+    assert reopened.snapshot().version == 3
+    assert reopened.health()["event_count"] == 2
+    assert reopened.health()["snapshot_count"] == 2
+
+
+def test_first_noop_command_is_audited_at_initial_snapshot_version(
+    tmp_path: Path,
+) -> None:
+    ledger = SQLitePrivateWorldLedger(
+        tmp_path / "private-world-noop.sqlite3"
+    )
+    service = PrivateWorldCommandService(ledger)
+    noop = SetHomeAccess(
+        **_common(1),
+        home_access=HomeAccess.NO_ACCESS,
+    )
+
+    result = service.execute(noop)
+
+    assert result.status is CommandExecutionStatus.NOOP
+    assert result.snapshot_version == 1
+    assert ledger.snapshot().version == 1
+    assert ledger.health()["event_count"] == 1
+    assert ledger.health()["snapshot_count"] == 1


### PR DESCRIPTION
Implements PW-03 from #33.

## Changes

- adds a narrow `PrivateWorldCommandService` over the typed PW-02 commands and existing ledger;
- serializes command execution with a process-local lock;
- authorizes only explicit local-user and migration sources;
- rejects `system_candidate` mutations until a user approves a candidate;
- allows approved-candidate execution only for bounded relationship events with evidence;
- requires relationship-stage evidence to reference existing relationship-effect ledger events;
- derives deterministic event and idempotency identities without storing raw command payload values in audit events;
- records actor, source, bounded reason, evidence references, payload field names, fingerprint, applied/no-op result, changed fields, and snapshot version;
- returns exact duplicate retries without a second state change or event;
- rejects command-ID or idempotency-key reuse with different content;
- keeps no-op commands auditable without incrementing the snapshot version;
- wraps ledger read/write failures in stable product errors;
- packages the service module.

## Validation

- 60 focused command/reducer/service tests passed locally using an in-memory ledger;
- includes real SQLite integration tests for persistence, no-op auditing, and duplicate recovery across reopen;
- GitHub `Public smoke (Windows / Python 3.12)` is the required merge gate.

## Boundary

This PR does not add HTTP management routes, sessions, candidates, automatic analysis, or UI. Those remain PW-04 through PW-06.

Part of #33.