### PR TITLE
feat(control): add secured loopback PrivateWorld management API

### DIFF
--- a/control_center/__init__.py
+++ b/control_center/__init__.py
@@ -1,0 +1,6 @@
+"""Local management surface for the Companion Control Center."""
+
+from .app import create_control_app
+from .auth import ControlSessionManager
+
+__all__ = ["ControlSessionManager", "create_control_app"]

--- a/control_center/app.py
+++ b/control_center/app.py
@@ -1,0 +1,364 @@
+"""Loopback-only aiohttp management API for the Companion Control Center."""
+
+from __future__ import annotations
+
+import json
+from typing import Awaitable, Callable
+from urllib.parse import urlsplit
+
+from aiohttp import web
+
+from private_world_commands import PrivateWorldCommandError
+from private_world_service import (
+    PrivateWorldCommandLedger,
+    PrivateWorldCommandService,
+)
+
+from .auth import (
+    CONTROL_CSRF_HEADER,
+    CONTROL_SESSION_COOKIE,
+    ControlAuthError,
+    ControlSessionManager,
+)
+from .private_world_api import (
+    PrivateWorldAPIError,
+    PrivateWorldControlAPI,
+)
+
+
+AUTH_KEY = web.AppKey("control_center.auth", ControlSessionManager)
+PRIVATE_WORLD_API_KEY = web.AppKey(
+    "control_center.private_world_api",
+    PrivateWorldControlAPI,
+)
+SESSION_TOKEN_KEY = web.AppKey("control_center.session_token", str)
+
+_PUBLIC_ROUTES = frozenset(
+    {
+        ("GET", "/control/health"),
+        ("POST", "/control/api/session/bootstrap"),
+    }
+)
+_MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+_SECURITY_HEADERS = {
+    "Cache-Control": "no-store",
+    "Content-Security-Policy": (
+        "default-src 'self'; base-uri 'none'; object-src 'none'; "
+        "frame-ancestors 'none'; form-action 'self'; connect-src 'self'; "
+        "img-src 'self' data:; media-src 'self' blob:; "
+        "script-src 'self'; style-src 'self'"
+    ),
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "Cross-Origin-Resource-Policy": "same-origin",
+    "Permissions-Policy": (
+        "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
+    ),
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+}
+
+
+class ControlRequestError(RuntimeError):
+    def __init__(self, code: str, *, http_status: int = 400) -> None:
+        self.code = code
+        self.http_status = http_status
+        super().__init__(code)
+
+
+def _response(
+    data: dict[str, object],
+    *,
+    status: int = 200,
+) -> web.Response:
+    return web.json_response(
+        {"ok": True, "data": data},
+        status=status,
+    )
+
+
+def _error_response(status: int, code: str) -> web.Response:
+    return web.json_response(
+        {"ok": False, "error": {"code": code}},
+        status=status,
+    )
+
+
+def _host_name(value: str) -> str | None:
+    if not value:
+        return None
+    try:
+        parsed = urlsplit(f"//{value}")
+        return parsed.hostname
+    except ValueError:
+        return None
+
+
+def _loopback_request_host(request: web.Request) -> bool:
+    return _host_name(request.host) in _LOOPBACK_HOSTS
+
+
+def _same_loopback_origin(request: web.Request) -> bool:
+    origin = request.headers.get("Origin", "")
+    if not origin:
+        return False
+    try:
+        parsed = urlsplit(origin)
+    except ValueError:
+        return False
+    if (
+        parsed.scheme not in {"http", "https"}
+        or parsed.hostname not in _LOOPBACK_HOSTS
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        return False
+    request_host = urlsplit(f"//{request.host}")
+    origin_port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    request_port = request_host.port or (
+        443 if request.scheme == "https" else 80
+    )
+    return (
+        parsed.hostname == request_host.hostname
+        and origin_port == request_port
+    )
+
+
+def _auth_error_status(code: str) -> int:
+    if code in {"CONTROL_CSRF_REQUIRED", "CONTROL_CSRF_INVALID"}:
+        return 403
+    return 401
+
+
+@web.middleware
+async def control_boundary_middleware(
+    request: web.Request,
+    handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
+) -> web.StreamResponse:
+    response: web.StreamResponse
+    try:
+        if not _loopback_request_host(request):
+            raise ControlRequestError(
+                "CONTROL_HOST_FORBIDDEN",
+                http_status=403,
+            )
+        origin_present = bool(request.headers.get("Origin"))
+        if origin_present and not _same_loopback_origin(request):
+            raise ControlRequestError(
+                "CONTROL_ORIGIN_FORBIDDEN",
+                http_status=403,
+            )
+        if request.method in _MUTATING_METHODS and not origin_present:
+            raise ControlRequestError(
+                "CONTROL_ORIGIN_FORBIDDEN",
+                http_status=403,
+            )
+
+        if (request.method, request.path) not in _PUBLIC_ROUTES:
+            token = request.cookies.get(CONTROL_SESSION_COOKIE)
+            request.app[AUTH_KEY].authenticate(token)
+            request[SESSION_TOKEN_KEY] = token or ""
+            if request.method in _MUTATING_METHODS:
+                request.app[AUTH_KEY].validate_csrf(
+                    token,
+                    request.headers.get(CONTROL_CSRF_HEADER),
+                )
+
+        response = await handler(request)
+    except ControlRequestError as exc:
+        response = _error_response(exc.http_status, exc.code)
+    except ControlAuthError as exc:
+        response = _error_response(_auth_error_status(exc.code), exc.code)
+    except PrivateWorldAPIError as exc:
+        response = _error_response(exc.http_status, exc.code)
+    except PrivateWorldCommandError:
+        response = _error_response(400, "PRIVATE_WORLD_COMMAND_INVALID")
+    except json.JSONDecodeError:
+        response = _error_response(400, "CONTROL_JSON_INVALID")
+    except web.HTTPException as exc:
+        code = {
+            404: "CONTROL_ROUTE_NOT_FOUND",
+            405: "CONTROL_METHOD_NOT_ALLOWED",
+            413: "CONTROL_BODY_TOO_LARGE",
+            415: "CONTROL_CONTENT_TYPE_INVALID",
+        }.get(exc.status, "CONTROL_HTTP_ERROR")
+        response = _error_response(exc.status, code)
+    except (OSError, RuntimeError, TypeError, ValueError, KeyError):
+        response = _error_response(500, "CONTROL_INTERNAL_ERROR")
+
+    response.headers.update(_SECURITY_HEADERS)
+    response.headers.pop("Access-Control-Allow-Origin", None)
+    return response
+
+
+async def _json_body(request: web.Request) -> object:
+    if request.content_type != "application/json":
+        raise web.HTTPUnsupportedMediaType()
+    try:
+        return await request.json(loads=json.loads)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise json.JSONDecodeError("invalid", "", 0) from exc
+
+
+async def health(request: web.Request) -> web.Response:
+    del request
+    return _response(
+        {
+            "status": "READY",
+            "authentication": "required",
+            "network_scope": "loopback",
+        }
+    )
+
+
+async def bootstrap(request: web.Request) -> web.Response:
+    body = await _json_body(request)
+    if not isinstance(body, dict) or set(body) != {"token"}:
+        raise ControlRequestError("CONTROL_BODY_FIELDS_INVALID")
+    credentials = request.app[AUTH_KEY].bootstrap(body["token"])
+    response = _response(
+        {
+            "status": "READY",
+            "csrf_token": credentials.csrf_token,
+            "expires_in_seconds": int(
+                request.app[AUTH_KEY].idle_timeout_seconds
+            ),
+        }
+    )
+    response.set_cookie(
+        CONTROL_SESSION_COOKIE,
+        credentials.session_token,
+        httponly=True,
+        secure=request.secure,
+        samesite="Strict",
+        max_age=int(request.app[AUTH_KEY].idle_timeout_seconds),
+        path="/control",
+    )
+    return response
+
+
+async def logout(request: web.Request) -> web.Response:
+    request.app[AUTH_KEY].logout(request.get(SESSION_TOKEN_KEY))
+    response = _response({"status": "LOGGED_OUT"})
+    response.del_cookie(CONTROL_SESSION_COOKIE, path="/control")
+    return response
+
+
+async def private_world_snapshot(request: web.Request) -> web.Response:
+    return _response(request.app[PRIVATE_WORLD_API_KEY].snapshot())
+
+
+async def private_world_events(request: web.Request) -> web.Response:
+    return _response(request.app[PRIVATE_WORLD_API_KEY].events())
+
+
+async def private_world_relationship_event(
+    request: web.Request,
+) -> web.Response:
+    return _response(
+        request.app[PRIVATE_WORLD_API_KEY].relationship_event(
+            await _json_body(request)
+        )
+    )
+
+
+async def private_world_relationship_stage(
+    request: web.Request,
+) -> web.Response:
+    return _response(
+        request.app[PRIVATE_WORLD_API_KEY].relationship_stage(
+            await _json_body(request)
+        )
+    )
+
+
+async def private_world_nickname(request: web.Request) -> web.Response:
+    return _response(
+        request.app[PRIVATE_WORLD_API_KEY].nickname(
+            await _json_body(request)
+        )
+    )
+
+
+async def private_world_home_access(request: web.Request) -> web.Response:
+    return _response(
+        request.app[PRIVATE_WORLD_API_KEY].home_access(
+            await _json_body(request)
+        )
+    )
+
+
+async def private_world_continuation(request: web.Request) -> web.Response:
+    return _response(
+        request.app[PRIVATE_WORLD_API_KEY].continuation(
+            await _json_body(request)
+        )
+    )
+
+
+def create_control_app(
+    ledger: PrivateWorldCommandLedger,
+    *,
+    service: PrivateWorldCommandService | None = None,
+    session_manager: ControlSessionManager | None = None,
+) -> web.Application:
+    command_service = service or PrivateWorldCommandService(ledger)
+    app = web.Application(
+        middlewares=[control_boundary_middleware],
+        client_max_size=64 * 1024,
+    )
+    app[AUTH_KEY] = session_manager or ControlSessionManager()
+    app[PRIVATE_WORLD_API_KEY] = PrivateWorldControlAPI(
+        ledger,
+        command_service,
+    )
+    app.add_routes(
+        [
+            web.get("/control/health", health),
+            web.post("/control/api/session/bootstrap", bootstrap),
+            web.post("/control/api/session/logout", logout),
+            web.get(
+                "/control/api/private-world/snapshot",
+                private_world_snapshot,
+            ),
+            web.get(
+                "/control/api/private-world/events",
+                private_world_events,
+            ),
+            web.post(
+                "/control/api/private-world/relationship-events",
+                private_world_relationship_event,
+            ),
+            web.post(
+                "/control/api/private-world/relationship-stage",
+                private_world_relationship_stage,
+            ),
+            web.post(
+                "/control/api/private-world/nicknames",
+                private_world_nickname,
+            ),
+            web.post(
+                "/control/api/private-world/home-access",
+                private_world_home_access,
+            ),
+            web.post(
+                "/control/api/private-world/continuations",
+                private_world_continuation,
+            ),
+        ]
+    )
+    return app
+
+
+__all__ = [
+    "AUTH_KEY",
+    "PRIVATE_WORLD_API_KEY",
+    "SESSION_TOKEN_KEY",
+    "ControlRequestError",
+    "create_control_app",
+]

--- a/control_center/auth.py
+++ b/control_center/auth.py
@@ -1,0 +1,165 @@
+"""In-memory, loopback-only sessions for the local Control Center."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import hmac
+import secrets
+from threading import RLock
+import time
+from typing import Callable
+
+
+CONTROL_SESSION_COOKIE = "olivia_control_session"
+CONTROL_CSRF_HEADER = "X-CSRF-Token"
+
+
+class ControlAuthError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True, repr=False)
+class SessionCredentials:
+    session_token: str
+    csrf_token: str
+    expires_at: float
+
+
+@dataclass(frozen=True)
+class _Session:
+    csrf_digest: str
+    expires_at: float
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+class ControlSessionManager:
+    def __init__(
+        self,
+        *,
+        bootstrap_ttl_seconds: float = 120.0,
+        idle_timeout_seconds: float = 1800.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if bootstrap_ttl_seconds <= 0 or idle_timeout_seconds <= 0:
+            raise ValueError("control session TTLs must be positive")
+        self.bootstrap_ttl_seconds = float(bootstrap_ttl_seconds)
+        self.idle_timeout_seconds = float(idle_timeout_seconds)
+        self._clock = clock
+        self._bootstrap: dict[str, float] = {}
+        self._sessions: dict[str, _Session] = {}
+        self._lock = RLock()
+
+    def _prune(self, now: float) -> None:
+        self._bootstrap = {
+            key: expires
+            for key, expires in self._bootstrap.items()
+            if expires > now
+        }
+        self._sessions = {
+            key: session
+            for key, session in self._sessions.items()
+            if session.expires_at > now
+        }
+
+    def issue_bootstrap_token(self) -> str:
+        token = secrets.token_urlsafe(32)
+        now = self._clock()
+        with self._lock:
+            self._prune(now)
+            self._bootstrap[_digest(token)] = (
+                now + self.bootstrap_ttl_seconds
+            )
+        return token
+
+    def bootstrap(self, token: str) -> SessionCredentials:
+        if not isinstance(token, str) or not token:
+            raise ControlAuthError("CONTROL_BOOTSTRAP_INVALID")
+        now = self._clock()
+        with self._lock:
+            self._prune(now)
+            expires = self._bootstrap.pop(_digest(token), None)
+            if expires is None or expires <= now:
+                raise ControlAuthError("CONTROL_BOOTSTRAP_INVALID")
+            session_token = secrets.token_urlsafe(32)
+            csrf_token = secrets.token_urlsafe(32)
+            session_expires = now + self.idle_timeout_seconds
+            self._sessions[_digest(session_token)] = _Session(
+                _digest(csrf_token),
+                session_expires,
+            )
+        return SessionCredentials(
+            session_token,
+            csrf_token,
+            session_expires,
+        )
+
+    def authenticate(self, session_token: str | None) -> float:
+        if not isinstance(session_token, str) or not session_token:
+            raise ControlAuthError("CONTROL_SESSION_REQUIRED")
+        now = self._clock()
+        session_digest = _digest(session_token)
+        with self._lock:
+            self._prune(now)
+            session = self._sessions.get(session_digest)
+            if session is None or session.expires_at <= now:
+                raise ControlAuthError("CONTROL_SESSION_INVALID")
+            expires = now + self.idle_timeout_seconds
+            self._sessions[session_digest] = _Session(
+                session.csrf_digest,
+                expires,
+            )
+        return expires
+
+    def validate_csrf(
+        self,
+        session_token: str | None,
+        csrf_token: str | None,
+    ) -> None:
+        if not isinstance(session_token, str) or not session_token:
+            raise ControlAuthError("CONTROL_SESSION_REQUIRED")
+        if not isinstance(csrf_token, str) or not csrf_token:
+            raise ControlAuthError("CONTROL_CSRF_REQUIRED")
+        now = self._clock()
+        with self._lock:
+            self._prune(now)
+            session = self._sessions.get(_digest(session_token))
+            if session is None or session.expires_at <= now:
+                raise ControlAuthError("CONTROL_SESSION_INVALID")
+            if not hmac.compare_digest(
+                session.csrf_digest,
+                _digest(csrf_token),
+            ):
+                raise ControlAuthError("CONTROL_CSRF_INVALID")
+
+    def logout(self, session_token: str | None) -> None:
+        if not isinstance(session_token, str) or not session_token:
+            return
+        with self._lock:
+            self._sessions.pop(_digest(session_token), None)
+
+    def status(self) -> dict[str, int | str]:
+        now = self._clock()
+        with self._lock:
+            self._prune(now)
+            sessions = len(self._sessions)
+            bootstraps = len(self._bootstrap)
+        return {
+            "status": "READY",
+            "active_sessions": sessions,
+            "pending_bootstraps": bootstraps,
+        }
+
+
+__all__ = [
+    "CONTROL_CSRF_HEADER",
+    "CONTROL_SESSION_COOKIE",
+    "ControlAuthError",
+    "ControlSessionManager",
+    "SessionCredentials",
+]

--- a/control_center/private_world_api.py
+++ b/control_center/private_world_api.py
@@ -1,0 +1,466 @@
+"""Authenticated Control Center adapter for PrivateWorld commands."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import hashlib
+import re
+from typing import Mapping, Sequence
+
+from private_world_commands import (
+    ConfirmRelationshipStage,
+    DeleteContinuationFact,
+    GrantNickname,
+    PrivateWorldActor,
+    PrivateWorldCommandSource,
+    RecordBoundaryRespected,
+    RecordConflict,
+    RecordRepair,
+    RevokeNickname,
+    SetContinuationAwareness,
+    SetHomeAccess,
+    UpsertContinuationFact,
+)
+from private_world_ledger import LedgerEvent
+from private_world_port import (
+    ContinuationAwareness,
+    HomeAccess,
+    PrivateWorldSnapshot,
+)
+from private_world_service import (
+    PRIVATE_WORLD_COMMAND_AUDIT_SCHEMA,
+    CommandExecutionResult,
+    PrivateWorldCommandLedger,
+    PrivateWorldCommandService,
+    PrivateWorldCommandServiceError,
+)
+from reply_context import RelationshipStage
+
+
+PRIVATE_WORLD_CONTROL_SCHEMA = "p03.private-world-control.v1"
+_REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_RELATIONSHIP_EVENTS = {
+    "boundary_respected": RecordBoundaryRespected,
+    "conflict": RecordConflict,
+    "repair": RecordRepair,
+}
+
+
+class PrivateWorldAPIError(RuntimeError):
+    def __init__(self, code: str, *, http_status: int = 400) -> None:
+        self.code = code
+        self.http_status = http_status
+        super().__init__(code)
+
+
+def _level(value: int) -> str:
+    if value == 0:
+        return "unknown"
+    if value < 35:
+        return "low"
+    if value < 70:
+        return "medium"
+    return "high"
+
+
+def _strict_body(
+    value: object,
+    *,
+    required: Sequence[str],
+    optional: Sequence[str] = (),
+) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise PrivateWorldAPIError("CONTROL_BODY_INVALID")
+    allowed = frozenset((*required, *optional))
+    keys = frozenset(value)
+    if not frozenset(required).issubset(keys) or not keys.issubset(allowed):
+        raise PrivateWorldAPIError("CONTROL_BODY_FIELDS_INVALID")
+    if any(not isinstance(key, str) for key in value):
+        raise PrivateWorldAPIError("CONTROL_BODY_FIELDS_INVALID")
+    return value
+
+
+def _text(value: object, *, code: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise PrivateWorldAPIError(code)
+    return value.strip()
+
+
+def _request_identity(value: object) -> tuple[str, str]:
+    request_id = _text(value, code="CONTROL_REQUEST_ID_INVALID")
+    if not _REQUEST_ID_RE.fullmatch(request_id):
+        raise PrivateWorldAPIError("CONTROL_REQUEST_ID_INVALID")
+    digest = hashlib.sha256(request_id.encode("utf-8")).hexdigest()
+    return f"control.{digest}", f"control.{digest}"
+
+
+def _occurred_at(value: object) -> datetime:
+    raw = _text(value, code="CONTROL_OCCURRED_AT_INVALID")
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise PrivateWorldAPIError("CONTROL_OCCURRED_AT_INVALID") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise PrivateWorldAPIError("CONTROL_OCCURRED_AT_INVALID")
+    return parsed
+
+
+def _string_tuple(
+    value: object,
+    *,
+    code: str,
+    maximum: int,
+) -> tuple[str, ...]:
+    if not isinstance(value, list) or len(value) > maximum:
+        raise PrivateWorldAPIError(code)
+    result = tuple(value)
+    if (
+        any(not isinstance(item, str) or not item for item in result)
+        or len(set(result)) != len(result)
+    ):
+        raise PrivateWorldAPIError(code)
+    return result
+
+
+def _common_fields(
+    body: Mapping[str, object],
+) -> dict[str, object]:
+    command_id, idempotency_key = _request_identity(body["request_id"])
+    evidence = _string_tuple(
+        body.get("evidence_refs", []),
+        code="CONTROL_EVIDENCE_REFS_INVALID",
+        maximum=8,
+    )
+    return {
+        "command_id": command_id,
+        "idempotency_key": idempotency_key,
+        "actor": PrivateWorldActor.LOCAL_USER,
+        "source": PrivateWorldCommandSource.CONTROL_CENTER,
+        "occurred_at": _occurred_at(body["occurred_at"]),
+        "reason": _text(body["reason"], code="CONTROL_REASON_INVALID"),
+        "evidence_refs": evidence,
+    }
+
+
+def _execution_payload(result: CommandExecutionResult) -> dict[str, object]:
+    return {
+        "schema_version": PRIVATE_WORLD_CONTROL_SCHEMA,
+        "result": result.to_dict(),
+    }
+
+
+def _snapshot_payload(snapshot: PrivateWorldSnapshot) -> dict[str, object]:
+    if not isinstance(snapshot, PrivateWorldSnapshot):
+        raise PrivateWorldAPIError(
+            "PRIVATE_WORLD_CONTROL_STORAGE_UNAVAILABLE",
+            http_status=503,
+        )
+    return {
+        "schema_version": PRIVATE_WORLD_CONTROL_SCHEMA,
+        "version": snapshot.version,
+        "relationship_stage": snapshot.relationship_stage,
+        "levels": {
+            "familiarity": _level(snapshot.familiarity),
+            "trust": _level(snapshot.trust),
+            "comfort": _level(snapshot.comfort),
+            "closeness": _level(snapshot.closeness),
+            "tension": _level(snapshot.tension),
+        },
+        "nickname_permissions": list(snapshot.nickname_permissions),
+        "home_access": snapshot.home_access.value,
+        "continuation_awareness": snapshot.continuation_awareness.value,
+        "continuation_facts": [
+            fact.to_dict() for fact in snapshot.continuation_facts
+        ],
+    }
+
+
+def _event_payload(event: LedgerEvent) -> dict[str, object]:
+    if not isinstance(event, LedgerEvent):
+        raise PrivateWorldAPIError(
+            "PRIVATE_WORLD_CONTROL_AUDIT_INVALID",
+            http_status=503,
+        )
+    payload = event.payload
+    result: dict[str, object] = {
+        "event_id": event.event_id,
+        "event_type": event.event_type,
+        "occurred_at": event.occurred_at,
+        "applied": payload.get("applied") is True,
+        "reason_code": str(payload.get("reason_code", "UNKNOWN"))[:96],
+        "change_fields": [],
+    }
+    raw_fields = payload.get("change_fields", ())
+    if isinstance(raw_fields, list) and all(
+        isinstance(field, str) for field in raw_fields
+    ):
+        result["change_fields"] = list(raw_fields)
+    if payload.get("schema_version") == PRIVATE_WORLD_COMMAND_AUDIT_SCHEMA:
+        evidence_refs = payload.get("evidence_refs")
+        result.update(
+            {
+                "command_id": str(payload.get("command_id", ""))[:96],
+                "command_kind": str(payload.get("command_kind", ""))[:96],
+                "actor": str(payload.get("actor", ""))[:64],
+                "source": str(payload.get("source", ""))[:64],
+                "reason": str(payload.get("reason", ""))[:280],
+                "evidence_refs": (
+                    list(evidence_refs)
+                    if isinstance(evidence_refs, list)
+                    and all(isinstance(item, str) for item in evidence_refs)
+                    else []
+                ),
+                "snapshot_version": int(
+                    payload.get("snapshot_version", 0)
+                ),
+            }
+        )
+    return result
+
+
+def _service_error(exc: PrivateWorldCommandServiceError) -> PrivateWorldAPIError:
+    if exc.code == "PRIVATE_WORLD_COMMAND_IDENTITY_CONFLICT":
+        status = 409
+    elif exc.code == "PRIVATE_WORLD_COMMAND_STORAGE_UNAVAILABLE":
+        status = 503
+    elif exc.code in {
+        "PRIVATE_WORLD_COMMAND_APPROVAL_REQUIRED",
+        "PRIVATE_WORLD_COMMAND_SOURCE_FORBIDDEN",
+    }:
+        status = 403
+    else:
+        status = 400
+    return PrivateWorldAPIError(exc.code, http_status=status)
+
+
+class PrivateWorldControlAPI:
+    def __init__(
+        self,
+        ledger: PrivateWorldCommandLedger,
+        service: PrivateWorldCommandService,
+    ) -> None:
+        if not isinstance(ledger, PrivateWorldCommandLedger):
+            raise TypeError("a PrivateWorld command ledger is required")
+        if not isinstance(service, PrivateWorldCommandService):
+            raise TypeError("a PrivateWorld command service is required")
+        self._ledger = ledger
+        self._service = service
+
+    def snapshot(self) -> dict[str, object]:
+        try:
+            return _snapshot_payload(self._ledger.snapshot())
+        except PrivateWorldAPIError:
+            raise
+        except (OSError, RuntimeError, ValueError, TypeError, KeyError) as exc:
+            raise PrivateWorldAPIError(
+                "PRIVATE_WORLD_CONTROL_STORAGE_UNAVAILABLE",
+                http_status=503,
+            ) from exc
+
+    def events(self) -> dict[str, object]:
+        try:
+            rows = self._ledger.events()
+            return {
+                "schema_version": PRIVATE_WORLD_CONTROL_SCHEMA,
+                "events": [_event_payload(event) for event in rows],
+            }
+        except PrivateWorldAPIError:
+            raise
+        except (OSError, RuntimeError, ValueError, TypeError, KeyError) as exc:
+            raise PrivateWorldAPIError(
+                "PRIVATE_WORLD_CONTROL_STORAGE_UNAVAILABLE",
+                http_status=503,
+            ) from exc
+
+    def relationship_event(self, raw_body: object) -> dict[str, object]:
+        body = _strict_body(
+            raw_body,
+            required=(
+                "request_id",
+                "occurred_at",
+                "reason",
+                "event_type",
+            ),
+            optional=("evidence_refs",),
+        )
+        event_type = _text(
+            body["event_type"],
+            code="CONTROL_RELATIONSHIP_EVENT_INVALID",
+        )
+        command_type = _RELATIONSHIP_EVENTS.get(event_type)
+        if command_type is None:
+            raise PrivateWorldAPIError("CONTROL_RELATIONSHIP_EVENT_INVALID")
+        command = command_type(**_common_fields(body))
+        return self._execute(command)
+
+    def relationship_stage(self, raw_body: object) -> dict[str, object]:
+        body = _strict_body(
+            raw_body,
+            required=(
+                "request_id",
+                "occurred_at",
+                "reason",
+                "target_stage",
+                "basis_event_ids",
+            ),
+            optional=("evidence_refs",),
+        )
+        try:
+            stage = RelationshipStage(body["target_stage"])
+        except (TypeError, ValueError) as exc:
+            raise PrivateWorldAPIError(
+                "CONTROL_RELATIONSHIP_STAGE_INVALID"
+            ) from exc
+        basis = _string_tuple(
+            body["basis_event_ids"],
+            code="CONTROL_STAGE_BASIS_INVALID",
+            maximum=8,
+        )
+        command = ConfirmRelationshipStage(
+            **_common_fields(body),
+            target_stage=stage,
+            basis_event_ids=basis,
+        )
+        return self._execute(command)
+
+    def nickname(self, raw_body: object) -> dict[str, object]:
+        body = _strict_body(
+            raw_body,
+            required=(
+                "request_id",
+                "occurred_at",
+                "reason",
+                "action",
+                "nickname",
+            ),
+            optional=("evidence_refs",),
+        )
+        action = _text(
+            body["action"],
+            code="CONTROL_NICKNAME_ACTION_INVALID",
+        )
+        command_type = {
+            "grant": GrantNickname,
+            "revoke": RevokeNickname,
+        }.get(action)
+        if command_type is None:
+            raise PrivateWorldAPIError("CONTROL_NICKNAME_ACTION_INVALID")
+        command = command_type(
+            **_common_fields(body),
+            nickname=_text(
+                body["nickname"],
+                code="CONTROL_NICKNAME_INVALID",
+            ),
+        )
+        return self._execute(command)
+
+    def home_access(self, raw_body: object) -> dict[str, object]:
+        body = _strict_body(
+            raw_body,
+            required=(
+                "request_id",
+                "occurred_at",
+                "reason",
+                "home_access",
+            ),
+            optional=("evidence_refs",),
+        )
+        try:
+            access = HomeAccess(body["home_access"])
+        except (TypeError, ValueError) as exc:
+            raise PrivateWorldAPIError("CONTROL_HOME_ACCESS_INVALID") from exc
+        command = SetHomeAccess(
+            **_common_fields(body),
+            home_access=access,
+        )
+        return self._execute(command)
+
+    def continuation(self, raw_body: object) -> dict[str, object]:
+        if not isinstance(raw_body, Mapping):
+            raise PrivateWorldAPIError("CONTROL_BODY_INVALID")
+        action = _text(
+            raw_body.get("action"),
+            code="CONTROL_CONTINUATION_ACTION_INVALID",
+        )
+        common_required = (
+            "request_id",
+            "occurred_at",
+            "reason",
+            "action",
+            "fact_id",
+        )
+        if action == "upsert":
+            body = _strict_body(
+                raw_body,
+                required=(*common_required, "statement", "awareness"),
+                optional=("evidence_refs",),
+            )
+            try:
+                awareness = ContinuationAwareness(body["awareness"])
+            except (TypeError, ValueError) as exc:
+                raise PrivateWorldAPIError(
+                    "CONTROL_CONTINUATION_AWARENESS_INVALID"
+                ) from exc
+            command = UpsertContinuationFact(
+                **_common_fields(body),
+                fact_id=_text(
+                    body["fact_id"],
+                    code="CONTROL_CONTINUATION_ID_INVALID",
+                ),
+                statement=_text(
+                    body["statement"],
+                    code="CONTROL_CONTINUATION_STATEMENT_INVALID",
+                ),
+                awareness=awareness,
+            )
+        elif action == "set_awareness":
+            body = _strict_body(
+                raw_body,
+                required=(*common_required, "awareness"),
+                optional=("evidence_refs",),
+            )
+            try:
+                awareness = ContinuationAwareness(body["awareness"])
+            except (TypeError, ValueError) as exc:
+                raise PrivateWorldAPIError(
+                    "CONTROL_CONTINUATION_AWARENESS_INVALID"
+                ) from exc
+            command = SetContinuationAwareness(
+                **_common_fields(body),
+                fact_id=_text(
+                    body["fact_id"],
+                    code="CONTROL_CONTINUATION_ID_INVALID",
+                ),
+                awareness=awareness,
+            )
+        elif action == "delete":
+            body = _strict_body(
+                raw_body,
+                required=common_required,
+                optional=("evidence_refs",),
+            )
+            command = DeleteContinuationFact(
+                **_common_fields(body),
+                fact_id=_text(
+                    body["fact_id"],
+                    code="CONTROL_CONTINUATION_ID_INVALID",
+                ),
+            )
+        else:
+            raise PrivateWorldAPIError("CONTROL_CONTINUATION_ACTION_INVALID")
+        return self._execute(command)
+
+    def _execute(self, command) -> dict[str, object]:
+        try:
+            return _execution_payload(self._service.execute(command))
+        except PrivateWorldCommandServiceError as exc:
+            raise _service_error(exc) from exc
+        except (TypeError, ValueError) as exc:
+            raise PrivateWorldAPIError("PRIVATE_WORLD_COMMAND_INVALID") from exc
+
+
+__all__ = [
+    "PRIVATE_WORLD_CONTROL_SCHEMA",
+    "PrivateWorldAPIError",
+    "PrivateWorldControlAPI",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,12 +49,22 @@ py-modules = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["asr*", "contracts*", "installer*", "linli_character*", "media_state*", "runtime*", "tts*"]
+include = [
+    "asr*",
+    "contracts*",
+    "control_center*",
+    "installer*",
+    "linli_character*",
+    "media_state*",
+    "runtime*",
+    "tts*",
+]
 
 [tool.pytest.ini_options]
 testpaths = [
     "tests/persona",
     "tests/private_world",
+    "tests/control_center",
     "tests/http",
     "tests/installer",
     "tests/media",

--- a/tests/control_center/test_auth.py
+++ b/tests/control_center/test_auth.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+
+from control_center.auth import (
+    ControlAuthError,
+    ControlSessionManager,
+)
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.value = 100.0
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def test_bootstrap_is_one_time_and_session_repr_hides_tokens() -> None:
+    manager = ControlSessionManager()
+    bootstrap = manager.issue_bootstrap_token()
+
+    credentials = manager.bootstrap(bootstrap)
+
+    assert credentials.session_token
+    assert credentials.csrf_token
+    assert credentials.session_token not in repr(credentials)
+    assert credentials.csrf_token not in repr(credentials)
+    with pytest.raises(
+        ControlAuthError,
+        match="CONTROL_BOOTSTRAP_INVALID",
+    ):
+        manager.bootstrap(bootstrap)
+
+
+def test_authentication_slides_expiry_and_requires_matching_csrf() -> None:
+    clock = Clock()
+    manager = ControlSessionManager(
+        idle_timeout_seconds=30,
+        clock=clock,
+    )
+    credentials = manager.bootstrap(manager.issue_bootstrap_token())
+
+    first_expiry = manager.authenticate(credentials.session_token)
+    manager.validate_csrf(
+        credentials.session_token,
+        credentials.csrf_token,
+    )
+    clock.advance(10)
+    second_expiry = manager.authenticate(credentials.session_token)
+
+    assert first_expiry == 130
+    assert second_expiry == 140
+    with pytest.raises(ControlAuthError, match="CONTROL_CSRF_INVALID"):
+        manager.validate_csrf(
+            credentials.session_token,
+            "wrong-token",
+        )
+    with pytest.raises(ControlAuthError, match="CONTROL_CSRF_REQUIRED"):
+        manager.validate_csrf(credentials.session_token, None)
+
+
+def test_expired_bootstrap_and_session_are_pruned() -> None:
+    clock = Clock()
+    manager = ControlSessionManager(
+        bootstrap_ttl_seconds=5,
+        idle_timeout_seconds=10,
+        clock=clock,
+    )
+    expired_bootstrap = manager.issue_bootstrap_token()
+    clock.advance(6)
+    with pytest.raises(
+        ControlAuthError,
+        match="CONTROL_BOOTSTRAP_INVALID",
+    ):
+        manager.bootstrap(expired_bootstrap)
+
+    credentials = manager.bootstrap(manager.issue_bootstrap_token())
+    assert manager.status()["active_sessions"] == 1
+    clock.advance(11)
+    with pytest.raises(
+        ControlAuthError,
+        match="CONTROL_SESSION_INVALID",
+    ):
+        manager.authenticate(credentials.session_token)
+    assert manager.status()["active_sessions"] == 0
+
+
+def test_logout_is_idempotent() -> None:
+    manager = ControlSessionManager()
+    credentials = manager.bootstrap(manager.issue_bootstrap_token())
+
+    manager.logout(credentials.session_token)
+    manager.logout(credentials.session_token)
+    manager.logout(None)
+
+    with pytest.raises(
+        ControlAuthError,
+        match="CONTROL_SESSION_INVALID",
+    ):
+        manager.authenticate(credentials.session_token)

--- a/tests/control_center/test_private_world_api.py
+++ b/tests/control_center/test_private_world_api.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timezone
 import json
-from pathlib import Path
 from threading import Lock
 
 from aiohttp import CookieJar
@@ -36,9 +35,9 @@ class FakeLedger:
     ) -> bool:
         with self._lock:
             if any(
-                item.event_id == event.event_id
-                or item.delivery_id == event.delivery_id
-                for item in self.items
+                row.event_id == event.event_id
+                or row.delivery_id == event.delivery_id
+                for row in self.items
             ):
                 return False
             self.items.append(event)
@@ -55,9 +54,8 @@ def _common(request_id: str) -> dict[str, object]:
     }
 
 
-async def _authenticated_client() -> tuple[TestClient, str]:
-    ledger = FakeLedger()
-    app = create_control_app(ledger)
+async def _start_authenticated() -> tuple[TestClient, str, str]:
+    app = create_control_app(FakeLedger())
     client = TestClient(
         TestServer(app),
         cookie_jar=CookieJar(unsafe=True),
@@ -71,17 +69,13 @@ async def _authenticated_client() -> tuple[TestClient, str]:
         headers={"Origin": origin},
     )
     assert response.status == 200
-    payload = await response.json()
-    return client, payload["data"]["csrf_token"]
+    csrf = (await response.json())["data"]["csrf_token"]
+    return client, origin, csrf
 
 
-def test_control_boundary_bootstrap_and_security_headers(
-    tmp_path: Path,
-) -> None:
+def test_boundary_bootstrap_and_security_headers() -> None:
     async def scenario() -> None:
-        del tmp_path
-        ledger = FakeLedger()
-        app = create_control_app(ledger)
+        app = create_control_app(FakeLedger())
         async with TestClient(
             TestServer(app),
             cookie_jar=CookieJar(unsafe=True),
@@ -100,53 +94,30 @@ def test_control_boundary_bootstrap_and_security_headers(
             assert health.headers["X-Frame-Options"] == "DENY"
             assert "Access-Control-Allow-Origin" not in health.headers
 
-            foreign_get = await client.get(
-                "/control/health",
-                headers={
-                    "Origin": (
-                        "https://toy-cnbeta01.olivia.miyoushe.com"
-                    )
-                },
-            )
-            assert foreign_get.status == 403
-            assert (await foreign_get.json())["error"]["code"] == (
-                "CONTROL_ORIGIN_FORBIDDEN"
-            )
-
-            forbidden_host = await client.get(
-                "/control/health",
-                headers={"Host": "example.invalid"},
-            )
-            assert forbidden_host.status == 403
-            assert (
-                await forbidden_host.json()
-            )["error"]["code"] == "CONTROL_HOST_FORBIDDEN"
-
-            token = app[AUTH_KEY].issue_bootstrap_token()
-            foreign = await client.post(
-                "/control/api/session/bootstrap",
-                json={"token": token},
-                headers={
-                    "Origin": (
-                        "https://toy-cnbeta01.olivia.miyoushe.com"
-                    )
-                },
-            )
-            assert foreign.status == 403
-            assert (await foreign.json())["error"]["code"] == (
-                "CONTROL_ORIGIN_FORBIDDEN"
-            )
+            for headers, code in (
+                ({"Host": "example.invalid"}, "CONTROL_HOST_FORBIDDEN"),
+                (
+                    {
+                        "Origin": (
+                            "https://toy-cnbeta01.olivia.miyoushe.com"
+                        )
+                    },
+                    "CONTROL_ORIGIN_FORBIDDEN",
+                ),
+            ):
+                denied = await client.get("/control/health", headers=headers)
+                assert denied.status == 403
+                assert (await denied.json())["error"]["code"] == code
 
             origin = str(client.make_url("/")).rstrip("/")
-            bootstrap = await client.post(
+            token = app[AUTH_KEY].issue_bootstrap_token()
+            bootstrapped = await client.post(
                 "/control/api/session/bootstrap",
                 json={"token": token},
                 headers={"Origin": origin},
             )
-            assert bootstrap.status == 200
-            body = await bootstrap.json()
-            assert body["data"]["csrf_token"]
-            cookie = bootstrap.headers["Set-Cookie"]
+            assert bootstrapped.status == 200
+            cookie = bootstrapped.headers["Set-Cookie"]
             assert "HttpOnly" in cookie
             assert "SameSite=Strict" in cookie
             assert "Path=/control" in cookie
@@ -172,11 +143,9 @@ def test_control_boundary_bootstrap_and_security_headers(
     asyncio.run(scenario())
 
 
-def test_authentication_csrf_and_logout(tmp_path: Path) -> None:
+def test_authentication_csrf_and_logout() -> None:
     async def scenario() -> None:
-        del tmp_path
-        ledger = FakeLedger()
-        app = create_control_app(ledger)
+        app = create_control_app(FakeLedger())
         async with TestClient(
             TestServer(app),
             cookie_jar=CookieJar(unsafe=True),
@@ -185,44 +154,39 @@ def test_authentication_csrf_and_logout(tmp_path: Path) -> None:
                 "/control/api/private-world/snapshot"
             )
             assert unauthenticated.status == 401
-            assert (await unauthenticated.json())["error"]["code"] == (
-                "CONTROL_SESSION_REQUIRED"
-            )
 
             origin = str(client.make_url("/")).rstrip("/")
             token = app[AUTH_KEY].issue_bootstrap_token()
-            bootstrapped = await client.post(
+            session = await client.post(
                 "/control/api/session/bootstrap",
                 json={"token": token},
                 headers={"Origin": origin},
             )
-            csrf = (await bootstrapped.json())["data"]["csrf_token"]
+            csrf = (await session.json())["data"]["csrf_token"]
+            body = {
+                **_common("request.csrf"),
+                "event_type": "conflict",
+            }
 
-            missing_csrf = await client.post(
+            missing = await client.post(
                 "/control/api/private-world/relationship-events",
-                json={
-                    **_common("request.missing-csrf"),
-                    "event_type": "conflict",
-                },
+                json=body,
                 headers={"Origin": origin},
             )
-            assert missing_csrf.status == 403
-            assert (await missing_csrf.json())["error"]["code"] == (
+            assert missing.status == 403
+            assert (await missing.json())["error"]["code"] == (
                 "CONTROL_CSRF_REQUIRED"
             )
 
-            wrong_csrf = await client.post(
+            wrong = await client.post(
                 "/control/api/private-world/relationship-events",
-                json={
-                    **_common("request.wrong-csrf"),
-                    "event_type": "conflict",
-                },
+                json=body,
                 headers={
                     "Origin": origin,
                     "X-CSRF-Token": "wrong",
                 },
             )
-            assert wrong_csrf.status == 403
+            assert wrong.status == 403
 
             logged_out = await client.post(
                 "/control/api/session/logout",
@@ -236,25 +200,20 @@ def test_authentication_csrf_and_logout(tmp_path: Path) -> None:
             assert (await logged_out.json())["data"]["status"] == (
                 "LOGGED_OUT"
             )
-
-            after = await client.get(
-                "/control/api/private-world/snapshot"
-            )
-            assert after.status == 401
+            assert (
+                await client.get(
+                    "/control/api/private-world/snapshot"
+                )
+            ).status == 401
 
     asyncio.run(scenario())
 
 
-def test_private_world_mutations_are_typed_idempotent_and_sanitized(
-    tmp_path: Path,
-) -> None:
+def test_private_world_mutations_are_typed_and_sanitized() -> None:
     async def scenario() -> None:
-        del tmp_path
-        client, csrf = await _authenticated_client()
+        client, origin, csrf = await _start_authenticated()
+        headers = {"Origin": origin, "X-CSRF-Token": csrf}
         try:
-            origin = str(client.make_url("/")).rstrip("/")
-            headers = {"Origin": origin, "X-CSRF-Token": csrf}
-
             conflict = await client.post(
                 "/control/api/private-world/relationship-events",
                 json={
@@ -263,10 +222,9 @@ def test_private_world_mutations_are_typed_idempotent_and_sanitized(
                 },
                 headers=headers,
             )
-            assert conflict.status == 200
-            conflict_result = (await conflict.json())["data"]["result"]
-            assert conflict_result["status"] == "APPLIED"
-            assert conflict_result["change_fields"] == ["tension"]
+            result = (await conflict.json())["data"]["result"]
+            assert result["status"] == "APPLIED"
+            assert result["change_fields"] == ["tension"]
 
             duplicate = await client.post(
                 "/control/api/private-world/relationship-events",
@@ -276,17 +234,14 @@ def test_private_world_mutations_are_typed_idempotent_and_sanitized(
                 },
                 headers=headers,
             )
-            assert duplicate.status == 200
-            assert (await duplicate.json())["data"]["result"][
-                "status"
-            ] == "DUPLICATE"
+            assert (await duplicate.json())["data"]["result"]["status"] == (
+                "DUPLICATE"
+            )
 
             snapshot = await client.get(
                 "/control/api/private-world/snapshot"
             )
-            assert snapshot.status == 200
             state = (await snapshot.json())["data"]
-            assert state["version"] == 2
             assert state["levels"] == {
                 "familiarity": "unknown",
                 "trust": "unknown",
@@ -295,99 +250,85 @@ def test_private_world_mutations_are_typed_idempotent_and_sanitized(
                 "tension": "low",
             }
             serialized = json.dumps(state, ensure_ascii=False)
-            for raw_score in (
-                '"familiarity": 0',
-                '"trust": 0',
-                '"comfort": 0',
-                '"closeness": 0',
-                '"tension": 3',
-            ):
-                assert raw_score not in serialized
+            assert '"tension": 3' not in serialized
+            assert '"trust": 0' not in serialized
 
-            events = await client.get(
+            events_response = await client.get(
                 "/control/api/private-world/events"
             )
-            timeline = (await events.json())["data"]["events"]
-            assert len(timeline) == 1
+            timeline = (await events_response.json())["data"]["events"]
             event = timeline[0]
-            assert event["event_id"] == conflict_result["event_id"]
             assert event["event_type"] == "record_conflict"
             assert event["actor"] == "local_user"
             assert event["source"] == "control_center"
-            assert event["reason"] == "synthetic confirmed change"
-            assert "command_fingerprint" not in event
-            assert "payload_fields" not in event
-            assert "delivery_id" not in event
-            assert "payload" not in event
+            for hidden in (
+                "command_fingerprint",
+                "payload_fields",
+                "delivery_id",
+                "payload",
+            ):
+                assert hidden not in event
 
-            stage = await client.post(
-                "/control/api/private-world/relationship-stage",
-                json={
-                    **_common("request.stage-1"),
-                    "target_stage": "familiar",
-                    "basis_event_ids": [conflict_result["event_id"]],
-                },
-                headers=headers,
+            requests = (
+                (
+                    "/control/api/private-world/relationship-stage",
+                    {
+                        **_common("request.stage-1"),
+                        "target_stage": "familiar",
+                        "basis_event_ids": [result["event_id"]],
+                    },
+                ),
+                (
+                    "/control/api/private-world/nicknames",
+                    {
+                        **_common("request.nickname-1"),
+                        "action": "grant",
+                        "nickname": "小河豚",
+                    },
+                ),
+                (
+                    "/control/api/private-world/home-access",
+                    {
+                        **_common("request.home-1"),
+                        "home_access": "visit_access",
+                    },
+                ),
+                (
+                    "/control/api/private-world/continuations",
+                    {
+                        **_common("request.continuation-1"),
+                        "action": "upsert",
+                        "fact_id": "continuation.synthetic-1",
+                        "statement": "一条只用于合成测试的世界线事实。",
+                        "awareness": "control_only",
+                    },
+                ),
+                (
+                    "/control/api/private-world/continuations",
+                    {
+                        **_common("request.continuation-2"),
+                        "action": "set_awareness",
+                        "fact_id": "continuation.synthetic-1",
+                        "awareness": "character_known",
+                    },
+                ),
             )
-            assert stage.status == 200
-            assert (await stage.json())["data"]["result"]["status"] == (
-                "APPLIED"
-            )
+            for path, body in requests:
+                response = await client.post(
+                    path,
+                    json=body,
+                    headers=headers,
+                )
+                assert response.status == 200
 
-            nickname = await client.post(
-                "/control/api/private-world/nicknames",
-                json={
-                    **_common("request.nickname-1"),
-                    "action": "grant",
-                    "nickname": "小河豚",
-                },
-                headers=headers,
-            )
-            assert nickname.status == 200
-
-            access = await client.post(
-                "/control/api/private-world/home-access",
-                json={
-                    **_common("request.home-1"),
-                    "home_access": "visit_access",
-                },
-                headers=headers,
-            )
-            assert access.status == 200
-
-            continuation = await client.post(
-                "/control/api/private-world/continuations",
-                json={
-                    **_common("request.continuation-1"),
-                    "action": "upsert",
-                    "fact_id": "continuation.synthetic-1",
-                    "statement": "一条只用于合成测试的世界线事实。",
-                    "awareness": "control_only",
-                },
-                headers=headers,
-            )
-            assert continuation.status == 200
-
-            awareness = await client.post(
-                "/control/api/private-world/continuations",
-                json={
-                    **_common("request.continuation-2"),
-                    "action": "set_awareness",
-                    "fact_id": "continuation.synthetic-1",
-                    "awareness": "character_known",
-                },
-                headers=headers,
-            )
-            assert awareness.status == 200
-
-            final = await client.get(
+            final_response = await client.get(
                 "/control/api/private-world/snapshot"
             )
-            final_state = (await final.json())["data"]
-            assert final_state["relationship_stage"] == "familiar"
-            assert final_state["nickname_permissions"] == ["小河豚"]
-            assert final_state["home_access"] == "visit_access"
-            assert final_state["continuation_facts"] == [
+            final = (await final_response.json())["data"]
+            assert final["relationship_stage"] == "familiar"
+            assert final["nickname_permissions"] == ["小河豚"]
+            assert final["home_access"] == "visit_access"
+            assert final["continuation_facts"] == [
                 {
                     "fact_id": "continuation.synthetic-1",
                     "statement": "一条只用于合成测试的世界线事实。",
@@ -400,59 +341,53 @@ def test_private_world_mutations_are_typed_idempotent_and_sanitized(
     asyncio.run(scenario())
 
 
-def test_api_rejects_client_authority_extra_fields_and_invalid_evidence(
-    tmp_path: Path,
-) -> None:
+def test_api_rejects_client_authority_and_invalid_inputs() -> None:
     async def scenario() -> None:
-        del tmp_path
-        client, csrf = await _authenticated_client()
+        client, origin, csrf = await _start_authenticated()
+        headers = {"Origin": origin, "X-CSRF-Token": csrf}
         try:
-            origin = str(client.make_url("/")).rstrip("/")
-            headers = {"Origin": origin, "X-CSRF-Token": csrf}
-            authority = await client.post(
-                "/control/api/private-world/relationship-events",
-                json={
-                    **_common("request.authority"),
-                    "event_type": "conflict",
-                    "actor": "migration",
-                },
-                headers=headers,
+            cases = (
+                (
+                    "/control/api/private-world/relationship-events",
+                    {
+                        **_common("request.authority"),
+                        "event_type": "conflict",
+                        "actor": "migration",
+                    },
+                    "CONTROL_BODY_FIELDS_INVALID",
+                ),
+                (
+                    "/control/api/private-world/relationship-events",
+                    {
+                        **_common("request.invalid-event"),
+                        "event_type": "confession",
+                    },
+                    "CONTROL_RELATIONSHIP_EVENT_INVALID",
+                ),
+                (
+                    "/control/api/private-world/relationship-stage",
+                    {
+                        **_common("request.missing-basis"),
+                        "target_stage": "close",
+                        "basis_event_ids": ["event.missing"],
+                    },
+                    "PRIVATE_WORLD_COMMAND_EVIDENCE_INVALID",
+                ),
             )
-            assert authority.status == 400
-            assert (await authority.json())["error"]["code"] == (
-                "CONTROL_BODY_FIELDS_INVALID"
-            )
-
-            invalid_event = await client.post(
-                "/control/api/private-world/relationship-events",
-                json={
-                    **_common("request.invalid-event"),
-                    "event_type": "confession",
-                },
-                headers=headers,
-            )
-            assert invalid_event.status == 400
-
-            missing_basis = await client.post(
-                "/control/api/private-world/relationship-stage",
-                json={
-                    **_common("request.missing-basis"),
-                    "target_stage": "close",
-                    "basis_event_ids": ["event.missing"],
-                },
-                headers=headers,
-            )
-            assert missing_basis.status == 400
-            assert (await missing_basis.json())["error"]["code"] == (
-                "PRIVATE_WORLD_COMMAND_EVIDENCE_INVALID"
-            )
+            for path, body, code in cases:
+                response = await client.post(
+                    path,
+                    json=body,
+                    headers=headers,
+                )
+                assert response.status == 400
+                assert (await response.json())["error"]["code"] == code
 
             invalid_content_type = await client.post(
                 "/control/api/private-world/nicknames",
                 data="{}",
                 headers={
-                    "Origin": origin,
-                    "X-CSRF-Token": csrf,
+                    **headers,
                     "Content-Type": "text/plain",
                 },
             )

--- a/tests/control_center/test_private_world_api.py
+++ b/tests/control_center/test_private_world_api.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from threading import Lock
+
+from aiohttp import CookieJar
+from aiohttp.test_utils import TestClient, TestServer
+
+from control_center.app import AUTH_KEY, create_control_app
+from private_world_ledger import LedgerEvent
+from private_world_port import PrivateWorldSnapshot
+
+
+NOW = datetime(2026, 8, 22, 20, 0, tzinfo=timezone.utc).isoformat()
+
+
+class FakeLedger:
+    def __init__(self) -> None:
+        self.current = PrivateWorldSnapshot()
+        self.items: list[LedgerEvent] = []
+        self._lock = Lock()
+
+    def snapshot(self) -> PrivateWorldSnapshot:
+        return self.current
+
+    def events(self) -> tuple[LedgerEvent, ...]:
+        return tuple(self.items)
+
+    def apply_once(
+        self,
+        event: LedgerEvent,
+        snapshot: PrivateWorldSnapshot,
+    ) -> bool:
+        with self._lock:
+            if any(
+                item.event_id == event.event_id
+                or item.delivery_id == event.delivery_id
+                for item in self.items
+            ):
+                return False
+            self.items.append(event)
+            self.current = snapshot
+            return True
+
+
+def _common(request_id: str) -> dict[str, object]:
+    return {
+        "request_id": request_id,
+        "occurred_at": NOW,
+        "reason": "synthetic confirmed change",
+        "evidence_refs": ["letter:synthetic-1"],
+    }
+
+
+async def _authenticated_client() -> tuple[TestClient, str]:
+    ledger = FakeLedger()
+    app = create_control_app(ledger)
+    client = TestClient(
+        TestServer(app),
+        cookie_jar=CookieJar(unsafe=True),
+    )
+    await client.start_server()
+    origin = str(client.make_url("/")).rstrip("/")
+    token = app[AUTH_KEY].issue_bootstrap_token()
+    response = await client.post(
+        "/control/api/session/bootstrap",
+        json={"token": token},
+        headers={"Origin": origin},
+    )
+    assert response.status == 200
+    payload = await response.json()
+    return client, payload["data"]["csrf_token"]
+
+
+def test_control_boundary_bootstrap_and_security_headers(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        del tmp_path
+        ledger = FakeLedger()
+        app = create_control_app(ledger)
+        async with TestClient(
+            TestServer(app),
+            cookie_jar=CookieJar(unsafe=True),
+        ) as client:
+            health = await client.get("/control/health")
+            assert health.status == 200
+            assert (await health.json())["data"] == {
+                "status": "READY",
+                "authentication": "required",
+                "network_scope": "loopback",
+            }
+            assert health.headers["Cache-Control"] == "no-store"
+            assert "default-src 'self'" in health.headers[
+                "Content-Security-Policy"
+            ]
+            assert health.headers["X-Frame-Options"] == "DENY"
+            assert "Access-Control-Allow-Origin" not in health.headers
+
+            foreign_get = await client.get(
+                "/control/health",
+                headers={
+                    "Origin": (
+                        "https://toy-cnbeta01.olivia.miyoushe.com"
+                    )
+                },
+            )
+            assert foreign_get.status == 403
+            assert (await foreign_get.json())["error"]["code"] == (
+                "CONTROL_ORIGIN_FORBIDDEN"
+            )
+
+            forbidden_host = await client.get(
+                "/control/health",
+                headers={"Host": "example.invalid"},
+            )
+            assert forbidden_host.status == 403
+            assert (
+                await forbidden_host.json()
+            )["error"]["code"] == "CONTROL_HOST_FORBIDDEN"
+
+            token = app[AUTH_KEY].issue_bootstrap_token()
+            foreign = await client.post(
+                "/control/api/session/bootstrap",
+                json={"token": token},
+                headers={
+                    "Origin": (
+                        "https://toy-cnbeta01.olivia.miyoushe.com"
+                    )
+                },
+            )
+            assert foreign.status == 403
+            assert (await foreign.json())["error"]["code"] == (
+                "CONTROL_ORIGIN_FORBIDDEN"
+            )
+
+            origin = str(client.make_url("/")).rstrip("/")
+            bootstrap = await client.post(
+                "/control/api/session/bootstrap",
+                json={"token": token},
+                headers={"Origin": origin},
+            )
+            assert bootstrap.status == 200
+            body = await bootstrap.json()
+            assert body["data"]["csrf_token"]
+            cookie = bootstrap.headers["Set-Cookie"]
+            assert "HttpOnly" in cookie
+            assert "SameSite=Strict" in cookie
+            assert "Path=/control" in cookie
+            assert "Secure" not in cookie
+
+            reused = await client.post(
+                "/control/api/session/bootstrap",
+                json={"token": token},
+                headers={"Origin": origin},
+            )
+            assert reused.status == 401
+            assert (await reused.json())["error"]["code"] == (
+                "CONTROL_BOOTSTRAP_INVALID"
+            )
+
+            unknown = await client.get("/control/not-found")
+            assert unknown.status == 404
+            assert (await unknown.json())["error"]["code"] == (
+                "CONTROL_ROUTE_NOT_FOUND"
+            )
+            assert unknown.headers["Referrer-Policy"] == "no-referrer"
+
+    asyncio.run(scenario())
+
+
+def test_authentication_csrf_and_logout(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        del tmp_path
+        ledger = FakeLedger()
+        app = create_control_app(ledger)
+        async with TestClient(
+            TestServer(app),
+            cookie_jar=CookieJar(unsafe=True),
+        ) as client:
+            unauthenticated = await client.get(
+                "/control/api/private-world/snapshot"
+            )
+            assert unauthenticated.status == 401
+            assert (await unauthenticated.json())["error"]["code"] == (
+                "CONTROL_SESSION_REQUIRED"
+            )
+
+            origin = str(client.make_url("/")).rstrip("/")
+            token = app[AUTH_KEY].issue_bootstrap_token()
+            bootstrapped = await client.post(
+                "/control/api/session/bootstrap",
+                json={"token": token},
+                headers={"Origin": origin},
+            )
+            csrf = (await bootstrapped.json())["data"]["csrf_token"]
+
+            missing_csrf = await client.post(
+                "/control/api/private-world/relationship-events",
+                json={
+                    **_common("request.missing-csrf"),
+                    "event_type": "conflict",
+                },
+                headers={"Origin": origin},
+            )
+            assert missing_csrf.status == 403
+            assert (await missing_csrf.json())["error"]["code"] == (
+                "CONTROL_CSRF_REQUIRED"
+            )
+
+            wrong_csrf = await client.post(
+                "/control/api/private-world/relationship-events",
+                json={
+                    **_common("request.wrong-csrf"),
+                    "event_type": "conflict",
+                },
+                headers={
+                    "Origin": origin,
+                    "X-CSRF-Token": "wrong",
+                },
+            )
+            assert wrong_csrf.status == 403
+
+            logged_out = await client.post(
+                "/control/api/session/logout",
+                json={},
+                headers={
+                    "Origin": origin,
+                    "X-CSRF-Token": csrf,
+                },
+            )
+            assert logged_out.status == 200
+            assert (await logged_out.json())["data"]["status"] == (
+                "LOGGED_OUT"
+            )
+
+            after = await client.get(
+                "/control/api/private-world/snapshot"
+            )
+            assert after.status == 401
+
+    asyncio.run(scenario())
+
+
+def test_private_world_mutations_are_typed_idempotent_and_sanitized(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        del tmp_path
+        client, csrf = await _authenticated_client()
+        try:
+            origin = str(client.make_url("/")).rstrip("/")
+            headers = {"Origin": origin, "X-CSRF-Token": csrf}
+
+            conflict = await client.post(
+                "/control/api/private-world/relationship-events",
+                json={
+                    **_common("request.conflict-1"),
+                    "event_type": "conflict",
+                },
+                headers=headers,
+            )
+            assert conflict.status == 200
+            conflict_result = (await conflict.json())["data"]["result"]
+            assert conflict_result["status"] == "APPLIED"
+            assert conflict_result["change_fields"] == ["tension"]
+
+            duplicate = await client.post(
+                "/control/api/private-world/relationship-events",
+                json={
+                    **_common("request.conflict-1"),
+                    "event_type": "conflict",
+                },
+                headers=headers,
+            )
+            assert duplicate.status == 200
+            assert (await duplicate.json())["data"]["result"][
+                "status"
+            ] == "DUPLICATE"
+
+            snapshot = await client.get(
+                "/control/api/private-world/snapshot"
+            )
+            assert snapshot.status == 200
+            state = (await snapshot.json())["data"]
+            assert state["version"] == 2
+            assert state["levels"] == {
+                "familiarity": "unknown",
+                "trust": "unknown",
+                "comfort": "unknown",
+                "closeness": "unknown",
+                "tension": "low",
+            }
+            serialized = json.dumps(state, ensure_ascii=False)
+            for raw_score in (
+                '"familiarity": 0',
+                '"trust": 0',
+                '"comfort": 0',
+                '"closeness": 0',
+                '"tension": 3',
+            ):
+                assert raw_score not in serialized
+
+            events = await client.get(
+                "/control/api/private-world/events"
+            )
+            timeline = (await events.json())["data"]["events"]
+            assert len(timeline) == 1
+            event = timeline[0]
+            assert event["event_id"] == conflict_result["event_id"]
+            assert event["event_type"] == "record_conflict"
+            assert event["actor"] == "local_user"
+            assert event["source"] == "control_center"
+            assert event["reason"] == "synthetic confirmed change"
+            assert "command_fingerprint" not in event
+            assert "payload_fields" not in event
+            assert "delivery_id" not in event
+            assert "payload" not in event
+
+            stage = await client.post(
+                "/control/api/private-world/relationship-stage",
+                json={
+                    **_common("request.stage-1"),
+                    "target_stage": "familiar",
+                    "basis_event_ids": [conflict_result["event_id"]],
+                },
+                headers=headers,
+            )
+            assert stage.status == 200
+            assert (await stage.json())["data"]["result"]["status"] == (
+                "APPLIED"
+            )
+
+            nickname = await client.post(
+                "/control/api/private-world/nicknames",
+                json={
+                    **_common("request.nickname-1"),
+                    "action": "grant",
+                    "nickname": "小河豚",
+                },
+                headers=headers,
+            )
+            assert nickname.status == 200
+
+            access = await client.post(
+                "/control/api/private-world/home-access",
+                json={
+                    **_common("request.home-1"),
+                    "home_access": "visit_access",
+                },
+                headers=headers,
+            )
+            assert access.status == 200
+
+            continuation = await client.post(
+                "/control/api/private-world/continuations",
+                json={
+                    **_common("request.continuation-1"),
+                    "action": "upsert",
+                    "fact_id": "continuation.synthetic-1",
+                    "statement": "一条只用于合成测试的世界线事实。",
+                    "awareness": "control_only",
+                },
+                headers=headers,
+            )
+            assert continuation.status == 200
+
+            awareness = await client.post(
+                "/control/api/private-world/continuations",
+                json={
+                    **_common("request.continuation-2"),
+                    "action": "set_awareness",
+                    "fact_id": "continuation.synthetic-1",
+                    "awareness": "character_known",
+                },
+                headers=headers,
+            )
+            assert awareness.status == 200
+
+            final = await client.get(
+                "/control/api/private-world/snapshot"
+            )
+            final_state = (await final.json())["data"]
+            assert final_state["relationship_stage"] == "familiar"
+            assert final_state["nickname_permissions"] == ["小河豚"]
+            assert final_state["home_access"] == "visit_access"
+            assert final_state["continuation_facts"] == [
+                {
+                    "fact_id": "continuation.synthetic-1",
+                    "statement": "一条只用于合成测试的世界线事实。",
+                    "awareness": "character_known",
+                }
+            ]
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_api_rejects_client_authority_extra_fields_and_invalid_evidence(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        del tmp_path
+        client, csrf = await _authenticated_client()
+        try:
+            origin = str(client.make_url("/")).rstrip("/")
+            headers = {"Origin": origin, "X-CSRF-Token": csrf}
+            authority = await client.post(
+                "/control/api/private-world/relationship-events",
+                json={
+                    **_common("request.authority"),
+                    "event_type": "conflict",
+                    "actor": "migration",
+                },
+                headers=headers,
+            )
+            assert authority.status == 400
+            assert (await authority.json())["error"]["code"] == (
+                "CONTROL_BODY_FIELDS_INVALID"
+            )
+
+            invalid_event = await client.post(
+                "/control/api/private-world/relationship-events",
+                json={
+                    **_common("request.invalid-event"),
+                    "event_type": "confession",
+                },
+                headers=headers,
+            )
+            assert invalid_event.status == 400
+
+            missing_basis = await client.post(
+                "/control/api/private-world/relationship-stage",
+                json={
+                    **_common("request.missing-basis"),
+                    "target_stage": "close",
+                    "basis_event_ids": ["event.missing"],
+                },
+                headers=headers,
+            )
+            assert missing_basis.status == 400
+            assert (await missing_basis.json())["error"]["code"] == (
+                "PRIVATE_WORLD_COMMAND_EVIDENCE_INVALID"
+            )
+
+            invalid_content_type = await client.post(
+                "/control/api/private-world/nicknames",
+                data="{}",
+                headers={
+                    "Origin": origin,
+                    "X-CSRF-Token": csrf,
+                    "Content-Type": "text/plain",
+                },
+            )
+            assert invalid_content_type.status == 415
+            assert (await invalid_content_type.json())["error"]["code"] == (
+                "CONTROL_CONTENT_TYPE_INVALID"
+            )
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Implements PW-04 from #33 and establishes the backend security boundary required by #35.

## Changes

- adds a packaged `control_center` module with an independent aiohttp app factory;
- restricts the management surface to loopback Host and same-origin loopback requests;
- rejects the original Olivia frontend origin and emits no CORS grant;
- adds one-time bootstrap tokens, in-memory sliding sessions, an HttpOnly/SameSite=Strict cookie, CSRF validation, logout, and token-safe representations;
- applies no-store, strict CSP, frame, referrer, permissions, and cross-origin security headers to success and error responses;
- exposes authenticated, typed PrivateWorld endpoints for:
  - qualitative snapshot and sanitized audit timeline;
  - boundary/conflict/repair events;
  - relationship-stage confirmation with existing evidence;
  - nickname grant/revoke;
  - home-access changes;
  - Local Continuation upsert, awareness changes, and deletion;
- fixes actor/source server-side as `local_user/control_center`; clients cannot override authority;
- derives command identities from client request IDs and preserves PW-03 idempotency;
- never returns raw hidden relationship scores, command fingerprints, raw audit payloads, delivery IDs, database paths, or session tokens;
- returns stable JSON error codes without exception text;
- packages the module and adds its tests to the default public gate.

## Validation

- 8 focused auth/API scenarios passed locally;
- focused tests cover one-time bootstrap, expiry, logout, Host/Origin isolation, CSRF, security headers, typed mutations, duplicate recovery, qualitative projection, sanitized events, authority rejection, and content-type errors;
- GitHub `Public smoke (Windows / Python 3.12)` is the required merge gate.

## Boundary

This PR does not add the visual Control Center shell, launcher wiring, persistent candidate sessions, or automatic candidate analysis. It creates the loopback management API and security foundation only; PW-05 and #35 add the user-facing pages later.

Part of #33.