### PR TITLE
feat(control): add graphical PrivateWorld management page

### DIFF
--- a/control_center/app.py
+++ b/control_center/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Awaitable, Callable
 from urllib.parse import urlsplit
 
@@ -33,9 +34,15 @@ PRIVATE_WORLD_API_KEY = web.AppKey(
 )
 SESSION_TOKEN_KEY = web.AppKey("control_center.session_token", str)
 
+_STATIC_ROOT = Path(__file__).with_name("static")
 _PUBLIC_ROUTES = frozenset(
     {
+        ("GET", "/control"),
+        ("GET", "/control/"),
         ("GET", "/control/health"),
+        ("GET", "/control/static/app.css"),
+        ("GET", "/control/static/api.js"),
+        ("GET", "/control/static/app.js"),
         ("POST", "/control/api/session/bootstrap"),
     }
 )
@@ -205,6 +212,36 @@ async def _json_body(request: web.Request) -> object:
         raise json.JSONDecodeError("invalid", "", 0) from exc
 
 
+def _static_response(name: str) -> web.FileResponse:
+    path = _STATIC_ROOT / name
+    if not path.is_file():
+        raise ControlRequestError(
+            "CONTROL_STATIC_UNAVAILABLE",
+            http_status=503,
+        )
+    return web.FileResponse(path)
+
+
+async def control_index(request: web.Request) -> web.FileResponse:
+    del request
+    return _static_response("index.html")
+
+
+async def control_css(request: web.Request) -> web.FileResponse:
+    del request
+    return _static_response("app.css")
+
+
+async def control_api_script(request: web.Request) -> web.FileResponse:
+    del request
+    return _static_response("api.js")
+
+
+async def control_app_script(request: web.Request) -> web.FileResponse:
+    del request
+    return _static_response("app.js")
+
+
 async def health(request: web.Request) -> web.Response:
     del request
     return _response(
@@ -319,7 +356,12 @@ def create_control_app(
     )
     app.add_routes(
         [
+            web.get("/control", control_index),
+            web.get("/control/", control_index),
             web.get("/control/health", health),
+            web.get("/control/static/app.css", control_css),
+            web.get("/control/static/api.js", control_api_script),
+            web.get("/control/static/app.js", control_app_script),
             web.post("/control/api/session/bootstrap", bootstrap),
             web.post("/control/api/session/logout", logout),
             web.get(

--- a/control_center/static/api.js
+++ b/control_center/static/api.js
@@ -1,0 +1,79 @@
+const CSRF_STORAGE_KEY = "olivia.control.csrf";
+let csrfToken = sessionStorage.getItem(CSRF_STORAGE_KEY) || "";
+
+export class ControlAPIError extends Error {
+  constructor(code, status) {
+    super(code);
+    this.code = code;
+    this.status = status;
+  }
+}
+
+async function decode(response) {
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new ControlAPIError("CONTROL_RESPONSE_INVALID", response.status);
+  }
+  if (!response.ok || payload.ok !== true) {
+    throw new ControlAPIError(
+      payload?.error?.code || "CONTROL_REQUEST_FAILED",
+      response.status,
+    );
+  }
+  return payload.data;
+}
+
+async function request(path, {method = "GET", body} = {}) {
+  const headers = {Accept: "application/json"};
+  const options = {method, headers, credentials: "same-origin"};
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    options.body = JSON.stringify(body);
+  }
+  if (method !== "GET" && method !== "HEAD") {
+    if (!csrfToken) {
+      throw new ControlAPIError("CONTROL_CSRF_REQUIRED", 403);
+    }
+    headers["X-CSRF-Token"] = csrfToken;
+  }
+  return decode(await fetch(path, options));
+}
+
+export async function establishSession() {
+  const fragment = new URLSearchParams(window.location.hash.slice(1));
+  const bootstrap = fragment.get("bootstrap") || "";
+  if (window.location.hash) {
+    history.replaceState(null, "", window.location.pathname);
+  }
+  if (!bootstrap) {
+    return {bootstrapped: false, csrfAvailable: Boolean(csrfToken)};
+  }
+  const response = await fetch("/control/api/session/bootstrap", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: {"Content-Type": "application/json", Accept: "application/json"},
+    body: JSON.stringify({token: bootstrap}),
+  });
+  const data = await decode(response);
+  csrfToken = data.csrf_token;
+  sessionStorage.setItem(CSRF_STORAGE_KEY, csrfToken);
+  return {bootstrapped: true, csrfAvailable: true};
+}
+
+export function get(path) {
+  return request(path);
+}
+
+export function post(path, body) {
+  return request(path, {method: "POST", body});
+}
+
+export async function logout() {
+  if (csrfToken) {
+    await post("/control/api/session/logout", {});
+  }
+  csrfToken = "";
+  sessionStorage.removeItem(CSRF_STORAGE_KEY);
+}

--- a/control_center/static/app.css
+++ b/control_center/static/app.css
@@ -1,0 +1,148 @@
+:root {
+  color-scheme: light;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f5f3ef;
+  color: #25231f;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 320px; }
+button, input, select, textarea { font: inherit; }
+button, input, select, textarea {
+  border: 1px solid #918b80;
+  border-radius: 0.45rem;
+  background: #fff;
+  color: inherit;
+  padding: 0.65rem 0.75rem;
+}
+button { cursor: pointer; background: #25231f; color: #fff; }
+button:hover { background: #49443c; }
+button:focus-visible, input:focus-visible, select:focus-visible,
+textarea:focus-visible, a:focus-visible {
+  outline: 3px solid #7b5f37;
+  outline-offset: 2px;
+}
+textarea { min-height: 5.5rem; resize: vertical; }
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  padding: 1.25rem 2rem;
+  background: #fff;
+  border-bottom: 1px solid #d8d3c9;
+}
+h1, h2 { margin: 0; font-weight: 650; }
+h1 { font-size: 1.5rem; }
+h2 { font-size: 1.15rem; }
+.eyebrow {
+  margin: 0 0 0.25rem;
+  color: #6f675b;
+  font-size: 0.8rem;
+}
+.session-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+.layout { display: grid; grid-template-columns: 15rem minmax(0, 1fr); }
+nav {
+  padding: 1.5rem;
+  border-right: 1px solid #d8d3c9;
+  min-height: calc(100vh - 5rem);
+}
+nav a, nav span {
+  display: block;
+  padding: 0.7rem 0.8rem;
+  margin-bottom: 0.3rem;
+  border-radius: 0.45rem;
+  text-decoration: none;
+  color: inherit;
+}
+nav a[aria-current="page"] {
+  background: #e3ddd2;
+  font-weight: 650;
+}
+nav span[aria-disabled="true"] { color: #777168; }
+main { max-width: 76rem; padding: 1.5rem; }
+section {
+  background: #fff;
+  border: 1px solid #d8d3c9;
+  border-radius: 0.7rem;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+}
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.hint { color: #625d55; line-height: 1.55; }
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.75rem;
+}
+.status-grid div {
+  background: #f5f3ef;
+  border-radius: 0.5rem;
+  padding: 0.8rem;
+}
+dt { color: #6f675b; font-size: 0.8rem; }
+dd { margin: 0.25rem 0 0; font-weight: 650; }
+form { display: grid; gap: 0.65rem; max-width: 42rem; }
+fieldset { border: 1px solid #d8d3c9; border-radius: 0.5rem; }
+fieldset label { display: block; padding: 0.3rem; }
+.choice-list {
+  display: grid;
+  gap: 0.35rem;
+  max-height: 14rem;
+  overflow: auto;
+}
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0;
+}
+.tag-list li {
+  list-style: none;
+  background: #e3ddd2;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+}
+.table-wrap { overflow-x: auto; margin-bottom: 1rem; }
+table { width: 100%; border-collapse: collapse; }
+th, td {
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid #e1ddd5;
+  padding: 0.65rem;
+}
+.timeline { padding-left: 1.4rem; }
+.timeline li { margin-bottom: 0.85rem; }
+.timeline strong, .timeline span { display: block; }
+.timeline span { color: #6f675b; font-size: 0.8rem; }
+.timeline p { margin: 0.25rem 0; }
+.notice {
+  position: sticky;
+  bottom: 1rem;
+  padding: 0.8rem 1rem;
+  border-radius: 0.5rem;
+  background: #e5efe2;
+}
+.notice:empty { display: none; }
+.notice[data-state="error"] { background: #f5dfdc; }
+@media (max-width: 760px) {
+  .topbar { align-items: flex-start; padding: 1rem; }
+  .session-actions {
+    flex-direction: column;
+    align-items: flex-end;
+  }
+  .layout { grid-template-columns: 1fr; }
+  nav {
+    min-height: auto;
+    border-right: 0;
+    border-bottom: 1px solid #d8d3c9;
+  }
+  main { padding: 1rem; }
+}

--- a/control_center/static/app.js
+++ b/control_center/static/app.js
@@ -1,0 +1,350 @@
+import {ControlAPIError, establishSession, get, logout, post} from "./api.js";
+
+const labels = {
+  unknown: "未知",
+  low: "低",
+  medium: "中",
+  high: "高",
+  acquaintance: "相识",
+  familiar: "熟悉",
+  close: "亲近",
+  no_access: "无访问权限",
+  visit_access: "拜访权限",
+  errand_access: "代办权限",
+  domestic_access: "共同生活权限",
+  control_only: "仅系统知道",
+  pending: "待确认",
+  character_known: "林离已知",
+  record_boundary_respected: "边界被尊重",
+  record_conflict: "冲突",
+  record_repair: "修复",
+  confirm_relationship_stage: "关系阶段确认",
+};
+
+const byId = (id) => document.getElementById(id);
+const notice = byId("notice");
+
+function label(value) {
+  return labels[value] || value || "—";
+}
+
+function requestId(prefix) {
+  const suffix = globalThis.crypto?.randomUUID?.()
+    || `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return `${prefix}.${suffix}`;
+}
+
+function common(prefix, reason) {
+  return {
+    request_id: requestId(prefix),
+    occurred_at: new Date().toISOString(),
+    reason,
+    evidence_refs: [],
+  };
+}
+
+function showNotice(message, failed = false) {
+  notice.textContent = message;
+  notice.dataset.state = failed ? "error" : "ok";
+}
+
+function clearChildren(node) {
+  while (node.firstChild) {
+    node.removeChild(node.firstChild);
+  }
+}
+
+function renderSnapshot(snapshot) {
+  byId("relationship-stage").textContent = label(snapshot.relationship_stage);
+  for (const [name, value] of Object.entries(snapshot.levels)) {
+    byId(`level-${name}`).textContent = label(value);
+  }
+  byId("home-access").textContent = label(snapshot.home_access);
+  byId("home-select").value = snapshot.home_access;
+  byId("nickname-summary").textContent = snapshot.nickname_permissions.length
+    ? snapshot.nickname_permissions.join("、")
+    : "未授权";
+
+  const nicknameList = byId("nickname-list");
+  clearChildren(nicknameList);
+  for (const nickname of snapshot.nickname_permissions) {
+    const item = document.createElement("li");
+    item.textContent = nickname;
+    nicknameList.append(item);
+  }
+  if (!snapshot.nickname_permissions.length) {
+    const item = document.createElement("li");
+    item.textContent = "暂无已授权称呼";
+    nicknameList.append(item);
+  }
+
+  const continuationList = byId("continuation-list");
+  clearChildren(continuationList);
+  for (const fact of snapshot.continuation_facts) {
+    const row = document.createElement("tr");
+    for (const value of [
+      fact.fact_id,
+      fact.statement,
+      label(fact.awareness),
+    ]) {
+      const cell = document.createElement("td");
+      cell.textContent = value;
+      row.append(cell);
+    }
+    continuationList.append(row);
+  }
+  if (!snapshot.continuation_facts.length) {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 3;
+    cell.textContent = "暂无私人世界线事实";
+    row.append(cell);
+    continuationList.append(row);
+  }
+}
+
+function renderEvents(events) {
+  const timeline = byId("event-list");
+  const basisList = byId("stage-basis-list");
+  clearChildren(timeline);
+  clearChildren(basisList);
+
+  for (const event of [...events].reverse()) {
+    const item = document.createElement("li");
+    const title = document.createElement("strong");
+    title.textContent = label(event.command_kind || event.event_type);
+    const metadata = document.createElement("span");
+    metadata.textContent = `${event.occurred_at} · ${event.reason_code}`;
+    const reason = document.createElement("p");
+    reason.textContent = event.reason || "系统记录";
+    item.append(title, metadata, reason);
+    timeline.append(item);
+  }
+  if (!events.length) {
+    const item = document.createElement("li");
+    item.textContent = "暂无已确认事件";
+    timeline.append(item);
+  }
+
+  const allowed = new Set([
+    "record_boundary_respected",
+    "record_conflict",
+    "record_repair",
+  ]);
+  for (const event of events.filter((row) => allowed.has(row.event_type))) {
+    const wrapper = document.createElement("label");
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.name = "stage-basis";
+    input.value = event.event_id;
+    wrapper.append(
+      input,
+      ` ${label(event.event_type)} · ${event.occurred_at}`,
+    );
+    basisList.append(wrapper);
+  }
+  if (!basisList.childElementCount) {
+    const hint = document.createElement("p");
+    hint.textContent = "请先记录至少一个关系事件。";
+    basisList.append(hint);
+  }
+}
+
+async function refresh() {
+  const [snapshot, events] = await Promise.all([
+    get("/control/api/private-world/snapshot"),
+    get("/control/api/private-world/events"),
+  ]);
+  renderSnapshot(snapshot);
+  renderEvents(events.events);
+}
+
+async function mutate(path, body, successMessage) {
+  await post(path, body);
+  await refresh();
+  showNotice(successMessage);
+}
+
+function selectedBasis() {
+  return [
+    ...document.querySelectorAll(
+      'input[name="stage-basis"]:checked',
+    ),
+  ].map((node) => node.value);
+}
+
+function bindForms() {
+  byId("refresh-button").addEventListener("click", async () => {
+    try {
+      await refresh();
+      showNotice("状态已刷新");
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+  byId("relationship-event-form").addEventListener(
+    "submit",
+    async (event) => {
+      event.preventDefault();
+      const form = new FormData(event.currentTarget);
+      try {
+        await mutate(
+          "/control/api/private-world/relationship-events",
+          {
+            ...common(
+              "relationship",
+              byId("relationship-reason").value,
+            ),
+            event_type: form.get("event-type"),
+          },
+          "关系事件已记录",
+        );
+        event.currentTarget.reset();
+      } catch (error) {
+        handleError(error);
+      }
+    },
+  );
+
+  byId("stage-form").addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const basis = selectedBasis();
+    if (!basis.length) {
+      showNotice("请先选择关系事件依据", true);
+      return;
+    }
+    if (!window.confirm("确认修改关系阶段？这会写入可审计的私人世界记录。")) {
+      return;
+    }
+    try {
+      await mutate(
+        "/control/api/private-world/relationship-stage",
+        {
+          ...common("stage", byId("stage-reason").value),
+          target_stage: byId("stage-select").value,
+          basis_event_ids: basis,
+        },
+        "关系阶段已确认",
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+  byId("nickname-form").addEventListener("submit", async (event) => {
+    event.preventDefault();
+    try {
+      await mutate(
+        "/control/api/private-world/nicknames",
+        {
+          ...common("nickname", byId("nickname-reason").value),
+          action: byId("nickname-action").value,
+          nickname: byId("nickname-value").value,
+        },
+        "称呼权限已更新",
+      );
+      event.currentTarget.reset();
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+  byId("home-form").addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!window.confirm("确认修改住所权限？请确保这符合已经建立的私人历史。")) {
+      return;
+    }
+    try {
+      await mutate(
+        "/control/api/private-world/home-access",
+        {
+          ...common("home", byId("home-reason").value),
+          home_access: byId("home-select").value,
+        },
+        "住所权限已更新",
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+  byId("continuation-form").addEventListener(
+    "submit",
+    async (event) => {
+      event.preventDefault();
+      const action = byId("continuation-action").value;
+      const awareness = byId("continuation-awareness").value;
+      if (
+        awareness === "character_known"
+        && !window.confirm(
+          "确认让林离知道这条事实？控制层未来信息可能因此进入角色视角。",
+        )
+      ) {
+        return;
+      }
+      const body = {
+        ...common(
+          "continuation",
+          byId("continuation-reason").value,
+        ),
+        action,
+        fact_id: byId("continuation-id").value,
+      };
+      if (action === "upsert") {
+        body.statement = byId("continuation-statement").value;
+        body.awareness = awareness;
+      } else if (action === "set_awareness") {
+        body.awareness = awareness;
+      }
+      try {
+        await mutate(
+          "/control/api/private-world/continuations",
+          body,
+          "私人世界线已更新",
+        );
+        event.currentTarget.reset();
+      } catch (error) {
+        handleError(error);
+      }
+    },
+  );
+
+  byId("logout-button").addEventListener("click", async () => {
+    try {
+      await logout();
+      byId("session-status").textContent = "管理会话已退出";
+      showNotice(
+        "请从 Windows 开始菜单重新打开 Control Center。",
+        true,
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  });
+}
+
+function handleError(error) {
+  const code = error instanceof ControlAPIError
+    ? error.code
+    : "CONTROL_UI_ERROR";
+  byId("session-status").textContent = "本地管理不可用";
+  showNotice(`操作失败：${code}`, true);
+}
+
+async function start() {
+  bindForms();
+  try {
+    const session = await establishSession();
+    byId("session-status").textContent = session.csrfAvailable
+      ? "本地安全会话已建立"
+      : "只读会话；重新从开始菜单打开后可修改";
+    await refresh();
+    showNotice("PrivateWorld 已加载");
+    byId("private-world").focus();
+  } catch (error) {
+    handleError(error);
+  }
+}
+
+start();

--- a/control_center/static/index.html
+++ b/control_center/static/index.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Olivia Control Center</title>
+  <link rel="stylesheet" href="/control/static/app.css">
+</head>
+<body>
+  <header class="topbar">
+    <div>
+      <p class="eyebrow">本地陪伴系统</p>
+      <h1>Olivia Control Center</h1>
+    </div>
+    <div class="session-actions">
+      <span id="session-status" role="status">正在建立本地会话</span>
+      <button id="logout-button" type="button">退出管理</button>
+    </div>
+  </header>
+
+  <div class="layout">
+    <nav aria-label="管理功能">
+      <a href="#private-world" aria-current="page">私有世界</a>
+      <span aria-disabled="true">长期记忆（后续）</span>
+      <span aria-disabled="true">音乐校准（后续）</span>
+      <span aria-disabled="true">诊断（后续）</span>
+    </nav>
+
+    <main id="private-world" tabindex="-1">
+      <section aria-labelledby="overview-title">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">PrivateWorld</p>
+            <h2 id="overview-title">关系与私人世界概览</h2>
+          </div>
+          <button id="refresh-button" type="button">刷新</button>
+        </div>
+        <p class="hint">这里显示的是定性状态。系统不会把隐藏数值做成可刷取的亲密度游戏。</p>
+        <dl class="status-grid">
+          <div><dt>关系阶段</dt><dd id="relationship-stage">—</dd></div>
+          <div><dt>熟悉度</dt><dd id="level-familiarity">—</dd></div>
+          <div><dt>信任</dt><dd id="level-trust">—</dd></div>
+          <div><dt>舒适度</dt><dd id="level-comfort">—</dd></div>
+          <div><dt>亲近度</dt><dd id="level-closeness">—</dd></div>
+          <div><dt>紧张度</dt><dd id="level-tension">—</dd></div>
+          <div><dt>住所权限</dt><dd id="home-access">—</dd></div>
+          <div><dt>已授权称呼</dt><dd id="nickname-summary">—</dd></div>
+        </dl>
+      </section>
+
+      <section aria-labelledby="event-title">
+        <h2 id="event-title">记录关系事件</h2>
+        <p class="hint">成功回信不会自动增加关系。只有你明确提交的事件才会改变状态。</p>
+        <form id="relationship-event-form">
+          <fieldset>
+            <legend>事件类型</legend>
+            <label><input type="radio" name="event-type" value="boundary_respected" required> 边界被尊重</label>
+            <label><input type="radio" name="event-type" value="conflict"> 冲突</label>
+            <label><input type="radio" name="event-type" value="repair"> 修复</label>
+          </fieldset>
+          <label for="relationship-reason">确认依据</label>
+          <textarea id="relationship-reason" maxlength="280" required></textarea>
+          <button type="submit">记录事件</button>
+        </form>
+      </section>
+
+      <section aria-labelledby="stage-title">
+        <h2 id="stage-title">确认关系阶段</h2>
+        <p class="hint">必须从下方时间线选择已有的关系事件作为依据。</p>
+        <form id="stage-form">
+          <label for="stage-select">目标阶段</label>
+          <select id="stage-select" required>
+            <option value="unknown">未知</option>
+            <option value="acquaintance">相识</option>
+            <option value="familiar">熟悉</option>
+            <option value="close">亲近</option>
+          </select>
+          <label for="stage-reason">确认说明</label>
+          <textarea id="stage-reason" maxlength="280" required></textarea>
+          <fieldset>
+            <legend>依据事件</legend>
+            <div id="stage-basis-list" class="choice-list"></div>
+          </fieldset>
+          <button type="submit">确认阶段</button>
+        </form>
+      </section>
+
+      <section aria-labelledby="nickname-title">
+        <h2 id="nickname-title">私人称呼</h2>
+        <ul id="nickname-list" class="tag-list"></ul>
+        <form id="nickname-form">
+          <label for="nickname-action">操作</label>
+          <select id="nickname-action">
+            <option value="grant">授权</option>
+            <option value="revoke">撤销</option>
+          </select>
+          <label for="nickname-value">称呼</label>
+          <input id="nickname-value" maxlength="32" autocomplete="off" required>
+          <label for="nickname-reason">说明</label>
+          <input id="nickname-reason" maxlength="280" required>
+          <button type="submit">提交称呼变更</button>
+        </form>
+      </section>
+
+      <section aria-labelledby="home-title">
+        <h2 id="home-title">住所边界</h2>
+        <form id="home-form">
+          <label for="home-select">权限</label>
+          <select id="home-select">
+            <option value="no_access">无访问权限</option>
+            <option value="visit_access">拜访权限</option>
+            <option value="errand_access">代办权限</option>
+            <option value="domestic_access">共同生活权限</option>
+          </select>
+          <label for="home-reason">说明</label>
+          <textarea id="home-reason" maxlength="280" required></textarea>
+          <button type="submit">更新住所权限</button>
+        </form>
+      </section>
+
+      <section aria-labelledby="continuation-title">
+        <h2 id="continuation-title">私人世界线</h2>
+        <p class="hint">「系统知道」与「林离知道」是两回事。切换为角色已知前会再次确认。</p>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>事实 ID</th><th>内容</th><th>知情状态</th></tr></thead>
+            <tbody id="continuation-list"></tbody>
+          </table>
+        </div>
+        <form id="continuation-form">
+          <label for="continuation-action">操作</label>
+          <select id="continuation-action">
+            <option value="upsert">新增或更新</option>
+            <option value="set_awareness">只调整知情状态</option>
+            <option value="delete">删除</option>
+          </select>
+          <label for="continuation-id">事实 ID</label>
+          <input id="continuation-id" maxlength="64" pattern="[A-Za-z0-9._:-]+" required>
+          <label for="continuation-statement">事实内容</label>
+          <textarea id="continuation-statement" maxlength="600"></textarea>
+          <label for="continuation-awareness">知情状态</label>
+          <select id="continuation-awareness">
+            <option value="control_only">仅系统知道</option>
+            <option value="pending">待确认</option>
+            <option value="character_known">林离已知</option>
+          </select>
+          <label for="continuation-reason">说明</label>
+          <textarea id="continuation-reason" maxlength="280" required></textarea>
+          <button type="submit">提交世界线变更</button>
+        </form>
+      </section>
+
+      <section aria-labelledby="timeline-title">
+        <h2 id="timeline-title">事件时间线</h2>
+        <ol id="event-list" class="timeline"></ol>
+      </section>
+
+      <p id="notice" class="notice" role="status" aria-live="polite"></p>
+    </main>
+  </div>
+
+  <script type="module" src="/control/static/app.js"></script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ include = [
     "tts*",
 ]
 
+[tool.setuptools.package-data]
+control_center = ["static/*.html", "static/*.css", "static/*.js"]
+
 [tool.pytest.ini_options]
 testpaths = [
     "tests/persona",

--- a/tests/control_center/test_static_ui.py
+++ b/tests/control_center/test_static_ui.py
@@ -61,16 +61,23 @@ def test_static_shell_is_public_but_private_api_remains_authenticated() -> None:
     async def scenario() -> None:
         app = create_control_app(FakeLedger())
         async with TestClient(TestServer(app)) as client:
-            for path, content_type in (
-                ("/control", "text/html"),
-                ("/control/", "text/html"),
-                ("/control/static/app.css", "text/css"),
-                ("/control/static/api.js", "text/javascript"),
-                ("/control/static/app.js", "text/javascript"),
-            ):
+            expected_types = {
+                "/control": {"text/html"},
+                "/control/": {"text/html"},
+                "/control/static/app.css": {"text/css"},
+                "/control/static/api.js": {
+                    "text/javascript",
+                    "application/javascript",
+                },
+                "/control/static/app.js": {
+                    "text/javascript",
+                    "application/javascript",
+                },
+            }
+            for path, content_types in expected_types.items():
                 response = await client.get(path)
                 assert response.status == 200
-                assert response.content_type == content_type
+                assert response.content_type in content_types
                 assert response.headers["Cache-Control"] == "no-store"
                 assert "Access-Control-Allow-Origin" not in response.headers
                 assert await response.text()

--- a/tests/control_center/test_static_ui.py
+++ b/tests/control_center/test_static_ui.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+from importlib import resources
+from threading import Lock
+
+from aiohttp.test_utils import TestClient, TestServer
+
+from control_center.app import create_control_app
+from private_world_ledger import LedgerEvent
+from private_world_port import PrivateWorldSnapshot
+
+
+class FakeLedger:
+    def __init__(self) -> None:
+        self.current = PrivateWorldSnapshot()
+        self.items: list[LedgerEvent] = []
+        self._lock = Lock()
+
+    def snapshot(self) -> PrivateWorldSnapshot:
+        return self.current
+
+    def events(self) -> tuple[LedgerEvent, ...]:
+        return tuple(self.items)
+
+    def apply_once(
+        self,
+        event: LedgerEvent,
+        snapshot: PrivateWorldSnapshot,
+    ) -> bool:
+        with self._lock:
+            self.items.append(event)
+            self.current = snapshot
+        return True
+
+
+def test_static_assets_are_packaged_and_external_resource_free() -> None:
+    root = resources.files("control_center").joinpath("static")
+    index = root.joinpath("index.html").read_text(encoding="utf-8")
+    css = root.joinpath("app.css").read_text(encoding="utf-8")
+    api = root.joinpath("api.js").read_text(encoding="utf-8")
+    app = root.joinpath("app.js").read_text(encoding="utf-8")
+
+    for document in (index, css, api, app):
+        assert "https://" not in document
+        assert "http://" not in document
+    assert '<html lang="zh-CN">' in index
+    assert "<main" in index
+    assert 'aria-live="polite"' in index
+    assert 'type="number"' not in index
+    assert '<script type="module" src="/control/static/app.js">' in index
+    assert "window.location.hash" in api
+    assert "history.replaceState" in api
+    assert "sessionStorage" in api
+    assert "innerHTML" not in app
+    assert "document.write" not in app
+    assert "eval(" not in app
+
+
+def test_static_shell_is_public_but_private_api_remains_authenticated() -> None:
+    async def scenario() -> None:
+        app = create_control_app(FakeLedger())
+        async with TestClient(TestServer(app)) as client:
+            for path, content_type in (
+                ("/control", "text/html"),
+                ("/control/", "text/html"),
+                ("/control/static/app.css", "text/css"),
+                ("/control/static/api.js", "text/javascript"),
+                ("/control/static/app.js", "text/javascript"),
+            ):
+                response = await client.get(path)
+                assert response.status == 200
+                assert response.content_type == content_type
+                assert response.headers["Cache-Control"] == "no-store"
+                assert "Access-Control-Allow-Origin" not in response.headers
+                assert await response.text()
+
+            private = await client.get(
+                "/control/api/private-world/snapshot"
+            )
+            assert private.status == 401
+            assert (await private.json())["error"]["code"] == (
+                "CONTROL_SESSION_REQUIRED"
+            )
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Implements PW-05 from #33 and the first user-facing slice of #35.

## Changes

- adds a packaged, Chinese-language Control Center shell served entirely from the loopback management app;
- keeps the HTML/CSS/ES modules self-contained with no CDN, analytics, external fonts, or remote resources;
- bootstraps the management session from a one-time token in the URL fragment, clears the fragment immediately, stores only the CSRF token in session storage, and keeps the session token HttpOnly;
- exposes a graphical PrivateWorld page for:
  - qualitative relationship overview without raw hidden scores;
  - explicit boundary/conflict/repair events;
  - relationship-stage confirmation using selected existing evidence events;
  - nickname grant/revoke;
  - home-access changes;
  - Local Continuation upsert, awareness changes, and deletion;
  - sanitized event timeline;
- adds confirmation prompts for relationship-stage, home-access, and character-known transitions;
- uses DOM `textContent` rather than HTML injection for all runtime data;
- includes semantic labels, keyboard focus states, live status text, responsive layout, and no relationship-score gamification;
- serves only fixed static paths and leaves every PrivateWorld API route authenticated;
- packages static HTML/CSS/JS in the wheel.

## Validation

- 10 focused auth/API/static UI tests passed locally;
- JavaScript syntax passed `node --check`;
- tests verify public static shell versus authenticated data, package resources, no external URLs, no inline remote code, no `innerHTML`/`eval`/`document.write`, CSP/security headers, and platform-safe MIME handling;
- GitHub `Public smoke (Windows / Python 3.12)` is the required merge gate.

## Boundary

This PR does not yet launch the Control Center from Windows, create shortcuts, add candidate approval, Mem0 pages, music calibration, or diagnostics. Launcher wiring belongs to #37; candidates remain PW-06; the other pages remain #35.

Part of #33.