### PR TITLE
feat(http): define original-client letter status contract

### DIFF
--- a/letter_status.py
+++ b/letter_status.py
@@ -1,0 +1,65 @@
+"""Pure mapping between internal letter states and the original client wire enum."""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class OriginalLetterStatus(IntEnum):
+    PENDING = 1
+    REPLIED = 4
+    FAILED = 5
+
+
+_INTERNAL_TO_WIRE = {
+    "PENDING": OriginalLetterStatus.PENDING,
+    "PROCESSING": OriginalLetterStatus.PENDING,
+    "COMPLETED": OriginalLetterStatus.REPLIED,
+    "REPLIED": OriginalLetterStatus.REPLIED,
+    "FAILED": OriginalLetterStatus.FAILED,
+    "CANCELED": OriginalLetterStatus.FAILED,
+    "CANCELLED": OriginalLetterStatus.FAILED,
+}
+
+
+class LetterStatusError(ValueError):
+    code = "LETTER_STATUS_INVALID"
+
+
+def original_letter_status(value: object) -> int:
+    """Return the exact numeric status expected by the original frontend.
+
+    Existing imported records may already contain one of the public numeric
+    values.  Unknown strings, booleans, and arbitrary numbers are rejected so
+    callers cannot silently publish a misleading terminal state.
+    """
+
+    if type(value) is int:
+        try:
+            return int(OriginalLetterStatus(value))
+        except ValueError as exc:
+            raise LetterStatusError("unsupported numeric letter status") from exc
+    if not isinstance(value, str):
+        raise LetterStatusError("letter status must be text or a known wire value")
+    normalized = value.strip().upper()
+    try:
+        return int(_INTERNAL_TO_WIRE[normalized])
+    except KeyError as exc:
+        raise LetterStatusError("unsupported internal letter status") from exc
+
+
+def original_letter_status_or_failed(value: object) -> int:
+    """Fail closed for public serialization without raising provider details."""
+
+    try:
+        return original_letter_status(value)
+    except LetterStatusError:
+        return int(OriginalLetterStatus.FAILED)
+
+
+__all__ = [
+    "LetterStatusError",
+    "OriginalLetterStatus",
+    "original_letter_status",
+    "original_letter_status_or_failed",
+]

--- a/letter_status.py
+++ b/letter_status.py
@@ -30,10 +30,12 @@ def original_letter_status(value: object) -> int:
     """Return the exact numeric status expected by the original frontend.
 
     Existing imported records may already contain one of the public numeric
-    values.  Unknown strings, booleans, and arbitrary numbers are rejected so
-    callers cannot silently publish a misleading terminal state.
+    values. Unknown strings, booleans, arbitrary integers, and unrelated enum
+    types are rejected so callers cannot silently publish a misleading state.
     """
 
+    if isinstance(value, OriginalLetterStatus):
+        return int(value)
     if type(value) is int:
         try:
             return int(OriginalLetterStatus(value))

--- a/tests/http/test_letter_status_contract.py
+++ b/tests/http/test_letter_status_contract.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+from letter_status import (
+    LetterStatusError,
+    OriginalLetterStatus,
+    original_letter_status,
+    original_letter_status_or_failed,
+)
+
+
+@pytest.mark.parametrize(
+    ("internal", "wire"),
+    [
+        ("PENDING", 1),
+        ("processing", 1),
+        (" COMPLETED ", 4),
+        ("REPLIED", 4),
+        ("FAILED", 5),
+        ("CANCELED", 5),
+        ("cancelled", 5),
+    ],
+)
+def test_internal_states_map_to_original_numeric_enum(internal: str, wire: int) -> None:
+    assert original_letter_status(internal) == wire
+
+
+def test_existing_valid_wire_values_are_preserved() -> None:
+    assert original_letter_status(OriginalLetterStatus.PENDING) == 1
+    assert original_letter_status(4) == 4
+    assert original_letter_status(5) == 5
+
+
+@pytest.mark.parametrize("value", [None, True, False, 0, 2, 3, 6, "", "READY", [], {}])
+def test_unknown_states_are_rejected(value: object) -> None:
+    with pytest.raises(LetterStatusError):
+        original_letter_status(value)
+
+
+def test_public_fallback_fails_closed_as_failed() -> None:
+    assert original_letter_status_or_failed("not-a-state") == 5
+    assert original_letter_status_or_failed(None) == 5


### PR DESCRIPTION
Implements COMPAT-01 from #36.

## Scope

- defines the original frontend wire enum: pending `1`, replied `4`, failed `5`;
- maps internal `PENDING/PROCESSING`, `COMPLETED/REPLIED`, and `FAILED/CANCELED` states explicitly;
- preserves already-normalized imported numeric values;
- rejects booleans, arbitrary numbers, unknown strings, and malformed values;
- provides a privacy-safe public serializer fallback that fails closed to `5` without exposing internal provider errors.

## Tests

Locks every accepted mapping, existing wire values, invalid inputs, and fail-closed behavior.

## Boundary

This PR is the pure contract only. COMPAT-02 will wire it into current-letter list/detail/send responses from the latest protected main while keeping canonical text status separate from media status.