### PR TITLE
feat(memory): add optional local Mem0 adapter

### DIFF
--- a/mem0_memory.py
+++ b/mem0_memory.py
@@ -1,0 +1,629 @@
+"""Optional local Mem0 OSS adapter for new-conversation long-term memory.
+
+The adapter keeps Archive, Persona evidence, and PrivateWorld outside Mem0.  It
+imports the optional dependency lazily, uses a local Qdrant path, and reports
+stable failure codes without echoing messages, provider responses, credentials,
+or absolute paths.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import importlib
+import os
+from pathlib import Path
+import re
+import threading
+from typing import Any, Callable, Mapping, Protocol, Sequence
+
+from conversation_memory_port import (
+    ConversationMemoryPort,
+    ConversationMemoryRecord,
+    ConversationMemoryStatus,
+    MemoryWriteResult,
+    MemoryWriteStatus,
+    NullConversationMemoryPort,
+    UnavailableConversationMemoryPort,
+)
+
+
+_DOMAIN = "conversation_memory"
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
+
+
+class Mem0AdapterError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+class Mem0Backend(Protocol):
+    def add(self, messages: object, **kwargs: object) -> object: ...
+
+    def search(self, query: str, **kwargs: object) -> object: ...
+
+    def get_all(self, **kwargs: object) -> object: ...
+
+    def delete(self, memory_id: str) -> object: ...
+
+    def delete_all(self, **kwargs: object) -> object: ...
+
+
+@dataclass(frozen=True)
+class Mem0Config:
+    enabled: bool
+    data_root: Path
+    user_id: str = "local-user"
+    agent_id: str = "linli"
+    collection_name: str = "olivia_conversation_memory_v1"
+    llm_base_url: str = ""
+    llm_model: str = ""
+    llm_api_key_env: str = "DEEPSEEK_API_KEY"
+    embedding_model: str = "BAAI/bge-small-zh-v1.5"
+    embedding_dims: int = 512
+    embedding_cache: Path | None = None
+    context_max_chars: int = 2400
+    config_error: str | None = None
+
+    def __post_init__(self) -> None:
+        if type(self.enabled) is not bool:
+            raise ValueError("enabled must be boolean")
+        root = Path(self.data_root)
+        if str(root) in {"", "."}:
+            raise ValueError("an explicit data root is required")
+        object.__setattr__(self, "data_root", root)
+        for value, name in (
+            (self.user_id, "user_id"),
+            (self.agent_id, "agent_id"),
+            (self.collection_name, "collection_name"),
+        ):
+            if not isinstance(value, str) or not _ID_RE.fullmatch(value):
+                raise ValueError(f"{name} is invalid")
+        if not isinstance(self.llm_base_url, str) or len(self.llm_base_url) > 2048:
+            raise ValueError("llm_base_url is invalid")
+        if not isinstance(self.llm_model, str) or len(self.llm_model) > 256:
+            raise ValueError("llm_model is invalid")
+        if not isinstance(self.llm_api_key_env, str) or not re.fullmatch(
+            r"^[A-Z][A-Z0-9_]{0,95}$",
+            self.llm_api_key_env,
+        ):
+            raise ValueError("llm_api_key_env is invalid")
+        if not isinstance(self.embedding_model, str) or not self.embedding_model.strip():
+            raise ValueError("embedding_model is invalid")
+        if type(self.embedding_dims) is not int or not 64 <= self.embedding_dims <= 8192:
+            raise ValueError("embedding_dims is invalid")
+        if self.embedding_cache is not None:
+            object.__setattr__(self, "embedding_cache", Path(self.embedding_cache))
+        if type(self.context_max_chars) is not int or not 0 <= self.context_max_chars <= 20_000:
+            raise ValueError("context_max_chars is invalid")
+        if self.config_error is not None and (
+            not isinstance(self.config_error, str)
+            or not re.fullmatch(r"^[A-Z][A-Z0-9_]{0,95}$", self.config_error)
+        ):
+            raise ValueError("config_error is invalid")
+
+    @property
+    def qdrant_path(self) -> Path:
+        return self.data_root / "qdrant"
+
+    @property
+    def history_path(self) -> Path:
+        return self.data_root / "history" / "history.db"
+
+    @property
+    def model_cache(self) -> Path:
+        return self.embedding_cache or self.data_root.parent / "model-cache"
+
+    def provider_config(self, environ: Mapping[str, str] | None = None) -> dict[str, object]:
+        environment = environ or os.environ
+        api_key = environment.get(self.llm_api_key_env, "")
+        return {
+            "vector_store": {
+                "provider": "qdrant",
+                "config": {
+                    "collection_name": self.collection_name,
+                    "path": str(self.qdrant_path),
+                    "on_disk": True,
+                    "embedding_model_dims": self.embedding_dims,
+                },
+            },
+            "llm": {
+                "provider": "openai",
+                "config": {
+                    "model": self.llm_model,
+                    "api_key": api_key,
+                    "openai_base_url": self.llm_base_url,
+                    "temperature": 0.1,
+                },
+            },
+            "embedder": {
+                "provider": "huggingface",
+                "config": {
+                    "model": self.embedding_model,
+                    "embedding_dims": self.embedding_dims,
+                    "model_kwargs": {
+                        "device": "cpu",
+                        "cache_folder": str(self.model_cache),
+                        "local_files_only": True,
+                    },
+                },
+            },
+            "history_db_path": str(self.history_path),
+        }
+
+
+def _bool(value: object, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().casefold()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off", ""}:
+            return False
+    return default
+
+
+def _integer(value: object, default: int) -> int:
+    try:
+        if isinstance(value, bool):
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def load_mem0_config(
+    *,
+    environ: Mapping[str, str] | None = None,
+    project_root: Path | None = None,
+) -> Mem0Config:
+    environment = environ or os.environ
+    root = Path(project_root or Path(__file__).resolve().parent)
+    configured_root = environment.get("OLIVIA_MEMORY_ROOT", "").strip()
+    data_root = (
+        Path(configured_root).expanduser()
+        if configured_root
+        else root / ".olivia_data" / "memory" / "mem0"
+    )
+    if not data_root.is_absolute():
+        data_root = root / data_root
+    cache_value = environment.get("OLIVIA_MEMORY_EMBEDDING_CACHE", "").strip()
+    embedding_cache = Path(cache_value).expanduser() if cache_value else None
+    if embedding_cache is not None and not embedding_cache.is_absolute():
+        embedding_cache = root / embedding_cache
+
+    enabled = _bool(environment.get("OLIVIA_MEMORY_ENABLED"), False)
+    llm_base_url = environment.get(
+        "OLIVIA_MEMORY_LLM_BASE_URL",
+        environment.get("OLIVIA_LLM_BASE_URL", ""),
+    ).strip()
+    llm_model = environment.get(
+        "OLIVIA_MEMORY_LLM_MODEL",
+        environment.get("OLIVIA_LLM_MODEL", ""),
+    ).strip()
+    key_env = environment.get(
+        "OLIVIA_MEMORY_LLM_API_KEY_ENV",
+        environment.get("OLIVIA_LLM_API_KEY_ENV", "DEEPSEEK_API_KEY"),
+    ).strip()
+    error: str | None = None
+    if enabled and (not llm_base_url or not llm_model):
+        error = "MEM0_LLM_CONFIG_INCOMPLETE"
+    dims = _integer(environment.get("OLIVIA_MEMORY_EMBEDDING_DIMS"), 512)
+    if not 64 <= dims <= 8192:
+        error = "MEM0_EMBEDDING_DIMS_INVALID"
+        dims = 512
+    context_max = _integer(environment.get("OLIVIA_MEMORY_CONTEXT_MAX_CHARS"), 2400)
+    if not 0 <= context_max <= 20_000:
+        error = "MEM0_CONTEXT_LIMIT_INVALID"
+        context_max = 2400
+
+    return Mem0Config(
+        enabled=enabled,
+        data_root=data_root,
+        user_id=environment.get("OLIVIA_MEMORY_USER_ID", "local-user").strip()
+        or "local-user",
+        agent_id=environment.get("OLIVIA_MEMORY_AGENT_ID", "linli").strip()
+        or "linli",
+        collection_name=environment.get(
+            "OLIVIA_MEMORY_COLLECTION",
+            "olivia_conversation_memory_v1",
+        ).strip()
+        or "olivia_conversation_memory_v1",
+        llm_base_url=llm_base_url,
+        llm_model=llm_model,
+        llm_api_key_env=key_env or "DEEPSEEK_API_KEY",
+        embedding_model=environment.get(
+            "OLIVIA_MEMORY_EMBEDDING_MODEL",
+            "BAAI/bge-small-zh-v1.5",
+        ).strip()
+        or "BAAI/bge-small-zh-v1.5",
+        embedding_dims=dims,
+        embedding_cache=embedding_cache,
+        context_max_chars=context_max,
+        config_error=error,
+    )
+
+
+def _rows(value: object) -> tuple[Mapping[str, object], ...]:
+    if isinstance(value, Mapping):
+        candidate = value.get("results")
+        if candidate is None:
+            candidate = value.get("memories")
+        if candidate is None:
+            candidate = value.get("data")
+        value = candidate if candidate is not None else ()
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return ()
+    return tuple(item for item in value if isinstance(item, Mapping))
+
+
+def _date(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _score(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    normalized = float(value)
+    return normalized if 0.0 <= normalized <= 1.0 else None
+
+
+def _row_metadata(row: Mapping[str, object]) -> Mapping[str, object]:
+    metadata = row.get("metadata")
+    return metadata if isinstance(metadata, Mapping) else {}
+
+
+def _row_id(row: Mapping[str, object]) -> str | None:
+    value = row.get("id", row.get("memory_id"))
+    return value if isinstance(value, str) and _ID_RE.fullmatch(value) else None
+
+
+def _row_to_record(
+    row: Mapping[str, object],
+    *,
+    user_id: str,
+) -> ConversationMemoryRecord | None:
+    memory_id = _row_id(row)
+    text = row.get("memory", row.get("text"))
+    metadata = _row_metadata(row)
+    domain = metadata.get("domain", row.get("domain", _DOMAIN))
+    source_id = metadata.get("source_id", row.get("source_id"))
+    if (
+        memory_id is None
+        or not isinstance(text, str)
+        or not text.strip()
+        or domain != _DOMAIN
+        or not isinstance(source_id, str)
+        or not _ID_RE.fullmatch(source_id)
+    ):
+        return None
+    row_user = row.get("user_id", metadata.get("user_id", user_id))
+    if row_user != user_id:
+        return None
+    safe_metadata = {
+        key: value
+        for key, value in metadata.items()
+        if key in {"category", "canonical", "manual", "actor"}
+        and (value is None or isinstance(value, (bool, int, float, str)))
+    }
+    try:
+        return ConversationMemoryRecord(
+            memory_id=memory_id,
+            text=text,
+            user_id=user_id,
+            source_id=source_id,
+            score=_score(row.get("score")),
+            occurred_at=_date(metadata.get("occurred_at", row.get("occurred_at"))),
+            created_at=_date(row.get("created_at")),
+            metadata=safe_metadata,
+        )
+    except ValueError:
+        return None
+
+
+class Mem0ConversationMemoryAdapter:
+    enabled = True
+
+    def __init__(
+        self,
+        backend: Mem0Backend,
+        config: Mem0Config,
+    ) -> None:
+        if not isinstance(config, Mem0Config) or not config.enabled:
+            raise ValueError("an enabled Mem0 config is required")
+        self.backend = backend
+        self.config = config
+        self._lock = threading.RLock()
+        self._last_error_code: str | None = None
+
+    def _filters(self, user_id: str) -> dict[str, object]:
+        return {
+            "AND": [
+                {"user_id": user_id},
+                {"agent_id": self.config.agent_id},
+                {"domain": _DOMAIN},
+            ]
+        }
+
+    def _get_all(self, user_id: str) -> tuple[Mapping[str, object], ...]:
+        with self._lock:
+            try:
+                value = self.backend.get_all(filters=self._filters(user_id))
+            except TypeError:
+                value = self.backend.get_all(
+                    user_id=user_id,
+                    agent_id=self.config.agent_id,
+                )
+        return _rows(value)
+
+    def _records(
+        self,
+        rows: Sequence[Mapping[str, object]],
+        *,
+        user_id: str,
+        limit: int,
+    ) -> tuple[ConversationMemoryRecord, ...]:
+        records: list[ConversationMemoryRecord] = []
+        for row in rows:
+            record = _row_to_record(row, user_id=user_id)
+            if record is not None:
+                records.append(record)
+            if len(records) >= limit:
+                break
+        return tuple(records)
+
+    def search_context(
+        self,
+        query: str,
+        *,
+        user_id: str,
+        limit: int,
+    ) -> tuple[ConversationMemoryRecord, ...]:
+        if not isinstance(query, str) or not query.strip() or not 1 <= limit <= 100:
+            return ()
+        try:
+            with self._lock:
+                value = self.backend.search(
+                    query=query.strip(),
+                    filters=self._filters(user_id),
+                    top_k=limit,
+                )
+            self._last_error_code = None
+            return self._records(_rows(value), user_id=user_id, limit=limit)
+        except Exception:
+            self._last_error_code = "MEM0_SEARCH_FAILED"
+            return ()
+
+    def remember_exchange(
+        self,
+        *,
+        user_message: str,
+        assistant_message: str,
+        occurred_at: datetime,
+        source_id: str,
+        user_id: str,
+    ) -> MemoryWriteResult:
+        if not isinstance(occurred_at, datetime) or occurred_at.tzinfo is None:
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                source_id,
+                error_code="MEM0_EXCHANGE_INVALID",
+            )
+        try:
+            existing = self.list_memories(user_id=user_id, limit=500)
+            if any(record.source_id == source_id for record in existing):
+                return MemoryWriteResult(MemoryWriteStatus.DUPLICATE, source_id)
+            metadata = {
+                "source_id": source_id,
+                "occurred_at": occurred_at.isoformat(),
+                "domain": _DOMAIN,
+                "canonical": True,
+            }
+            with self._lock:
+                value = self.backend.add(
+                    [
+                        {"role": "user", "content": str(user_message)},
+                        {"role": "assistant", "content": str(assistant_message)},
+                    ],
+                    user_id=user_id,
+                    agent_id=self.config.agent_id,
+                    metadata=metadata,
+                )
+            ids = tuple(
+                memory_id
+                for row in _rows(value)
+                if (memory_id := _row_id(row)) is not None
+            )
+            self._last_error_code = None
+            return MemoryWriteResult(
+                MemoryWriteStatus.WRITTEN if ids else MemoryWriteStatus.SKIPPED,
+                source_id,
+                ids,
+            )
+        except Exception:
+            self._last_error_code = "MEM0_WRITE_FAILED"
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                source_id,
+                error_code="MEM0_WRITE_FAILED",
+            )
+
+    def list_memories(
+        self,
+        *,
+        user_id: str,
+        limit: int = 100,
+    ) -> tuple[ConversationMemoryRecord, ...]:
+        if not 1 <= limit <= 1000:
+            return ()
+        try:
+            records = self._records(
+                self._get_all(user_id),
+                user_id=user_id,
+                limit=limit,
+            )
+            self._last_error_code = None
+            return records
+        except Exception:
+            self._last_error_code = "MEM0_LIST_FAILED"
+            return ()
+
+    def add_manual_memory(
+        self,
+        text: str,
+        *,
+        user_id: str,
+        source_id: str,
+    ) -> ConversationMemoryRecord:
+        metadata = {
+            "source_id": source_id,
+            "occurred_at": datetime.now(timezone.utc).isoformat(),
+            "domain": _DOMAIN,
+            "manual": True,
+            "actor": "local_user",
+        }
+        try:
+            with self._lock:
+                value = self.backend.add(
+                    str(text),
+                    user_id=user_id,
+                    agent_id=self.config.agent_id,
+                    metadata=metadata,
+                    infer=False,
+                )
+            records = self._records(_rows(value), user_id=user_id, limit=1)
+            if not records:
+                records = tuple(
+                    record
+                    for record in self.list_memories(user_id=user_id, limit=500)
+                    if record.source_id == source_id
+                )[:1]
+            if not records:
+                raise Mem0AdapterError("MEM0_MANUAL_WRITE_FAILED")
+            self._last_error_code = None
+            return records[0]
+        except Mem0AdapterError:
+            raise
+        except Exception as exc:
+            self._last_error_code = "MEM0_MANUAL_WRITE_FAILED"
+            raise Mem0AdapterError("MEM0_MANUAL_WRITE_FAILED") from exc
+
+    def delete_memory(self, memory_id: str, *, user_id: str) -> bool:
+        try:
+            owned = any(
+                record.memory_id == memory_id
+                for record in self.list_memories(user_id=user_id, limit=1000)
+            )
+            if not owned:
+                return False
+            with self._lock:
+                self.backend.delete(memory_id)
+            self._last_error_code = None
+            return True
+        except Exception:
+            self._last_error_code = "MEM0_DELETE_FAILED"
+            return False
+
+    def clear_user(self, *, user_id: str) -> int:
+        records = self.list_memories(user_id=user_id, limit=1000)
+        if not records:
+            return 0
+        try:
+            with self._lock:
+                try:
+                    self.backend.delete_all(filters=self._filters(user_id))
+                except TypeError:
+                    self.backend.delete_all(
+                        user_id=user_id,
+                        agent_id=self.config.agent_id,
+                    )
+            self._last_error_code = None
+            return len(records)
+        except Exception:
+            self._last_error_code = "MEM0_CLEAR_FAILED"
+            return 0
+
+    def export_user(self, *, user_id: str) -> dict[str, object]:
+        records = self.list_memories(user_id=user_id, limit=1000)
+        return {
+            "schema_version": "p03.conversation-memory-export.v1",
+            "user_id": user_id,
+            "provider": "mem0",
+            "records": [record.to_prompt_dict() for record in records],
+        }
+
+    def status(self) -> ConversationMemoryStatus:
+        records = self.list_memories(user_id=self.config.user_id, limit=1000)
+        if self._last_error_code is not None:
+            return ConversationMemoryStatus(
+                "degraded",
+                True,
+                "mem0",
+                "qdrant-local",
+                reason_code=self._last_error_code,
+            )
+        return ConversationMemoryStatus(
+            "available",
+            True,
+            "mem0",
+            "qdrant-local",
+            memory_count=len(records),
+        )
+
+
+def _default_factory(config: Mapping[str, object]) -> Mem0Backend:
+    module = importlib.import_module("mem0")
+    memory_type = getattr(module, "Memory", None)
+    if memory_type is None or not hasattr(memory_type, "from_config"):
+        raise ImportError("Mem0 Memory.from_config is unavailable")
+    return memory_type.from_config(dict(config))
+
+
+def create_mem0_adapter(
+    config: Mem0Config | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+    memory_factory: Callable[[Mapping[str, object]], Mem0Backend] | None = None,
+) -> ConversationMemoryPort:
+    active = config or load_mem0_config(environ=environ)
+    if active.config_error:
+        return UnavailableConversationMemoryPort(active.config_error)
+    if not active.enabled:
+        return NullConversationMemoryPort()
+    try:
+        active.qdrant_path.parent.mkdir(parents=True, exist_ok=True)
+        active.history_path.parent.mkdir(parents=True, exist_ok=True)
+        active.model_cache.mkdir(parents=True, exist_ok=True)
+        factory = memory_factory or _default_factory
+        backend = factory(active.provider_config(environ))
+        return Mem0ConversationMemoryAdapter(backend, active)
+    except ModuleNotFoundError:
+        return UnavailableConversationMemoryPort("MEM0_IMPORT_FAILED")
+    except ImportError:
+        return UnavailableConversationMemoryPort("MEM0_IMPORT_FAILED")
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return UnavailableConversationMemoryPort("MEM0_INITIALIZATION_FAILED")
+
+
+__all__ = [
+    "Mem0AdapterError",
+    "Mem0Config",
+    "Mem0ConversationMemoryAdapter",
+    "create_mem0_adapter",
+    "load_mem0_config",
+]

--- a/tests/memory/test_mem0_memory.py
+++ b/tests/memory/test_mem0_memory.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from conversation_memory_port import (
+    MemoryWriteStatus,
+    NullConversationMemoryPort,
+    UnavailableConversationMemoryPort,
+)
+from mem0_memory import (
+    Mem0AdapterError,
+    Mem0Config,
+    Mem0ConversationMemoryAdapter,
+    create_mem0_adapter,
+    load_mem0_config,
+)
+
+
+NOW = datetime(2026, 8, 23, 2, 0, tzinfo=timezone.utc)
+
+
+class FakeMem0:
+    def __init__(self) -> None:
+        self.rows: list[dict[str, object]] = []
+        self.calls: list[tuple[str, object]] = []
+        self.fail: set[str] = set()
+        self.counter = 0
+
+    def _raise(self, name: str) -> None:
+        if name in self.fail:
+            raise RuntimeError(f"private provider error from {name}")
+
+    def add(self, messages, **kwargs):
+        self._raise("add")
+        self.calls.append(("add", {"messages": messages, **kwargs}))
+        self.counter += 1
+        metadata = dict(kwargs.get("metadata", {}))
+        text = (
+            messages
+            if isinstance(messages, str)
+            else "用户在东京工作。"
+        )
+        row = {
+            "id": f"memory.fixture.{self.counter}",
+            "memory": text,
+            "user_id": kwargs.get("user_id"),
+            "agent_id": kwargs.get("agent_id"),
+            "metadata": metadata,
+            "created_at": NOW.isoformat(),
+        }
+        self.rows.append(row)
+        return {"results": [row]}
+
+    def search(self, query, **kwargs):
+        self._raise("search")
+        self.calls.append(("search", {"query": query, **kwargs}))
+        return {"results": [{**row, "score": 0.91} for row in self.rows]}
+
+    def get_all(self, **kwargs):
+        self._raise("get_all")
+        self.calls.append(("get_all", kwargs))
+        return {"results": list(self.rows)}
+
+    def delete(self, memory_id):
+        self._raise("delete")
+        self.calls.append(("delete", memory_id))
+        self.rows[:] = [row for row in self.rows if row["id"] != memory_id]
+
+    def delete_all(self, **kwargs):
+        self._raise("delete_all")
+        self.calls.append(("delete_all", kwargs))
+        self.rows.clear()
+
+
+def _config(tmp_path: Path) -> Mem0Config:
+    return Mem0Config(
+        enabled=True,
+        data_root=tmp_path / "memory" / "mem0",
+        llm_base_url="http://127.0.0.1:9/v1",
+        llm_model="fixture-model",
+        embedding_cache=tmp_path / "models",
+    )
+
+
+def test_config_builds_local_only_provider_mapping(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    mapping = config.provider_config({"DEEPSEEK_API_KEY": "fixture-secret"})
+
+    assert mapping["vector_store"] == {
+        "provider": "qdrant",
+        "config": {
+            "collection_name": "olivia_conversation_memory_v1",
+            "path": str(config.qdrant_path),
+            "on_disk": True,
+            "embedding_model_dims": 512,
+        },
+    }
+    assert mapping["embedder"]["provider"] == "huggingface"
+    assert mapping["embedder"]["config"]["model_kwargs"] == {
+        "device": "cpu",
+        "cache_folder": str(config.model_cache),
+        "local_files_only": True,
+    }
+    assert mapping["llm"]["config"]["openai_base_url"] == "http://127.0.0.1:9/v1"
+    assert mapping["llm"]["config"]["api_key"] == "fixture-secret"
+    assert "private_world" not in repr(mapping)
+
+
+def test_load_config_reuses_primary_llm_and_rejects_incomplete_enabled_config(tmp_path: Path) -> None:
+    config = load_mem0_config(
+        environ={
+            "OLIVIA_MEMORY_ENABLED": "true",
+            "OLIVIA_MEMORY_ROOT": str(tmp_path / "mem0"),
+            "OLIVIA_LLM_BASE_URL": "http://127.0.0.1:8000/v1",
+            "OLIVIA_LLM_MODEL": "fixture-model",
+            "OLIVIA_LLM_API_KEY_ENV": "FIXTURE_KEY",
+        },
+        project_root=tmp_path,
+    )
+    assert config.enabled is True
+    assert config.llm_base_url == "http://127.0.0.1:8000/v1"
+    assert config.llm_model == "fixture-model"
+    assert config.llm_api_key_env == "FIXTURE_KEY"
+    assert config.config_error is None
+
+    incomplete = load_mem0_config(
+        environ={
+            "OLIVIA_MEMORY_ENABLED": "true",
+            "OLIVIA_MEMORY_ROOT": str(tmp_path / "mem0-missing"),
+        },
+        project_root=tmp_path,
+    )
+    assert incomplete.config_error == "MEM0_LLM_CONFIG_INCOMPLETE"
+
+
+def test_exchange_search_list_export_delete_and_clear(tmp_path: Path) -> None:
+    backend = FakeMem0()
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+    written = adapter.remember_exchange(
+        user_message="我现在在东京工作。",
+        assistant_message="这次我记住了。",
+        occurred_at=NOW,
+        source_id="letter:fixture:1",
+        user_id="local-user",
+    )
+    assert written.status is MemoryWriteStatus.WRITTEN
+    assert written.memory_ids == ("memory.fixture.1",)
+
+    add_call = next(value for name, value in backend.calls if name == "add")
+    assert add_call["messages"] == [
+        {"role": "user", "content": "我现在在东京工作。"},
+        {"role": "assistant", "content": "这次我记住了。"},
+    ]
+    assert add_call["metadata"] == {
+        "source_id": "letter:fixture:1",
+        "occurred_at": NOW.isoformat(),
+        "domain": "conversation_memory",
+        "canonical": True,
+    }
+    serialized = repr(add_call)
+    assert "system_prompt" not in serialized
+    assert "private_world" not in serialized
+
+    duplicate = adapter.remember_exchange(
+        user_message="重复投递",
+        assistant_message="重复回复",
+        occurred_at=NOW,
+        source_id="letter:fixture:1",
+        user_id="local-user",
+    )
+    assert duplicate.status is MemoryWriteStatus.DUPLICATE
+    assert len([name for name, _value in backend.calls if name == "add"]) == 1
+
+    searched = adapter.search_context("东京", user_id="local-user", limit=3)
+    assert len(searched) == 1
+    assert searched[0].text == "用户在东京工作。"
+    assert searched[0].score == 0.91
+    assert searched[0].source_id == "letter:fixture:1"
+
+    listed = adapter.list_memories(user_id="local-user")
+    assert [record.memory_id for record in listed] == ["memory.fixture.1"]
+    exported = adapter.export_user(user_id="local-user")
+    assert exported["provider"] == "mem0"
+    assert exported["records"][0]["source_id"] == "letter:fixture:1"
+    assert "user_id" not in exported["records"][0]
+
+    assert adapter.delete_memory("memory.fixture.1", user_id="other-user") is False
+    assert adapter.delete_memory("memory.fixture.1", user_id="local-user") is True
+    assert adapter.list_memories(user_id="local-user") == ()
+
+    adapter.remember_exchange(
+        user_message="我喜欢黑咖啡。",
+        assistant_message="知道了。",
+        occurred_at=NOW,
+        source_id="letter:fixture:2",
+        user_id="local-user",
+    )
+    assert adapter.clear_user(user_id="local-user") == 1
+    assert adapter.list_memories(user_id="local-user") == ()
+
+
+def test_manual_memory_is_exact_and_user_owned(tmp_path: Path) -> None:
+    backend = FakeMem0()
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+    record = adapter.add_manual_memory(
+        "用户不吃香菜。",
+        user_id="local-user",
+        source_id="manual:fixture:1",
+    )
+    assert record.text == "用户不吃香菜。"
+    add_call = next(value for name, value in backend.calls if name == "add")
+    assert add_call["messages"] == "用户不吃香菜。"
+    assert add_call["infer"] is False
+    assert add_call["metadata"]["manual"] is True
+    assert add_call["metadata"]["actor"] == "local_user"
+
+
+def test_provider_failures_degrade_without_echoing_private_content(tmp_path: Path) -> None:
+    backend = FakeMem0()
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+    backend.fail.add("add")
+
+    result = adapter.remember_exchange(
+        user_message="private user message",
+        assistant_message="private assistant message",
+        occurred_at=NOW,
+        source_id="letter:fixture:failure",
+        user_id="local-user",
+    )
+    assert result.status is MemoryWriteStatus.UNAVAILABLE
+    assert result.error_code == "MEM0_WRITE_FAILED"
+    assert "private user message" not in repr(result)
+    assert "private assistant message" not in repr(result)
+    assert adapter.status().reason_code in {"MEM0_WRITE_FAILED", "MEM0_LIST_FAILED"}
+
+    backend.fail.clear()
+    backend.fail.add("add")
+    with pytest.raises(Mem0AdapterError) as manual:
+        adapter.add_manual_memory(
+            "private manual fact",
+            user_id="local-user",
+            source_id="manual:fixture:failure",
+        )
+    assert manual.value.code == "MEM0_MANUAL_WRITE_FAILED"
+    assert "private manual fact" not in str(manual.value)
+
+
+def test_factory_is_lazy_optional_and_returns_stable_ports(tmp_path: Path) -> None:
+    disabled = create_mem0_adapter(
+        Mem0Config(enabled=False, data_root=tmp_path / "disabled")
+    )
+    assert isinstance(disabled, NullConversationMemoryPort)
+
+    incomplete = create_mem0_adapter(
+        Mem0Config(
+            enabled=True,
+            data_root=tmp_path / "incomplete",
+            config_error="MEM0_LLM_CONFIG_INCOMPLETE",
+        )
+    )
+    assert isinstance(incomplete, UnavailableConversationMemoryPort)
+    assert incomplete.reason_code == "MEM0_LLM_CONFIG_INCOMPLETE"
+
+    captured: list[dict[str, object]] = []
+    backend = FakeMem0()
+
+    def factory(mapping):
+        captured.append(dict(mapping))
+        return backend
+
+    created = create_mem0_adapter(
+        _config(tmp_path),
+        environ={"DEEPSEEK_API_KEY": "fixture-secret"},
+        memory_factory=factory,
+    )
+    assert isinstance(created, Mem0ConversationMemoryAdapter)
+    assert captured[0]["vector_store"]["provider"] == "qdrant"
+    assert created.status().provider == "mem0"


### PR DESCRIPTION
Implements MEM-03 from #34.

## Scope

- adds a lazy optional `Mem0ConversationMemoryAdapter` behind the typed conversation-memory port;
- configures local Qdrant storage, a CPU Hugging Face Chinese embedding model, a local model cache, and a configurable OpenAI-compatible extraction LLM;
- uses `local_files_only` for the production embedder so server startup cannot silently download model assets;
- supports canonical exchange writes, idempotency by source reference, search, list, exact manual facts, ownership-checked delete, clear, export, and sanitized status;
- keeps Archive, Persona evidence, system prompts, Reviewer payloads, PrivateWorld, hidden scores, and control-only state outside Mem0;
- imports Mem0 only when the provider is enabled and returns stable disabled/unavailable ports otherwise;
- suppresses provider exception text and private message bodies from status and write results.

## Tests

- local provider mapping and primary-LLM configuration reuse;
- canonical user/assistant role preservation and metadata boundary;
- duplicate source handling;
- search/list/export/delete/clear;
- exact `infer=False` manual memories;
- provider failure degradation without private-content echo;
- lazy factory behavior and stable unavailable states.

## Boundary

This PR does not yet attach Mem0 to PersonaAssembly or canonical reply delivery. MEM-04 will add bounded retrieval, and MEM-05 will add asynchronous exactly-once exchange writes.