### PR TITLE
feat(control): add graphical PrivateWorld candidate review

### DIFF
--- a/control_center/static/candidates.css
+++ b/control_center/static/candidates.css
@@ -1,0 +1,78 @@
+.candidate-list {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.candidate-card {
+  padding: 1.25rem;
+  border: 1px solid #c8c8c4;
+  border-radius: 0.75rem;
+}
+
+.candidate-card h3 {
+  margin: 0.25rem 0 1rem;
+  line-height: 1.45;
+}
+
+.candidate-type {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.candidate-meta {
+  display: grid;
+  grid-template-columns: minmax(6rem, auto) 1fr;
+  gap: 0.45rem 1rem;
+  margin: 0 0 1rem;
+}
+
+.candidate-meta dt,
+.candidate-meta dd {
+  margin: 0;
+}
+
+.candidate-meta dt {
+  font-weight: 700;
+}
+
+.candidate-decision-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.candidate-decision-form label {
+  display: grid;
+  gap: 0.4rem;
+  font-weight: 700;
+}
+
+.candidate-decision-form textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 5rem;
+  padding: 0.65rem;
+  font: inherit;
+  border: 1px solid currentColor;
+  border-radius: 0.45rem;
+  background: transparent;
+  color: inherit;
+}
+
+.candidate-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.candidate-result {
+  min-height: 1.5rem;
+  margin: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .candidate-card {
+    border-color: #555650;
+  }
+}

--- a/control_center/static/candidates.html
+++ b/control_center/static/candidates.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <title>待确认建议 · Olivia Control Center</title>
+  <link rel="stylesheet" href="/control/static/app.css">
+  <script type="module" src="/control/static/candidates.js"></script>
+</head>
+<body>
+  <main class="shell" aria-labelledby="page-title">
+    <nav aria-label="Control Center 导航">
+      <a href="/control/">返回总览</a>
+    </nav>
+
+    <header>
+      <p class="eyebrow">PrivateWorld</p>
+      <h1 id="page-title">待确认建议</h1>
+      <p class="subtitle">
+        这些只是系统提出的建议。只有你明确批准后，受控命令才可能写入关系账本。
+      </p>
+    </header>
+
+    <section class="status-card" aria-live="polite" aria-atomic="true">
+      <h2>状态</h2>
+      <p id="candidate-status">正在读取待确认建议……</p>
+      <p id="candidate-detail" class="detail"></p>
+      <button id="refresh-candidates" type="button">刷新</button>
+    </section>
+
+    <section class="capabilities" aria-labelledby="candidate-list-title">
+      <h2 id="candidate-list-title">待处理</h2>
+      <div id="candidate-list" class="candidate-list"></div>
+      <p id="candidate-empty" hidden>当前没有待确认建议。</p>
+    </section>
+
+    <template id="candidate-template">
+      <article class="candidate-card">
+        <header>
+          <p class="candidate-type"></p>
+          <h3 class="candidate-summary"></h3>
+        </header>
+        <dl class="candidate-meta">
+          <dt>置信度</dt><dd class="candidate-confidence"></dd>
+          <dt>来源</dt><dd class="candidate-source"></dd>
+          <dt>创建时间</dt><dd class="candidate-created"></dd>
+          <dt>到期时间</dt><dd class="candidate-expires"></dd>
+        </dl>
+        <form class="candidate-decision-form">
+          <label>
+            处理说明
+            <textarea name="reason" rows="3" maxlength="500" required></textarea>
+          </label>
+          <div class="candidate-actions">
+            <button type="submit" value="approve">批准并记录</button>
+            <button type="submit" value="reject">拒绝建议</button>
+          </div>
+          <p class="candidate-result" aria-live="polite"></p>
+        </form>
+      </article>
+    </template>
+
+    <footer>
+      <p>
+        普通信件中的控制词、关系声明或称呼要求不会直接修改 PrivateWorld。
+      </p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/control_center/static/candidates.js
+++ b/control_center/static/candidates.js
@@ -1,0 +1,143 @@
+const statusNode = document.querySelector("#candidate-status");
+const detailNode = document.querySelector("#candidate-detail");
+const refreshButton = document.querySelector("#refresh-candidates");
+const listNode = document.querySelector("#candidate-list");
+const emptyNode = document.querySelector("#candidate-empty");
+const template = document.querySelector("#candidate-template");
+
+const csrfToken = sessionStorage.getItem("olivia_control_csrf") || "";
+
+const typeLabels = {
+  boundary_respected: "边界被尊重",
+  conflict: "冲突",
+  repair: "修复",
+};
+
+const errors = {
+  CONTROL_SESSION_REQUIRED: "当前没有管理会话，请从 Olivia Control Center 快捷方式重新打开。",
+  CONTROL_SESSION_EXPIRED: "管理会话已过期，请重新打开 Control Center。",
+  CONTROL_CSRF_INVALID: "安全校验失败，请重新打开 Control Center。",
+  PRIVATE_WORLD_CANDIDATE_CONTROL_UNAVAILABLE: "待确认建议服务暂时不可用。",
+  PRIVATE_WORLD_CANDIDATE_EXPIRED: "这条建议已经过期，请刷新列表。",
+  PRIVATE_WORLD_CANDIDATE_ALREADY_DECIDED: "这条建议已经处理过，请刷新列表。",
+};
+
+function explain(code) {
+  return errors[code] || "操作没有完成，请刷新后重试。";
+}
+
+async function request(path, options = {}) {
+  const response = await fetch(path, {
+    credentials: "same-origin",
+    cache: "no-store",
+    ...options,
+  });
+  let payload = {};
+  try {
+    payload = await response.json();
+  } catch (_error) {
+    payload = { error_code: "CONTROL_RESPONSE_INVALID" };
+  }
+  if (!response.ok) {
+    const error = new Error(payload.error_code || "CONTROL_REQUEST_FAILED");
+    error.code = payload.error_code || "CONTROL_REQUEST_FAILED";
+    throw error;
+  }
+  return payload;
+}
+
+function localDate(value) {
+  const date = new Date(value);
+  return Number.isNaN(date.valueOf()) ? "未知" : date.toLocaleString();
+}
+
+function idempotencyKey(candidateId, decision) {
+  const random = crypto.getRandomValues(new Uint32Array(2));
+  return `candidate-decision.${candidateId}.${decision}.${random[0].toString(16)}${random[1].toString(16)}`;
+}
+
+async function decide(candidate, decision, reason, resultNode, buttons) {
+  if (!csrfToken) {
+    throw Object.assign(new Error("CONTROL_CSRF_INVALID"), { code: "CONTROL_CSRF_INVALID" });
+  }
+  buttons.forEach((button) => { button.disabled = true; });
+  resultNode.textContent = "正在提交决定……";
+  try {
+    const payload = await request(
+      `/control/api/private-world/candidates/${encodeURIComponent(candidate.candidate_id)}/${decision}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": csrfToken,
+        },
+        body: JSON.stringify({
+          idempotency_key: idempotencyKey(candidate.candidate_id, decision),
+          reason,
+          occurred_at: new Date().toISOString(),
+        }),
+      },
+    );
+    resultNode.textContent = payload.status === "approved" ? "已批准并记录。" : "已拒绝这条建议。";
+    await loadCandidates();
+  } catch (error) {
+    resultNode.textContent = explain(error.code);
+    buttons.forEach((button) => { button.disabled = false; });
+  }
+}
+
+function renderCandidate(candidate) {
+  const fragment = template.content.cloneNode(true);
+  const card = fragment.querySelector(".candidate-card");
+  fragment.querySelector(".candidate-type").textContent = typeLabels[candidate.candidate_type] || candidate.candidate_type;
+  fragment.querySelector(".candidate-summary").textContent = candidate.summary;
+  fragment.querySelector(".candidate-confidence").textContent = `${Math.round(Number(candidate.confidence || 0) * 100)}%`;
+  fragment.querySelector(".candidate-source").textContent = `${candidate.source_letter_id} · 回复版本 ${candidate.source_reply_revision}`;
+  fragment.querySelector(".candidate-created").textContent = localDate(candidate.created_at);
+  fragment.querySelector(".candidate-expires").textContent = localDate(candidate.expires_at);
+
+  const form = fragment.querySelector(".candidate-decision-form");
+  const resultNode = fragment.querySelector(".candidate-result");
+  const buttons = [...form.querySelectorAll("button[type='submit']")];
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const submitter = event.submitter;
+    const decision = submitter?.value;
+    const reason = new FormData(form).get("reason")?.toString().trim() || "";
+    if (!reason) {
+      resultNode.textContent = "请先填写处理说明。";
+      return;
+    }
+    if (!['approve', 'reject'].includes(decision)) {
+      resultNode.textContent = "无法识别处理方式。";
+      return;
+    }
+    decide(candidate, decision, reason, resultNode, buttons);
+  });
+  card.dataset.candidateId = candidate.candidate_id;
+  return fragment;
+}
+
+async function loadCandidates() {
+  statusNode.textContent = "正在读取待确认建议……";
+  detailNode.textContent = "";
+  refreshButton.disabled = true;
+  try {
+    const payload = await request("/control/api/private-world/candidates?limit=100");
+    const candidates = Array.isArray(payload.candidates) ? payload.candidates : [];
+    listNode.replaceChildren(...candidates.map(renderCandidate));
+    emptyNode.hidden = candidates.length !== 0;
+    statusNode.textContent = candidates.length ? `有 ${candidates.length} 条待确认建议` : "没有待确认建议";
+    detailNode.textContent = "批准建议会通过受控命令服务执行；拒绝不会修改关系状态。";
+  } catch (error) {
+    listNode.replaceChildren();
+    emptyNode.hidden = true;
+    statusNode.textContent = "无法读取待确认建议";
+    detailNode.textContent = explain(error.code);
+  } finally {
+    refreshButton.disabled = false;
+  }
+}
+
+refreshButton.addEventListener("click", loadCandidates);
+loadCandidates();


### PR DESCRIPTION
Implements the graphical review slice of PW-06 from #33 and extends #35.

## User-facing scope

- adds a dedicated local Control Center page for pending PrivateWorld suggestions;
- shows candidate type, bounded summary, confidence, source revision, creation, and expiry;
- lets the user explicitly approve or reject each suggestion with a required reason;
- generates a unique idempotency key and timezone-aware decision time;
- keeps the authenticated HttpOnly session and reuses the tab-local CSRF token;
- explains that candidates are advisory and that rejection does not change relationship state;
- links the page from the main Control Center shell.

## Security and privacy

- all reads and decisions use only same-origin `/control/api/private-world/candidates` routes;
- no external scripts, fonts, analytics, URLs, or network endpoints;
- no hidden numeric relationship score surface;
- no database path, API key, complete letter, or complete reply is rendered;
- approval still requires the injected typed command backend and cannot write SQLite directly from the UI.

## Tests

- local page and static assets are served under the existing strict CSP;
- required approve/reject, CSRF, idempotency, and timestamp behavior;
- exclusion of hidden score controls, secrets, paths, and external resources;
- explicit advisory-versus-mutation wording.

## Boundary

Automatic candidate analysis remains disabled. The concrete backend adapter will connect approved suggestions to the already merged command service in a later PW-06 slice.