### PR TITLE
feat(memory): add typed conversation memory port

### DIFF
--- a/conversation_memory_port.py
+++ b/conversation_memory_port.py
@@ -1,0 +1,374 @@
+"""Provider-neutral contracts for new-conversation long-term memory.
+
+Archive storage, Persona evidence, and PrivateWorld state intentionally remain
+outside this port. Implementations may use Mem0 or another provider, but callers
+see only bounded records and stable results.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+import re
+from typing import Mapping, Protocol, runtime_checkable
+
+
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
+_DOMAIN = "conversation_memory"
+
+
+class ConversationMemoryError(ValueError):
+    code = "CONVERSATION_MEMORY_INVALID"
+
+
+def _identifier(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str) or not _ID_RE.fullmatch(value):
+        raise ConversationMemoryError(f"{field_name} is invalid")
+    return value
+
+
+def _plain_text(value: object, *, field_name: str, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise ConversationMemoryError(f"{field_name} must be text")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > maximum
+        or any(ord(character) < 32 or ord(character) == 127 for character in normalized)
+    ):
+        raise ConversationMemoryError(f"{field_name} is invalid")
+    return normalized
+
+
+def _timestamp(value: object, *, field_name: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise ConversationMemoryError(f"{field_name} must be a datetime")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ConversationMemoryError(f"{field_name} must be timezone-aware")
+    return value
+
+
+def _metadata(value: Mapping[str, object]) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        raise ConversationMemoryError("metadata must be an object")
+    normalized: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not re.fullmatch(r"^[a-z][a-z0-9_]{0,63}$", key):
+            raise ConversationMemoryError("metadata key is invalid")
+        if key in {
+            "private_world",
+            "hidden_scores",
+            "control_state",
+            "system_prompt",
+            "api_key",
+            "credential",
+        }:
+            raise ConversationMemoryError("metadata key is reserved")
+        if item is None or isinstance(item, (bool, int, float, str)):
+            normalized[key] = item
+        else:
+            raise ConversationMemoryError("metadata value is not scalar")
+    if len(normalized) > 24:
+        raise ConversationMemoryError("metadata is too large")
+    return normalized
+
+
+class MemoryWriteStatus(StrEnum):
+    WRITTEN = "written"
+    DUPLICATE = "duplicate"
+    SKIPPED = "skipped"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class ConversationMemoryRecord:
+    memory_id: str
+    text: str
+    user_id: str
+    source_id: str
+    score: float | None = None
+    occurred_at: datetime | None = None
+    created_at: datetime | None = None
+    domain: str = _DOMAIN
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "memory_id",
+            _identifier(self.memory_id, field_name="memory_id"),
+        )
+        object.__setattr__(
+            self,
+            "text",
+            _plain_text(self.text, field_name="memory text", maximum=2000),
+        )
+        object.__setattr__(
+            self,
+            "user_id",
+            _identifier(self.user_id, field_name="user_id"),
+        )
+        object.__setattr__(
+            self,
+            "source_id",
+            _identifier(self.source_id, field_name="source_id"),
+        )
+        if self.domain != _DOMAIN:
+            raise ConversationMemoryError("memory domain is invalid")
+        if self.score is not None and (
+            isinstance(self.score, bool)
+            or not isinstance(self.score, (int, float))
+            or not 0.0 <= float(self.score) <= 1.0
+        ):
+            raise ConversationMemoryError("memory score is invalid")
+        if self.occurred_at is not None:
+            _timestamp(self.occurred_at, field_name="occurred_at")
+        if self.created_at is not None:
+            _timestamp(self.created_at, field_name="created_at")
+        object.__setattr__(self, "metadata", _metadata(self.metadata))
+
+    def to_prompt_dict(self) -> dict[str, object]:
+        """Return only fields allowed to enter bounded prompt references."""
+
+        payload: dict[str, object] = {
+            "memory_id": self.memory_id,
+            "text": self.text,
+            "source_id": self.source_id,
+            "domain": self.domain,
+        }
+        if self.score is not None:
+            payload["score"] = round(float(self.score), 6)
+        if self.occurred_at is not None:
+            payload["occurred_at"] = self.occurred_at.isoformat()
+        if self.created_at is not None:
+            payload["created_at"] = self.created_at.isoformat()
+        return payload
+
+
+@dataclass(frozen=True)
+class MemoryWriteResult:
+    status: MemoryWriteStatus
+    source_id: str
+    memory_ids: tuple[str, ...] = ()
+    error_code: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, MemoryWriteStatus):
+            raise ConversationMemoryError("write status is invalid")
+        object.__setattr__(
+            self,
+            "source_id",
+            _identifier(self.source_id, field_name="source_id"),
+        )
+        if len(self.memory_ids) > 64:
+            raise ConversationMemoryError("too many memory ids")
+        for memory_id in self.memory_ids:
+            _identifier(memory_id, field_name="memory_id")
+        if self.error_code is not None and (
+            not isinstance(self.error_code, str)
+            or not re.fullmatch(r"^[A-Z][A-Z0-9_]{0,95}$", self.error_code)
+        ):
+            raise ConversationMemoryError("error_code is invalid")
+        if self.status is MemoryWriteStatus.UNAVAILABLE and self.error_code is None:
+            raise ConversationMemoryError("unavailable writes require an error code")
+        if self.status is not MemoryWriteStatus.UNAVAILABLE and self.error_code is not None:
+            raise ConversationMemoryError("successful writes cannot carry an error code")
+
+
+@dataclass(frozen=True)
+class ConversationMemoryStatus:
+    status: str
+    enabled: bool
+    provider: str
+    storage: str
+    reason_code: str | None = None
+    memory_count: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.status not in {"available", "degraded", "unavailable", "disabled"}:
+            raise ConversationMemoryError("provider status is invalid")
+        if type(self.enabled) is not bool:
+            raise ConversationMemoryError("enabled flag is invalid")
+        _identifier(self.provider, field_name="provider")
+        _identifier(self.storage, field_name="storage")
+        if self.reason_code is not None and (
+            not isinstance(self.reason_code, str)
+            or not re.fullmatch(r"^[A-Z][A-Z0-9_]{0,95}$", self.reason_code)
+        ):
+            raise ConversationMemoryError("reason_code is invalid")
+        if self.memory_count is not None and (
+            type(self.memory_count) is not int or self.memory_count < 0
+        ):
+            raise ConversationMemoryError("memory_count is invalid")
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "status": self.status,
+            "enabled": self.enabled,
+            "provider": self.provider,
+            "storage": self.storage,
+        }
+        if self.reason_code is not None:
+            payload["reason_code"] = self.reason_code
+        if self.memory_count is not None:
+            payload["memory_count"] = self.memory_count
+        return payload
+
+
+@runtime_checkable
+class ConversationMemoryPort(Protocol):
+    enabled: bool
+
+    def search_context(
+        self,
+        query: str,
+        *,
+        user_id: str,
+        limit: int,
+    ) -> tuple[ConversationMemoryRecord, ...]: ...
+
+    def remember_exchange(
+        self,
+        *,
+        user_message: str,
+        assistant_message: str,
+        occurred_at: datetime,
+        source_id: str,
+        user_id: str,
+    ) -> MemoryWriteResult: ...
+
+    def list_memories(
+        self,
+        *,
+        user_id: str,
+        limit: int = 100,
+    ) -> tuple[ConversationMemoryRecord, ...]: ...
+
+    def add_manual_memory(
+        self,
+        text: str,
+        *,
+        user_id: str,
+        source_id: str,
+    ) -> ConversationMemoryRecord: ...
+
+    def delete_memory(self, memory_id: str, *, user_id: str) -> bool: ...
+
+    def clear_user(self, *, user_id: str) -> int: ...
+
+    def export_user(self, *, user_id: str) -> dict[str, object]: ...
+
+    def status(self) -> ConversationMemoryStatus: ...
+
+
+class NullConversationMemoryPort:
+    enabled = False
+
+    def search_context(
+        self,
+        query: str,
+        *,
+        user_id: str,
+        limit: int,
+    ) -> tuple[ConversationMemoryRecord, ...]:
+        del query, user_id, limit
+        return ()
+
+    def remember_exchange(
+        self,
+        *,
+        user_message: str,
+        assistant_message: str,
+        occurred_at: datetime,
+        source_id: str,
+        user_id: str,
+    ) -> MemoryWriteResult:
+        del user_message, assistant_message, occurred_at, user_id
+        return MemoryWriteResult(MemoryWriteStatus.SKIPPED, source_id)
+
+    def list_memories(
+        self,
+        *,
+        user_id: str,
+        limit: int = 100,
+    ) -> tuple[ConversationMemoryRecord, ...]:
+        del user_id, limit
+        return ()
+
+    def add_manual_memory(
+        self,
+        text: str,
+        *,
+        user_id: str,
+        source_id: str,
+    ) -> ConversationMemoryRecord:
+        del text, user_id, source_id
+        raise RuntimeError("CONVERSATION_MEMORY_DISABLED")
+
+    def delete_memory(self, memory_id: str, *, user_id: str) -> bool:
+        del memory_id, user_id
+        return False
+
+    def clear_user(self, *, user_id: str) -> int:
+        del user_id
+        return 0
+
+    def export_user(self, *, user_id: str) -> dict[str, object]:
+        return {
+            "schema_version": "p03.conversation-memory-export.v1",
+            "user_id": user_id,
+            "records": [],
+        }
+
+    def status(self) -> ConversationMemoryStatus:
+        return ConversationMemoryStatus("disabled", False, "none", "none")
+
+
+class UnavailableConversationMemoryPort(NullConversationMemoryPort):
+    enabled = False
+
+    def __init__(self, reason_code: str) -> None:
+        if not isinstance(reason_code, str) or not re.fullmatch(
+            r"^[A-Z][A-Z0-9_]{0,95}$",
+            reason_code,
+        ):
+            raise ConversationMemoryError("reason_code is invalid")
+        self.reason_code = reason_code
+
+    def remember_exchange(
+        self,
+        *,
+        user_message: str,
+        assistant_message: str,
+        occurred_at: datetime,
+        source_id: str,
+        user_id: str,
+    ) -> MemoryWriteResult:
+        del user_message, assistant_message, occurred_at, user_id
+        return MemoryWriteResult(
+            MemoryWriteStatus.UNAVAILABLE,
+            source_id,
+            error_code=self.reason_code,
+        )
+
+    def status(self) -> ConversationMemoryStatus:
+        return ConversationMemoryStatus(
+            "unavailable",
+            False,
+            "none",
+            "none",
+            reason_code=self.reason_code,
+        )
+
+
+__all__ = [
+    "ConversationMemoryError",
+    "ConversationMemoryPort",
+    "ConversationMemoryRecord",
+    "ConversationMemoryStatus",
+    "MemoryWriteResult",
+    "MemoryWriteStatus",
+    "NullConversationMemoryPort",
+    "UnavailableConversationMemoryPort",
+]

--- a/tests/memory/test_conversation_memory_port.py
+++ b/tests/memory/test_conversation_memory_port.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from conversation_memory_port import (
+    ConversationMemoryError,
+    ConversationMemoryRecord,
+    ConversationMemoryStatus,
+    MemoryWriteResult,
+    MemoryWriteStatus,
+    NullConversationMemoryPort,
+    UnavailableConversationMemoryPort,
+)
+
+
+NOW = datetime(2026, 8, 23, 1, 0, tzinfo=timezone.utc)
+
+
+def test_record_exposes_only_bounded_prompt_fields() -> None:
+    record = ConversationMemoryRecord(
+        memory_id="memory.fixture.1",
+        text="用户目前在东京工作。",
+        user_id="local-user",
+        source_id="letter:fixture:1",
+        score=0.87654321,
+        occurred_at=NOW,
+        created_at=NOW,
+        metadata={"category": "personal_info", "canonical": True},
+    )
+
+    assert record.to_prompt_dict() == {
+        "memory_id": "memory.fixture.1",
+        "text": "用户目前在东京工作。",
+        "source_id": "letter:fixture:1",
+        "domain": "conversation_memory",
+        "score": 0.876543,
+        "occurred_at": NOW.isoformat(),
+        "created_at": NOW.isoformat(),
+    }
+    assert "user_id" not in record.to_prompt_dict()
+    assert "metadata" not in record.to_prompt_dict()
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"private_world": "hidden"},
+        {"hidden_scores": 100},
+        {"system_prompt": "secret"},
+        {"credential": "secret"},
+        {"Bad-Key": "value"},
+        {"nested": {"not": "scalar"}},
+    ],
+)
+def test_record_rejects_reserved_or_unbounded_metadata(metadata) -> None:
+    with pytest.raises(ConversationMemoryError):
+        ConversationMemoryRecord(
+            "memory.fixture.1",
+            "用户喜欢黑咖啡。",
+            "local-user",
+            "letter:fixture:1",
+            metadata=metadata,
+        )
+
+
+def test_record_rejects_naive_time_and_invalid_score() -> None:
+    with pytest.raises(ConversationMemoryError):
+        ConversationMemoryRecord(
+            "memory.fixture.1",
+            "用户喜欢黑咖啡。",
+            "local-user",
+            "letter:fixture:1",
+            occurred_at=datetime(2026, 8, 23),
+        )
+    with pytest.raises(ConversationMemoryError):
+        ConversationMemoryRecord(
+            "memory.fixture.1",
+            "用户喜欢黑咖啡。",
+            "local-user",
+            "letter:fixture:1",
+            score=1.1,
+        )
+
+
+def test_write_result_requires_stable_unavailable_error() -> None:
+    written = MemoryWriteResult(
+        MemoryWriteStatus.WRITTEN,
+        "letter:fixture:1",
+        ("memory.fixture.1",),
+    )
+    assert written.status is MemoryWriteStatus.WRITTEN
+
+    unavailable = MemoryWriteResult(
+        MemoryWriteStatus.UNAVAILABLE,
+        "letter:fixture:1",
+        error_code="MEM0_UNAVAILABLE",
+    )
+    assert unavailable.error_code == "MEM0_UNAVAILABLE"
+
+    with pytest.raises(ConversationMemoryError):
+        MemoryWriteResult(
+            MemoryWriteStatus.UNAVAILABLE,
+            "letter:fixture:1",
+        )
+    with pytest.raises(ConversationMemoryError):
+        MemoryWriteResult(
+            MemoryWriteStatus.WRITTEN,
+            "letter:fixture:1",
+            error_code="MEM0_UNAVAILABLE",
+        )
+
+
+def test_null_port_is_non_blocking_and_contains_no_records() -> None:
+    port = NullConversationMemoryPort()
+
+    assert port.search_context("东京", user_id="local-user", limit=3) == ()
+    assert port.list_memories(user_id="local-user") == ()
+    assert port.delete_memory("memory.fixture.1", user_id="local-user") is False
+    assert port.clear_user(user_id="local-user") == 0
+    assert port.remember_exchange(
+        user_message="我在东京工作。",
+        assistant_message="记住了。",
+        occurred_at=NOW,
+        source_id="letter:fixture:1",
+        user_id="local-user",
+    ) == MemoryWriteResult(MemoryWriteStatus.SKIPPED, "letter:fixture:1")
+    assert port.status() == ConversationMemoryStatus(
+        "disabled",
+        False,
+        "none",
+        "none",
+    )
+    assert port.export_user(user_id="local-user")["records"] == []
+
+    with pytest.raises(RuntimeError, match="CONVERSATION_MEMORY_DISABLED"):
+        port.add_manual_memory(
+            "用户在东京工作。",
+            user_id="local-user",
+            source_id="manual:fixture:1",
+        )
+
+
+def test_unavailable_port_degrades_without_echoing_messages() -> None:
+    port = UnavailableConversationMemoryPort("MEM0_IMPORT_FAILED")
+    result = port.remember_exchange(
+        user_message="private user text",
+        assistant_message="private assistant text",
+        occurred_at=NOW,
+        source_id="letter:fixture:2",
+        user_id="local-user",
+    )
+
+    assert result == MemoryWriteResult(
+        MemoryWriteStatus.UNAVAILABLE,
+        "letter:fixture:2",
+        error_code="MEM0_IMPORT_FAILED",
+    )
+    assert port.status().to_dict() == {
+        "status": "unavailable",
+        "enabled": False,
+        "provider": "none",
+        "storage": "none",
+        "reason_code": "MEM0_IMPORT_FAILED",
+    }
+    assert "private user text" not in repr(result)
+    assert "private assistant text" not in repr(result)


### PR DESCRIPTION
Clean replacement for #54, recreated from the latest protected `main` after #58 so the strict up-to-date branch rule is satisfied without rewriting public history.

## Scope

- adds a provider-neutral `ConversationMemoryPort` for new-conversation long-term memory;
- keeps Archive, Persona evidence, and PrivateWorld outside the contract;
- defines bounded records, canonical exchange writes, search, list, manual add, delete, clear, export, and provider status;
- exposes only prompt-safe record fields and does not forward user IDs or provider metadata into prompt references;
- rejects reserved metadata keys for PrivateWorld, hidden scores, system prompts, credentials, and other control state;
- adds explicit disabled and unavailable adapters so memory failures remain non-blocking and privacy-safe.

## Tests

Covers prompt projection, reserved metadata, timestamp/score/identifier validation, disabled behavior, unavailable degradation, and private-content non-echo.

## Boundary

No Mem0 dependency and no production caller change. MEM-03 remains a separate Adapter PR.

Supersedes #54. Part of #34.