### PR TITLE
feat(memory): add pinned local Mem0 OSS adapter

### DIFF
--- a/mem0_memory.py
+++ b/mem0_memory.py
@@ -1,0 +1,601 @@
+"""Optional local Mem0 OSS adapter for new-conversation long-term memory.
+
+Archive, Persona evidence, system prompts, Reviewer payloads, and PrivateWorld
+remain outside this adapter.  The optional provider is imported lazily and all
+provider failures collapse to stable, privacy-safe states.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import importlib
+import os
+from pathlib import Path
+import re
+import threading
+from typing import Callable, Mapping, Protocol, Sequence
+
+from conversation_memory_port import (
+    ConversationMemoryPort,
+    ConversationMemoryRecord,
+    ConversationMemoryStatus,
+    MemoryWriteResult,
+    MemoryWriteStatus,
+    NullConversationMemoryPort,
+    UnavailableConversationMemoryPort,
+)
+
+
+MEM0_OSS_VERSION = "2.0.18"
+_DOMAIN = "conversation_memory"
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
+
+
+class Mem0AdapterError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+class Mem0Backend(Protocol):
+    def add(self, messages: object, **kwargs: object) -> object: ...
+
+    def search(self, query: str, **kwargs: object) -> object: ...
+
+    def get_all(self, **kwargs: object) -> object: ...
+
+    def delete(self, memory_id: str) -> object: ...
+
+    def delete_all(
+        self,
+        user_id: str | None = None,
+        agent_id: str | None = None,
+        run_id: str | None = None,
+    ) -> object: ...
+
+
+@dataclass(frozen=True)
+class Mem0Config:
+    enabled: bool
+    data_root: Path
+    user_id: str = "local-user"
+    agent_id: str = "linli"
+    collection_name: str = "olivia_conversation_memory_v1"
+    llm_base_url: str = ""
+    llm_model: str = ""
+    llm_api_key_env: str = "DEEPSEEK_API_KEY"
+    embedding_model: str = "BAAI/bge-small-zh-v1.5"
+    embedding_dims: int = 512
+    embedding_cache: Path | None = None
+    context_max_chars: int = 2400
+    config_error: str | None = None
+
+    def __post_init__(self) -> None:
+        if type(self.enabled) is not bool:
+            raise ValueError("enabled must be boolean")
+        root = Path(self.data_root)
+        if str(root) in {"", "."}:
+            raise ValueError("an explicit data root is required")
+        object.__setattr__(self, "data_root", root)
+        for value, field_name in (
+            (self.user_id, "user_id"),
+            (self.agent_id, "agent_id"),
+            (self.collection_name, "collection_name"),
+        ):
+            if not isinstance(value, str) or not _ID_RE.fullmatch(value):
+                raise ValueError(f"{field_name} is invalid")
+        if not isinstance(self.llm_base_url, str) or len(self.llm_base_url) > 2048:
+            raise ValueError("llm_base_url is invalid")
+        if not isinstance(self.llm_model, str) or len(self.llm_model) > 256:
+            raise ValueError("llm_model is invalid")
+        if not isinstance(self.llm_api_key_env, str) or not re.fullmatch(
+            r"^[A-Z][A-Z0-9_]{0,95}$", self.llm_api_key_env
+        ):
+            raise ValueError("llm_api_key_env is invalid")
+        if not isinstance(self.embedding_model, str) or not self.embedding_model.strip():
+            raise ValueError("embedding_model is invalid")
+        if type(self.embedding_dims) is not int or not 64 <= self.embedding_dims <= 8192:
+            raise ValueError("embedding_dims is invalid")
+        if self.embedding_cache is not None:
+            object.__setattr__(self, "embedding_cache", Path(self.embedding_cache))
+        if type(self.context_max_chars) is not int or not 0 <= self.context_max_chars <= 20_000:
+            raise ValueError("context_max_chars is invalid")
+        if self.config_error is not None and not re.fullmatch(
+            r"^[A-Z][A-Z0-9_]{0,95}$", self.config_error
+        ):
+            raise ValueError("config_error is invalid")
+
+    @property
+    def qdrant_path(self) -> Path:
+        return self.data_root / "qdrant"
+
+    @property
+    def history_path(self) -> Path:
+        return self.data_root / "history" / "history.db"
+
+    @property
+    def model_cache(self) -> Path:
+        return self.embedding_cache or self.data_root.parent / "model-cache"
+
+    def provider_config(
+        self,
+        environ: Mapping[str, str] | None = None,
+    ) -> dict[str, object]:
+        environment = environ or os.environ
+        return {
+            "vector_store": {
+                "provider": "qdrant",
+                "config": {
+                    "collection_name": self.collection_name,
+                    "path": str(self.qdrant_path),
+                    "on_disk": True,
+                    "embedding_model_dims": self.embedding_dims,
+                },
+            },
+            "llm": {
+                "provider": "openai",
+                "config": {
+                    "model": self.llm_model,
+                    "api_key": environment.get(self.llm_api_key_env, ""),
+                    "openai_base_url": self.llm_base_url,
+                    "temperature": 0.1,
+                },
+            },
+            "embedder": {
+                "provider": "huggingface",
+                "config": {
+                    "model": self.embedding_model,
+                    "embedding_dims": self.embedding_dims,
+                    "model_kwargs": {
+                        "device": "cpu",
+                        "cache_folder": str(self.model_cache),
+                        "local_files_only": True,
+                    },
+                },
+            },
+            "history_db_path": str(self.history_path),
+        }
+
+
+def _bool(value: object, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().casefold()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off", ""}:
+            return False
+    return default
+
+
+def _integer(value: object, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def load_mem0_config(
+    *,
+    environ: Mapping[str, str] | None = None,
+    project_root: Path | None = None,
+) -> Mem0Config:
+    environment = environ or os.environ
+    root = Path(project_root or Path(__file__).resolve().parent)
+    configured_root = environment.get("OLIVIA_MEMORY_ROOT", "").strip()
+    data_root = (
+        Path(configured_root).expanduser()
+        if configured_root
+        else root / ".olivia_data" / "memory" / "mem0"
+    )
+    if not data_root.is_absolute():
+        data_root = root / data_root
+    cache_value = environment.get("OLIVIA_MEMORY_EMBEDDING_CACHE", "").strip()
+    embedding_cache = Path(cache_value).expanduser() if cache_value else None
+    if embedding_cache is not None and not embedding_cache.is_absolute():
+        embedding_cache = root / embedding_cache
+
+    enabled = _bool(environment.get("OLIVIA_MEMORY_ENABLED"), False)
+    llm_base_url = environment.get(
+        "OLIVIA_MEMORY_LLM_BASE_URL",
+        environment.get("OLIVIA_LLM_BASE_URL", ""),
+    ).strip()
+    llm_model = environment.get(
+        "OLIVIA_MEMORY_LLM_MODEL",
+        environment.get("OLIVIA_LLM_MODEL", ""),
+    ).strip()
+    key_env = environment.get(
+        "OLIVIA_MEMORY_LLM_API_KEY_ENV",
+        environment.get("OLIVIA_LLM_API_KEY_ENV", "DEEPSEEK_API_KEY"),
+    ).strip()
+    error: str | None = None
+    if enabled and (not llm_base_url or not llm_model):
+        error = "MEM0_LLM_CONFIG_INCOMPLETE"
+
+    dims = _integer(environment.get("OLIVIA_MEMORY_EMBEDDING_DIMS"), 512)
+    if not 64 <= dims <= 8192:
+        dims = 512
+        error = "MEM0_EMBEDDING_DIMS_INVALID"
+    context_max = _integer(environment.get("OLIVIA_MEMORY_CONTEXT_MAX_CHARS"), 2400)
+    if not 0 <= context_max <= 20_000:
+        context_max = 2400
+        error = "MEM0_CONTEXT_LIMIT_INVALID"
+
+    return Mem0Config(
+        enabled=enabled,
+        data_root=data_root,
+        user_id=environment.get("OLIVIA_MEMORY_USER_ID", "local-user").strip()
+        or "local-user",
+        agent_id=environment.get("OLIVIA_MEMORY_AGENT_ID", "linli").strip()
+        or "linli",
+        collection_name=environment.get(
+            "OLIVIA_MEMORY_COLLECTION", "olivia_conversation_memory_v1"
+        ).strip()
+        or "olivia_conversation_memory_v1",
+        llm_base_url=llm_base_url,
+        llm_model=llm_model,
+        llm_api_key_env=key_env or "DEEPSEEK_API_KEY",
+        embedding_model=environment.get(
+            "OLIVIA_MEMORY_EMBEDDING_MODEL", "BAAI/bge-small-zh-v1.5"
+        ).strip()
+        or "BAAI/bge-small-zh-v1.5",
+        embedding_dims=dims,
+        embedding_cache=embedding_cache,
+        context_max_chars=context_max,
+        config_error=error,
+    )
+
+
+def _rows(value: object) -> tuple[Mapping[str, object], ...]:
+    if isinstance(value, Mapping):
+        value = value.get("results", value.get("memories", value.get("data", ())))
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return ()
+    return tuple(item for item in value if isinstance(item, Mapping))
+
+
+def _date(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def _row_id(row: Mapping[str, object]) -> str | None:
+    value = row.get("id", row.get("memory_id"))
+    return value if isinstance(value, str) and _ID_RE.fullmatch(value) else None
+
+
+def _row_to_record(
+    row: Mapping[str, object],
+    *,
+    user_id: str,
+) -> ConversationMemoryRecord | None:
+    metadata = row.get("metadata")
+    metadata = metadata if isinstance(metadata, Mapping) else {}
+    memory_id = _row_id(row)
+    text = row.get("memory", row.get("text"))
+    source_id = metadata.get("source_id", row.get("source_id"))
+    domain = metadata.get("domain", row.get("domain", _DOMAIN))
+    row_user = row.get("user_id", user_id)
+    if (
+        memory_id is None
+        or not isinstance(text, str)
+        or not text.strip()
+        or not isinstance(source_id, str)
+        or not _ID_RE.fullmatch(source_id)
+        or domain != _DOMAIN
+        or row_user != user_id
+    ):
+        return None
+    score_value = row.get("score")
+    score = (
+        float(score_value)
+        if not isinstance(score_value, bool)
+        and isinstance(score_value, (int, float))
+        and 0 <= float(score_value) <= 1
+        else None
+    )
+    safe_metadata = {
+        key: value
+        for key, value in metadata.items()
+        if key in {"category", "canonical", "manual", "actor"}
+        and (value is None or isinstance(value, (bool, int, float, str)))
+    }
+    try:
+        return ConversationMemoryRecord(
+            memory_id=memory_id,
+            text=text,
+            user_id=user_id,
+            source_id=source_id,
+            score=score,
+            occurred_at=_date(metadata.get("occurred_at", row.get("occurred_at"))),
+            created_at=_date(row.get("created_at")),
+            metadata=safe_metadata,
+        )
+    except ValueError:
+        return None
+
+
+class Mem0ConversationMemoryAdapter:
+    enabled = True
+
+    def __init__(self, backend: Mem0Backend, config: Mem0Config) -> None:
+        if not isinstance(config, Mem0Config) or not config.enabled:
+            raise ValueError("an enabled Mem0 config is required")
+        self.backend = backend
+        self.config = config
+        self._lock = threading.RLock()
+        self._last_error_code: str | None = None
+
+    def _filters(self, user_id: str) -> dict[str, object]:
+        if not isinstance(user_id, str) or not _ID_RE.fullmatch(user_id):
+            raise Mem0AdapterError("MEM0_USER_ID_INVALID")
+        return {
+            "user_id": user_id,
+            "agent_id": self.config.agent_id,
+            "domain": _DOMAIN,
+        }
+
+    def _records(
+        self,
+        value: object,
+        *,
+        user_id: str,
+        limit: int,
+    ) -> tuple[ConversationMemoryRecord, ...]:
+        records: list[ConversationMemoryRecord] = []
+        for row in _rows(value):
+            record = _row_to_record(row, user_id=user_id)
+            if record is not None:
+                records.append(record)
+            if len(records) >= limit:
+                break
+        return tuple(records)
+
+    def list_memories(
+        self,
+        *,
+        user_id: str,
+        limit: int = 100,
+    ) -> tuple[ConversationMemoryRecord, ...]:
+        if not 1 <= limit <= 1000:
+            return ()
+        try:
+            with self._lock:
+                value = self.backend.get_all(
+                    filters=self._filters(user_id),
+                    top_k=limit,
+                )
+            self._last_error_code = None
+            return self._records(value, user_id=user_id, limit=limit)
+        except Exception:
+            self._last_error_code = "MEM0_LIST_FAILED"
+            return ()
+
+    def search_context(
+        self,
+        query: str,
+        *,
+        user_id: str,
+        limit: int,
+    ) -> tuple[ConversationMemoryRecord, ...]:
+        if not isinstance(query, str) or not query.strip() or not 1 <= limit <= 100:
+            return ()
+        try:
+            with self._lock:
+                value = self.backend.search(
+                    query.strip(),
+                    filters=self._filters(user_id),
+                    top_k=limit,
+                )
+            self._last_error_code = None
+            return self._records(value, user_id=user_id, limit=limit)
+        except Exception:
+            self._last_error_code = "MEM0_SEARCH_FAILED"
+            return ()
+
+    def remember_exchange(
+        self,
+        *,
+        user_message: str,
+        assistant_message: str,
+        occurred_at: datetime,
+        source_id: str,
+        user_id: str,
+    ) -> MemoryWriteResult:
+        if not isinstance(occurred_at, datetime) or occurred_at.tzinfo is None:
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                source_id,
+                error_code="MEM0_EXCHANGE_INVALID",
+            )
+        try:
+            existing = self.list_memories(user_id=user_id, limit=1000)
+            if any(record.source_id == source_id for record in existing):
+                return MemoryWriteResult(MemoryWriteStatus.DUPLICATE, source_id)
+            metadata = {
+                "source_id": source_id,
+                "occurred_at": occurred_at.isoformat(),
+                "domain": _DOMAIN,
+                "canonical": True,
+            }
+            with self._lock:
+                value = self.backend.add(
+                    [
+                        {"role": "user", "content": str(user_message)},
+                        {"role": "assistant", "content": str(assistant_message)},
+                    ],
+                    user_id=user_id,
+                    agent_id=self.config.agent_id,
+                    metadata=metadata,
+                )
+            ids = tuple(
+                memory_id
+                for row in _rows(value)
+                if (memory_id := _row_id(row)) is not None
+            )
+            self._last_error_code = None
+            return MemoryWriteResult(
+                MemoryWriteStatus.WRITTEN if ids else MemoryWriteStatus.SKIPPED,
+                source_id,
+                ids,
+            )
+        except Exception:
+            self._last_error_code = "MEM0_WRITE_FAILED"
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                source_id,
+                error_code="MEM0_WRITE_FAILED",
+            )
+
+    def add_manual_memory(
+        self,
+        text: str,
+        *,
+        user_id: str,
+        source_id: str,
+    ) -> ConversationMemoryRecord:
+        metadata = {
+            "source_id": source_id,
+            "occurred_at": datetime.now(timezone.utc).isoformat(),
+            "domain": _DOMAIN,
+            "manual": True,
+            "actor": "local_user",
+        }
+        try:
+            with self._lock:
+                value = self.backend.add(
+                    str(text),
+                    user_id=user_id,
+                    agent_id=self.config.agent_id,
+                    metadata=metadata,
+                    infer=False,
+                )
+            records = self._records(value, user_id=user_id, limit=1)
+            if not records:
+                records = tuple(
+                    record
+                    for record in self.list_memories(user_id=user_id, limit=1000)
+                    if record.source_id == source_id
+                )[:1]
+            if not records:
+                raise Mem0AdapterError("MEM0_MANUAL_WRITE_FAILED")
+            self._last_error_code = None
+            return records[0]
+        except Mem0AdapterError:
+            raise
+        except Exception as exc:
+            self._last_error_code = "MEM0_MANUAL_WRITE_FAILED"
+            raise Mem0AdapterError("MEM0_MANUAL_WRITE_FAILED") from exc
+
+    def delete_memory(self, memory_id: str, *, user_id: str) -> bool:
+        try:
+            if not any(
+                record.memory_id == memory_id
+                for record in self.list_memories(user_id=user_id, limit=1000)
+            ):
+                return False
+            with self._lock:
+                self.backend.delete(memory_id)
+            self._last_error_code = None
+            return True
+        except Exception:
+            self._last_error_code = "MEM0_DELETE_FAILED"
+            return False
+
+    def clear_user(self, *, user_id: str) -> int:
+        records = self.list_memories(user_id=user_id, limit=1000)
+        if not records:
+            return 0
+        try:
+            with self._lock:
+                self.backend.delete_all(
+                    user_id=user_id,
+                    agent_id=self.config.agent_id,
+                )
+            self._last_error_code = None
+            return len(records)
+        except Exception:
+            self._last_error_code = "MEM0_CLEAR_FAILED"
+            return 0
+
+    def export_user(self, *, user_id: str) -> dict[str, object]:
+        return {
+            "schema_version": "p03.conversation-memory-export.v1",
+            "user_id": user_id,
+            "provider": "mem0",
+            "records": [
+                record.to_prompt_dict()
+                for record in self.list_memories(user_id=user_id, limit=1000)
+            ],
+        }
+
+    def status(self) -> ConversationMemoryStatus:
+        records = self.list_memories(user_id=self.config.user_id, limit=1000)
+        if self._last_error_code:
+            return ConversationMemoryStatus(
+                "degraded",
+                True,
+                "mem0",
+                "qdrant-local",
+                reason_code=self._last_error_code,
+            )
+        return ConversationMemoryStatus(
+            "available",
+            True,
+            "mem0",
+            "qdrant-local",
+            memory_count=len(records),
+        )
+
+
+def _default_factory(config: Mapping[str, object]) -> Mem0Backend:
+    module = importlib.import_module("mem0")
+    memory_type = getattr(module, "Memory", None)
+    if memory_type is None or not hasattr(memory_type, "from_config"):
+        raise ImportError("Mem0 Memory.from_config is unavailable")
+    return memory_type.from_config(dict(config))
+
+
+def create_mem0_adapter(
+    config: Mem0Config | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+    memory_factory: Callable[[Mapping[str, object]], Mem0Backend] | None = None,
+) -> ConversationMemoryPort:
+    active = config or load_mem0_config(environ=environ)
+    if active.config_error:
+        return UnavailableConversationMemoryPort(active.config_error)
+    if not active.enabled:
+        return NullConversationMemoryPort()
+    try:
+        active.qdrant_path.parent.mkdir(parents=True, exist_ok=True)
+        active.history_path.parent.mkdir(parents=True, exist_ok=True)
+        active.model_cache.mkdir(parents=True, exist_ok=True)
+        backend = (memory_factory or _default_factory)(active.provider_config(environ))
+        return Mem0ConversationMemoryAdapter(backend, active)
+    except (ModuleNotFoundError, ImportError):
+        return UnavailableConversationMemoryPort("MEM0_IMPORT_FAILED")
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return UnavailableConversationMemoryPort("MEM0_INITIALIZATION_FAILED")
+
+
+__all__ = [
+    "MEM0_OSS_VERSION",
+    "Mem0AdapterError",
+    "Mem0Config",
+    "Mem0ConversationMemoryAdapter",
+    "create_mem0_adapter",
+    "load_mem0_config",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,20 @@ dev = [
     "numpy>=1.26,<3",
     "opencv-python-headless>=4.9,<5",
 ]
+memory-mem0 = [
+    "mem0ai==2.0.18",
+    "sentence-transformers>=5.2,<6",
+]
 
 [tool.setuptools]
 py-modules = [
     "baseline_hardening_scan",
+    "conversation_memory_port",
     "extract_player",
     "http_contract",
+    "letter_status",
     "local_server",
+    "mem0_memory",
     "memory",
     "patch_feapp",
     "persona_loader",
@@ -72,6 +79,7 @@ testpaths = [
     "tests/http",
     "tests/installer",
     "tests/media",
+    "tests/memory",
     "tests/test_asset_manifest.py",
     "tests/test_third_party_download.py",
     "tests/test_baseline_hardening.py",

--- a/tests/memory/test_mem0_memory.py
+++ b/tests/memory/test_mem0_memory.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from conversation_memory_port import (
+    MemoryWriteStatus,
+    NullConversationMemoryPort,
+    UnavailableConversationMemoryPort,
+)
+from mem0_memory import (
+    MEM0_OSS_VERSION,
+    Mem0AdapterError,
+    Mem0Config,
+    Mem0ConversationMemoryAdapter,
+    create_mem0_adapter,
+    load_mem0_config,
+)
+
+
+NOW = datetime(2026, 8, 23, 2, 0, tzinfo=timezone.utc)
+
+
+class FakeMem0:
+    def __init__(self) -> None:
+        self.rows: list[dict[str, object]] = []
+        self.calls: list[tuple[str, object]] = []
+        self.fail: set[str] = set()
+        self.counter = 0
+
+    def _raise(self, name: str) -> None:
+        if name in self.fail:
+            raise RuntimeError(f"private provider error from {name}")
+
+    @staticmethod
+    def _assert_filters(filters: object) -> None:
+        assert filters == {
+            "user_id": "local-user",
+            "agent_id": "linli",
+            "domain": "conversation_memory",
+        }
+
+    def add(self, messages, **kwargs):
+        self._raise("add")
+        self.calls.append(("add", {"messages": messages, **kwargs}))
+        self.counter += 1
+        metadata = dict(kwargs.get("metadata", {}))
+        text = messages if isinstance(messages, str) else "用户在东京工作。"
+        row = {
+            "id": f"memory.fixture.{self.counter}",
+            "memory": text,
+            "user_id": kwargs.get("user_id"),
+            "agent_id": kwargs.get("agent_id"),
+            "metadata": metadata,
+            "created_at": NOW.isoformat(),
+        }
+        self.rows.append(row)
+        return [row]
+
+    def search(self, query, **kwargs):
+        self._raise("search")
+        self._assert_filters(kwargs.get("filters"))
+        self.calls.append(("search", {"query": query, **kwargs}))
+        return {"results": [{**row, "score": 0.91} for row in self.rows]}
+
+    def get_all(self, **kwargs):
+        self._raise("get_all")
+        self._assert_filters(kwargs.get("filters"))
+        assert 1 <= kwargs.get("top_k", 0) <= 1000
+        self.calls.append(("get_all", kwargs))
+        return {"results": list(self.rows)[: kwargs["top_k"]]}
+
+    def delete(self, memory_id):
+        self._raise("delete")
+        self.calls.append(("delete", memory_id))
+        self.rows[:] = [row for row in self.rows if row["id"] != memory_id]
+
+    def delete_all(self, user_id=None, agent_id=None, run_id=None):
+        self._raise("delete_all")
+        assert user_id == "local-user"
+        assert agent_id == "linli"
+        assert run_id is None
+        self.calls.append(("delete_all", {"user_id": user_id, "agent_id": agent_id}))
+        self.rows.clear()
+
+
+def _config(tmp_path: Path) -> Mem0Config:
+    return Mem0Config(
+        enabled=True,
+        data_root=tmp_path / "memory" / "mem0",
+        llm_base_url="http://127.0.0.1:9/v1",
+        llm_model="fixture-model",
+        embedding_cache=tmp_path / "models",
+    )
+
+
+def test_version_and_config_match_current_mem0_oss_contract(tmp_path: Path) -> None:
+    assert MEM0_OSS_VERSION == "2.0.18"
+    config = _config(tmp_path)
+    mapping = config.provider_config({"DEEPSEEK_API_KEY": "fixture-secret"})
+
+    assert mapping["vector_store"] == {
+        "provider": "qdrant",
+        "config": {
+            "collection_name": "olivia_conversation_memory_v1",
+            "path": str(config.qdrant_path),
+            "on_disk": True,
+            "embedding_model_dims": 512,
+        },
+    }
+    assert mapping["history_db_path"] == str(config.history_path)
+    assert mapping["embedder"]["provider"] == "huggingface"
+    assert mapping["embedder"]["config"]["model_kwargs"] == {
+        "device": "cpu",
+        "cache_folder": str(config.model_cache),
+        "local_files_only": True,
+    }
+    assert mapping["llm"]["config"]["openai_base_url"] == "http://127.0.0.1:9/v1"
+    assert mapping["llm"]["config"]["api_key"] == "fixture-secret"
+    assert "private_world" not in repr(mapping)
+
+
+def test_load_config_reuses_primary_llm_and_fails_closed(tmp_path: Path) -> None:
+    config = load_mem0_config(
+        environ={
+            "OLIVIA_MEMORY_ENABLED": "true",
+            "OLIVIA_MEMORY_ROOT": str(tmp_path / "mem0"),
+            "OLIVIA_LLM_BASE_URL": "http://127.0.0.1:8000/v1",
+            "OLIVIA_LLM_MODEL": "fixture-model",
+            "OLIVIA_LLM_API_KEY_ENV": "FIXTURE_KEY",
+        },
+        project_root=tmp_path,
+    )
+    assert config.enabled is True
+    assert config.llm_base_url == "http://127.0.0.1:8000/v1"
+    assert config.llm_model == "fixture-model"
+    assert config.llm_api_key_env == "FIXTURE_KEY"
+    assert config.config_error is None
+
+    incomplete = load_mem0_config(
+        environ={
+            "OLIVIA_MEMORY_ENABLED": "true",
+            "OLIVIA_MEMORY_ROOT": str(tmp_path / "missing"),
+        },
+        project_root=tmp_path,
+    )
+    assert incomplete.config_error == "MEM0_LLM_CONFIG_INCOMPLETE"
+
+
+def test_exchange_search_export_delete_and_clear(tmp_path: Path) -> None:
+    backend = FakeMem0()
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+    written = adapter.remember_exchange(
+        user_message="我现在在东京工作。",
+        assistant_message="这次我记住了。",
+        occurred_at=NOW,
+        source_id="letter:fixture:1",
+        user_id="local-user",
+    )
+    assert written.status is MemoryWriteStatus.WRITTEN
+    assert written.memory_ids == ("memory.fixture.1",)
+
+    add_call = next(value for name, value in backend.calls if name == "add")
+    assert add_call["messages"] == [
+        {"role": "user", "content": "我现在在东京工作。"},
+        {"role": "assistant", "content": "这次我记住了。"},
+    ]
+    assert add_call["metadata"] == {
+        "source_id": "letter:fixture:1",
+        "occurred_at": NOW.isoformat(),
+        "domain": "conversation_memory",
+        "canonical": True,
+    }
+    assert "system_prompt" not in repr(add_call)
+    assert "private_world" not in repr(add_call)
+
+    duplicate = adapter.remember_exchange(
+        user_message="重复投递",
+        assistant_message="重复回复",
+        occurred_at=NOW,
+        source_id="letter:fixture:1",
+        user_id="local-user",
+    )
+    assert duplicate.status is MemoryWriteStatus.DUPLICATE
+    assert len([name for name, _value in backend.calls if name == "add"]) == 1
+
+    searched = adapter.search_context("东京", user_id="local-user", limit=3)
+    assert len(searched) == 1
+    assert searched[0].text == "用户在东京工作。"
+    assert searched[0].score == 0.91
+    assert searched[0].source_id == "letter:fixture:1"
+
+    exported = adapter.export_user(user_id="local-user")
+    assert exported["provider"] == "mem0"
+    assert exported["records"][0]["source_id"] == "letter:fixture:1"
+    assert "user_id" not in exported["records"][0]
+
+    assert adapter.delete_memory("memory.fixture.1", user_id="other-user") is False
+    assert adapter.delete_memory("memory.fixture.1", user_id="local-user") is True
+
+    adapter.remember_exchange(
+        user_message="我喜欢黑咖啡。",
+        assistant_message="知道了。",
+        occurred_at=NOW,
+        source_id="letter:fixture:2",
+        user_id="local-user",
+    )
+    assert adapter.clear_user(user_id="local-user") == 1
+    assert any(name == "delete_all" for name, _value in backend.calls)
+
+
+def test_manual_memory_uses_exact_infer_false(tmp_path: Path) -> None:
+    backend = FakeMem0()
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+    record = adapter.add_manual_memory(
+        "用户明确表示喜欢黑咖啡。",
+        user_id="local-user",
+        source_id="manual:fixture:1",
+    )
+    assert record.text == "用户明确表示喜欢黑咖啡。"
+    call = next(value for name, value in backend.calls if name == "add")
+    assert call["infer"] is False
+    assert call["metadata"]["manual"] is True
+    assert call["metadata"]["actor"] == "local_user"
+
+
+def test_provider_failures_degrade_without_echoing_private_text(tmp_path: Path) -> None:
+    backend = FakeMem0()
+    backend.fail.add("add")
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+    result = adapter.remember_exchange(
+        user_message="private user text",
+        assistant_message="private assistant text",
+        occurred_at=NOW,
+        source_id="letter:private:1",
+        user_id="local-user",
+    )
+    assert result.status is MemoryWriteStatus.UNAVAILABLE
+    assert result.error_code == "MEM0_WRITE_FAILED"
+    assert "private user text" not in repr(result)
+    assert "private assistant text" not in repr(result)
+
+    backend.fail.clear()
+    backend.fail.add("get_all")
+    status = adapter.status().to_dict()
+    assert status["status"] == "degraded"
+    assert status["reason_code"] == "MEM0_LIST_FAILED"
+
+
+def test_factory_is_lazy_and_returns_stable_disabled_or_unavailable_ports(tmp_path: Path) -> None:
+    assert isinstance(
+        create_mem0_adapter(
+            Mem0Config(enabled=False, data_root=tmp_path / "disabled")
+        ),
+        NullConversationMemoryPort,
+    )
+
+    broken = Mem0Config(
+        enabled=True,
+        data_root=tmp_path / "broken",
+        config_error="MEM0_LLM_CONFIG_INCOMPLETE",
+    )
+    assert isinstance(create_mem0_adapter(broken), UnavailableConversationMemoryPort)
+
+    captured: dict[str, object] = {}
+    backend = FakeMem0()
+
+    def factory(config):
+        captured.update(config)
+        return backend
+
+    adapter = create_mem0_adapter(
+        _config(tmp_path),
+        environ={"DEEPSEEK_API_KEY": "fixture-secret"},
+        memory_factory=factory,
+    )
+    assert isinstance(adapter, Mem0ConversationMemoryAdapter)
+    assert captured["vector_store"]["provider"] == "qdrant"
+
+    def failing_factory(_config):
+        raise RuntimeError("private path and secret")
+
+    unavailable = create_mem0_adapter(
+        _config(tmp_path),
+        memory_factory=failing_factory,
+    )
+    assert isinstance(unavailable, UnavailableConversationMemoryPort)
+    assert unavailable.reason_code == "MEM0_INITIALIZATION_FAILED"
+
+
+def test_manual_failure_uses_stable_error(tmp_path: Path) -> None:
+    backend = FakeMem0()
+    backend.fail.add("add")
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+    try:
+        adapter.add_manual_memory(
+            "private manual fact",
+            user_id="local-user",
+            source_id="manual:private:1",
+        )
+    except Mem0AdapterError as exc:
+        assert exc.code == "MEM0_MANUAL_WRITE_FAILED"
+        assert "private manual fact" not in str(exc)
+    else:
+        raise AssertionError("manual provider failure must be explicit")


### PR DESCRIPTION
Clean replacement for #55, recreated from the latest protected `main` after MEM-02.

## Scope

- adds a lazy optional `Mem0ConversationMemoryAdapter` behind `ConversationMemoryPort`;
- pins the optional provider to `mem0ai==2.0.18` and keeps it out of the core install;
- uses current Mem0 OSS API contracts:
  - flat `user_id` / `agent_id` / `domain` filters for `search()` and `get_all()`;
  - explicit `top_k` for bounded listing;
  - top-level user and agent scope for `delete_all()`;
- configures local Qdrant, a CPU Hugging Face Chinese embedding model, local-only model loading, local history storage, and an OpenAI-compatible extraction LLM;
- preserves canonical user/assistant role order;
- supports search, list, canonical exchange write, exact manual facts, ownership-checked delete, clear, export, and sanitized status;
- keeps Archive, Persona evidence, system prompts, Reviewer payloads, PrivateWorld, hidden scores, and control-only state outside Mem0;
- imports Mem0 only when enabled and degrades with stable error codes;
- packages `letter_status`, `conversation_memory_port`, and `mem0_memory`;
- restores `tests/memory` to the required public test gate.

## Corrections versus #55

The original branch's green CI did not run `tests/memory` and its modules were absent from the explicit wheel module list. It also used an `AND`-only filter that current Mem0 rejects because `get_all()` and `search()` require a top-level entity field, and it relied on the default 20-row list limit. This replacement fixes all three before integration.

## Boundary

This PR does not yet inject retrieved memories into PersonaAssembly or write from canonical reply delivery. MEM-04 and MEM-05 remain separate. The embedding model is configured with `local_files_only`; installer work must explicitly download and verify it.

Supersedes #55. Part of #34.