### PR TITLE
feat(private-world): add bounded candidate review API

### DIFF
--- a/control_center/private_world_candidate_api.py
+++ b/control_center/private_world_candidate_api.py
@@ -1,0 +1,348 @@
+"""Authenticated review API for advisory PrivateWorld candidates.
+
+The HTTP layer never mutates relationship state directly. Approval is delegated
+to an injected backend that must execute the typed command and record the
+candidate decision; rejection records only the user's decision.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import re
+from typing import Protocol, Sequence, runtime_checkable
+
+from aiohttp import web
+
+from .app import CSRF_HEADER, SESSION_COOKIE
+from .auth import ControlSessionError
+
+
+CANDIDATE_API_SCHEMA = "p03.private-world-candidate-control.v1"
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
+_MAX_BODY_BYTES = 8192
+_MAX_REASON_LENGTH = 280
+
+
+class CandidateApiError(ValueError):
+    def __init__(self, code: str, *, status: int = 400) -> None:
+        self.code = code
+        self.status = status
+        super().__init__(code)
+
+
+def _token(value: object, *, maximum: int, code: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not 1 <= len(value) <= maximum
+        or not _TOKEN_RE.fullmatch(value)
+    ):
+        raise CandidateApiError(code)
+    return value
+
+
+def _reason(value: object) -> str:
+    if not isinstance(value, str):
+        raise CandidateApiError("PRIVATE_WORLD_DECISION_REASON_INVALID")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > _MAX_REASON_LENGTH
+        or any(ord(character) < 32 or ord(character) == 127 for character in normalized)
+    ):
+        raise CandidateApiError("PRIVATE_WORLD_DECISION_REASON_INVALID")
+    return normalized
+
+
+def _timestamp(value: object) -> str:
+    if not isinstance(value, str):
+        raise CandidateApiError("PRIVATE_WORLD_DECISION_TIME_INVALID")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise CandidateApiError("PRIVATE_WORLD_DECISION_TIME_INVALID") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CandidateApiError("PRIVATE_WORLD_DECISION_TIME_INVALID")
+    return value
+
+
+@dataclass(frozen=True)
+class CandidateSummary:
+    candidate_id: str
+    candidate_type: str
+    summary: str
+    confidence: float
+    source_letter_id: str
+    source_reply_revision: int
+    created_at: str
+    expires_at: str
+    evidence_refs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _token(
+            self.candidate_id,
+            maximum=128,
+            code="PRIVATE_WORLD_CANDIDATE_ID_INVALID",
+        )
+        if self.candidate_type not in {"boundary_respected", "conflict", "repair"}:
+            raise CandidateApiError("PRIVATE_WORLD_CANDIDATE_TYPE_INVALID")
+        _reason(self.summary)
+        if (
+            isinstance(self.confidence, bool)
+            or not isinstance(self.confidence, (int, float))
+            or not 0 <= float(self.confidence) <= 1
+        ):
+            raise CandidateApiError("PRIVATE_WORLD_CONFIDENCE_INVALID")
+        _token(
+            self.source_letter_id,
+            maximum=128,
+            code="PRIVATE_WORLD_SOURCE_ID_INVALID",
+        )
+        if type(self.source_reply_revision) is not int or self.source_reply_revision < 1:
+            raise CandidateApiError("PRIVATE_WORLD_REVISION_INVALID")
+        _timestamp(self.created_at)
+        _timestamp(self.expires_at)
+        if len(self.evidence_refs) > 8:
+            raise CandidateApiError("PRIVATE_WORLD_EVIDENCE_INVALID")
+        for reference in self.evidence_refs:
+            _token(
+                reference,
+                maximum=96,
+                code="PRIVATE_WORLD_EVIDENCE_INVALID",
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "candidate_id": self.candidate_id,
+            "candidate_type": self.candidate_type,
+            "summary": self.summary,
+            "confidence": round(float(self.confidence), 6),
+            "source_letter_id": self.source_letter_id,
+            "source_reply_revision": self.source_reply_revision,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "evidence_refs": list(self.evidence_refs),
+        }
+
+
+@dataclass(frozen=True)
+class CandidateDecisionRequest:
+    candidate_id: str
+    decision: str
+    idempotency_key: str
+    reason: str
+    occurred_at: str
+
+    def __post_init__(self) -> None:
+        _token(
+            self.candidate_id,
+            maximum=128,
+            code="PRIVATE_WORLD_CANDIDATE_ID_INVALID",
+        )
+        if self.decision not in {"approve", "reject"}:
+            raise CandidateApiError("PRIVATE_WORLD_DECISION_INVALID")
+        _token(
+            self.idempotency_key,
+            maximum=96,
+            code="PRIVATE_WORLD_IDEMPOTENCY_KEY_INVALID",
+        )
+        object.__setattr__(self, "reason", _reason(self.reason))
+        _timestamp(self.occurred_at)
+
+
+@dataclass(frozen=True)
+class CandidateDecisionResult:
+    candidate_id: str
+    status: str
+    decision: str
+    command_id: str | None = None
+    reason_code: str = "decision_recorded"
+
+    def __post_init__(self) -> None:
+        _token(
+            self.candidate_id,
+            maximum=128,
+            code="PRIVATE_WORLD_CANDIDATE_ID_INVALID",
+        )
+        if self.status not in {"approved", "rejected", "duplicate", "expired"}:
+            raise CandidateApiError("PRIVATE_WORLD_CANDIDATE_STATUS_INVALID")
+        if self.decision not in {"approve", "reject"}:
+            raise CandidateApiError("PRIVATE_WORLD_DECISION_INVALID")
+        if self.command_id is not None:
+            _token(
+                self.command_id,
+                maximum=96,
+                code="PRIVATE_WORLD_COMMAND_ID_INVALID",
+            )
+        _token(
+            self.reason_code,
+            maximum=96,
+            code="PRIVATE_WORLD_REASON_CODE_INVALID",
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema_version": CANDIDATE_API_SCHEMA,
+            "candidate_id": self.candidate_id,
+            "status": self.status,
+            "decision": self.decision,
+            "reason_code": self.reason_code,
+        }
+        if self.command_id is not None:
+            payload["command_id"] = self.command_id
+        return payload
+
+
+@runtime_checkable
+class CandidateReviewBackend(Protocol):
+    def pending(self, *, limit: int) -> Sequence[CandidateSummary]: ...
+
+    def decide(self, request: CandidateDecisionRequest) -> CandidateDecisionResult: ...
+
+
+def _backend(request: web.Request) -> CandidateReviewBackend:
+    backend = request.app.get("private_world_candidate_backend")
+    if not isinstance(backend, CandidateReviewBackend):
+        raise CandidateApiError(
+            "PRIVATE_WORLD_CANDIDATE_CONTROL_UNAVAILABLE",
+            status=503,
+        )
+    return backend
+
+
+def _require_session(request: web.Request, *, csrf: bool = False) -> None:
+    store = request.app.get("control_session_store")
+    if store is None:
+        raise CandidateApiError("CONTROL_SESSION_REQUIRED", status=403)
+    try:
+        store.authenticate(
+            request.cookies.get(SESSION_COOKIE),
+            csrf_token=request.headers.get(CSRF_HEADER),
+            require_csrf=csrf,
+        )
+    except ControlSessionError as exc:
+        raise CandidateApiError(exc.code, status=403) from exc
+
+
+async def _body(request: web.Request) -> dict[str, object]:
+    if request.content_length is not None and request.content_length > _MAX_BODY_BYTES:
+        raise CandidateApiError("PRIVATE_WORLD_REQUEST_TOO_LARGE", status=413)
+    try:
+        value = await request.json(loads=json.loads)
+    except (json.JSONDecodeError, UnicodeError, TypeError, ValueError) as exc:
+        raise CandidateApiError("PRIVATE_WORLD_JSON_INVALID") from exc
+    if not isinstance(value, dict):
+        raise CandidateApiError("PRIVATE_WORLD_JSON_INVALID")
+    return value
+
+
+def _error(exc: CandidateApiError) -> web.Response:
+    return web.json_response(
+        {
+            "schema_version": CANDIDATE_API_SCHEMA,
+            "status": "UNAVAILABLE" if exc.status == 503 else "FAILED",
+            "error_code": exc.code,
+        },
+        status=exc.status,
+    )
+
+
+async def _pending(request: web.Request) -> web.Response:
+    try:
+        _require_session(request)
+        try:
+            limit = int(request.query.get("limit", "50"))
+        except ValueError as exc:
+            raise CandidateApiError("PRIVATE_WORLD_LIMIT_INVALID") from exc
+        if not 1 <= limit <= 200:
+            raise CandidateApiError("PRIVATE_WORLD_LIMIT_INVALID")
+        values = tuple(_backend(request).pending(limit=limit))
+        if len(values) > limit or any(not isinstance(item, CandidateSummary) for item in values):
+            raise CandidateApiError(
+                "PRIVATE_WORLD_CANDIDATE_CONTROL_INVALID",
+                status=503,
+            )
+        return web.json_response(
+            {
+                "schema_version": CANDIDATE_API_SCHEMA,
+                "status": "READY",
+                "candidates": [item.to_dict() for item in values],
+            }
+        )
+    except CandidateApiError as exc:
+        return _error(exc)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return _error(
+            CandidateApiError(
+                "PRIVATE_WORLD_CANDIDATE_CONTROL_UNAVAILABLE",
+                status=503,
+            )
+        )
+
+
+async def _decision(request: web.Request) -> web.Response:
+    try:
+        _require_session(request, csrf=True)
+        candidate_id = _token(
+            request.match_info.get("candidate_id", ""),
+            maximum=128,
+            code="PRIVATE_WORLD_CANDIDATE_ID_INVALID",
+        )
+        decision = request.match_info.get("decision", "")
+        if decision not in {"approve", "reject"}:
+            raise CandidateApiError("PRIVATE_WORLD_DECISION_INVALID")
+        body = await _body(request)
+        submitted = body.get("candidate_id")
+        if submitted is not None and submitted != candidate_id:
+            raise CandidateApiError("PRIVATE_WORLD_CANDIDATE_ID_CONFLICT")
+        value = CandidateDecisionRequest(
+            candidate_id=candidate_id,
+            decision=decision,
+            idempotency_key=str(body.get("idempotency_key", "")),
+            reason=str(body.get("reason", "")),
+            occurred_at=str(body.get("occurred_at", "")),
+        )
+        result = _backend(request).decide(value)
+        if not isinstance(result, CandidateDecisionResult):
+            raise CandidateApiError(
+                "PRIVATE_WORLD_CANDIDATE_CONTROL_INVALID",
+                status=503,
+            )
+        return web.json_response(result.to_dict())
+    except CandidateApiError as exc:
+        return _error(exc)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return _error(
+            CandidateApiError(
+                "PRIVATE_WORLD_CANDIDATE_CONTROL_UNAVAILABLE",
+                status=503,
+            )
+        )
+
+
+def mount_candidate_review_api(
+    app: web.Application,
+    backend: CandidateReviewBackend,
+) -> None:
+    if not isinstance(backend, CandidateReviewBackend):
+        raise TypeError("a typed candidate review backend is required")
+    if "private_world_candidate_backend" in app:
+        raise RuntimeError("PRIVATE_WORLD_CANDIDATE_CONTROL_ALREADY_MOUNTED")
+    app["private_world_candidate_backend"] = backend
+    app.router.add_get("/control/api/private-world/candidates", _pending)
+    app.router.add_post(
+        "/control/api/private-world/candidates/{candidate_id}/{decision}",
+        _decision,
+    )
+
+
+__all__ = [
+    "CANDIDATE_API_SCHEMA",
+    "CandidateApiError",
+    "CandidateDecisionRequest",
+    "CandidateDecisionResult",
+    "CandidateReviewBackend",
+    "CandidateSummary",
+    "mount_candidate_review_api",
+]

--- a/tests/control_center/test_private_world_candidate_api.py
+++ b/tests/control_center/test_private_world_candidate_api.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+from aiohttp import CookieJar
+from aiohttp.test_utils import TestClient, TestServer
+
+from control_center.app import CSRF_HEADER, create_control_app, issue_bootstrap_token
+from control_center.private_world_candidate_api import (
+    CandidateDecisionRequest,
+    CandidateDecisionResult,
+    CandidateSummary,
+    mount_candidate_review_api,
+)
+
+
+class RecordingCandidateBackend:
+    def __init__(self) -> None:
+        self.limits: list[int] = []
+        self.decisions: list[CandidateDecisionRequest] = []
+
+    def pending(self, *, limit: int):
+        self.limits.append(limit)
+        return (
+            CandidateSummary(
+                candidate_id="candidate.conflict.1",
+                candidate_type="conflict",
+                summary="双方对一个边界产生了明确分歧，等待确认。",
+                confidence=0.82,
+                source_letter_id="letter-fixture-1",
+                source_reply_revision=1,
+                created_at="2026-08-23T03:00:00+00:00",
+                expires_at="2026-08-30T03:00:00+00:00",
+                evidence_refs=(
+                    "letter:letter-fixture-1",
+                    "reply:letter-fixture-1:1",
+                ),
+            ),
+        )
+
+    def decide(self, request: CandidateDecisionRequest) -> CandidateDecisionResult:
+        self.decisions.append(request)
+        return CandidateDecisionResult(
+            candidate_id=request.candidate_id,
+            status="approved" if request.decision == "approve" else "rejected",
+            decision=request.decision,
+            command_id=(
+                "command.conflict.1" if request.decision == "approve" else None
+            ),
+        )
+
+
+async def _client(backend: RecordingCandidateBackend):
+    app = create_control_app()
+    mount_candidate_review_api(app, backend)
+    token = issue_bootstrap_token(app)
+    client = TestClient(TestServer(app), cookie_jar=CookieJar(unsafe=True))
+    await client.start_server()
+    origin = str(client.make_url("/")).rstrip("/")
+    response = await client.post(
+        "/control/api/session/bootstrap",
+        json={"token": token},
+        headers={"Origin": origin},
+    )
+    assert response.status == 200
+    csrf = (await response.json())["csrf_token"]
+    return client, origin, csrf
+
+
+def test_candidate_list_and_approval_use_authenticated_csrf_flow() -> None:
+    async def scenario() -> None:
+        backend = RecordingCandidateBackend()
+        client, origin, csrf = await _client(backend)
+        try:
+            listed = await client.get("/control/api/private-world/candidates?limit=12")
+            assert listed.status == 200
+            payload = await listed.json()
+            assert payload["candidates"][0]["candidate_type"] == "conflict"
+            assert payload["candidates"][0]["confidence"] == 0.82
+            assert backend.limits == [12]
+
+            approved = await client.post(
+                "/control/api/private-world/candidates/candidate.conflict.1/approve",
+                json={
+                    "idempotency_key": "candidate-decision.conflict.1",
+                    "reason": "用户在管理界面确认应记录为冲突。",
+                    "occurred_at": datetime.now(timezone.utc).isoformat(),
+                },
+                headers={"Origin": origin, CSRF_HEADER: csrf},
+            )
+            assert approved.status == 200
+            result = await approved.json()
+            assert result["status"] == "approved"
+            assert result["command_id"] == "command.conflict.1"
+            assert backend.decisions[0].decision == "approve"
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_candidate_rejection_records_no_command() -> None:
+    async def scenario() -> None:
+        backend = RecordingCandidateBackend()
+        client, origin, csrf = await _client(backend)
+        try:
+            rejected = await client.post(
+                "/control/api/private-world/candidates/candidate.conflict.1/reject",
+                json={
+                    "idempotency_key": "candidate-decision.conflict.reject.1",
+                    "reason": "用户认为这只是普通讨论，不需要写入关系账本。",
+                    "occurred_at": "2026-08-23T03:05:00+00:00",
+                },
+                headers={"Origin": origin, CSRF_HEADER: csrf},
+            )
+            assert rejected.status == 200
+            payload = await rejected.json()
+            assert payload["status"] == "rejected"
+            assert "command_id" not in payload
+            assert backend.decisions[0].decision == "reject"
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_mutation_rejects_missing_csrf_conflicts_and_contract_overflow() -> None:
+    async def scenario() -> None:
+        backend = RecordingCandidateBackend()
+        client, origin, csrf = await _client(backend)
+        body = {
+            "idempotency_key": "candidate-decision.fixture.1",
+            "reason": "确认候选。",
+            "occurred_at": "2026-08-23T03:05:00+00:00",
+        }
+        try:
+            no_csrf = await client.post(
+                "/control/api/private-world/candidates/candidate.conflict.1/approve",
+                json=body,
+                headers={"Origin": origin},
+            )
+            assert no_csrf.status == 403
+            assert (await no_csrf.json())["error_code"] == "CONTROL_CSRF_INVALID"
+
+            conflicting = {**body, "candidate_id": "candidate.other"}
+            conflict = await client.post(
+                "/control/api/private-world/candidates/candidate.conflict.1/approve",
+                json=conflicting,
+                headers={"Origin": origin, CSRF_HEADER: csrf},
+            )
+            assert conflict.status == 400
+            assert (await conflict.json())["error_code"] == "PRIVATE_WORLD_CANDIDATE_ID_CONFLICT"
+
+            invalid = await client.post(
+                "/control/api/private-world/candidates/candidate.conflict.1/ignore",
+                json=body,
+                headers={"Origin": origin, CSRF_HEADER: csrf},
+            )
+            assert invalid.status == 400
+            assert (await invalid.json())["error_code"] == "PRIVATE_WORLD_DECISION_INVALID"
+
+            long_reason = await client.post(
+                "/control/api/private-world/candidates/candidate.conflict.1/reject",
+                json={**body, "reason": "界" * 281},
+                headers={"Origin": origin, CSRF_HEADER: csrf},
+            )
+            assert long_reason.status == 400
+            assert (await long_reason.json())["error_code"] == "PRIVATE_WORLD_DECISION_REASON_INVALID"
+
+            long_key = await client.post(
+                "/control/api/private-world/candidates/candidate.conflict.1/reject",
+                json={**body, "idempotency_key": "a" * 97},
+                headers={"Origin": origin, CSRF_HEADER: csrf},
+            )
+            assert long_key.status == 400
+            assert (await long_key.json())["error_code"] == "PRIVATE_WORLD_IDEMPOTENCY_KEY_INVALID"
+            assert backend.decisions == []
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_routes_require_session_and_sanitize_backend_failure() -> None:
+    class FailingBackend(RecordingCandidateBackend):
+        def pending(self, *, limit: int):
+            del limit
+            raise OSError("C:/private/path/private_world.sqlite3")
+
+    async def scenario() -> None:
+        backend = FailingBackend()
+        app = create_control_app()
+        mount_candidate_review_api(app, backend)
+        async with TestClient(TestServer(app)) as client:
+            denied = await client.get("/control/api/private-world/candidates")
+            assert denied.status == 403
+            assert (await denied.json())["error_code"] == "CONTROL_SESSION_REQUIRED"
+
+        client, _origin, _csrf = await _client(backend)
+        try:
+            failed = await client.get("/control/api/private-world/candidates")
+            assert failed.status == 503
+            payload = await failed.json()
+            assert payload == {
+                "schema_version": "p03.private-world-candidate-control.v1",
+                "status": "UNAVAILABLE",
+                "error_code": "PRIVATE_WORLD_CANDIDATE_CONTROL_UNAVAILABLE",
+            }
+            assert "private_world.sqlite3" not in str(payload)
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Clean replacement for #56, recreated from the latest protected `main` after the memory stack cleanup.

## Scope

- adds authenticated loopback routes for listing pending PrivateWorld suggestions and explicitly approving or rejecting them;
- exposes only bounded candidate summaries, confidence, source revision, timestamps, and evidence references;
- requires a management session for reads and session + CSRF for decisions;
- delegates decisions to an injected typed backend; the HTTP layer cannot write SQLite or relationship state directly;
- keeps actor authority server-side and returns stable path-free errors;
- aligns candidate IDs, decision reasons, evidence references, and idempotency keys with the existing candidate store and typed command limits;
- rejects oversized or incompatible values before they reach the backend.

## Tests

- authenticated list/approve/reject flows;
- approval command reference and rejection without a command;
- session and CSRF enforcement;
- candidate-ID conflicts and unsupported decisions;
- store-compatible reason/idempotency bounds;
- privacy-safe backend failure handling.

## Boundary

Automatic candidate analysis remains disabled. A concrete backend adapter and the graphical review page are separate PW-06 slices.

Supersedes #56. Part of #33 and #35.