### PR TITLE
feat(private-world): add candidate review API to the canonical Control Center

### DIFF
--- a/control_center/private_world_candidate_api.py
+++ b/control_center/private_world_candidate_api.py
@@ -1,0 +1,372 @@
+"""Authenticated review API for bounded PrivateWorld candidates.
+
+The Control Center middleware owns loopback, session, Origin, and CSRF checks.
+This adapter exposes advisory summaries and delegates decisions to an injected
+backend; it never writes SQLite or relationship state directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import re
+from typing import Mapping, Protocol, Sequence, runtime_checkable
+
+from aiohttp import web
+
+from .private_world_api import PrivateWorldAPIError
+
+
+PRIVATE_WORLD_CANDIDATE_CONTROL_SCHEMA = (
+    "p03.private-world-candidate-control.v1"
+)
+_CANDIDATE_TYPES = frozenset(
+    {"boundary_respected", "conflict", "repair"}
+)
+_DECISIONS = frozenset({"approve", "reject"})
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
+_MAX_TEXT_LENGTH = 280
+
+
+class CandidateAPIError(PrivateWorldAPIError):
+    """Stable candidate-control error handled by the shared middleware."""
+
+
+@dataclass(frozen=True)
+class CandidateSummary:
+    candidate_id: str
+    candidate_type: str
+    summary: str
+    confidence: float
+    source_letter_id: str
+    source_reply_revision: int
+    created_at: str
+    expires_at: str
+
+    def __post_init__(self) -> None:
+        _identifier(
+            self.candidate_id,
+            code="PRIVATE_WORLD_CANDIDATE_ID_INVALID",
+        )
+        if self.candidate_type not in _CANDIDATE_TYPES:
+            raise CandidateAPIError(
+                "PRIVATE_WORLD_CANDIDATE_TYPE_INVALID"
+            )
+        object.__setattr__(
+            self,
+            "summary",
+            _text(
+                self.summary,
+                code="PRIVATE_WORLD_CANDIDATE_SUMMARY_INVALID",
+            ),
+        )
+        if (
+            isinstance(self.confidence, bool)
+            or not isinstance(self.confidence, (int, float))
+            or not 0 <= float(self.confidence) <= 1
+        ):
+            raise CandidateAPIError(
+                "PRIVATE_WORLD_CANDIDATE_CONFIDENCE_INVALID"
+            )
+        object.__setattr__(self, "confidence", float(self.confidence))
+        _identifier(
+            self.source_letter_id,
+            code="PRIVATE_WORLD_CANDIDATE_SOURCE_INVALID",
+        )
+        if (
+            type(self.source_reply_revision) is not int
+            or self.source_reply_revision < 1
+        ):
+            raise CandidateAPIError(
+                "PRIVATE_WORLD_CANDIDATE_REVISION_INVALID"
+            )
+        _timestamp(
+            self.created_at,
+            code="PRIVATE_WORLD_CANDIDATE_CREATED_AT_INVALID",
+        )
+        _timestamp(
+            self.expires_at,
+            code="PRIVATE_WORLD_CANDIDATE_EXPIRES_AT_INVALID",
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "candidate_id": self.candidate_id,
+            "candidate_type": self.candidate_type,
+            "summary": self.summary,
+            "confidence": round(self.confidence, 6),
+            "source_letter_id": self.source_letter_id,
+            "source_reply_revision": self.source_reply_revision,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+        }
+
+
+@dataclass(frozen=True)
+class CandidateDecisionRequest:
+    candidate_id: str
+    decision: str
+    request_id: str
+    reason: str
+    decided_at: str
+
+    def __post_init__(self) -> None:
+        _identifier(
+            self.candidate_id,
+            code="PRIVATE_WORLD_CANDIDATE_ID_INVALID",
+        )
+        if self.decision not in _DECISIONS:
+            raise CandidateAPIError(
+                "PRIVATE_WORLD_CANDIDATE_DECISION_INVALID"
+            )
+        if (
+            not isinstance(self.request_id, str)
+            or not _REQUEST_ID_RE.fullmatch(self.request_id)
+        ):
+            raise CandidateAPIError("CONTROL_REQUEST_ID_INVALID")
+        object.__setattr__(
+            self,
+            "reason",
+            _text(
+                self.reason,
+                code=(
+                    "PRIVATE_WORLD_CANDIDATE_DECISION_REASON_INVALID"
+                ),
+            ),
+        )
+        _timestamp(
+            self.decided_at,
+            code="PRIVATE_WORLD_CANDIDATE_DECIDED_AT_INVALID",
+        )
+
+
+@dataclass(frozen=True)
+class CandidateDecisionResult:
+    candidate_id: str
+    decision: str
+    status: str
+    reason_code: str
+
+    def __post_init__(self) -> None:
+        _identifier(
+            self.candidate_id,
+            code="PRIVATE_WORLD_CANDIDATE_ID_INVALID",
+        )
+        if self.decision not in _DECISIONS:
+            raise CandidateAPIError(
+                "PRIVATE_WORLD_CANDIDATE_DECISION_INVALID"
+            )
+        if self.status not in {
+            "approved",
+            "rejected",
+            "duplicate",
+            "expired",
+        }:
+            raise CandidateAPIError(
+                "PRIVATE_WORLD_CANDIDATE_STATUS_INVALID"
+            )
+        if (
+            not isinstance(self.reason_code, str)
+            or not re.fullmatch(r"^[A-Z][A-Z0-9_]{0,95}$", self.reason_code)
+        ):
+            raise CandidateAPIError(
+                "PRIVATE_WORLD_CANDIDATE_REASON_CODE_INVALID"
+            )
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "schema_version": PRIVATE_WORLD_CANDIDATE_CONTROL_SCHEMA,
+            "candidate_id": self.candidate_id,
+            "decision": self.decision,
+            "status": self.status,
+            "reason_code": self.reason_code,
+        }
+
+
+@runtime_checkable
+class CandidateReviewBackend(Protocol):
+    def pending(self, *, limit: int) -> Sequence[CandidateSummary]: ...
+
+    def decide(
+        self,
+        request: CandidateDecisionRequest,
+    ) -> CandidateDecisionResult: ...
+
+
+CANDIDATE_REVIEW_KEY = web.AppKey(
+    "control_center.private_world_candidate_review",
+    CandidateReviewBackend,
+)
+
+
+def _identifier(value: object, *, code: str) -> str:
+    if not isinstance(value, str) or not _ID_RE.fullmatch(value):
+        raise CandidateAPIError(code)
+    return value
+
+
+def _text(value: object, *, code: str) -> str:
+    if not isinstance(value, str):
+        raise CandidateAPIError(code)
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > _MAX_TEXT_LENGTH
+        or any(
+            ord(character) < 32 or ord(character) == 127
+            for character in normalized
+        )
+    ):
+        raise CandidateAPIError(code)
+    return normalized
+
+
+def _timestamp(value: object, *, code: str) -> str:
+    if not isinstance(value, str):
+        raise CandidateAPIError(code)
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise CandidateAPIError(code) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CandidateAPIError(code)
+    return value
+
+
+def _response(data: dict[str, object]) -> web.Response:
+    return web.json_response({"ok": True, "data": data})
+
+
+def _strict_body(value: object) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise CandidateAPIError("CONTROL_BODY_INVALID")
+    required = frozenset({"request_id", "reason", "decided_at"})
+    if frozenset(value) != required or any(
+        not isinstance(key, str) for key in value
+    ):
+        raise CandidateAPIError("CONTROL_BODY_FIELDS_INVALID")
+    return value
+
+
+async def _json_body(request: web.Request) -> object:
+    if request.content_type != "application/json":
+        raise web.HTTPUnsupportedMediaType()
+    return await request.json(loads=json.loads)
+
+
+def _backend(request: web.Request) -> CandidateReviewBackend:
+    backend = request.app.get(CANDIDATE_REVIEW_KEY)
+    if not isinstance(backend, CandidateReviewBackend):
+        raise CandidateAPIError(
+            "PRIVATE_WORLD_CANDIDATE_CONTROL_UNAVAILABLE",
+            http_status=503,
+        )
+    return backend
+
+
+async def pending_candidates(request: web.Request) -> web.Response:
+    try:
+        limit = int(request.query.get("limit", "50"))
+    except ValueError as exc:
+        raise CandidateAPIError("CONTROL_LIMIT_INVALID") from exc
+    if not 1 <= limit <= 200:
+        raise CandidateAPIError("CONTROL_LIMIT_INVALID")
+    try:
+        candidates = tuple(_backend(request).pending(limit=limit))
+    except CandidateAPIError:
+        raise
+    except (OSError, RuntimeError, TypeError, ValueError, KeyError) as exc:
+        raise CandidateAPIError(
+            "PRIVATE_WORLD_CANDIDATE_CONTROL_UNAVAILABLE",
+            http_status=503,
+        ) from exc
+    if len(candidates) > limit or any(
+        not isinstance(candidate, CandidateSummary)
+        for candidate in candidates
+    ):
+        raise CandidateAPIError(
+            "PRIVATE_WORLD_CANDIDATE_CONTROL_INVALID",
+            http_status=503,
+        )
+    return _response(
+        {
+            "schema_version": PRIVATE_WORLD_CANDIDATE_CONTROL_SCHEMA,
+            "status": "READY",
+            "candidates": [candidate.to_dict() for candidate in candidates],
+        }
+    )
+
+
+async def decide_candidate(request: web.Request) -> web.Response:
+    candidate_id = _identifier(
+        request.match_info.get("candidate_id", ""),
+        code="PRIVATE_WORLD_CANDIDATE_ID_INVALID",
+    )
+    decision = request.match_info.get("decision", "")
+    if decision not in _DECISIONS:
+        raise CandidateAPIError(
+            "PRIVATE_WORLD_CANDIDATE_DECISION_INVALID"
+        )
+    body = _strict_body(await _json_body(request))
+    command = CandidateDecisionRequest(
+        candidate_id=candidate_id,
+        decision=decision,
+        request_id=str(body["request_id"]),
+        reason=str(body["reason"]),
+        decided_at=str(body["decided_at"]),
+    )
+    try:
+        result = _backend(request).decide(command)
+    except CandidateAPIError:
+        raise
+    except (OSError, RuntimeError, TypeError, ValueError, KeyError) as exc:
+        raise CandidateAPIError(
+            "PRIVATE_WORLD_CANDIDATE_CONTROL_UNAVAILABLE",
+            http_status=503,
+        ) from exc
+    if not isinstance(result, CandidateDecisionResult):
+        raise CandidateAPIError(
+            "PRIVATE_WORLD_CANDIDATE_CONTROL_INVALID",
+            http_status=503,
+        )
+    return _response(result.to_dict())
+
+
+def mount_candidate_review_api(
+    app: web.Application,
+    backend: CandidateReviewBackend,
+) -> None:
+    if not isinstance(backend, CandidateReviewBackend):
+        raise TypeError("a typed candidate review backend is required")
+    if CANDIDATE_REVIEW_KEY in app:
+        raise RuntimeError(
+            "PRIVATE_WORLD_CANDIDATE_CONTROL_ALREADY_MOUNTED"
+        )
+    app[CANDIDATE_REVIEW_KEY] = backend
+    app.add_routes(
+        [
+            web.get(
+                "/control/api/private-world/candidates",
+                pending_candidates,
+            ),
+            web.post(
+                "/control/api/private-world/candidates/"
+                "{candidate_id}/{decision}",
+                decide_candidate,
+            ),
+        ]
+    )
+
+
+__all__ = [
+    "CANDIDATE_REVIEW_KEY",
+    "PRIVATE_WORLD_CANDIDATE_CONTROL_SCHEMA",
+    "CandidateAPIError",
+    "CandidateDecisionRequest",
+    "CandidateDecisionResult",
+    "CandidateReviewBackend",
+    "CandidateSummary",
+    "mount_candidate_review_api",
+]

--- a/tests/control_center/test_private_world_candidate_api.py
+++ b/tests/control_center/test_private_world_candidate_api.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from threading import Lock
+
+from aiohttp import CookieJar
+from aiohttp.test_utils import TestClient, TestServer
+
+from control_center.app import AUTH_KEY, create_control_app
+from control_center.auth import CONTROL_CSRF_HEADER
+from control_center.private_world_candidate_api import (
+    CandidateDecisionRequest,
+    CandidateDecisionResult,
+    CandidateSummary,
+    mount_candidate_review_api,
+)
+from private_world_ledger import LedgerEvent
+from private_world_port import PrivateWorldSnapshot
+
+
+class FakeLedger:
+    def __init__(self) -> None:
+        self.current = PrivateWorldSnapshot()
+        self.items: list[LedgerEvent] = []
+        self._lock = Lock()
+
+    def snapshot(self) -> PrivateWorldSnapshot:
+        return self.current
+
+    def events(self) -> tuple[LedgerEvent, ...]:
+        return tuple(self.items)
+
+    def apply_once(
+        self,
+        event: LedgerEvent,
+        snapshot: PrivateWorldSnapshot,
+    ) -> bool:
+        with self._lock:
+            if any(
+                row.event_id == event.event_id
+                or row.delivery_id == event.delivery_id
+                for row in self.items
+            ):
+                return False
+            self.items.append(event)
+            self.current = snapshot
+            return True
+
+
+class RecordingCandidateBackend:
+    def __init__(self) -> None:
+        self.limits: list[int] = []
+        self.decisions: list[CandidateDecisionRequest] = []
+
+    def pending(self, *, limit: int):
+        self.limits.append(limit)
+        return (
+            CandidateSummary(
+                candidate_id="candidate.conflict.1",
+                candidate_type="conflict",
+                summary="双方对一个边界产生了明确分歧，等待确认。",
+                confidence=0.82,
+                source_letter_id="letter-fixture-1",
+                source_reply_revision=1,
+                created_at="2026-08-23T03:00:00+00:00",
+                expires_at="2026-08-30T03:00:00+00:00",
+            ),
+        )
+
+    def decide(
+        self,
+        request: CandidateDecisionRequest,
+    ) -> CandidateDecisionResult:
+        self.decisions.append(request)
+        return CandidateDecisionResult(
+            candidate_id=request.candidate_id,
+            decision=request.decision,
+            status=(
+                "approved"
+                if request.decision == "approve"
+                else "rejected"
+            ),
+            reason_code=(
+                "PRIVATE_WORLD_CANDIDATE_APPROVED"
+                if request.decision == "approve"
+                else "PRIVATE_WORLD_CANDIDATE_REJECTED"
+            ),
+        )
+
+
+async def _authenticated_client(
+    backend: RecordingCandidateBackend,
+) -> tuple[TestClient, str, str]:
+    app = create_control_app(FakeLedger())
+    mount_candidate_review_api(app, backend)
+    client = TestClient(
+        TestServer(app),
+        cookie_jar=CookieJar(unsafe=True),
+    )
+    await client.start_server()
+    origin = str(client.make_url("/")).rstrip("/")
+    token = app[AUTH_KEY].issue_bootstrap_token()
+    response = await client.post(
+        "/control/api/session/bootstrap",
+        json={"token": token},
+        headers={"Origin": origin},
+    )
+    assert response.status == 200
+    csrf = (await response.json())["data"]["csrf_token"]
+    return client, origin, csrf
+
+
+def test_candidate_list_and_approval_use_shared_auth_boundary() -> None:
+    async def scenario() -> None:
+        backend = RecordingCandidateBackend()
+        client, origin, csrf = await _authenticated_client(backend)
+        try:
+            listed = await client.get(
+                "/control/api/private-world/candidates?limit=12"
+            )
+            assert listed.status == 200
+            payload = (await listed.json())["data"]
+            assert payload["schema_version"] == (
+                "p03.private-world-candidate-control.v1"
+            )
+            assert payload["candidates"][0]["candidate_type"] == (
+                "conflict"
+            )
+            assert payload["candidates"][0]["confidence"] == 0.82
+            assert backend.limits == [12]
+
+            approved = await client.post(
+                "/control/api/private-world/candidates/"
+                "candidate.conflict.1/approve",
+                json={
+                    "request_id": "candidate-decision.conflict.1",
+                    "reason": "用户确认应记录为一次冲突。",
+                    "decided_at": datetime.now(timezone.utc).isoformat(),
+                },
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert approved.status == 200
+            result = (await approved.json())["data"]
+            assert result["status"] == "approved"
+            assert result["reason_code"] == (
+                "PRIVATE_WORLD_CANDIDATE_APPROVED"
+            )
+            assert backend.decisions[0].decision == "approve"
+            assert backend.decisions[0].request_id == (
+                "candidate-decision.conflict.1"
+            )
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_candidate_rejection_is_explicit_and_command_free_at_http_layer() -> None:
+    async def scenario() -> None:
+        backend = RecordingCandidateBackend()
+        client, origin, csrf = await _authenticated_client(backend)
+        try:
+            rejected = await client.post(
+                "/control/api/private-world/candidates/"
+                "candidate.conflict.1/reject",
+                json={
+                    "request_id": "candidate-decision.reject.1",
+                    "reason": "用户认为这只是普通讨论。",
+                    "decided_at": "2026-08-23T03:05:00+00:00",
+                },
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert rejected.status == 200
+            payload = (await rejected.json())["data"]
+            assert payload["status"] == "rejected"
+            assert "command_id" not in payload
+            assert "command_event_id" not in payload
+            assert backend.decisions[0].decision == "reject"
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_candidate_routes_require_session_csrf_and_strict_fields() -> None:
+    async def scenario() -> None:
+        backend = RecordingCandidateBackend()
+        app = create_control_app(FakeLedger())
+        mount_candidate_review_api(app, backend)
+        async with TestClient(
+            TestServer(app),
+            cookie_jar=CookieJar(unsafe=True),
+        ) as unauthenticated_client:
+            denied = await unauthenticated_client.get(
+                "/control/api/private-world/candidates"
+            )
+            assert denied.status == 401
+            assert (await denied.json())["error"]["code"] == (
+                "CONTROL_SESSION_REQUIRED"
+            )
+
+        client, origin, csrf = await _authenticated_client(backend)
+        body = {
+            "request_id": "candidate-decision.fixture.1",
+            "reason": "确认候选。",
+            "decided_at": "2026-08-23T03:05:00+00:00",
+        }
+        try:
+            no_csrf = await client.post(
+                "/control/api/private-world/candidates/"
+                "candidate.conflict.1/approve",
+                json=body,
+                headers={"Origin": origin},
+            )
+            assert no_csrf.status == 403
+            assert (await no_csrf.json())["error"]["code"] == (
+                "CONTROL_CSRF_REQUIRED"
+            )
+
+            unsupported = await client.post(
+                "/control/api/private-world/candidates/"
+                "candidate.conflict.1/ignore",
+                json=body,
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert unsupported.status == 400
+            assert (await unsupported.json())["error"]["code"] == (
+                "PRIVATE_WORLD_CANDIDATE_DECISION_INVALID"
+            )
+
+            extra_field = await client.post(
+                "/control/api/private-world/candidates/"
+                "candidate.conflict.1/reject",
+                json={**body, "candidate_id": "candidate.other"},
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert extra_field.status == 400
+            assert (await extra_field.json())["error"]["code"] == (
+                "CONTROL_BODY_FIELDS_INVALID"
+            )
+
+            too_long = await client.post(
+                "/control/api/private-world/candidates/"
+                "candidate.conflict.1/reject",
+                json={**body, "reason": "界" * 281},
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert too_long.status == 400
+            assert (await too_long.json())["error"]["code"] == (
+                "PRIVATE_WORLD_CANDIDATE_DECISION_REASON_INVALID"
+            )
+            assert backend.decisions == []
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_candidate_backend_failures_are_path_free() -> None:
+    class FailingBackend(RecordingCandidateBackend):
+        def pending(self, *, limit: int):
+            del limit
+            raise OSError("C:/private/path/private_world.sqlite3")
+
+    async def scenario() -> None:
+        backend = FailingBackend()
+        client, _origin, _csrf = await _authenticated_client(backend)
+        try:
+            failed = await client.get(
+                "/control/api/private-world/candidates"
+            )
+            assert failed.status == 503
+            payload = await failed.json()
+            assert payload == {
+                "ok": False,
+                "error": {
+                    "code": (
+                        "PRIVATE_WORLD_CANDIDATE_CONTROL_UNAVAILABLE"
+                    )
+                },
+            }
+            assert "private_world.sqlite3" not in str(payload)
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Replaces superseded #61 after PR #62 restored the real Control Center test gate.

## Scope

- mounts pending-candidate read and explicit approve/reject routes onto the existing canonical Control Center app;
- reuses the shared loopback, Origin, session, CSRF, security-header, error-envelope, and logout middleware;
- exposes only bounded candidate type, summary, confidence, source revision, and timestamps;
- accepts a strict decision body containing only `request_id`, `reason`, and timezone-aware `decided_at`;
- delegates decisions to an injected typed backend, so HTTP code cannot write SQLite or relationship state directly;
- returns no command identifiers, database paths, raw candidate rows, full letters, full replies, or hidden relationship scores;
- aligns all identifier and text bounds with the existing candidate store and command contracts.

## Tests

- authenticated list, approve, and reject flows;
- rejection with no command surface;
- session and CSRF enforcement;
- unsupported decisions, extra fields, and oversized reasons;
- path-free backend failure responses;
- all tests now execute under the corrected required public gate from #62.

## Boundary

Automatic candidate analysis remains disabled. A concrete store/command-service backend and the graphical review page remain separate PW-06 slices.

Part of #33 and #35.