### PR TITLE
feat(control): add protected graphical candidate review

### DIFF
--- a/control_center/private_world_candidate_ui.py
+++ b/control_center/private_world_candidate_ui.py
@@ -1,0 +1,63 @@
+"""Protected graphical review surface for PrivateWorld candidates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aiohttp import web
+
+from .private_world_candidate_api import (
+    CandidateReviewBackend,
+    mount_candidate_review_api,
+)
+
+
+_STATIC_ROOT = Path(__file__).with_name("static")
+
+
+def _asset(name: str) -> web.FileResponse:
+    path = _STATIC_ROOT / name
+    if not path.is_file():
+        raise RuntimeError("CONTROL_CANDIDATE_STATIC_UNAVAILABLE")
+    return web.FileResponse(path)
+
+
+async def candidate_index(request: web.Request) -> web.FileResponse:
+    del request
+    return _asset("candidates.html")
+
+
+async def candidate_css(request: web.Request) -> web.FileResponse:
+    del request
+    return _asset("candidates.css")
+
+
+async def candidate_script(request: web.Request) -> web.FileResponse:
+    del request
+    return _asset("candidates.js")
+
+
+def mount_candidate_control(
+    app: web.Application,
+    backend: CandidateReviewBackend,
+) -> None:
+    """Mount the authenticated API and its protected graphical page."""
+
+    mount_candidate_review_api(app, backend)
+    app.add_routes(
+        [
+            web.get("/control/candidates", candidate_index),
+            web.get("/control/candidates/", candidate_index),
+            web.get(
+                "/control/static/candidates.css",
+                candidate_css,
+            ),
+            web.get(
+                "/control/static/candidates.js",
+                candidate_script,
+            ),
+        ]
+    )
+
+
+__all__ = ["mount_candidate_control"]

--- a/control_center/static/candidates.css
+++ b/control_center/static/candidates.css
@@ -1,0 +1,122 @@
+.candidate-intro {
+  max-width: 70ch;
+  margin: 0.75rem 0 0;
+  line-height: 1.6;
+}
+
+.button-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.5rem;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid currentColor;
+  border-radius: 0.45rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.button-link:focus-visible {
+  outline: 3px solid currentColor;
+  outline-offset: 3px;
+}
+
+.candidate-page {
+  width: min(62rem, calc(100% - 2rem));
+  margin: 2rem auto 4rem;
+}
+
+.candidate-list {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.25rem;
+}
+
+.candidate-card {
+  padding: 1.25rem;
+  border: 1px solid var(--border, #c8c8c4);
+  border-radius: 0.8rem;
+  background: var(--surface, #fff);
+}
+
+.candidate-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.candidate-type {
+  margin: 0 0 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.candidate-summary {
+  margin: 0;
+  max-width: 48rem;
+  line-height: 1.5;
+}
+
+.candidate-confidence {
+  flex: 0 0 auto;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.candidate-metadata {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.candidate-metadata div {
+  padding-top: 0.65rem;
+  border-top: 1px solid var(--border-soft, #e1e1dd);
+}
+
+.candidate-metadata dt {
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.candidate-metadata dd {
+  margin: 0.25rem 0 0;
+  overflow-wrap: anywhere;
+}
+
+.candidate-reason {
+  width: 100%;
+  min-height: 5.5rem;
+  margin-top: 0.4rem;
+}
+
+.candidate-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.candidate-actions .secondary {
+  opacity: 0.9;
+}
+
+.candidate-empty {
+  padding: 2rem;
+  border: 1px dashed var(--border, #c8c8c4);
+  border-radius: 0.8rem;
+  text-align: center;
+}
+
+@media (max-width: 44rem) {
+  .candidate-heading {
+    display: block;
+  }
+
+  .candidate-confidence {
+    display: inline-block;
+    margin-top: 0.65rem;
+  }
+}

--- a/control_center/static/candidates.html
+++ b/control_center/static/candidates.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>待确认建议 · Olivia Control Center</title>
+  <link rel="stylesheet" href="/control/static/app.css">
+  <link rel="stylesheet" href="/control/static/candidates.css">
+</head>
+<body>
+  <header class="topbar">
+    <div>
+      <p class="eyebrow">本地陪伴系统</p>
+      <h1>待确认建议</h1>
+      <p class="candidate-intro">这些只是系统提出的关系事件建议。批准前不会改变任何关系状态，拒绝也不会产生负面影响。</p>
+    </div>
+    <div class="session-actions">
+      <a class="button-link" href="/control/">返回私有世界</a>
+      <button id="refresh-button" type="button">刷新</button>
+      <button id="logout-button" type="button">退出管理</button>
+    </div>
+  </header>
+
+  <main class="candidate-page" tabindex="-1">
+    <section aria-labelledby="pending-title">
+      <div class="section-heading">
+        <div>
+          <p class="eyebrow">PrivateWorld Candidates</p>
+          <h2 id="pending-title">等待你的判断</h2>
+        </div>
+        <span id="candidate-count" role="status">正在加载</span>
+      </div>
+      <p class="hint">只会出现「边界被尊重」「冲突」「修复」三种建议。关系阶段、私人称呼、住所权限和私人世界线不会由模型自动提出或提交。</p>
+      <div id="candidate-list" class="candidate-list" aria-live="polite"></div>
+    </section>
+
+    <p id="notice" class="notice" role="status" aria-live="polite"></p>
+  </main>
+
+  <template id="candidate-template">
+    <article class="candidate-card">
+      <div class="candidate-heading">
+        <div>
+          <p class="candidate-type"></p>
+          <h3 class="candidate-summary"></h3>
+        </div>
+        <span class="candidate-confidence"></span>
+      </div>
+      <dl class="candidate-metadata">
+        <div><dt>来源</dt><dd class="candidate-source"></dd></div>
+        <div><dt>建立时间</dt><dd class="candidate-created"></dd></div>
+        <div><dt>到期时间</dt><dd class="candidate-expires"></dd></div>
+      </dl>
+      <label>
+        你的确认说明
+        <textarea class="candidate-reason" maxlength="280" required></textarea>
+      </label>
+      <div class="candidate-actions">
+        <button class="candidate-approve" type="button">批准并记录</button>
+        <button class="candidate-reject secondary" type="button">拒绝建议</button>
+      </div>
+    </article>
+  </template>
+
+  <script type="module" src="/control/static/candidates.js"></script>
+</body>
+</html>

--- a/control_center/static/candidates.js
+++ b/control_center/static/candidates.js
@@ -1,0 +1,217 @@
+import {ControlAPIError, establishSession, get, logout, post} from "./api.js";
+
+const labels = {
+  boundary_respected: "边界被尊重",
+  conflict: "冲突",
+  repair: "修复",
+};
+
+const byId = (id) => document.getElementById(id);
+const listNode = byId("candidate-list");
+const countNode = byId("candidate-count");
+const noticeNode = byId("notice");
+const template = byId("candidate-template");
+
+function clearChildren(node) {
+  while (node.firstChild) {
+    node.removeChild(node.firstChild);
+  }
+}
+
+function showNotice(message, failed = false) {
+  noticeNode.textContent = message;
+  noticeNode.dataset.state = failed ? "error" : "ok";
+}
+
+function formatDate(value) {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat("zh-CN", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(parsed);
+}
+
+function randomRequestId() {
+  const random = globalThis.crypto?.randomUUID?.()
+    || Array.from(globalThis.crypto.getRandomValues(new Uint8Array(16)))
+      .map((value) => value.toString(16).padStart(2, "0"))
+      .join("");
+  return `candidate-review.${random}`;
+}
+
+function pendingStorageKey(candidateId, decision) {
+  return `olivia.control.candidate.${candidateId}.${decision}`;
+}
+
+function decisionEnvelope(candidateId, decision, reason) {
+  const key = pendingStorageKey(candidateId, decision);
+  const stored = sessionStorage.getItem(key);
+  if (stored) {
+    try {
+      const value = JSON.parse(stored);
+      if (
+        value.reason === reason
+        && typeof value.request_id === "string"
+        && typeof value.decided_at === "string"
+      ) {
+        return {key, body: value};
+      }
+    } catch {
+      sessionStorage.removeItem(key);
+    }
+  }
+  const body = {
+    request_id: randomRequestId(),
+    reason,
+    decided_at: new Date().toISOString(),
+  };
+  sessionStorage.setItem(key, JSON.stringify(body));
+  return {key, body};
+}
+
+function errorCode(error) {
+  return error instanceof ControlAPIError
+    ? error.code
+    : "CONTROL_CANDIDATE_UI_ERROR";
+}
+
+async function decide(candidate, decision, reason, buttons) {
+  if (!reason) {
+    showNotice("请先填写确认说明。", true);
+    return;
+  }
+  const action = decision === "approve" ? "批准并记录" : "拒绝";
+  if (!window.confirm(`确认${action}这条建议？`)) {
+    return;
+  }
+
+  const envelope = decisionEnvelope(
+    candidate.candidate_id,
+    decision,
+    reason,
+  );
+  for (const button of buttons) {
+    button.disabled = true;
+  }
+  try {
+    const result = await post(
+      `/control/api/private-world/candidates/${encodeURIComponent(candidate.candidate_id)}/${decision}`,
+      envelope.body,
+    );
+    sessionStorage.removeItem(envelope.key);
+    showNotice(
+      result.status === "duplicate"
+        ? "这项决定已经记录，没有重复修改关系状态。"
+        : decision === "approve"
+          ? "建议已批准并写入可审计关系事件。"
+          : "建议已拒绝，关系状态没有变化。",
+    );
+    await refresh();
+  } catch (error) {
+    showNotice(`操作失败：${errorCode(error)}`, true);
+    for (const button of buttons) {
+      button.disabled = false;
+    }
+  }
+}
+
+function renderEmpty() {
+  const empty = document.createElement("p");
+  empty.className = "candidate-empty";
+  empty.textContent = "目前没有等待确认的关系事件建议。";
+  listNode.append(empty);
+}
+
+function renderCandidate(candidate) {
+  const fragment = template.content.cloneNode(true);
+  const card = fragment.querySelector(".candidate-card");
+  const reason = fragment.querySelector(".candidate-reason");
+  const approve = fragment.querySelector(".candidate-approve");
+  const reject = fragment.querySelector(".candidate-reject");
+
+  card.dataset.candidateId = candidate.candidate_id;
+  fragment.querySelector(".candidate-type").textContent = (
+    labels[candidate.candidate_type] || candidate.candidate_type
+  );
+  fragment.querySelector(".candidate-summary").textContent = (
+    candidate.summary
+  );
+  fragment.querySelector(".candidate-confidence").textContent = (
+    `建议可信度 ${Math.round(candidate.confidence * 100)}%`
+  );
+  fragment.querySelector(".candidate-source").textContent = (
+    `${candidate.source_letter_id} · 回复版本 ${candidate.source_reply_revision}`
+  );
+  fragment.querySelector(".candidate-created").textContent = (
+    formatDate(candidate.created_at)
+  );
+  fragment.querySelector(".candidate-expires").textContent = (
+    formatDate(candidate.expires_at)
+  );
+
+  const buttons = [approve, reject];
+  approve.addEventListener("click", () => {
+    decide(candidate, "approve", reason.value.trim(), buttons);
+  });
+  reject.addEventListener("click", () => {
+    decide(candidate, "reject", reason.value.trim(), buttons);
+  });
+  listNode.append(fragment);
+}
+
+async function refresh() {
+  const data = await get("/control/api/private-world/candidates?limit=100");
+  clearChildren(listNode);
+  const candidates = Array.isArray(data.candidates) ? data.candidates : [];
+  countNode.textContent = `${candidates.length} 条待确认`;
+  if (!candidates.length) {
+    renderEmpty();
+    return;
+  }
+  for (const candidate of candidates) {
+    renderCandidate(candidate);
+  }
+}
+
+function bindActions() {
+  byId("refresh-button").addEventListener("click", async () => {
+    try {
+      await refresh();
+      showNotice("建议列表已刷新。")
+    } catch (error) {
+      showNotice(`刷新失败：${errorCode(error)}`, true);
+    }
+  });
+
+  byId("logout-button").addEventListener("click", async () => {
+    try {
+      await logout();
+      window.location.assign("/control/");
+    } catch (error) {
+      showNotice(`退出失败：${errorCode(error)}`, true);
+    }
+  });
+}
+
+async function start() {
+  bindActions();
+  try {
+    const session = await establishSession();
+    if (!session.csrfAvailable) {
+      showNotice(
+        "当前标签页缺少修改凭据，请从私有世界首页进入本页面。",
+        true,
+      );
+    }
+    await refresh();
+    byId("pending-title").focus?.();
+  } catch (error) {
+    showNotice(`加载失败：${errorCode(error)}`, true);
+    countNode.textContent = "不可用";
+  }
+}
+
+start();

--- a/control_center/static/candidates.js
+++ b/control_center/static/candidates.js
@@ -34,12 +34,21 @@ function formatDate(value) {
   }).format(parsed);
 }
 
-function randomRequestId() {
-  const random = globalThis.crypto?.randomUUID?.()
-    || Array.from(globalThis.crypto.getRandomValues(new Uint8Array(16)))
+function randomToken() {
+  const cryptoObject = globalThis.crypto;
+  if (typeof cryptoObject?.randomUUID === "function") {
+    return cryptoObject.randomUUID();
+  }
+  if (typeof cryptoObject?.getRandomValues === "function") {
+    return Array.from(cryptoObject.getRandomValues(new Uint8Array(16)))
       .map((value) => value.toString(16).padStart(2, "0"))
       .join("");
-  return `candidate-review.${random}`;
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function randomRequestId() {
+  return `candidate-review.${randomToken()}`;
 }
 
 function pendingStorageKey(candidateId, decision) {
@@ -180,7 +189,7 @@ function bindActions() {
   byId("refresh-button").addEventListener("click", async () => {
     try {
       await refresh();
-      showNotice("建议列表已刷新。")
+      showNotice("建议列表已刷新。");
     } catch (error) {
       showNotice(`刷新失败：${errorCode(error)}`, true);
     }

--- a/control_center/static/index.html
+++ b/control_center/static/index.html
@@ -21,6 +21,7 @@
   <div class="layout">
     <nav aria-label="管理功能">
       <a href="#private-world" aria-current="page">私有世界</a>
+      <a href="/control/candidates">待确认建议</a>
       <span aria-disabled="true">长期记忆（后续）</span>
       <span aria-disabled="true">音乐校准（后续）</span>
       <span aria-disabled="true">诊断（后续）</span>

--- a/tests/control_center/test_private_world_candidate_ui.py
+++ b/tests/control_center/test_private_world_candidate_ui.py
@@ -149,7 +149,8 @@ def test_candidate_assets_are_packaged_self_contained_and_non_gamified() -> None
     assert "document.write" not in script
     assert "eval(" not in script
     assert "sessionStorage" in script
-    assert "crypto.randomUUID" in script
+    assert "randomUUID" in script
+    assert "getRandomValues" in script
     assert "request_id" in script
     assert "decided_at" in script
     assert "/control/api/private-world/candidates/" in script

--- a/tests/control_center/test_private_world_candidate_ui.py
+++ b/tests/control_center/test_private_world_candidate_ui.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import asyncio
+from importlib import resources
+from threading import Lock
+
+from aiohttp import CookieJar
+from aiohttp.test_utils import TestClient, TestServer
+
+from control_center.app import AUTH_KEY, create_control_app
+from control_center.private_world_candidate_api import (
+    CandidateDecisionRequest,
+    CandidateDecisionResult,
+    CandidateSummary,
+)
+from control_center.private_world_candidate_ui import (
+    mount_candidate_control,
+)
+from private_world_ledger import LedgerEvent
+from private_world_port import PrivateWorldSnapshot
+
+
+class FakeLedger:
+    def __init__(self) -> None:
+        self.current = PrivateWorldSnapshot()
+        self.items: list[LedgerEvent] = []
+        self._lock = Lock()
+
+    def snapshot(self) -> PrivateWorldSnapshot:
+        return self.current
+
+    def events(self) -> tuple[LedgerEvent, ...]:
+        return tuple(self.items)
+
+    def apply_once(
+        self,
+        event: LedgerEvent,
+        snapshot: PrivateWorldSnapshot,
+    ) -> bool:
+        with self._lock:
+            self.items.append(event)
+            self.current = snapshot
+        return True
+
+
+class RecordingBackend:
+    def pending(self, *, limit: int):
+        assert limit == 100
+        return (
+            CandidateSummary(
+                candidate_id="candidate.conflict.1",
+                candidate_type="conflict",
+                summary="双方对一个边界产生了明确分歧，等待确认。",
+                confidence=0.82,
+                source_letter_id="letter-fixture-1",
+                source_reply_revision=1,
+                created_at="2026-08-23T03:00:00+00:00",
+                expires_at="2026-08-30T03:00:00+00:00",
+            ),
+        )
+
+    def decide(
+        self,
+        request: CandidateDecisionRequest,
+    ) -> CandidateDecisionResult:
+        return CandidateDecisionResult(
+            candidate_id=request.candidate_id,
+            decision=request.decision,
+            status=(
+                "approved"
+                if request.decision == "approve"
+                else "rejected"
+            ),
+            reason_code="PRIVATE_WORLD_CANDIDATE_DECISION_RECORDED",
+        )
+
+
+def test_candidate_page_is_protected_and_served_after_bootstrap() -> None:
+    async def scenario() -> None:
+        app = create_control_app(FakeLedger())
+        mount_candidate_control(app, RecordingBackend())
+        async with TestClient(
+            TestServer(app),
+            cookie_jar=CookieJar(unsafe=True),
+        ) as client:
+            denied = await client.get("/control/candidates")
+            assert denied.status == 401
+            assert (await denied.json())["error"]["code"] == (
+                "CONTROL_SESSION_REQUIRED"
+            )
+
+            origin = str(client.make_url("/")).rstrip("/")
+            token = app[AUTH_KEY].issue_bootstrap_token()
+            session = await client.post(
+                "/control/api/session/bootstrap",
+                json={"token": token},
+                headers={"Origin": origin},
+            )
+            assert session.status == 200
+
+            expected_types = {
+                "/control/candidates": {"text/html"},
+                "/control/candidates/": {"text/html"},
+                "/control/static/candidates.css": {"text/css"},
+                "/control/static/candidates.js": {
+                    "text/javascript",
+                    "application/javascript",
+                },
+            }
+            for path, content_types in expected_types.items():
+                response = await client.get(path)
+                assert response.status == 200
+                assert response.content_type in content_types
+                assert response.headers["Cache-Control"] == "no-store"
+                assert "Access-Control-Allow-Origin" not in response.headers
+                assert await response.text()
+
+            listed = await client.get(
+                "/control/api/private-world/candidates?limit=100"
+            )
+            assert listed.status == 200
+            assert (await listed.json())["data"]["candidates"][0][
+                "candidate_type"
+            ] == "conflict"
+
+    asyncio.run(scenario())
+
+
+def test_candidate_assets_are_packaged_self_contained_and_non_gamified() -> None:
+    root = resources.files("control_center").joinpath("static")
+    index = root.joinpath("index.html").read_text(encoding="utf-8")
+    page = root.joinpath("candidates.html").read_text(encoding="utf-8")
+    css = root.joinpath("candidates.css").read_text(encoding="utf-8")
+    script = root.joinpath("candidates.js").read_text(encoding="utf-8")
+
+    assert 'href="/control/candidates"' in index
+    assert '<html lang="zh-CN">' in page
+    assert 'maxlength="280"' in page
+    assert "批准并记录" in page
+    assert "拒绝建议" in page
+    assert "批准前不会改变任何关系状态" in page
+    assert "关系阶段、私人称呼、住所权限和私人世界线不会" in page
+
+    for document in (page, css, script):
+        assert "https://" not in document
+        assert "http://" not in document
+        assert "//cdn" not in document
+    assert "innerHTML" not in script
+    assert "document.write" not in script
+    assert "eval(" not in script
+    assert "sessionStorage" in script
+    assert "crypto.randomUUID" in script
+    assert "request_id" in script
+    assert "decided_at" in script
+    assert "/control/api/private-world/candidates/" in script
+    assert "trust =" not in script
+    assert "closeness =" not in script
+    assert 'type="number"' not in page


### PR DESCRIPTION
Clean replacement for stale #57, built on the canonical candidate API and decision backend.

## User-facing scope

- adds a protected Chinese Control Center page for pending PrivateWorld suggestions;
- links it from the existing PrivateWorld navigation;
- shows only candidate type, bounded summary, confidence, source revision, creation, and expiry;
- requires an explicit user reason before approval or rejection;
- preserves the same request ID and decision timestamp in session storage for safe retry after a network or partial-persistence failure;
- clearly states that candidates are advisory, approval is required, and rejection does not change relationship state;
- explicitly states that relationship stage, nickname, home access, and Local Continuation are never automatic candidate operations.

## Security and privacy

- the page and its static assets are protected by the existing Control Center session middleware;
- all API calls use the shared same-origin client and CSRF token;
- runtime data is inserted with `textContent` only;
- no external scripts, fonts, analytics, or URLs;
- no raw hidden scores, command payloads, database paths, complete letters, or complete replies;
- the UI cannot write SQLite directly and only invokes the typed candidate API.

## Tests

- unauthenticated page denial and authenticated page/static/API access;
- package-resource and no-external-resource checks;
- advisory and non-gamified wording;
- bounded reason field, request ID, retry envelope, timestamp, and candidate API path;
- no `innerHTML`, `document.write`, `eval`, or numeric relationship controls.

## Boundary

This PR mounts the page only when a caller explicitly invokes `mount_candidate_control(app, backend)`. Production launcher wiring and automatic candidate analysis remain separate work.

Supersedes #57. Part of #33 and #35.