### PR TITLE
feat(control): assemble one complete local Control Center runtime

### DIFF
--- a/control_center/__init__.py
+++ b/control_center/__init__.py
@@ -2,5 +2,18 @@
 
 from .app import create_control_app
 from .auth import ControlSessionManager
+from .runtime import (
+    ControlCenterRuntime,
+    ControlCenterRuntimeError,
+    create_configured_control_center_runtime,
+    create_control_center_runtime,
+)
 
-__all__ = ["ControlSessionManager", "create_control_app"]
+__all__ = [
+    "ControlCenterRuntime",
+    "ControlCenterRuntimeError",
+    "ControlSessionManager",
+    "create_configured_control_center_runtime",
+    "create_control_app",
+    "create_control_center_runtime",
+]

--- a/control_center/runtime.py
+++ b/control_center/runtime.py
@@ -1,0 +1,183 @@
+"""Construct the complete local Companion Control Center runtime.
+
+The factory owns one PrivateWorld ledger, one typed command service, one
+candidate store, one candidate-review backend, and one session manager.  It
+never opens a socket or browser by itself; Windows launcher wiring remains a
+separate concern.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+from urllib.parse import quote
+
+from aiohttp import web
+
+from private_world_candidates import SQLitePrivateWorldCandidateStore
+from private_world_ledger import LedgerWriteError, SQLitePrivateWorldLedger
+from private_world_runtime import resolve_private_world_database
+from private_world_service import PrivateWorldCommandService
+
+from .app import AUTH_KEY, create_control_app
+from .auth import ControlSessionManager
+from .private_world_candidate_backend import SQLiteCandidateReviewBackend
+from .private_world_candidate_ui import mount_candidate_control
+
+
+CONTROL_CENTER_RUNTIME_SCHEMA = "p03.control-center-runtime.v1"
+CONTROL_CENTER_DEFAULT_PORT = 8900
+CONTROL_CENTER_HOST = "127.0.0.1"
+
+
+class ControlCenterRuntimeError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class ControlCenterRuntime:
+    app: web.Application
+    ledger: SQLitePrivateWorldLedger
+    command_service: PrivateWorldCommandService
+    candidate_store: SQLitePrivateWorldCandidateStore
+    candidate_backend: SQLiteCandidateReviewBackend
+    session_manager: ControlSessionManager
+
+    def public_status(self) -> dict[str, object]:
+        """Return path-free, content-free runtime status."""
+
+        try:
+            ledger = self.ledger.health()
+            candidates = self.candidate_store.health()
+            sessions = self.session_manager.status()
+        except (OSError, RuntimeError, ValueError, LedgerWriteError) as exc:
+            raise ControlCenterRuntimeError(
+                "CONTROL_CENTER_STATUS_UNAVAILABLE"
+            ) from exc
+        return {
+            "schema_version": CONTROL_CENTER_RUNTIME_SCHEMA,
+            "status": "available",
+            "network_scope": "loopback",
+            "provider": "aiohttp-local",
+            "private_world": {
+                "schema_version": self.ledger.schema_version,
+                "event_count": int(ledger["event_count"]),
+                "snapshot_count": int(ledger["snapshot_count"]),
+            },
+            "candidates": {
+                "schema_version": candidates["schema_version"],
+                "pending": int(candidates["pending"]),
+                "approved": int(candidates["approved"]),
+                "rejected": int(candidates["rejected"]),
+                "expired": int(candidates["expired"]),
+                "decisions": int(candidates["decisions"]),
+            },
+            "sessions": {
+                "active": int(sessions["active_sessions"]),
+                "pending_bootstraps": int(sessions["pending_bootstraps"]),
+            },
+        }
+
+    def issue_bootstrap_url(
+        self,
+        *,
+        port: int = CONTROL_CENTER_DEFAULT_PORT,
+    ) -> str:
+        """Issue a one-use browser URL without placing the token in HTTP logs."""
+
+        if type(port) is not int or not 1 <= port <= 65535:
+            raise ControlCenterRuntimeError("CONTROL_CENTER_PORT_INVALID")
+        token = self.session_manager.issue_bootstrap_token()
+        fragment = quote(token, safe="")
+        return (
+            f"http://{CONTROL_CENTER_HOST}:{port}/control/"
+            f"#bootstrap={fragment}"
+        )
+
+
+CONTROL_RUNTIME_KEY = web.AppKey(
+    "control_center.runtime",
+    ControlCenterRuntime,
+)
+
+
+def create_control_center_runtime(
+    database_path: Path,
+    *,
+    session_manager: ControlSessionManager | None = None,
+) -> ControlCenterRuntime:
+    """Build one complete in-process runtime over an explicit SQLite file."""
+
+    path = Path(database_path).expanduser()
+    if not path.is_absolute() or path.exists() and path.is_dir():
+        raise ControlCenterRuntimeError(
+            "CONTROL_CENTER_DATABASE_INVALID"
+        )
+    manager = session_manager or ControlSessionManager()
+    try:
+        ledger = SQLitePrivateWorldLedger(path)
+        service = PrivateWorldCommandService(ledger)
+        candidate_store = SQLitePrivateWorldCandidateStore(path)
+        candidate_backend = SQLiteCandidateReviewBackend(
+            candidate_store,
+            service,
+        )
+        app = create_control_app(
+            ledger,
+            service=service,
+            session_manager=manager,
+        )
+        mount_candidate_control(app, candidate_backend)
+        runtime = ControlCenterRuntime(
+            app,
+            ledger,
+            service,
+            candidate_store,
+            candidate_backend,
+            manager,
+        )
+        app[CONTROL_RUNTIME_KEY] = runtime
+        return runtime
+    except ControlCenterRuntimeError:
+        raise
+    except (OSError, RuntimeError, TypeError, ValueError, LedgerWriteError) as exc:
+        raise ControlCenterRuntimeError(
+            "CONTROL_CENTER_INITIALIZATION_FAILED"
+        ) from exc
+
+
+def create_configured_control_center_runtime(
+    environ: Mapping[str, str] | None = None,
+    *,
+    session_manager: ControlSessionManager | None = None,
+) -> ControlCenterRuntime:
+    """Resolve the installed PrivateWorld database and construct the runtime."""
+
+    path, reason, enabled = resolve_private_world_database(environ)
+    if not enabled:
+        raise ControlCenterRuntimeError(
+            reason or "CONTROL_CENTER_PRIVATE_WORLD_DISABLED"
+        )
+    if path is None:
+        raise ControlCenterRuntimeError(
+            reason or "CONTROL_CENTER_PRIVATE_WORLD_UNAVAILABLE"
+        )
+    return create_control_center_runtime(
+        path,
+        session_manager=session_manager,
+    )
+
+
+__all__ = [
+    "CONTROL_CENTER_DEFAULT_PORT",
+    "CONTROL_CENTER_HOST",
+    "CONTROL_CENTER_RUNTIME_SCHEMA",
+    "CONTROL_RUNTIME_KEY",
+    "ControlCenterRuntime",
+    "ControlCenterRuntimeError",
+    "create_configured_control_center_runtime",
+    "create_control_center_runtime",
+]

--- a/tests/control_center/test_runtime.py
+++ b/tests/control_center/test_runtime.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+from aiohttp import CookieJar
+from aiohttp.test_utils import TestClient, TestServer
+
+from control_center.auth import CONTROL_CSRF_HEADER
+from control_center.runtime import (
+    CONTROL_CENTER_RUNTIME_SCHEMA,
+    ControlCenterRuntimeError,
+    create_configured_control_center_runtime,
+    create_control_center_runtime,
+)
+from private_world_candidates import (
+    CandidateStatus,
+    CandidateType,
+    PrivateWorldCandidate,
+    candidate_identity,
+)
+
+
+NOW = datetime(2026, 8, 23, 5, 0, tzinfo=timezone.utc)
+
+
+def _candidate() -> PrivateWorldCandidate:
+    candidate_type = CandidateType.CONFLICT
+    return PrivateWorldCandidate(
+        candidate_id=candidate_identity(
+            "letter-runtime-fixture",
+            1,
+            candidate_type,
+        ),
+        source_letter_id="letter-runtime-fixture",
+        source_reply_revision=1,
+        candidate_type=candidate_type,
+        summary="双方对一条边界产生了明确分歧，等待确认。",
+        confidence=0.84,
+        status=CandidateStatus.PENDING,
+        created_at=NOW,
+        expires_at=NOW + timedelta(days=7),
+    )
+
+
+def _bootstrap_token(url: str) -> str:
+    parsed = urlsplit(url)
+    values = parse_qs(parsed.fragment)
+    return values["bootstrap"][0]
+
+
+def test_runtime_assembles_shared_ledger_candidates_api_and_ui(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        runtime = create_control_center_runtime(
+            (tmp_path / "private_world.sqlite3").resolve()
+        )
+        candidate = _candidate()
+        runtime.candidate_store.add(candidate)
+
+        bootstrap_url = runtime.issue_bootstrap_url(port=8900)
+        assert bootstrap_url.startswith(
+            "http://127.0.0.1:8900/control/#bootstrap="
+        )
+        assert "?bootstrap=" not in bootstrap_url
+        token = _bootstrap_token(bootstrap_url)
+
+        async with TestClient(
+            TestServer(runtime.app),
+            cookie_jar=CookieJar(unsafe=True),
+        ) as client:
+            denied = await client.get("/control/candidates")
+            assert denied.status == 401
+
+            origin = str(client.make_url("/")).rstrip("/")
+            bootstrapped = await client.post(
+                "/control/api/session/bootstrap",
+                json={"token": token},
+                headers={"Origin": origin},
+            )
+            assert bootstrapped.status == 200
+            csrf = (await bootstrapped.json())["data"]["csrf_token"]
+
+            page = await client.get("/control/candidates")
+            assert page.status == 200
+            assert "待确认建议" in await page.text()
+
+            pending = await client.get(
+                "/control/api/private-world/candidates?limit=10"
+            )
+            assert pending.status == 200
+            values = (await pending.json())["data"]["candidates"]
+            assert values[0]["candidate_id"] == candidate.candidate_id
+
+            approved = await client.post(
+                f"/control/api/private-world/candidates/"
+                f"{candidate.candidate_id}/approve",
+                json={
+                    "request_id": "runtime-review.fixture.1",
+                    "reason": "用户在管理界面确认应记录为冲突。",
+                    "decided_at": (
+                        NOW + timedelta(minutes=5)
+                    ).isoformat(),
+                },
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert approved.status == 200
+            assert (await approved.json())["data"]["status"] == (
+                "approved"
+            )
+
+        assert runtime.ledger.snapshot().tension == 3
+        assert runtime.candidate_store.get(
+            candidate.candidate_id
+        ).status is CandidateStatus.APPROVED
+
+    asyncio.run(scenario())
+
+
+def test_runtime_status_is_sanitized_and_tracks_counts(tmp_path: Path) -> None:
+    runtime = create_control_center_runtime(
+        (tmp_path / "private_world.sqlite3").resolve()
+    )
+    runtime.candidate_store.add(_candidate())
+    runtime.issue_bootstrap_url()
+
+    status = runtime.public_status()
+    assert status["schema_version"] == CONTROL_CENTER_RUNTIME_SCHEMA
+    assert status["status"] == "available"
+    assert status["network_scope"] == "loopback"
+    assert status["candidates"]["pending"] == 1
+    assert status["sessions"]["pending_bootstraps"] == 1
+
+    encoded = repr(status)
+    assert str(tmp_path) not in encoded
+    assert "sqlite3" not in encoded
+    assert "relationship" not in encoded
+    assert "summary" not in encoded
+
+
+def test_configured_runtime_uses_default_private_world_path(
+    tmp_path: Path,
+) -> None:
+    runtime = create_configured_control_center_runtime(
+        {
+            "OLIVIA_LOCAL_DATA_ROOT": str(tmp_path.resolve()),
+            "OLIVIA_PRIVATE_WORLD_ENABLED": "1",
+        }
+    )
+    expected = (
+        tmp_path / "private_world" / "private_world.sqlite3"
+    ).resolve()
+    assert expected.is_file()
+    assert runtime.ledger.health()["status"] == "READY"
+
+
+def test_invalid_or_disabled_runtime_fails_with_stable_codes(
+    tmp_path: Path,
+) -> None:
+    try:
+        create_control_center_runtime(Path("relative.sqlite3"))
+    except ControlCenterRuntimeError as exc:
+        assert exc.code == "CONTROL_CENTER_DATABASE_INVALID"
+    else:
+        raise AssertionError("relative database path must be rejected")
+
+    try:
+        create_configured_control_center_runtime(
+            {
+                "OLIVIA_LOCAL_DATA_ROOT": str(tmp_path.resolve()),
+                "OLIVIA_PRIVATE_WORLD_ENABLED": "0",
+            }
+        )
+    except ControlCenterRuntimeError as exc:
+        assert exc.code == "PRIVATE_WORLD_DISABLED"
+    else:
+        raise AssertionError("disabled PrivateWorld must be explicit")
+
+    try:
+        create_control_center_runtime(tmp_path.resolve())
+    except ControlCenterRuntimeError as exc:
+        assert exc.code == "CONTROL_CENTER_DATABASE_INVALID"
+    else:
+        raise AssertionError("directory paths must be rejected")


### PR DESCRIPTION
Implements the runtime-assembly slice shared by #33, #35, and #37.

## Scope

- constructs one explicit local runtime over the configured PrivateWorld SQLite database;
- shares the same ledger and typed command service between the existing PrivateWorld management API and candidate approvals;
- creates the candidate store and concrete candidate decision backend;
- mounts the protected candidate API and graphical review page onto the canonical Control Center app;
- exposes a path-free, content-free status summary for ledger, candidate, and session counts;
- issues one-use browser URLs with the bootstrap token in the URL fragment rather than the HTTP query;
- resolves the installed default database through the existing PrivateWorld runtime configuration;
- opens no socket and launches no browser in this PR, keeping Windows process/shortcut wiring separate.

## Tests

- full in-process bootstrap, protected page, pending list, approval, ledger mutation, and candidate decision flow;
- one shared ledger/service/store invariant;
- path-free status and pending-bootstrap counts;
- configured default database path;
- invalid, directory, and disabled storage failure codes.

## Boundary

This PR is the application factory only. The next launcher slice starts it on loopback, creates a one-use token when the user opens Control Center, and adds Windows shortcuts. Automatic candidate analysis remains disabled.

Part of #33, #35, and #37.