### PR TITLE
feat(memory): wire configured Mem0 retrieval into Persona prompt context

### DIFF
--- a/companion_memory_context.py
+++ b/companion_memory_context.py
@@ -135,6 +135,7 @@ class CompanionMemoryPromptBuilder:
         self._fallback = MemoryPromptBuilder(
             archive_memory,
             max_results=self.max_results,
+            conversation_memory=None,
         )
 
     def build(self, query: str, *, max_chars: int | None = None) -> MemoryPrompt:
@@ -142,7 +143,8 @@ class CompanionMemoryPromptBuilder:
         if budget <= 0 or not isinstance(query, str) or not query.strip():
             return MemoryPrompt(status="disabled")
 
-        if not bool(getattr(self.conversation_memory, "enabled", False)):
+        conversation_status = _port_status(self.conversation_memory)
+        if conversation_status == "disabled":
             return self._fallback.build(query, max_chars=budget)
 
         current_budget = max(0, int(budget * self.current_share))
@@ -155,12 +157,14 @@ class CompanionMemoryPromptBuilder:
             max_results=self.max_results,
             legacy_budget=0,
             conversation_budget=current_budget,
+            conversation_memory=None,
         ).build(query, max_chars=current_budget)
         archive = MemoryPromptBuilder(
             _LegacyArchiveView(self.archive_memory),
             max_results=self.max_results,
             legacy_budget=archive_budget,
             conversation_budget=0,
+            conversation_memory=None,
         ).build(query, max_chars=archive_budget)
 
         parts = tuple(prompt.text for prompt in (current, archive) if prompt.text)
@@ -173,6 +177,14 @@ class CompanionMemoryPromptBuilder:
             truncated=current.truncated or archive.truncated,
             domains=domains,
         )
+
+
+def _port_status(memory: ConversationMemoryPort) -> str:
+    try:
+        status = memory.status().status
+    except Exception:
+        return "unavailable"
+    return status if status in {"available", "degraded", "unavailable", "disabled"} else "unavailable"
 
 
 def _epoch(value: datetime | None) -> int:

--- a/memory_prompt.py
+++ b/memory_prompt.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
+from conversation_memory_port import ConversationMemoryPort
 from memory_port import CONVERSATION_MEMORY, LEGACY_LETTERS, MemoryPort, MemoryRecord
 
 
@@ -22,6 +24,7 @@ _ESCAPES = {
     "_": r"\u005F",
 }
 _UNESCAPE_RE = re.compile(r"\\u(003C|003E|005B|005C|005D|005F)")
+_AUTO_CONVERSATION_MEMORY = object()
 
 
 @dataclass(frozen=True)
@@ -86,11 +89,20 @@ class MemoryPromptBuilder:
         max_results: int = 8,
         legacy_budget: int = 1200,
         conversation_budget: int = 1200,
+        conversation_memory: ConversationMemoryPort | None | object = _AUTO_CONVERSATION_MEMORY,
+        conversation_memory_user_id: str | None = None,
     ) -> None:
         self.memory = memory
         self.max_results = max(1, min(32, int(max_results)))
         self.legacy_budget = max(0, int(legacy_budget))
         self.conversation_budget = max(0, int(conversation_budget))
+        if conversation_memory is _AUTO_CONVERSATION_MEMORY:
+            conversation_memory = _default_conversation_memory()
+        self.conversation_memory = conversation_memory
+        self.conversation_memory_user_id = _conversation_user_id(
+            conversation_memory,
+            conversation_memory_user_id,
+        )
 
     def build(self, query: str, *, max_chars: int | None = None) -> MemoryPrompt:
         budget = max(
@@ -99,6 +111,23 @@ class MemoryPromptBuilder:
         )
         if budget <= 0 or not isinstance(query, str) or not query.strip():
             return MemoryPrompt(status="disabled")
+
+        if self.conversation_memory is not None and _conversation_status(
+            self.conversation_memory
+        ) != "disabled":
+            from companion_memory_context import CompanionMemoryPromptBuilder
+
+            return CompanionMemoryPromptBuilder(
+                self.memory,
+                self.conversation_memory,
+                user_id=self.conversation_memory_user_id,
+                max_results=self.max_results,
+                current_share=_current_share(
+                    self.conversation_budget,
+                    self.legacy_budget,
+                ),
+            ).build(query, max_chars=budget)
+
         try:
             records = self.memory.search(
                 query,
@@ -176,6 +205,45 @@ class MemoryPromptBuilder:
             truncated=truncated,
             domains=tuple(used_domains),
         )
+
+
+def _default_conversation_memory() -> ConversationMemoryPort | None:
+    """Load the optional adapter lazily; disabled Core installs remain dependency-free."""
+
+    try:
+        from mem0_memory import create_mem0_adapter
+
+        return create_mem0_adapter()
+    except Exception:
+        return None
+
+
+def _conversation_status(memory: object) -> str:
+    try:
+        status = memory.status().status  # type: ignore[union-attr]
+    except Exception:
+        return "unavailable"
+    return status if status in {"available", "degraded", "unavailable", "disabled"} else "unavailable"
+
+
+def _conversation_user_id(memory: object, explicit: str | None) -> str:
+    candidates = (
+        explicit,
+        getattr(getattr(memory, "config", None), "user_id", None),
+        os.environ.get("OLIVIA_MEMORY_USER_ID"),
+        "local-user",
+    )
+    for value in candidates:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "local-user"
+
+
+def _current_share(conversation_budget: int, legacy_budget: int) -> float:
+    total = max(0, conversation_budget) + max(0, legacy_budget)
+    if total <= 0:
+        return 0.6
+    return min(0.8, max(0.2, conversation_budget / total))
 
 
 def _provenance(value: Mapping[str, Any]) -> str:

--- a/tests/memory/test_memory_prompt_mem0_wiring.py
+++ b/tests/memory/test_memory_prompt_mem0_wiring.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import mem0_memory
+from conversation_memory_port import (
+    ConversationMemoryRecord,
+    ConversationMemoryStatus,
+)
+from memory_port import CONVERSATION_MEMORY, LEGACY_LETTERS, MemoryRecord
+from memory_prompt import MemoryPromptBuilder
+
+
+NOW = datetime(2026, 8, 23, 4, 30, tzinfo=timezone.utc)
+
+
+class ArchiveMemory:
+    enabled = True
+
+    def status(self):
+        return {"status": "available", "enabled": True, "provider": "sqlite"}
+
+    def search(self, query, *, domains=None, limit=8):
+        del query, limit
+        rows = [
+            MemoryRecord(
+                memory_id="sqlite-current",
+                domain=CONVERSATION_MEMORY,
+                text="旧 SQLite 当前事实。",
+                source="sqlite",
+                created_at=1,
+                provenance={"domain": CONVERSATION_MEMORY},
+            ),
+            MemoryRecord(
+                memory_id="archive-reference",
+                domain=LEGACY_LETTERS,
+                text="旧信只读证据。",
+                source="archive",
+                created_at=1,
+                provenance={
+                    "domain": LEGACY_LETTERS,
+                    "source": "archive",
+                    "source_record_id": "legacy-1",
+                    "read_only": True,
+                },
+            ),
+        ]
+        if domains is None:
+            return rows
+        selected = set(domains)
+        return [row for row in rows if row.domain in selected]
+
+
+class CurrentMemory:
+    enabled = True
+
+    def __init__(self) -> None:
+        self.config = SimpleNamespace(user_id="mem0-scope")
+        self.calls: list[tuple[str, str, int]] = []
+
+    def status(self):
+        return ConversationMemoryStatus(
+            "available",
+            True,
+            "mem0",
+            "qdrant-local",
+            memory_count=1,
+        )
+
+    def search_context(self, query, *, user_id, limit):
+        self.calls.append((query, user_id, limit))
+        return (
+            ConversationMemoryRecord(
+                memory_id="mem0-current",
+                text="Mem0 当前事实。",
+                user_id=user_id,
+                source_id="reply:letter-1:1",
+                score=0.9,
+                occurred_at=NOW,
+                created_at=NOW,
+            ),
+        )
+
+
+class UnavailableCurrentMemory:
+    enabled = False
+
+    def status(self):
+        return ConversationMemoryStatus(
+            "unavailable",
+            False,
+            "none",
+            "none",
+            reason_code="MEM0_IMPORT_FAILED",
+        )
+
+    def search_context(self, query, *, user_id, limit):
+        del query, user_id, limit
+        return ()
+
+
+def test_default_memory_prompt_builder_uses_configured_mem0_adapter(monkeypatch) -> None:
+    current = CurrentMemory()
+    monkeypatch.setattr(mem0_memory, "create_mem0_adapter", lambda: current)
+
+    prompt = MemoryPromptBuilder(ArchiveMemory()).build("东京", max_chars=2400)
+
+    assert "Mem0 当前事实" in prompt.text
+    assert "旧信只读证据" in prompt.text
+    assert "旧 SQLite 当前事实" not in prompt.text
+    assert current.calls == [("东京", "mem0-scope", 8)]
+    assert prompt.domains == (CONVERSATION_MEMORY, LEGACY_LETTERS)
+
+
+def test_explicit_none_keeps_internal_builder_from_recursively_loading_mem0(monkeypatch) -> None:
+    def forbidden():
+        raise AssertionError("Mem0 factory must not be called")
+
+    monkeypatch.setattr(mem0_memory, "create_mem0_adapter", forbidden)
+
+    prompt = MemoryPromptBuilder(
+        ArchiveMemory(),
+        conversation_memory=None,
+    ).build("东京", max_chars=2400)
+
+    assert "旧 SQLite 当前事实" in prompt.text
+    assert "旧信只读证据" in prompt.text
+
+
+def test_configured_but_unavailable_mem0_does_not_restore_stale_sqlite_current_facts() -> None:
+    prompt = MemoryPromptBuilder(
+        ArchiveMemory(),
+        conversation_memory=UnavailableCurrentMemory(),
+    ).build("东京", max_chars=2400)
+
+    assert "旧信只读证据" in prompt.text
+    assert "旧 SQLite 当前事实" not in prompt.text
+    assert prompt.status == "degraded"
+    assert prompt.domains == (LEGACY_LETTERS,)


### PR DESCRIPTION
Completes the runtime wiring half of MEM-04 in #34, on top of #67.

## Scope

- keeps the existing `LetterAdapter` call path unchanged while making its existing `MemoryPromptBuilder` lazily load the optional Mem0 adapter;
- when Mem0 is available or configured-but-unavailable, delegates to the partitioned builder from #67;
- current-conversation facts then come only from Mem0, while legacy letters remain Archive-only;
- preserves the old SQLite conversation+Archive behavior only when the new conversation-memory provider is explicitly disabled;
- does not silently restore stale SQLite current facts when Mem0 is configured but unavailable;
- derives the local user scope from the Mem0 config or bounded runtime setting without rendering it into the prompt;
- keeps internal builder instances explicitly opt-out, preventing recursive adapter creation;
- requires no Mem0 import or dependency when the feature is disabled.

## Tests

- the default `MemoryPromptBuilder` path consumes a configured Mem0 adapter;
- Mem0 current facts and Archive references enter separate untrusted sections;
- old SQLite current facts are excluded;
- internal renderers do not recursively initialize Mem0;
- configured-but-unavailable Mem0 degrades to Archive-only context rather than stale current memory.

## Boundary

This PR performs retrieval and Persona prompt wiring only. It does not write canonical exchanges, enable Mem0 by default, download embeddings, expose a management API, or alter PrivateWorld and media behavior. MEM-05 remains the next step.