### PR TITLE
feat(memory): add non-blocking canonical exchange delivery service

### DIFF
--- a/conversation_memory_delivery.py
+++ b/conversation_memory_delivery.py
@@ -1,0 +1,236 @@
+"""Non-blocking delivery of canonical letter exchanges to long-term memory.
+
+This service owns no extraction or storage algorithm.  It validates the
+canonical exchange, derives one stable source identity, and delegates to the
+configured ConversationMemoryPort in a worker thread.  Provider failure never
+changes the already-persisted reply.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+import re
+
+from conversation_memory_port import (
+    ConversationMemoryPort,
+    MemoryWriteStatus,
+)
+
+
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_ERROR_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,95}$")
+
+
+class CanonicalMemoryDeliveryError(ValueError):
+    code = "CANONICAL_MEMORY_DELIVERY_INVALID"
+
+
+class CanonicalMemoryDeliveryStatus(StrEnum):
+    WRITTEN = "written"
+    DUPLICATE = "duplicate"
+    SKIPPED = "skipped"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class CanonicalMemoryDelivery:
+    letter_id: str
+    revision: int
+    user_message: str
+    assistant_message: str
+    occurred_at: datetime
+    user_id: str = "local-user"
+
+    def __post_init__(self) -> None:
+        for value, field_name in (
+            (self.letter_id, "letter_id"),
+            (self.user_id, "user_id"),
+        ):
+            if not isinstance(value, str) or not _ID_RE.fullmatch(value):
+                raise CanonicalMemoryDeliveryError(f"{field_name} is invalid")
+        if type(self.revision) is not int or self.revision < 1:
+            raise CanonicalMemoryDeliveryError("revision must be positive")
+        _message(self.user_message, field_name="user_message", maximum=10_000)
+        _message(
+            self.assistant_message,
+            field_name="assistant_message",
+            maximum=20_000,
+        )
+        if (
+            not isinstance(self.occurred_at, datetime)
+            or self.occurred_at.tzinfo is None
+            or self.occurred_at.utcoffset() is None
+        ):
+            raise CanonicalMemoryDeliveryError(
+                "occurred_at must be timezone-aware"
+            )
+        if len(self.source_id) > 160:
+            raise CanonicalMemoryDeliveryError("source_id is too long")
+
+    @property
+    def source_id(self) -> str:
+        return f"reply:{self.letter_id}:{self.revision}"
+
+
+@dataclass(frozen=True)
+class CanonicalMemoryDeliveryResult:
+    status: CanonicalMemoryDeliveryStatus
+    source_id: str
+    memory_count: int = 0
+    error_code: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, CanonicalMemoryDeliveryStatus):
+            raise CanonicalMemoryDeliveryError("status is invalid")
+        if not isinstance(self.source_id, str) or not self.source_id:
+            raise CanonicalMemoryDeliveryError("source_id is invalid")
+        if type(self.memory_count) is not int or self.memory_count < 0:
+            raise CanonicalMemoryDeliveryError("memory_count is invalid")
+        if self.error_code is not None and not _ERROR_RE.fullmatch(
+            self.error_code
+        ):
+            raise CanonicalMemoryDeliveryError("error_code is invalid")
+        if (
+            self.status is CanonicalMemoryDeliveryStatus.UNAVAILABLE
+            and self.error_code is None
+        ):
+            raise CanonicalMemoryDeliveryError(
+                "unavailable result requires an error code"
+            )
+        if (
+            self.status is not CanonicalMemoryDeliveryStatus.UNAVAILABLE
+            and self.error_code is not None
+        ):
+            raise CanonicalMemoryDeliveryError(
+                "successful result cannot carry an error code"
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "status": self.status.value,
+            "source_id": self.source_id,
+            "memory_count": self.memory_count,
+        }
+        if self.error_code is not None:
+            payload["error_code"] = self.error_code
+        return payload
+
+
+class ConversationMemoryDeliveryCommitter:
+    """Commit canonical exchanges without blocking the aiohttp event loop."""
+
+    def __init__(
+        self,
+        memory: ConversationMemoryPort,
+        *,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        if timeout_seconds <= 0 or timeout_seconds > 300:
+            raise ValueError("memory delivery timeout is invalid")
+        self.memory = memory
+        self.timeout_seconds = float(timeout_seconds)
+
+    async def commit(
+        self,
+        delivery: CanonicalMemoryDelivery,
+    ) -> CanonicalMemoryDeliveryResult:
+        if not isinstance(delivery, CanonicalMemoryDelivery):
+            raise TypeError("a canonical memory delivery is required")
+
+        provider_status = _provider_status(self.memory)
+        if provider_status == "disabled":
+            return CanonicalMemoryDeliveryResult(
+                CanonicalMemoryDeliveryStatus.SKIPPED,
+                delivery.source_id,
+            )
+        if provider_status == "unavailable":
+            return CanonicalMemoryDeliveryResult(
+                CanonicalMemoryDeliveryStatus.UNAVAILABLE,
+                delivery.source_id,
+                error_code=_provider_error(self.memory),
+            )
+
+        try:
+            result = await asyncio.wait_for(
+                asyncio.to_thread(
+                    self.memory.remember_exchange,
+                    user_message=delivery.user_message,
+                    assistant_message=delivery.assistant_message,
+                    occurred_at=delivery.occurred_at,
+                    source_id=delivery.source_id,
+                    user_id=delivery.user_id,
+                ),
+                timeout=self.timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            return CanonicalMemoryDeliveryResult(
+                CanonicalMemoryDeliveryStatus.UNAVAILABLE,
+                delivery.source_id,
+                error_code="MEM0_WRITE_TIMEOUT",
+            )
+        except Exception:
+            return CanonicalMemoryDeliveryResult(
+                CanonicalMemoryDeliveryStatus.UNAVAILABLE,
+                delivery.source_id,
+                error_code="MEM0_WRITE_FAILED",
+            )
+
+        mapping = {
+            MemoryWriteStatus.WRITTEN: CanonicalMemoryDeliveryStatus.WRITTEN,
+            MemoryWriteStatus.DUPLICATE: CanonicalMemoryDeliveryStatus.DUPLICATE,
+            MemoryWriteStatus.SKIPPED: CanonicalMemoryDeliveryStatus.SKIPPED,
+            MemoryWriteStatus.UNAVAILABLE: CanonicalMemoryDeliveryStatus.UNAVAILABLE,
+        }
+        status = mapping[result.status]
+        error_code = result.error_code if status is CanonicalMemoryDeliveryStatus.UNAVAILABLE else None
+        return CanonicalMemoryDeliveryResult(
+            status,
+            delivery.source_id,
+            memory_count=len(result.memory_ids),
+            error_code=error_code or (
+                "MEM0_WRITE_FAILED"
+                if status is CanonicalMemoryDeliveryStatus.UNAVAILABLE
+                else None
+            ),
+        )
+
+
+def _message(value: object, *, field_name: str, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise CanonicalMemoryDeliveryError(f"{field_name} must be text")
+    if (
+        not value.strip()
+        or len(value) > maximum
+        or any(ord(character) < 32 and character not in "\n\r\t" for character in value)
+        or any(ord(character) == 127 for character in value)
+    ):
+        raise CanonicalMemoryDeliveryError(f"{field_name} is invalid")
+    return value
+
+
+def _provider_status(memory: ConversationMemoryPort) -> str:
+    try:
+        status = memory.status().status
+    except Exception:
+        return "unavailable"
+    return status if status in {"available", "degraded", "unavailable", "disabled"} else "unavailable"
+
+
+def _provider_error(memory: ConversationMemoryPort) -> str:
+    try:
+        code = memory.status().reason_code
+    except Exception:
+        code = None
+    return code if isinstance(code, str) and _ERROR_RE.fullmatch(code) else "MEM0_WRITE_FAILED"
+
+
+__all__ = [
+    "CanonicalMemoryDelivery",
+    "CanonicalMemoryDeliveryError",
+    "CanonicalMemoryDeliveryResult",
+    "CanonicalMemoryDeliveryStatus",
+    "ConversationMemoryDeliveryCommitter",
+]

--- a/conversation_memory_delivery.py
+++ b/conversation_memory_delivery.py
@@ -184,12 +184,24 @@ class ConversationMemoryDeliveryCommitter:
             MemoryWriteStatus.SKIPPED: CanonicalMemoryDeliveryStatus.SKIPPED,
             MemoryWriteStatus.UNAVAILABLE: CanonicalMemoryDeliveryStatus.UNAVAILABLE,
         }
-        status = mapping[result.status]
-        error_code = result.error_code if status is CanonicalMemoryDeliveryStatus.UNAVAILABLE else None
+        try:
+            status = mapping[result.status]
+            memory_count = len(result.memory_ids)
+            error_code = (
+                result.error_code
+                if status is CanonicalMemoryDeliveryStatus.UNAVAILABLE
+                else None
+            )
+        except (AttributeError, KeyError, TypeError, ValueError):
+            return CanonicalMemoryDeliveryResult(
+                CanonicalMemoryDeliveryStatus.UNAVAILABLE,
+                delivery.source_id,
+                error_code="MEM0_WRITE_RESULT_INVALID",
+            )
         return CanonicalMemoryDeliveryResult(
             status,
             delivery.source_id,
-            memory_count=len(result.memory_ids),
+            memory_count=memory_count,
             error_code=error_code or (
                 "MEM0_WRITE_FAILED"
                 if status is CanonicalMemoryDeliveryStatus.UNAVAILABLE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ memory-mem0 = [
 py-modules = [
     "baseline_hardening_scan",
     "companion_memory_context",
+    "conversation_memory_delivery",
     "conversation_memory_port",
     "extract_player",
     "http_contract",

--- a/tests/memory/test_conversation_memory_delivery.py
+++ b/tests/memory/test_conversation_memory_delivery.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+import time
+
+import pytest
+
+from conversation_memory_delivery import (
+    CanonicalMemoryDelivery,
+    CanonicalMemoryDeliveryError,
+    CanonicalMemoryDeliveryStatus,
+    ConversationMemoryDeliveryCommitter,
+)
+from conversation_memory_port import (
+    ConversationMemoryStatus,
+    MemoryWriteResult,
+    MemoryWriteStatus,
+)
+
+
+NOW = datetime(2026, 8, 23, 5, 0, tzinfo=timezone.utc)
+
+
+class FakeMemory:
+    enabled = True
+
+    def __init__(
+        self,
+        *,
+        provider_status: str = "available",
+        result_status: MemoryWriteStatus = MemoryWriteStatus.WRITTEN,
+        error_code: str | None = None,
+        delay_seconds: float = 0.0,
+        raises: bool = False,
+    ) -> None:
+        self.provider_status = provider_status
+        self.result_status = result_status
+        self.error_code = error_code
+        self.delay_seconds = delay_seconds
+        self.raises = raises
+        self.calls: list[dict[str, object]] = []
+
+    def status(self) -> ConversationMemoryStatus:
+        enabled = self.provider_status not in {"disabled", "unavailable"}
+        return ConversationMemoryStatus(
+            self.provider_status,
+            enabled,
+            "mem0" if enabled else "none",
+            "qdrant-local" if enabled else "none",
+            reason_code=self.error_code,
+        )
+
+    def remember_exchange(self, **kwargs: object) -> MemoryWriteResult:
+        self.calls.append(dict(kwargs))
+        if self.delay_seconds:
+            time.sleep(self.delay_seconds)
+        if self.raises:
+            raise RuntimeError("private provider detail")
+        source_id = str(kwargs["source_id"])
+        if self.result_status is MemoryWriteStatus.UNAVAILABLE:
+            return MemoryWriteResult(
+                self.result_status,
+                source_id,
+                error_code=self.error_code or "MEM0_WRITE_FAILED",
+            )
+        ids = ("memory-1", "memory-2") if self.result_status is MemoryWriteStatus.WRITTEN else ()
+        return MemoryWriteResult(self.result_status, source_id, ids)
+
+
+class MalformedMemory(FakeMemory):
+    def remember_exchange(self, **kwargs: object):
+        self.calls.append(dict(kwargs))
+        return object()
+
+
+def _delivery(**changes: object) -> CanonicalMemoryDelivery:
+    values: dict[str, object] = {
+        "letter_id": "letter-1",
+        "revision": 2,
+        "user_message": "我现在住在东京。",
+        "assistant_message": "嗯，我记住这件事了。",
+        "occurred_at": NOW,
+        "user_id": "local-user",
+    }
+    values.update(changes)
+    return CanonicalMemoryDelivery(**values)  # type: ignore[arg-type]
+
+
+def test_available_provider_receives_exact_canonical_exchange_in_worker_thread() -> None:
+    async def scenario() -> None:
+        memory = FakeMemory()
+        result = await ConversationMemoryDeliveryCommitter(memory).commit(_delivery())
+
+        assert result.status is CanonicalMemoryDeliveryStatus.WRITTEN
+        assert result.source_id == "reply:letter-1:2"
+        assert result.memory_count == 2
+        assert result.error_code is None
+        assert memory.calls == [
+            {
+                "user_message": "我现在住在东京。",
+                "assistant_message": "嗯，我记住这件事了。",
+                "occurred_at": NOW,
+                "source_id": "reply:letter-1:2",
+                "user_id": "local-user",
+            }
+        ]
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("provider_result", "expected"),
+    [
+        (MemoryWriteStatus.DUPLICATE, CanonicalMemoryDeliveryStatus.DUPLICATE),
+        (MemoryWriteStatus.SKIPPED, CanonicalMemoryDeliveryStatus.SKIPPED),
+        (MemoryWriteStatus.UNAVAILABLE, CanonicalMemoryDeliveryStatus.UNAVAILABLE),
+    ],
+)
+def test_provider_results_are_mapped_without_private_content(
+    provider_result: MemoryWriteStatus,
+    expected: CanonicalMemoryDeliveryStatus,
+) -> None:
+    async def scenario() -> None:
+        memory = FakeMemory(
+            result_status=provider_result,
+            error_code=(
+                "MEM0_WRITE_FAILED"
+                if provider_result is MemoryWriteStatus.UNAVAILABLE
+                else None
+            ),
+        )
+        result = await ConversationMemoryDeliveryCommitter(memory).commit(_delivery())
+
+        assert result.status is expected
+        payload = result.to_dict()
+        encoded = repr(payload)
+        assert "我现在住在东京" not in encoded
+        assert "我记住这件事" not in encoded
+        if expected is CanonicalMemoryDeliveryStatus.UNAVAILABLE:
+            assert result.error_code == "MEM0_WRITE_FAILED"
+        else:
+            assert result.error_code is None
+
+    asyncio.run(scenario())
+
+
+def test_disabled_and_unavailable_ports_do_not_receive_messages() -> None:
+    async def scenario() -> None:
+        disabled = FakeMemory(provider_status="disabled")
+        skipped = await ConversationMemoryDeliveryCommitter(disabled).commit(_delivery())
+        assert skipped.status is CanonicalMemoryDeliveryStatus.SKIPPED
+        assert disabled.calls == []
+
+        unavailable = FakeMemory(
+            provider_status="unavailable",
+            error_code="MEM0_IMPORT_FAILED",
+        )
+        failed = await ConversationMemoryDeliveryCommitter(unavailable).commit(_delivery())
+        assert failed.status is CanonicalMemoryDeliveryStatus.UNAVAILABLE
+        assert failed.error_code == "MEM0_IMPORT_FAILED"
+        assert unavailable.calls == []
+
+    asyncio.run(scenario())
+
+
+def test_provider_exception_and_malformed_result_become_stable_failures() -> None:
+    async def scenario() -> None:
+        raised = await ConversationMemoryDeliveryCommitter(
+            FakeMemory(raises=True)
+        ).commit(_delivery())
+        assert raised.status is CanonicalMemoryDeliveryStatus.UNAVAILABLE
+        assert raised.error_code == "MEM0_WRITE_FAILED"
+
+        malformed = await ConversationMemoryDeliveryCommitter(
+            MalformedMemory()
+        ).commit(_delivery())
+        assert malformed.status is CanonicalMemoryDeliveryStatus.UNAVAILABLE
+        assert malformed.error_code == "MEM0_WRITE_RESULT_INVALID"
+
+    asyncio.run(scenario())
+
+
+def test_timeout_returns_without_blocking_canonical_reply_state() -> None:
+    async def scenario() -> None:
+        started = time.monotonic()
+        result = await ConversationMemoryDeliveryCommitter(
+            FakeMemory(delay_seconds=0.08),
+            timeout_seconds=0.01,
+        ).commit(_delivery())
+        elapsed = time.monotonic() - started
+
+        assert result.status is CanonicalMemoryDeliveryStatus.UNAVAILABLE
+        assert result.error_code == "MEM0_WRITE_TIMEOUT"
+        assert elapsed < 0.07
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"letter_id": "bad id"},
+        {"revision": 0},
+        {"revision": True},
+        {"user_message": ""},
+        {"assistant_message": "\x00bad"},
+        {"occurred_at": datetime(2026, 8, 23)},
+        {"user_id": "bad scope"},
+    ],
+)
+def test_delivery_contract_rejects_invalid_or_ambiguous_inputs(
+    changes: dict[str, object],
+) -> None:
+    with pytest.raises(CanonicalMemoryDeliveryError):
+        _delivery(**changes)
+
+
+def test_committer_requires_typed_delivery_and_bounded_timeout() -> None:
+    memory = FakeMemory()
+    with pytest.raises(ValueError):
+        ConversationMemoryDeliveryCommitter(memory, timeout_seconds=0)
+    with pytest.raises(ValueError):
+        ConversationMemoryDeliveryCommitter(memory, timeout_seconds=301)
+
+    async def scenario() -> None:
+        with pytest.raises(TypeError):
+            await ConversationMemoryDeliveryCommitter(memory).commit(object())  # type: ignore[arg-type]
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Implements the provider-neutral service slice of MEM-05 in #34.

## Scope

- adds a strict `CanonicalMemoryDelivery` contract over letter ID, canonical revision, user/assistant messages, user scope, and timezone-aware completion time;
- derives one stable source identity: `reply:<letter_id>:<revision>`;
- delegates the canonical exchange to the existing `ConversationMemoryPort.remember_exchange()` rather than implementing extraction or storage logic;
- executes synchronous provider work in a worker thread with a bounded timeout;
- maps written, duplicate, skipped, unavailable, timeout, exception, and malformed-provider results into stable privacy-safe states;
- never includes user or assistant content in result dictionaries or error codes;
- treats disabled memory as a clean skip and provider failure as non-blocking unavailability;
- packages the new service for installed-runtime use.

## Tests

- exact canonical message and source-ID delivery;
- written/duplicate/skipped/unavailable mapping;
- disabled and unavailable providers receive no message content;
- exception and malformed result handling;
- timeout returns without waiting for the full provider delay;
- invalid IDs, revisions, messages, timezones, scopes, and timeout bounds.

## Boundary

This PR is the delivery service only. The following MEM-05 wiring PR will call it after canonical text persistence, record pending/terminal memory status on the letter, recover pending deliveries after restart, and remove the legacy prefixed-string write from that path. It does not enable Mem0 by default or alter media and PrivateWorld behavior.