### PR TITLE
feat(memory): start durable canonical outbox in configured local runtime

### DIFF
--- a/conversation_memory_runtime.py
+++ b/conversation_memory_runtime.py
@@ -1,0 +1,365 @@
+"""Process-local runtime for optional canonical conversation-memory delivery.
+
+When Mem0 is configured, the old SQLite memory adapter remains the read-only
+Archive owner but its legacy conversation-write path is disabled.  One daemon
+thread then scans the atomically persisted letter state through the durable
+content-free outbox.  The runtime is optional, singleton, and never blocks or
+changes canonical reply persistence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import re
+import threading
+from typing import Mapping
+
+from conversation_memory_delivery import ConversationMemoryDeliveryCommitter
+from conversation_memory_outbox import CanonicalMemoryOutbox
+from conversation_memory_port import ConversationMemoryPort
+from memory_port import MemoryPort
+
+
+_ERROR_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,95}$")
+_RUNTIME_LOCK = threading.Lock()
+_RUNTIME: "ConversationMemoryRuntime | None" = None
+_RUNTIME_KEY: tuple[str, str] | None = None
+_ATEXIT_REGISTERED = False
+
+
+@dataclass(frozen=True)
+class ConversationMemoryRuntimeStatus:
+    status: str
+    enabled: bool
+    provider: str
+    worker_running: bool
+    reason_code: str | None = None
+    terminal_count: int = 0
+    pending_count: int = 0
+    attempt_count: int = 0
+
+    def __post_init__(self) -> None:
+        if self.status not in {"available", "degraded", "unavailable", "disabled"}:
+            raise ValueError("conversation memory runtime status is invalid")
+        if type(self.enabled) is not bool or type(self.worker_running) is not bool:
+            raise ValueError("runtime flags must be boolean")
+        if not isinstance(self.provider, str) or not self.provider:
+            raise ValueError("runtime provider is invalid")
+        if self.reason_code is not None and not _ERROR_RE.fullmatch(self.reason_code):
+            raise ValueError("runtime reason code is invalid")
+        for name in ("terminal_count", "pending_count", "attempt_count"):
+            value = getattr(self, name)
+            if type(value) is not int or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "status": self.status,
+            "enabled": self.enabled,
+            "provider": self.provider,
+            "worker_running": self.worker_running,
+            "terminal_count": self.terminal_count,
+            "pending_count": self.pending_count,
+            "attempt_count": self.attempt_count,
+        }
+        if self.reason_code is not None:
+            payload["reason_code"] = self.reason_code
+        return payload
+
+
+class ConversationMemoryRuntime:
+    """Own one daemon poller over a configured canonical-memory outbox."""
+
+    def __init__(
+        self,
+        outbox: CanonicalMemoryOutbox,
+        *,
+        interval_seconds: float = 5.0,
+    ) -> None:
+        if not isinstance(outbox, CanonicalMemoryOutbox):
+            raise TypeError("a canonical memory outbox is required")
+        if not 0.25 <= interval_seconds <= 3600:
+            raise ValueError("memory outbox interval is invalid")
+        self.outbox = outbox
+        self.interval_seconds = float(interval_seconds)
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._thread_lock = threading.Lock()
+
+    def start(self) -> bool:
+        with self._thread_lock:
+            if self._thread is not None and self._thread.is_alive():
+                return False
+            self._stop_event.clear()
+            self._thread = threading.Thread(
+                target=self._run,
+                name="olivia-conversation-memory-outbox",
+                daemon=True,
+            )
+            self._thread.start()
+            return True
+
+    def stop(self, *, join_timeout_seconds: float = 2.0) -> None:
+        self._stop_event.set()
+        thread = self._thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=max(0.0, float(join_timeout_seconds)))
+
+    def scan_once(self):
+        """Synchronous maintenance seam for tests and future diagnostics."""
+
+        return asyncio.run(self.outbox.scan_once())
+
+    def status(self) -> ConversationMemoryRuntimeStatus:
+        health = self.outbox.health()
+        worker_running = bool(self._thread and self._thread.is_alive())
+        raw_status = str(health.get("status", "unavailable"))
+        status = raw_status if raw_status in {"available", "degraded", "unavailable"} else "unavailable"
+        return ConversationMemoryRuntimeStatus(
+            status=status,
+            enabled=True,
+            provider="mem0-outbox",
+            worker_running=worker_running,
+            reason_code=(
+                str(health["reason_code"])
+                if isinstance(health.get("reason_code"), str)
+                and _ERROR_RE.fullmatch(str(health["reason_code"]))
+                else None
+            ),
+            terminal_count=_count(health.get("terminal_count")),
+            pending_count=_count(health.get("pending_count")),
+            attempt_count=_count(health.get("attempt_count")),
+        )
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                asyncio.run(self.outbox.scan_once())
+            except Exception:
+                # Optional memory delivery never terminates the letter runtime.
+                pass
+            if self._stop_event.wait(self.interval_seconds):
+                break
+
+
+def ensure_conversation_memory_runtime(
+    archive_memory: MemoryPort,
+    conversation_memory: ConversationMemoryPort,
+    *,
+    environ: Mapping[str, str] | None = None,
+    start_background: bool = True,
+) -> ConversationMemoryRuntimeStatus:
+    """Configure at most one outbox worker for the current local data root."""
+
+    environment = environ if environ is not None else os.environ
+    provider_status, reason_code = _provider_status(conversation_memory)
+    if provider_status == "disabled":
+        return ConversationMemoryRuntimeStatus(
+            "disabled",
+            False,
+            "none",
+            False,
+        )
+
+    _disable_legacy_conversation_writes(archive_memory)
+
+    if provider_status == "unavailable":
+        return ConversationMemoryRuntimeStatus(
+            "unavailable",
+            False,
+            "mem0",
+            False,
+            reason_code=reason_code or "MEM0_INITIALIZATION_FAILED",
+        )
+
+    if not _as_bool(environment.get("OLIVIA_MEMORY_OUTBOX_ENABLED", "1"), True):
+        return ConversationMemoryRuntimeStatus(
+            "disabled",
+            False,
+            "mem0-outbox",
+            False,
+        )
+
+    root_value = str(environment.get("OLIVIA_LOCAL_DATA_ROOT", "")).strip()
+    if not root_value:
+        return ConversationMemoryRuntimeStatus(
+            "degraded",
+            True,
+            "mem0",
+            False,
+            reason_code="MEMORY_OUTBOX_DATA_ROOT_NOT_CONFIGURED",
+        )
+    root = Path(root_value).expanduser()
+    if not root.is_absolute():
+        return ConversationMemoryRuntimeStatus(
+            "unavailable",
+            False,
+            "mem0",
+            False,
+            reason_code="MEMORY_OUTBOX_DATA_ROOT_INVALID",
+        )
+
+    user_id = _user_id(conversation_memory, environment)
+    timeout = _float(
+        environment.get("OLIVIA_MEMORY_WRITE_TIMEOUT_SECONDS"),
+        default=30.0,
+        minimum=0.1,
+        maximum=300.0,
+    )
+    interval = _float(
+        environment.get("OLIVIA_MEMORY_OUTBOX_INTERVAL_SECONDS"),
+        default=5.0,
+        minimum=0.25,
+        maximum=3600.0,
+    )
+    key = (str(root.resolve()), user_id)
+
+    global _RUNTIME, _RUNTIME_KEY, _ATEXIT_REGISTERED
+    with _RUNTIME_LOCK:
+        if _RUNTIME is None or _RUNTIME_KEY != key:
+            if _RUNTIME is not None:
+                _RUNTIME.stop()
+            try:
+                committer = ConversationMemoryDeliveryCommitter(
+                    conversation_memory,
+                    timeout_seconds=timeout,
+                )
+                outbox = CanonicalMemoryOutbox(
+                    root / "state.json",
+                    root / "memory" / "mem0" / "delivery.sqlite3",
+                    committer,
+                    user_id=user_id,
+                )
+                _RUNTIME = ConversationMemoryRuntime(
+                    outbox,
+                    interval_seconds=interval,
+                )
+                _RUNTIME_KEY = key
+            except (OSError, RuntimeError, TypeError, ValueError):
+                _RUNTIME = None
+                _RUNTIME_KEY = None
+                return ConversationMemoryRuntimeStatus(
+                    "unavailable",
+                    False,
+                    "mem0-outbox",
+                    False,
+                    reason_code="MEMORY_OUTBOX_INITIALIZATION_FAILED",
+                )
+        runtime = _RUNTIME
+        if not _ATEXIT_REGISTERED:
+            atexit.register(stop_conversation_memory_runtime)
+            _ATEXIT_REGISTERED = True
+
+    if runtime is None:
+        return ConversationMemoryRuntimeStatus(
+            "unavailable",
+            False,
+            "mem0-outbox",
+            False,
+            reason_code="MEMORY_OUTBOX_INITIALIZATION_FAILED",
+        )
+    if start_background:
+        runtime.start()
+    return runtime.status()
+
+
+def conversation_memory_runtime_status() -> ConversationMemoryRuntimeStatus:
+    with _RUNTIME_LOCK:
+        runtime = _RUNTIME
+    if runtime is None:
+        return ConversationMemoryRuntimeStatus(
+            "disabled",
+            False,
+            "none",
+            False,
+        )
+    return runtime.status()
+
+
+def stop_conversation_memory_runtime() -> None:
+    global _RUNTIME, _RUNTIME_KEY
+    with _RUNTIME_LOCK:
+        runtime = _RUNTIME
+        _RUNTIME = None
+        _RUNTIME_KEY = None
+    if runtime is not None:
+        runtime.stop()
+
+
+def _disable_legacy_conversation_writes(memory: MemoryPort) -> None:
+    if hasattr(memory, "conversation_enabled"):
+        try:
+            setattr(memory, "conversation_enabled", False)
+        except (AttributeError, TypeError, ValueError):
+            pass
+
+
+def _provider_status(
+    memory: ConversationMemoryPort,
+) -> tuple[str, str | None]:
+    try:
+        status = memory.status()
+    except Exception:
+        return "unavailable", "MEM0_STATUS_FAILED"
+    raw_status = status.status
+    if raw_status not in {"available", "degraded", "unavailable", "disabled"}:
+        return "unavailable", "MEM0_STATUS_INVALID"
+    reason = status.reason_code
+    return raw_status, reason if isinstance(reason, str) and _ERROR_RE.fullmatch(reason) else None
+
+
+def _user_id(
+    memory: ConversationMemoryPort,
+    environment: Mapping[str, str],
+) -> str:
+    for value in (
+        getattr(getattr(memory, "config", None), "user_id", None),
+        environment.get("OLIVIA_MEMORY_USER_ID"),
+        "local-user",
+    ):
+        if isinstance(value, str) and re.fullmatch(r"^[A-Za-z0-9._:-]{1,128}$", value.strip()):
+            return value.strip()
+    return "local-user"
+
+
+def _as_bool(value: object, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().casefold()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off", ""}:
+            return False
+    return default
+
+
+def _float(
+    value: object,
+    *,
+    default: float,
+    minimum: float,
+    maximum: float,
+) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if minimum <= parsed <= maximum else default
+
+
+def _count(value: object) -> int:
+    return int(value) if type(value) is int and value >= 0 else 0
+
+
+__all__ = [
+    "ConversationMemoryRuntime",
+    "ConversationMemoryRuntimeStatus",
+    "conversation_memory_runtime_status",
+    "ensure_conversation_memory_runtime",
+    "stop_conversation_memory_runtime",
+]

--- a/memory_prompt.py
+++ b/memory_prompt.py
@@ -103,6 +103,10 @@ class MemoryPromptBuilder:
             conversation_memory,
             conversation_memory_user_id,
         )
+        self.conversation_runtime_status = _ensure_conversation_runtime(
+            memory,
+            conversation_memory,
+        )
 
     def build(self, query: str, *, max_chars: int | None = None) -> MemoryPrompt:
         budget = max(
@@ -216,6 +220,34 @@ def _default_conversation_memory() -> ConversationMemoryPort | None:
         return create_mem0_adapter()
     except Exception:
         return None
+
+
+def _ensure_conversation_runtime(
+    archive_memory: MemoryPort,
+    conversation_memory: object,
+) -> dict[str, object] | None:
+    if conversation_memory is None:
+        return None
+    try:
+        from conversation_memory_runtime import ensure_conversation_memory_runtime
+
+        return ensure_conversation_memory_runtime(
+            archive_memory,
+            conversation_memory,  # type: ignore[arg-type]
+        ).to_dict()
+    except Exception:
+        # Prompt retrieval remains independently degradable when the outbox
+        # cannot be started.  No message content is logged or returned here.
+        return {
+            "status": "unavailable",
+            "enabled": False,
+            "provider": "mem0-outbox",
+            "worker_running": False,
+            "terminal_count": 0,
+            "pending_count": 0,
+            "attempt_count": 0,
+            "reason_code": "MEMORY_OUTBOX_INITIALIZATION_FAILED",
+        }
 
 
 def _conversation_status(memory: object) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ py-modules = [
     "conversation_memory_delivery",
     "conversation_memory_outbox",
     "conversation_memory_port",
+    "conversation_memory_runtime",
     "extract_player",
     "http_contract",
     "letter_status",

--- a/tests/memory/test_conversation_memory_runtime.py
+++ b/tests/memory/test_conversation_memory_runtime.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import time
+from types import SimpleNamespace
+
+from conversation_memory_port import (
+    ConversationMemoryStatus,
+    MemoryWriteResult,
+    MemoryWriteStatus,
+)
+from conversation_memory_runtime import (
+    conversation_memory_runtime_status,
+    ensure_conversation_memory_runtime,
+    stop_conversation_memory_runtime,
+)
+from memory_prompt import MemoryPromptBuilder
+
+
+class ArchiveMemory:
+    enabled = True
+
+    def __init__(self) -> None:
+        self.conversation_enabled = True
+
+    def status(self):
+        return {"status": "available", "enabled": True, "provider": "sqlite"}
+
+    def search(self, query, *, domains=None, limit=8):
+        del query, domains, limit
+        return []
+
+
+class ConversationMemory:
+    enabled = True
+
+    def __init__(self, status: str = "available") -> None:
+        self.provider_status = status
+        self.config = SimpleNamespace(user_id="local-user")
+        self.calls: list[dict[str, object]] = []
+
+    def status(self) -> ConversationMemoryStatus:
+        enabled = self.provider_status not in {"disabled", "unavailable"}
+        return ConversationMemoryStatus(
+            self.provider_status,
+            enabled,
+            "mem0" if enabled else "none",
+            "qdrant-local" if enabled else "none",
+            reason_code=(
+                "MEM0_IMPORT_FAILED"
+                if self.provider_status == "unavailable"
+                else None
+            ),
+        )
+
+    def search_context(self, query, *, user_id, limit):
+        del query, user_id, limit
+        return ()
+
+    def remember_exchange(self, **kwargs: object) -> MemoryWriteResult:
+        self.calls.append(dict(kwargs))
+        return MemoryWriteResult(
+            MemoryWriteStatus.WRITTEN,
+            str(kwargs["source_id"]),
+            ("memory-runtime-1",),
+        )
+
+
+def _write_state(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "state.json").write_text(
+        json.dumps(
+            {
+                "letters": [
+                    {
+                        "letter_id": "letter-runtime-1",
+                        "letter_status": "COMPLETED",
+                        "reply_revision": 1,
+                        "content": "用户的 canonical message。",
+                        "reply_text": "林离的 canonical reply。",
+                        "private_world_occurred_at": datetime(
+                            2026,
+                            8,
+                            23,
+                            6,
+                            0,
+                            tzinfo=timezone.utc,
+                        ).isoformat(),
+                    }
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _wait_for(predicate, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError("condition was not reached before timeout")
+
+
+def setup_function() -> None:
+    stop_conversation_memory_runtime()
+
+
+def teardown_function() -> None:
+    stop_conversation_memory_runtime()
+
+
+def test_available_mem0_starts_one_outbox_and_disables_legacy_writes(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "data"
+    _write_state(root)
+    archive = ArchiveMemory()
+    memory = ConversationMemory()
+    environment = {
+        "OLIVIA_LOCAL_DATA_ROOT": str(root.resolve()),
+        "OLIVIA_MEMORY_OUTBOX_INTERVAL_SECONDS": "0.25",
+    }
+
+    first = ensure_conversation_memory_runtime(
+        archive,
+        memory,
+        environ=environment,
+    )
+    assert first.enabled is True
+    assert archive.conversation_enabled is False
+    _wait_for(lambda: len(memory.calls) == 1)
+    assert memory.calls[0]["source_id"] == "reply:letter-runtime-1:1"
+    assert memory.calls[0]["user_message"] == "用户的 canonical message。"
+    assert memory.calls[0]["assistant_message"] == "林离的 canonical reply。"
+
+    second = ensure_conversation_memory_runtime(
+        archive,
+        memory,
+        environ=environment,
+    )
+    assert second.worker_running is True
+    time.sleep(0.35)
+    assert len(memory.calls) == 1
+    status = conversation_memory_runtime_status()
+    assert status.provider == "mem0-outbox"
+    assert status.terminal_count == 1
+    assert status.pending_count == 0
+
+
+def test_outbox_journal_prevents_duplicate_after_runtime_restart(tmp_path: Path) -> None:
+    root = tmp_path / "data"
+    _write_state(root)
+    environment = {
+        "OLIVIA_LOCAL_DATA_ROOT": str(root.resolve()),
+        "OLIVIA_MEMORY_OUTBOX_INTERVAL_SECONDS": "0.25",
+    }
+    first_memory = ConversationMemory()
+    ensure_conversation_memory_runtime(
+        ArchiveMemory(),
+        first_memory,
+        environ=environment,
+    )
+    _wait_for(lambda: len(first_memory.calls) == 1)
+    stop_conversation_memory_runtime()
+
+    second_memory = ConversationMemory()
+    ensure_conversation_memory_runtime(
+        ArchiveMemory(),
+        second_memory,
+        environ=environment,
+    )
+    time.sleep(0.4)
+    assert second_memory.calls == []
+    assert conversation_memory_runtime_status().terminal_count == 1
+
+
+def test_unavailable_mem0_disables_old_conversation_write_without_starting_worker(
+    tmp_path: Path,
+) -> None:
+    archive = ArchiveMemory()
+    status = ensure_conversation_memory_runtime(
+        archive,
+        ConversationMemory("unavailable"),
+        environ={"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path.resolve())},
+    )
+
+    assert archive.conversation_enabled is False
+    assert status.status == "unavailable"
+    assert status.reason_code == "MEM0_IMPORT_FAILED"
+    assert status.worker_running is False
+
+
+def test_disabled_mem0_preserves_existing_sqlite_conversation_behavior(
+    tmp_path: Path,
+) -> None:
+    archive = ArchiveMemory()
+    status = ensure_conversation_memory_runtime(
+        archive,
+        ConversationMemory("disabled"),
+        environ={"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path.resolve())},
+    )
+
+    assert archive.conversation_enabled is True
+    assert status.status == "disabled"
+    assert status.worker_running is False
+
+
+def test_missing_or_relative_data_root_never_starts_worker() -> None:
+    archive = ArchiveMemory()
+    missing = ensure_conversation_memory_runtime(
+        archive,
+        ConversationMemory(),
+        environ={},
+    )
+    assert archive.conversation_enabled is False
+    assert missing.status == "degraded"
+    assert missing.reason_code == "MEMORY_OUTBOX_DATA_ROOT_NOT_CONFIGURED"
+
+    stop_conversation_memory_runtime()
+    relative = ensure_conversation_memory_runtime(
+        ArchiveMemory(),
+        ConversationMemory(),
+        environ={"OLIVIA_LOCAL_DATA_ROOT": "relative/data"},
+    )
+    assert relative.status == "unavailable"
+    assert relative.reason_code == "MEMORY_OUTBOX_DATA_ROOT_INVALID"
+
+
+def test_memory_prompt_builder_configures_runtime_but_keeps_prompt_available(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    archive = ArchiveMemory()
+    memory = ConversationMemory()
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path.resolve()))
+    monkeypatch.setenv("OLIVIA_MEMORY_OUTBOX_ENABLED", "0")
+
+    builder = MemoryPromptBuilder(
+        archive,
+        conversation_memory=memory,
+    )
+
+    assert archive.conversation_enabled is False
+    assert builder.conversation_runtime_status is not None
+    assert builder.conversation_runtime_status["status"] == "disabled"
+    assert builder.build("synthetic", max_chars=1000).status == "available"


### PR DESCRIPTION
Completes the production runtime wiring slice of MEM-05 in #34 without coupling optional memory delivery to reply latency.

## Scope

- adds one process-local `ConversationMemoryRuntime` over the durable outbox from #70;
- when Mem0 is configured, disables only the legacy SQLite conversation-write path while preserving the same SQLite adapter as read-only Archive owner;
- starts one daemon worker for the configured absolute `OLIVIA_LOCAL_DATA_ROOT`;
- scans once immediately, then at a bounded interval, so already-persisted canonical replies are delivered after completion and recovered after restart;
- shares the same thread-safe Mem0 adapter used by retrieval;
- uses the content-free SQLite journal to prevent a second provider write across repeated scans, repeated builder construction, and runtime restart;
- keeps disabled Mem0 on the existing SQLite behavior;
- keeps configured-but-unavailable Mem0 honest: old current-fact writes are disabled rather than silently accumulating stale duplicate memory;
- exposes only path-free worker, terminal, pending, and attempt counts;
- starts from the existing `MemoryPromptBuilder` initialization path, so no large `local_server.py` rewrite or second product server is introduced;
- supports clean process shutdown and explicit test/diagnostic scanning.

## Tests

- available Mem0 starts one worker and receives the persisted canonical exchange;
- legacy SQLite conversation writes are disabled while Archive access remains;
- repeated configuration does not produce a second delivery;
- outbox journal prevents duplicate delivery after worker restart;
- unavailable, disabled, missing-root, relative-root, and explicit-outbox-disable behavior;
- prompt construction remains available when optional delivery is disabled.

## Boundary

This PR does not enable Mem0 by default, download embedding assets, add a management API, or change canonical text, PrivateWorld, routing, TTS, MiniMax, RoFormer, LatentSync, or FFmpeg behavior. The next memory work is the Control Center CRUD/correction/export surface and real Chinese retrieval acceptance.