### PR TITLE
feat(memory): add auditable long-term memory admin service

### DIFF
--- a/conversation_memory_admin.py
+++ b/conversation_memory_admin.py
@@ -1,0 +1,725 @@
+"""Auditable user administration over the provider-neutral memory port.
+
+The service provides bounded list/search/add/delete/correct/clear/export
+operations without reaching into Qdrant or Mem0 internals.  Its SQLite audit
+contains only request identities, target/replacement IDs, statuses, reasons,
+and timestamps—never memory text.  Correction is ordered as add replacement,
+then delete old, so a partial provider failure cannot silently erase the fact.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import StrEnum
+from pathlib import Path
+import re
+import sqlite3
+import threading
+from typing import Mapping
+
+from conversation_memory_port import (
+    ConversationMemoryPort,
+    ConversationMemoryRecord,
+    ConversationMemoryStatus,
+)
+
+
+MEMORY_ADMIN_AUDIT_SCHEMA = 1
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
+_ERROR_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,95}$")
+_OPERATIONS = frozenset({"add", "delete", "correct", "clear"})
+_AUDIT_STATUSES = frozenset(
+    {"completed", "noop", "replacement_written_delete_pending"}
+)
+
+
+class ConversationMemoryAdminError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        if not _ERROR_RE.fullmatch(code):
+            raise ValueError("memory admin error code is invalid")
+        self.code = code
+        super().__init__(code)
+
+
+class MemoryAdminMutationStatus(StrEnum):
+    APPLIED = "applied"
+    DUPLICATE = "duplicate"
+    NOOP = "noop"
+
+
+@dataclass(frozen=True)
+class MemoryAdminMutationResult:
+    status: MemoryAdminMutationStatus
+    request_id: str
+    operation: str
+    affected_count: int = 0
+    target_memory_id: str | None = None
+    replacement_memory_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, MemoryAdminMutationStatus):
+            raise ValueError("memory admin result status is invalid")
+        _identifier(self.request_id, field_name="request_id")
+        if self.operation not in _OPERATIONS:
+            raise ValueError("memory admin operation is invalid")
+        if type(self.affected_count) is not int or self.affected_count < 0:
+            raise ValueError("affected_count is invalid")
+        for value, field_name in (
+            (self.target_memory_id, "target_memory_id"),
+            (self.replacement_memory_id, "replacement_memory_id"),
+        ):
+            if value is not None:
+                _identifier(value, field_name=field_name)
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "status": self.status.value,
+            "request_id": self.request_id,
+            "operation": self.operation,
+            "affected_count": self.affected_count,
+        }
+        if self.target_memory_id is not None:
+            payload["target_memory_id"] = self.target_memory_id
+        if self.replacement_memory_id is not None:
+            payload["replacement_memory_id"] = self.replacement_memory_id
+        return payload
+
+
+@dataclass(frozen=True)
+class MemoryAdminStatus:
+    status: str
+    provider: str
+    enabled: bool
+    memory_count: int | None
+    audit_count: int
+    pending_correction_count: int
+    reason_code: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status not in {"available", "degraded", "unavailable", "disabled"}:
+            raise ValueError("memory admin status is invalid")
+        if not isinstance(self.provider, str) or not self.provider:
+            raise ValueError("memory admin provider is invalid")
+        if type(self.enabled) is not bool:
+            raise ValueError("memory admin enabled flag is invalid")
+        if self.memory_count is not None and (
+            type(self.memory_count) is not int or self.memory_count < 0
+        ):
+            raise ValueError("memory_count is invalid")
+        for name in ("audit_count", "pending_correction_count"):
+            value = getattr(self, name)
+            if type(value) is not int or value < 0:
+                raise ValueError(f"{name} is invalid")
+        if self.reason_code is not None and not _ERROR_RE.fullmatch(self.reason_code):
+            raise ValueError("memory admin reason code is invalid")
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "status": self.status,
+            "provider": self.provider,
+            "enabled": self.enabled,
+            "audit_count": self.audit_count,
+            "pending_correction_count": self.pending_correction_count,
+        }
+        if self.memory_count is not None:
+            payload["memory_count"] = self.memory_count
+        if self.reason_code is not None:
+            payload["reason_code"] = self.reason_code
+        return payload
+
+
+class ConversationMemoryAdminService:
+    """Serialize user mutations and preserve recoverable correction intent."""
+
+    def __init__(
+        self,
+        memory: ConversationMemoryPort,
+        audit_path: Path,
+        *,
+        user_id: str = "local-user",
+    ) -> None:
+        path = Path(audit_path)
+        if str(path) in {"", "."} or path.exists() and path.is_dir():
+            raise ValueError("an explicit memory admin audit file is required")
+        _identifier(user_id, field_name="user_id")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self.memory = memory
+        self.audit_path = path
+        self.user_id = user_id
+        self._lock = threading.RLock()
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.audit_path, timeout=5)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA busy_timeout=5000")
+        return connection
+
+    def _initialize(self) -> None:
+        try:
+            with self._connect() as connection:
+                version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+                if version not in {0, MEMORY_ADMIN_AUDIT_SCHEMA}:
+                    raise ConversationMemoryAdminError(
+                        "MEMORY_ADMIN_SCHEMA_UNSUPPORTED"
+                    )
+                connection.executescript(
+                    """
+                    CREATE TABLE IF NOT EXISTS memory_admin_operations (
+                        request_id TEXT PRIMARY KEY,
+                        operation TEXT NOT NULL CHECK (
+                            operation IN ('add', 'delete', 'correct', 'clear')
+                        ),
+                        target_memory_id TEXT,
+                        replacement_memory_id TEXT,
+                        replacement_source_id TEXT,
+                        status TEXT NOT NULL CHECK (
+                            status IN (
+                                'completed',
+                                'noop',
+                                'replacement_written_delete_pending'
+                            )
+                        ),
+                        affected_count INTEGER NOT NULL CHECK (affected_count >= 0),
+                        reason TEXT NOT NULL,
+                        created_at TEXT NOT NULL,
+                        updated_at TEXT NOT NULL
+                    );
+                    """
+                )
+                connection.execute(
+                    f"PRAGMA user_version={MEMORY_ADMIN_AUDIT_SCHEMA}"
+                )
+        except ConversationMemoryAdminError:
+            raise
+        except (OSError, sqlite3.Error, ValueError) as exc:
+            raise ConversationMemoryAdminError(
+                "MEMORY_ADMIN_INITIALIZATION_FAILED"
+            ) from exc
+
+    def list_memories(
+        self,
+        *,
+        query: str | None = None,
+        limit: int = 100,
+    ) -> tuple[ConversationMemoryRecord, ...]:
+        self._require_available()
+        if type(limit) is not int or not 1 <= limit <= 1000:
+            raise ConversationMemoryAdminError("MEMORY_ADMIN_LIMIT_INVALID")
+        try:
+            if query is None or not query.strip():
+                return self.memory.list_memories(
+                    user_id=self.user_id,
+                    limit=limit,
+                )
+            if not isinstance(query, str) or len(query) > 2000:
+                raise ConversationMemoryAdminError("MEMORY_ADMIN_QUERY_INVALID")
+            return self.memory.search_context(
+                query.strip(),
+                user_id=self.user_id,
+                limit=min(limit, 100),
+            )
+        except ConversationMemoryAdminError:
+            raise
+        except Exception as exc:
+            raise ConversationMemoryAdminError(
+                "MEMORY_ADMIN_READ_FAILED"
+            ) from exc
+
+    def add(
+        self,
+        text: str,
+        *,
+        request_id: str,
+        reason: str,
+    ) -> MemoryAdminMutationResult:
+        request_id = _identifier(request_id, field_name="request_id")
+        text = _text(text, field_name="memory text", maximum=2000)
+        reason = _text(reason, field_name="reason", maximum=500)
+        source_id = f"manual:{request_id}"
+        with self._lock:
+            existing = self._existing_result(request_id, "add")
+            if existing is not None:
+                return existing
+            record = self._record_by_source(source_id)
+            if record is None:
+                try:
+                    record = self.memory.add_manual_memory(
+                        text,
+                        user_id=self.user_id,
+                        source_id=source_id,
+                    )
+                except Exception as exc:
+                    raise ConversationMemoryAdminError(
+                        "MEMORY_ADMIN_ADD_FAILED"
+                    ) from exc
+            self._write_audit(
+                request_id=request_id,
+                operation="add",
+                status="completed",
+                reason=reason,
+                replacement_memory_id=record.memory_id,
+                replacement_source_id=source_id,
+                affected_count=1,
+            )
+            return MemoryAdminMutationResult(
+                MemoryAdminMutationStatus.APPLIED,
+                request_id,
+                "add",
+                affected_count=1,
+                replacement_memory_id=record.memory_id,
+            )
+
+    def delete(
+        self,
+        memory_id: str,
+        *,
+        request_id: str,
+        reason: str,
+    ) -> MemoryAdminMutationResult:
+        memory_id = _identifier(memory_id, field_name="memory_id")
+        request_id = _identifier(request_id, field_name="request_id")
+        reason = _text(reason, field_name="reason", maximum=500)
+        with self._lock:
+            existing = self._existing_result(request_id, "delete")
+            if existing is not None:
+                return existing
+            if self._record_by_id(memory_id) is None:
+                self._write_audit(
+                    request_id=request_id,
+                    operation="delete",
+                    status="noop",
+                    reason=reason,
+                    target_memory_id=memory_id,
+                    affected_count=0,
+                )
+                return MemoryAdminMutationResult(
+                    MemoryAdminMutationStatus.NOOP,
+                    request_id,
+                    "delete",
+                    target_memory_id=memory_id,
+                )
+            try:
+                deleted = self.memory.delete_memory(
+                    memory_id,
+                    user_id=self.user_id,
+                )
+            except Exception as exc:
+                raise ConversationMemoryAdminError(
+                    "MEMORY_ADMIN_DELETE_FAILED"
+                ) from exc
+            if not deleted and self._record_by_id(memory_id) is not None:
+                raise ConversationMemoryAdminError("MEMORY_ADMIN_DELETE_FAILED")
+            self._write_audit(
+                request_id=request_id,
+                operation="delete",
+                status="completed",
+                reason=reason,
+                target_memory_id=memory_id,
+                affected_count=1,
+            )
+            return MemoryAdminMutationResult(
+                MemoryAdminMutationStatus.APPLIED,
+                request_id,
+                "delete",
+                affected_count=1,
+                target_memory_id=memory_id,
+            )
+
+    def correct(
+        self,
+        memory_id: str,
+        corrected_text: str,
+        *,
+        request_id: str,
+        reason: str,
+    ) -> MemoryAdminMutationResult:
+        memory_id = _identifier(memory_id, field_name="memory_id")
+        request_id = _identifier(request_id, field_name="request_id")
+        corrected_text = _text(
+            corrected_text,
+            field_name="corrected memory text",
+            maximum=2000,
+        )
+        reason = _text(reason, field_name="reason", maximum=500)
+        source_id = f"correction:{request_id}"
+        with self._lock:
+            existing = self._audit_row(request_id)
+            if existing is not None:
+                if str(existing["operation"]) != "correct":
+                    raise ConversationMemoryAdminError(
+                        "MEMORY_ADMIN_REQUEST_CONFLICT"
+                    )
+                if str(existing["status"]) in {"completed", "noop"}:
+                    return self._result_from_row(existing, duplicate=True)
+                replacement = self._record_by_source(
+                    str(existing["replacement_source_id"] or source_id)
+                )
+            else:
+                replacement = self._record_by_source(source_id)
+
+            original = self._record_by_id(memory_id)
+            if replacement is None:
+                if original is None:
+                    self._write_audit(
+                        request_id=request_id,
+                        operation="correct",
+                        status="noop",
+                        reason=reason,
+                        target_memory_id=memory_id,
+                        replacement_source_id=source_id,
+                        affected_count=0,
+                    )
+                    return MemoryAdminMutationResult(
+                        MemoryAdminMutationStatus.NOOP,
+                        request_id,
+                        "correct",
+                        target_memory_id=memory_id,
+                    )
+                try:
+                    replacement = self.memory.add_manual_memory(
+                        corrected_text,
+                        user_id=self.user_id,
+                        source_id=source_id,
+                    )
+                except Exception as exc:
+                    raise ConversationMemoryAdminError(
+                        "MEMORY_ADMIN_CORRECTION_WRITE_FAILED"
+                    ) from exc
+                self._write_audit(
+                    request_id=request_id,
+                    operation="correct",
+                    status="replacement_written_delete_pending",
+                    reason=reason,
+                    target_memory_id=memory_id,
+                    replacement_memory_id=replacement.memory_id,
+                    replacement_source_id=source_id,
+                    affected_count=1,
+                )
+
+            if original is not None:
+                try:
+                    deleted = self.memory.delete_memory(
+                        memory_id,
+                        user_id=self.user_id,
+                    )
+                except Exception as exc:
+                    raise ConversationMemoryAdminError(
+                        "MEMORY_ADMIN_CORRECTION_DELETE_FAILED"
+                    ) from exc
+                if not deleted and self._record_by_id(memory_id) is not None:
+                    raise ConversationMemoryAdminError(
+                        "MEMORY_ADMIN_CORRECTION_DELETE_FAILED"
+                    )
+
+            self._write_audit(
+                request_id=request_id,
+                operation="correct",
+                status="completed",
+                reason=reason,
+                target_memory_id=memory_id,
+                replacement_memory_id=replacement.memory_id,
+                replacement_source_id=source_id,
+                affected_count=2 if original is not None else 1,
+            )
+            return MemoryAdminMutationResult(
+                MemoryAdminMutationStatus.APPLIED,
+                request_id,
+                "correct",
+                affected_count=2 if original is not None else 1,
+                target_memory_id=memory_id,
+                replacement_memory_id=replacement.memory_id,
+            )
+
+    def clear(
+        self,
+        *,
+        request_id: str,
+        reason: str,
+        confirmed: bool,
+    ) -> MemoryAdminMutationResult:
+        request_id = _identifier(request_id, field_name="request_id")
+        reason = _text(reason, field_name="reason", maximum=500)
+        if confirmed is not True:
+            raise ConversationMemoryAdminError(
+                "MEMORY_ADMIN_CONFIRMATION_REQUIRED"
+            )
+        with self._lock:
+            existing = self._existing_result(request_id, "clear")
+            if existing is not None:
+                return existing
+            records = self.list_memories(limit=1000)
+            if not records:
+                self._write_audit(
+                    request_id=request_id,
+                    operation="clear",
+                    status="noop",
+                    reason=reason,
+                    affected_count=0,
+                )
+                return MemoryAdminMutationResult(
+                    MemoryAdminMutationStatus.NOOP,
+                    request_id,
+                    "clear",
+                )
+            try:
+                count = self.memory.clear_user(user_id=self.user_id)
+            except Exception as exc:
+                raise ConversationMemoryAdminError(
+                    "MEMORY_ADMIN_CLEAR_FAILED"
+                ) from exc
+            if count <= 0 and self.list_memories(limit=1):
+                raise ConversationMemoryAdminError("MEMORY_ADMIN_CLEAR_FAILED")
+            affected = max(count, len(records))
+            self._write_audit(
+                request_id=request_id,
+                operation="clear",
+                status="completed",
+                reason=reason,
+                affected_count=affected,
+            )
+            return MemoryAdminMutationResult(
+                MemoryAdminMutationStatus.APPLIED,
+                request_id,
+                "clear",
+                affected_count=affected,
+            )
+
+    def export(self) -> dict[str, object]:
+        self._require_available()
+        try:
+            return self.memory.export_user(user_id=self.user_id)
+        except Exception as exc:
+            raise ConversationMemoryAdminError(
+                "MEMORY_ADMIN_EXPORT_FAILED"
+            ) from exc
+
+    def status(self) -> MemoryAdminStatus:
+        provider = self._provider_status()
+        try:
+            with self._connect() as connection:
+                audit_count = int(
+                    connection.execute(
+                        "SELECT COUNT(*) FROM memory_admin_operations"
+                    ).fetchone()[0]
+                )
+                pending_count = int(
+                    connection.execute(
+                        "SELECT COUNT(*) FROM memory_admin_operations "
+                        "WHERE status = 'replacement_written_delete_pending'"
+                    ).fetchone()[0]
+                )
+        except (OSError, sqlite3.Error, ValueError):
+            return MemoryAdminStatus(
+                "unavailable",
+                provider.provider,
+                False,
+                provider.memory_count,
+                0,
+                0,
+                reason_code="MEMORY_ADMIN_AUDIT_UNAVAILABLE",
+            )
+        return MemoryAdminStatus(
+            provider.status,
+            provider.provider,
+            provider.enabled,
+            provider.memory_count,
+            audit_count,
+            pending_count,
+            reason_code=provider.reason_code,
+        )
+
+    def _require_available(self) -> None:
+        status = self._provider_status()
+        if status.status == "disabled":
+            raise ConversationMemoryAdminError("MEMORY_ADMIN_DISABLED")
+        if status.status == "unavailable":
+            raise ConversationMemoryAdminError("MEMORY_ADMIN_UNAVAILABLE")
+
+    def _provider_status(self) -> ConversationMemoryStatus:
+        try:
+            status = self.memory.status()
+        except Exception as exc:
+            raise ConversationMemoryAdminError(
+                "MEMORY_ADMIN_UNAVAILABLE"
+            ) from exc
+        if not isinstance(status, ConversationMemoryStatus):
+            raise ConversationMemoryAdminError("MEMORY_ADMIN_UNAVAILABLE")
+        return status
+
+    def _records(self) -> tuple[ConversationMemoryRecord, ...]:
+        self._require_available()
+        try:
+            return self.memory.list_memories(
+                user_id=self.user_id,
+                limit=1000,
+            )
+        except Exception as exc:
+            raise ConversationMemoryAdminError(
+                "MEMORY_ADMIN_READ_FAILED"
+            ) from exc
+
+    def _record_by_id(self, memory_id: str) -> ConversationMemoryRecord | None:
+        return next(
+            (record for record in self._records() if record.memory_id == memory_id),
+            None,
+        )
+
+    def _record_by_source(self, source_id: str) -> ConversationMemoryRecord | None:
+        return next(
+            (record for record in self._records() if record.source_id == source_id),
+            None,
+        )
+
+    def _audit_row(self, request_id: str) -> sqlite3.Row | None:
+        try:
+            with self._connect() as connection:
+                return connection.execute(
+                    "SELECT * FROM memory_admin_operations WHERE request_id = ?",
+                    (request_id,),
+                ).fetchone()
+        except (OSError, sqlite3.Error) as exc:
+            raise ConversationMemoryAdminError(
+                "MEMORY_ADMIN_AUDIT_UNAVAILABLE"
+            ) from exc
+
+    def _existing_result(
+        self,
+        request_id: str,
+        operation: str,
+    ) -> MemoryAdminMutationResult | None:
+        row = self._audit_row(request_id)
+        if row is None:
+            return None
+        if str(row["operation"]) != operation:
+            raise ConversationMemoryAdminError(
+                "MEMORY_ADMIN_REQUEST_CONFLICT"
+            )
+        return self._result_from_row(row, duplicate=True)
+
+    @staticmethod
+    def _result_from_row(
+        row: sqlite3.Row,
+        *,
+        duplicate: bool,
+    ) -> MemoryAdminMutationResult:
+        status = (
+            MemoryAdminMutationStatus.DUPLICATE
+            if duplicate
+            else (
+                MemoryAdminMutationStatus.NOOP
+                if str(row["status"]) == "noop"
+                else MemoryAdminMutationStatus.APPLIED
+            )
+        )
+        return MemoryAdminMutationResult(
+            status,
+            str(row["request_id"]),
+            str(row["operation"]),
+            affected_count=int(row["affected_count"]),
+            target_memory_id=(
+                str(row["target_memory_id"])
+                if row["target_memory_id"] is not None
+                else None
+            ),
+            replacement_memory_id=(
+                str(row["replacement_memory_id"])
+                if row["replacement_memory_id"] is not None
+                else None
+            ),
+        )
+
+    def _write_audit(
+        self,
+        *,
+        request_id: str,
+        operation: str,
+        status: str,
+        reason: str,
+        affected_count: int,
+        target_memory_id: str | None = None,
+        replacement_memory_id: str | None = None,
+        replacement_source_id: str | None = None,
+    ) -> None:
+        if operation not in _OPERATIONS or status not in _AUDIT_STATUSES:
+            raise ConversationMemoryAdminError("MEMORY_ADMIN_AUDIT_INVALID")
+        timestamp = datetime.now(timezone.utc).isoformat()
+        try:
+            with self._connect() as connection:
+                existing = connection.execute(
+                    "SELECT operation, target_memory_id, replacement_source_id "
+                    "FROM memory_admin_operations WHERE request_id = ?",
+                    (request_id,),
+                ).fetchone()
+                if existing is not None and (
+                    str(existing["operation"]) != operation
+                    or (existing["target_memory_id"] or None) != target_memory_id
+                    or (existing["replacement_source_id"] or None)
+                    != replacement_source_id
+                ):
+                    raise ConversationMemoryAdminError(
+                        "MEMORY_ADMIN_REQUEST_CONFLICT"
+                    )
+                connection.execute(
+                    """
+                    INSERT INTO memory_admin_operations (
+                        request_id, operation, target_memory_id,
+                        replacement_memory_id, replacement_source_id,
+                        status, affected_count, reason, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(request_id) DO UPDATE SET
+                        replacement_memory_id = excluded.replacement_memory_id,
+                        status = excluded.status,
+                        affected_count = excluded.affected_count,
+                        reason = excluded.reason,
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        request_id,
+                        operation,
+                        target_memory_id,
+                        replacement_memory_id,
+                        replacement_source_id,
+                        status,
+                        affected_count,
+                        reason,
+                        timestamp,
+                        timestamp,
+                    ),
+                )
+        except ConversationMemoryAdminError:
+            raise
+        except (OSError, sqlite3.Error, ValueError) as exc:
+            raise ConversationMemoryAdminError(
+                "MEMORY_ADMIN_AUDIT_UNAVAILABLE"
+            ) from exc
+
+
+def _identifier(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str) or not _ID_RE.fullmatch(value):
+        raise ConversationMemoryAdminError("MEMORY_ADMIN_IDENTIFIER_INVALID")
+    return value
+
+
+def _text(value: object, *, field_name: str, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise ConversationMemoryAdminError("MEMORY_ADMIN_TEXT_INVALID")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > maximum
+        or any(ord(character) < 32 or ord(character) == 127 for character in normalized)
+    ):
+        raise ConversationMemoryAdminError("MEMORY_ADMIN_TEXT_INVALID")
+    return normalized
+
+
+__all__ = [
+    "ConversationMemoryAdminError",
+    "ConversationMemoryAdminService",
+    "MEMORY_ADMIN_AUDIT_SCHEMA",
+    "MemoryAdminMutationResult",
+    "MemoryAdminMutationStatus",
+    "MemoryAdminStatus",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ memory-mem0 = [
 py-modules = [
     "baseline_hardening_scan",
     "companion_memory_context",
+    "conversation_memory_admin",
     "conversation_memory_delivery",
     "conversation_memory_outbox",
     "conversation_memory_port",

--- a/tests/memory/test_conversation_memory_admin.py
+++ b/tests/memory/test_conversation_memory_admin.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+from conversation_memory_admin import (
+    ConversationMemoryAdminError,
+    ConversationMemoryAdminService,
+    MemoryAdminMutationStatus,
+)
+from conversation_memory_port import (
+    ConversationMemoryRecord,
+    ConversationMemoryStatus,
+)
+
+
+NOW = datetime(2026, 8, 23, 7, 0, tzinfo=timezone.utc)
+SECRET_OLD = "用户以前住在大阪。"
+SECRET_NEW = "用户现在住在东京。"
+
+
+class FakeMemory:
+    enabled = True
+
+    def __init__(self, *, provider_status: str = "available") -> None:
+        self.provider_status = provider_status
+        self.records: dict[str, ConversationMemoryRecord] = {}
+        self.operations: list[tuple[str, str]] = []
+        self.delete_failures = 0
+        self._sequence = 0
+
+    def status(self) -> ConversationMemoryStatus:
+        enabled = self.provider_status not in {"disabled", "unavailable"}
+        return ConversationMemoryStatus(
+            self.provider_status,
+            enabled,
+            "mem0" if enabled else "none",
+            "qdrant-local" if enabled else "none",
+            reason_code=(
+                "MEM0_IMPORT_FAILED"
+                if self.provider_status == "unavailable"
+                else None
+            ),
+            memory_count=len(self.records) if enabled else None,
+        )
+
+    def list_memories(self, *, user_id: str, limit: int = 100):
+        return tuple(
+            record
+            for record in self.records.values()
+            if record.user_id == user_id
+        )[:limit]
+
+    def search_context(self, query: str, *, user_id: str, limit: int):
+        needle = query.casefold()
+        return tuple(
+            record
+            for record in self.list_memories(user_id=user_id, limit=1000)
+            if needle in record.text.casefold()
+        )[:limit]
+
+    def add_manual_memory(self, text: str, *, user_id: str, source_id: str):
+        self.operations.append(("add", source_id))
+        for record in self.records.values():
+            if record.user_id == user_id and record.source_id == source_id:
+                return record
+        self._sequence += 1
+        memory_id = f"memory-{self._sequence}"
+        record = ConversationMemoryRecord(
+            memory_id=memory_id,
+            text=text,
+            user_id=user_id,
+            source_id=source_id,
+            occurred_at=NOW,
+            created_at=NOW,
+            metadata={"manual": True, "actor": "local_user"},
+        )
+        self.records[memory_id] = record
+        return record
+
+    def delete_memory(self, memory_id: str, *, user_id: str) -> bool:
+        self.operations.append(("delete", memory_id))
+        if self.delete_failures:
+            self.delete_failures -= 1
+            return False
+        record = self.records.get(memory_id)
+        if record is None or record.user_id != user_id:
+            return False
+        del self.records[memory_id]
+        return True
+
+    def clear_user(self, *, user_id: str) -> int:
+        self.operations.append(("clear", user_id))
+        matching = [
+            memory_id
+            for memory_id, record in self.records.items()
+            if record.user_id == user_id
+        ]
+        for memory_id in matching:
+            del self.records[memory_id]
+        return len(matching)
+
+    def export_user(self, *, user_id: str):
+        return {
+            "schema_version": "p03.conversation-memory-export.v1",
+            "user_id": user_id,
+            "provider": "mem0",
+            "records": [
+                record.to_prompt_dict()
+                for record in self.list_memories(user_id=user_id, limit=1000)
+            ],
+        }
+
+
+def _service(tmp_path: Path, memory: FakeMemory) -> ConversationMemoryAdminService:
+    return ConversationMemoryAdminService(
+        memory,
+        tmp_path / "memory" / "admin.sqlite3",
+    )
+
+
+def _seed(memory: FakeMemory, text: str = SECRET_OLD) -> ConversationMemoryRecord:
+    return memory.add_manual_memory(
+        text,
+        user_id="local-user",
+        source_id="manual:seed",
+    )
+
+
+def test_list_search_status_and_export_use_only_provider_port(tmp_path: Path) -> None:
+    memory = FakeMemory()
+    seeded = _seed(memory)
+    service = _service(tmp_path, memory)
+
+    assert service.list_memories() == (seeded,)
+    assert service.list_memories(query="大阪") == (seeded,)
+    assert service.list_memories(query="东京") == ()
+    assert service.status().to_dict() == {
+        "status": "available",
+        "provider": "mem0",
+        "enabled": True,
+        "audit_count": 0,
+        "pending_correction_count": 0,
+        "memory_count": 1,
+    }
+    exported = service.export()
+    assert exported["records"][0]["memory_id"] == seeded.memory_id
+    assert exported["records"][0]["text"] == SECRET_OLD
+
+
+def test_add_is_idempotent_and_audit_contains_no_memory_text(tmp_path: Path) -> None:
+    memory = FakeMemory()
+    service = _service(tmp_path, memory)
+
+    first = service.add(
+        SECRET_NEW,
+        request_id="add.request-1",
+        reason="用户明确要求记住当前居住地。",
+    )
+    second = service.add(
+        SECRET_NEW,
+        request_id="add.request-1",
+        reason="用户明确要求记住当前居住地。",
+    )
+
+    assert first.status is MemoryAdminMutationStatus.APPLIED
+    assert second.status is MemoryAdminMutationStatus.DUPLICATE
+    assert first.replacement_memory_id == second.replacement_memory_id
+    assert memory.operations == [("add", "manual:add.request-1")]
+    audit_bytes = service.audit_path.read_bytes()
+    assert SECRET_NEW.encode("utf-8") not in audit_bytes
+    assert service.status().audit_count == 1
+
+
+def test_delete_missing_is_noop_and_existing_delete_is_idempotent(tmp_path: Path) -> None:
+    memory = FakeMemory()
+    service = _service(tmp_path, memory)
+
+    missing = service.delete(
+        "memory-missing",
+        request_id="delete.missing-1",
+        reason="清理不存在的测试记忆。",
+    )
+    assert missing.status is MemoryAdminMutationStatus.NOOP
+    assert memory.operations == []
+
+    seeded = _seed(memory)
+    deleted = service.delete(
+        seeded.memory_id,
+        request_id="delete.existing-1",
+        reason="用户确认删除错误记忆。",
+    )
+    repeated = service.delete(
+        seeded.memory_id,
+        request_id="delete.existing-1",
+        reason="用户确认删除错误记忆。",
+    )
+    assert deleted.status is MemoryAdminMutationStatus.APPLIED
+    assert repeated.status is MemoryAdminMutationStatus.DUPLICATE
+    assert seeded.memory_id not in memory.records
+    assert memory.operations.count(("delete", seeded.memory_id)) == 1
+
+
+def test_correction_adds_replacement_before_deleting_old_memory(tmp_path: Path) -> None:
+    memory = FakeMemory()
+    original = _seed(memory)
+    memory.operations.clear()
+    service = _service(tmp_path, memory)
+
+    result = service.correct(
+        original.memory_id,
+        SECRET_NEW,
+        request_id="correct.request-1",
+        reason="用户纠正了居住地。",
+    )
+    duplicate = service.correct(
+        original.memory_id,
+        SECRET_NEW,
+        request_id="correct.request-1",
+        reason="用户纠正了居住地。",
+    )
+
+    assert result.status is MemoryAdminMutationStatus.APPLIED
+    assert duplicate.status is MemoryAdminMutationStatus.DUPLICATE
+    assert memory.operations == [
+        ("add", "correction:correct.request-1"),
+        ("delete", original.memory_id),
+    ]
+    assert original.memory_id not in memory.records
+    replacement = memory.records[result.replacement_memory_id]
+    assert replacement.text == SECRET_NEW
+    assert replacement.source_id == "correction:correct.request-1"
+    assert service.status().pending_correction_count == 0
+
+
+def test_partial_correction_retries_delete_without_writing_second_replacement(
+    tmp_path: Path,
+) -> None:
+    memory = FakeMemory()
+    original = _seed(memory)
+    memory.operations.clear()
+    memory.delete_failures = 1
+    service = _service(tmp_path, memory)
+
+    with pytest.raises(ConversationMemoryAdminError) as failed:
+        service.correct(
+            original.memory_id,
+            SECRET_NEW,
+            request_id="correct.recovery-1",
+            reason="用户纠正了居住地。",
+        )
+    assert failed.value.code == "MEMORY_ADMIN_CORRECTION_DELETE_FAILED"
+    assert service.status().pending_correction_count == 1
+    assert original.memory_id in memory.records
+    assert sum(
+        record.source_id == "correction:correct.recovery-1"
+        for record in memory.records.values()
+    ) == 1
+
+    recovered = service.correct(
+        original.memory_id,
+        SECRET_NEW,
+        request_id="correct.recovery-1",
+        reason="用户纠正了居住地。",
+    )
+    assert recovered.status is MemoryAdminMutationStatus.APPLIED
+    assert original.memory_id not in memory.records
+    assert memory.operations.count(("add", "correction:correct.recovery-1")) == 1
+    assert memory.operations.count(("delete", original.memory_id)) == 2
+    assert service.status().pending_correction_count == 0
+
+
+def test_clear_requires_confirmation_and_is_idempotent(tmp_path: Path) -> None:
+    memory = FakeMemory()
+    _seed(memory)
+    memory.add_manual_memory(
+        "用户喜欢黑胶。",
+        user_id="local-user",
+        source_id="manual:seed-2",
+    )
+    memory.operations.clear()
+    service = _service(tmp_path, memory)
+
+    with pytest.raises(ConversationMemoryAdminError) as unconfirmed:
+        service.clear(
+            request_id="clear.request-1",
+            reason="用户选择清空新对话长期记忆。",
+            confirmed=False,
+        )
+    assert unconfirmed.value.code == "MEMORY_ADMIN_CONFIRMATION_REQUIRED"
+
+    result = service.clear(
+        request_id="clear.request-1",
+        reason="用户选择清空新对话长期记忆。",
+        confirmed=True,
+    )
+    duplicate = service.clear(
+        request_id="clear.request-1",
+        reason="用户选择清空新对话长期记忆。",
+        confirmed=True,
+    )
+    assert result.status is MemoryAdminMutationStatus.APPLIED
+    assert result.affected_count == 2
+    assert duplicate.status is MemoryAdminMutationStatus.DUPLICATE
+    assert memory.records == {}
+    assert memory.operations == [("clear", "local-user")]
+
+
+@pytest.mark.parametrize(
+    ("provider_status", "expected"),
+    [
+        ("disabled", "MEMORY_ADMIN_DISABLED"),
+        ("unavailable", "MEMORY_ADMIN_UNAVAILABLE"),
+    ],
+)
+def test_disabled_or_unavailable_provider_rejects_user_operations(
+    tmp_path: Path,
+    provider_status: str,
+    expected: str,
+) -> None:
+    service = _service(tmp_path, FakeMemory(provider_status=provider_status))
+    with pytest.raises(ConversationMemoryAdminError) as raised:
+        service.list_memories()
+    assert raised.value.code == expected
+
+
+def test_request_id_cannot_be_reused_for_another_operation(tmp_path: Path) -> None:
+    memory = FakeMemory()
+    service = _service(tmp_path, memory)
+    added = service.add(
+        SECRET_NEW,
+        request_id="shared.request-1",
+        reason="添加一条明确事实。",
+    )
+
+    with pytest.raises(ConversationMemoryAdminError) as conflict:
+        service.delete(
+            added.replacement_memory_id,
+            request_id="shared.request-1",
+            reason="错误地复用请求编号。",
+        )
+    assert conflict.value.code == "MEMORY_ADMIN_REQUEST_CONFLICT"
+    assert added.replacement_memory_id in memory.records
+
+
+def test_unsupported_audit_schema_fails_closed(tmp_path: Path) -> None:
+    audit = tmp_path / "admin.sqlite3"
+    with sqlite3.connect(audit) as connection:
+        connection.execute("PRAGMA user_version=99")
+
+    with pytest.raises(ConversationMemoryAdminError) as raised:
+        ConversationMemoryAdminService(FakeMemory(), audit)
+    assert raised.value.code == "MEMORY_ADMIN_SCHEMA_UNSUPPORTED"


### PR DESCRIPTION
Implements the provider-neutral service layer of MEM-06 in #34.

## Scope

- adds bounded list, search, manual add, delete, correction, clear, export, and status operations over `ConversationMemoryPort`;
- never reaches into Mem0 or Qdrant implementation details;
- serializes mutations with one process-local lock;
- assigns stable user request IDs and provider source IDs for retry-safe manual additions and corrections;
- records a local SQLite audit containing only request IDs, operation, target/replacement IDs, status, affected count, bounded reason, and timestamps—never memory text;
- makes add/delete/clear retries idempotent;
- implements correction as `add replacement -> audit pending -> delete old -> audit complete`, preventing a partial provider failure from silently erasing the original fact;
- retries a pending correction by reusing the existing replacement rather than writing another one;
- distinguishes applied, duplicate, and no-op outcomes;
- requires explicit confirmation before clearing all new-conversation memory;
- keeps disabled/unavailable providers honest through stable error codes;
- packages the service for the future authenticated Control Center API.

## Tests

- list/search/status/export;
- idempotent manual add with content-free audit;
- missing and existing delete behavior;
- correction order and duplicate retry;
- recovery after replacement write succeeds but old-memory deletion fails;
- clear confirmation and idempotency;
- disabled/unavailable providers;
- request-ID operation conflicts;
- unsupported audit schema refusal.

## Boundary

This PR adds no HTTP route or user-facing page and does not enable Mem0 by default. MEM-06B will expose this service through the existing authenticated loopback Control Center; MEM-07 will add the graphical memory page.