### PR TITLE
feat(memory): add authenticated Control Center memory API

### DIFF
--- a/control_center/memory_api.py
+++ b/control_center/memory_api.py
@@ -1,0 +1,422 @@
+"""Authenticated Control Center API for long-term conversation memory.
+
+The shared Control Center middleware owns loopback, session, Origin, and CSRF
+checks.  This adapter exposes bounded memory records and delegates all
+mutations to the auditable provider-neutral admin service.  It never opens
+Qdrant files or returns user scope, provider configuration, credentials, or
+private-world state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Mapping, Protocol, Sequence, runtime_checkable
+
+from aiohttp import web
+
+from conversation_memory_admin import (
+    ConversationMemoryAdminError,
+    MemoryAdminMutationResult,
+    MemoryAdminStatus,
+)
+from conversation_memory_port import ConversationMemoryRecord
+
+from .private_world_api import PrivateWorldAPIError
+
+
+MEMORY_CONTROL_SCHEMA = "p03.conversation-memory-control.v1"
+MEMORY_ADMIN_KEY = web.AppKey(
+    "control_center.conversation_memory_admin",
+    object,
+)
+_MAX_LIST_LIMIT = 500
+
+
+class MemoryAPIError(PrivateWorldAPIError):
+    """Stable memory-control error handled by the shared middleware."""
+
+
+@runtime_checkable
+class MemoryControlBackend(Protocol):
+    def list_memories(
+        self,
+        *,
+        query: str | None = None,
+        limit: int = 100,
+    ) -> Sequence[ConversationMemoryRecord]: ...
+
+    def add(
+        self,
+        text: str,
+        *,
+        request_id: str,
+        reason: str,
+    ) -> MemoryAdminMutationResult: ...
+
+    def delete(
+        self,
+        memory_id: str,
+        *,
+        request_id: str,
+        reason: str,
+    ) -> MemoryAdminMutationResult: ...
+
+    def correct(
+        self,
+        memory_id: str,
+        corrected_text: str,
+        *,
+        request_id: str,
+        reason: str,
+    ) -> MemoryAdminMutationResult: ...
+
+    def clear(
+        self,
+        *,
+        request_id: str,
+        reason: str,
+        confirmed: bool,
+    ) -> MemoryAdminMutationResult: ...
+
+    def export(self) -> Mapping[str, object]: ...
+
+    def status(self) -> MemoryAdminStatus: ...
+
+
+@dataclass(frozen=True)
+class MemorySummary:
+    memory_id: str
+    text: str
+    source_id: str
+    domain: str
+    score: float | None = None
+    occurred_at: str | None = None
+    created_at: str | None = None
+
+    @classmethod
+    def from_record(cls, record: ConversationMemoryRecord) -> "MemorySummary":
+        if not isinstance(record, ConversationMemoryRecord):
+            raise MemoryAPIError(
+                "MEMORY_CONTROL_RECORD_INVALID",
+                http_status=503,
+            )
+        return cls(
+            memory_id=record.memory_id,
+            text=record.text,
+            source_id=record.source_id,
+            domain=record.domain,
+            score=record.score,
+            occurred_at=(
+                record.occurred_at.isoformat()
+                if record.occurred_at is not None
+                else None
+            ),
+            created_at=(
+                record.created_at.isoformat()
+                if record.created_at is not None
+                else None
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "memory_id": self.memory_id,
+            "text": self.text,
+            "source_id": self.source_id,
+            "domain": self.domain,
+        }
+        if self.score is not None:
+            payload["score"] = round(float(self.score), 6)
+        if self.occurred_at is not None:
+            payload["occurred_at"] = self.occurred_at
+        if self.created_at is not None:
+            payload["created_at"] = self.created_at
+        return payload
+
+
+def _response(data: Mapping[str, object]) -> web.Response:
+    return web.json_response({"ok": True, "data": dict(data)})
+
+
+async def _json_body(request: web.Request) -> object:
+    if request.content_type != "application/json":
+        raise web.HTTPUnsupportedMediaType()
+    return await request.json(loads=json.loads)
+
+
+def _strict_body(
+    value: object,
+    *,
+    required: Sequence[str],
+) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise MemoryAPIError("CONTROL_BODY_INVALID")
+    expected = frozenset(required)
+    if frozenset(value) != expected or any(
+        not isinstance(key, str) for key in value
+    ):
+        raise MemoryAPIError("CONTROL_BODY_FIELDS_INVALID")
+    return value
+
+
+def _backend(request: web.Request) -> MemoryControlBackend:
+    backend = request.app.get(MEMORY_ADMIN_KEY)
+    if not isinstance(backend, MemoryControlBackend):
+        raise MemoryAPIError(
+            "MEMORY_CONTROL_UNAVAILABLE",
+            http_status=503,
+        )
+    return backend
+
+
+def _limit(value: object, *, maximum: int = _MAX_LIST_LIMIT) -> int:
+    if isinstance(value, bool):
+        raise MemoryAPIError("CONTROL_LIMIT_INVALID")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise MemoryAPIError("CONTROL_LIMIT_INVALID") from exc
+    if not 1 <= parsed <= maximum:
+        raise MemoryAPIError("CONTROL_LIMIT_INVALID")
+    return parsed
+
+
+def _call(function, *args, **kwargs):
+    try:
+        return function(*args, **kwargs)
+    except ConversationMemoryAdminError as exc:
+        raise MemoryAPIError(
+            exc.code,
+            http_status=_admin_http_status(exc.code),
+        ) from exc
+    except MemoryAPIError:
+        raise
+    except (OSError, RuntimeError, TypeError, ValueError, KeyError) as exc:
+        raise MemoryAPIError(
+            "MEMORY_CONTROL_UNAVAILABLE",
+            http_status=503,
+        ) from exc
+
+
+def _admin_http_status(code: str) -> int:
+    if code in {
+        "MEMORY_ADMIN_DISABLED",
+        "MEMORY_ADMIN_UNAVAILABLE",
+        "MEMORY_ADMIN_READ_FAILED",
+        "MEMORY_ADMIN_ADD_FAILED",
+        "MEMORY_ADMIN_DELETE_FAILED",
+        "MEMORY_ADMIN_CORRECTION_WRITE_FAILED",
+        "MEMORY_ADMIN_CORRECTION_DELETE_FAILED",
+        "MEMORY_ADMIN_CLEAR_FAILED",
+        "MEMORY_ADMIN_EXPORT_FAILED",
+        "MEMORY_ADMIN_AUDIT_UNAVAILABLE",
+    }:
+        return 503
+    if code in {
+        "MEMORY_ADMIN_CONFIRMATION_REQUIRED",
+        "MEMORY_ADMIN_REQUEST_CONFLICT",
+    }:
+        return 409
+    return 400
+
+
+async def memory_status(request: web.Request) -> web.Response:
+    status = _call(_backend(request).status)
+    if not isinstance(status, MemoryAdminStatus):
+        raise MemoryAPIError(
+            "MEMORY_CONTROL_STATUS_INVALID",
+            http_status=503,
+        )
+    return _response(
+        {
+            "schema_version": MEMORY_CONTROL_SCHEMA,
+            **status.to_dict(),
+        }
+    )
+
+
+async def list_memories(request: web.Request) -> web.Response:
+    limit = _limit(request.query.get("limit", "100"))
+    records = tuple(
+        _call(
+            _backend(request).list_memories,
+            query=None,
+            limit=limit,
+        )
+    )
+    if len(records) > limit:
+        raise MemoryAPIError(
+            "MEMORY_CONTROL_RECORDS_INVALID",
+            http_status=503,
+        )
+    summaries = [MemorySummary.from_record(record).to_dict() for record in records]
+    return _response(
+        {
+            "schema_version": MEMORY_CONTROL_SCHEMA,
+            "status": "READY",
+            "memories": summaries,
+            "count": len(summaries),
+        }
+    )
+
+
+async def search_memories(request: web.Request) -> web.Response:
+    body = _strict_body(
+        await _json_body(request),
+        required=("query", "limit"),
+    )
+    query = body["query"]
+    if not isinstance(query, str) or not query.strip() or len(query) > 2000:
+        raise MemoryAPIError("MEMORY_CONTROL_QUERY_INVALID")
+    limit = _limit(body["limit"], maximum=100)
+    records = tuple(
+        _call(
+            _backend(request).list_memories,
+            query=query.strip(),
+            limit=limit,
+        )
+    )
+    if len(records) > limit:
+        raise MemoryAPIError(
+            "MEMORY_CONTROL_RECORDS_INVALID",
+            http_status=503,
+        )
+    summaries = [MemorySummary.from_record(record).to_dict() for record in records]
+    return _response(
+        {
+            "schema_version": MEMORY_CONTROL_SCHEMA,
+            "status": "READY",
+            "memories": summaries,
+            "count": len(summaries),
+        }
+    )
+
+
+async def add_memory(request: web.Request) -> web.Response:
+    body = _strict_body(
+        await _json_body(request),
+        required=("request_id", "text", "reason"),
+    )
+    result = _call(
+        _backend(request).add,
+        body["text"],
+        request_id=body["request_id"],
+        reason=body["reason"],
+    )
+    return _mutation_response(result)
+
+
+async def correct_memory(request: web.Request) -> web.Response:
+    body = _strict_body(
+        await _json_body(request),
+        required=("request_id", "text", "reason"),
+    )
+    result = _call(
+        _backend(request).correct,
+        request.match_info.get("memory_id", ""),
+        body["text"],
+        request_id=body["request_id"],
+        reason=body["reason"],
+    )
+    return _mutation_response(result)
+
+
+async def delete_memory(request: web.Request) -> web.Response:
+    body = _strict_body(
+        await _json_body(request),
+        required=("request_id", "reason"),
+    )
+    result = _call(
+        _backend(request).delete,
+        request.match_info.get("memory_id", ""),
+        request_id=body["request_id"],
+        reason=body["reason"],
+    )
+    return _mutation_response(result)
+
+
+async def clear_memories(request: web.Request) -> web.Response:
+    body = _strict_body(
+        await _json_body(request),
+        required=("request_id", "reason", "confirmed"),
+    )
+    if type(body["confirmed"]) is not bool:
+        raise MemoryAPIError("MEMORY_CONTROL_CONFIRMATION_INVALID")
+    result = _call(
+        _backend(request).clear,
+        request_id=body["request_id"],
+        reason=body["reason"],
+        confirmed=body["confirmed"],
+    )
+    return _mutation_response(result)
+
+
+async def export_memories(request: web.Request) -> web.Response:
+    del request
+    payload = _call(_backend(request).export)
+    if not isinstance(payload, Mapping):
+        raise MemoryAPIError(
+            "MEMORY_CONTROL_EXPORT_INVALID",
+            http_status=503,
+        )
+    return _response(
+        {
+            "schema_version": MEMORY_CONTROL_SCHEMA,
+            "status": "READY",
+            "export": dict(payload),
+        }
+    )
+
+
+def _mutation_response(result: object) -> web.Response:
+    if not isinstance(result, MemoryAdminMutationResult):
+        raise MemoryAPIError(
+            "MEMORY_CONTROL_RESULT_INVALID",
+            http_status=503,
+        )
+    return _response(
+        {
+            "schema_version": MEMORY_CONTROL_SCHEMA,
+            **result.to_dict(),
+        }
+    )
+
+
+def mount_memory_api(
+    app: web.Application,
+    backend: MemoryControlBackend,
+) -> None:
+    if not isinstance(backend, MemoryControlBackend):
+        raise TypeError("a typed memory control backend is required")
+    if MEMORY_ADMIN_KEY in app:
+        raise RuntimeError("MEMORY_CONTROL_ALREADY_MOUNTED")
+    app[MEMORY_ADMIN_KEY] = backend
+    app.add_routes(
+        [
+            web.get("/control/api/memory/status", memory_status),
+            web.get("/control/api/memory", list_memories),
+            web.post("/control/api/memory/search", search_memories),
+            web.post("/control/api/memory/manual", add_memory),
+            web.post(
+                "/control/api/memory/{memory_id}/correct",
+                correct_memory,
+            ),
+            web.delete(
+                "/control/api/memory/{memory_id}",
+                delete_memory,
+            ),
+            web.post("/control/api/memory/clear", clear_memories),
+            web.post("/control/api/memory/export", export_memories),
+        ]
+    )
+
+
+__all__ = [
+    "MEMORY_ADMIN_KEY",
+    "MEMORY_CONTROL_SCHEMA",
+    "MemoryAPIError",
+    "MemoryControlBackend",
+    "MemorySummary",
+    "mount_memory_api",
+]

--- a/control_center/memory_api.py
+++ b/control_center/memory_api.py
@@ -31,6 +31,17 @@ MEMORY_ADMIN_KEY = web.AppKey(
     object,
 )
 _MAX_LIST_LIMIT = 500
+_EXPORT_RECORD_FIELDS = frozenset(
+    {
+        "memory_id",
+        "text",
+        "source_id",
+        "domain",
+        "score",
+        "occurred_at",
+        "created_at",
+    }
+)
 
 
 class MemoryAPIError(PrivateWorldAPIError):
@@ -353,9 +364,34 @@ async def clear_memories(request: web.Request) -> web.Response:
 
 
 async def export_memories(request: web.Request) -> web.Response:
-    del request
     payload = _call(_backend(request).export)
     if not isinstance(payload, Mapping):
+        raise MemoryAPIError(
+            "MEMORY_CONTROL_EXPORT_INVALID",
+            http_status=503,
+        )
+    records = payload.get("records", ())
+    if not isinstance(records, Sequence) or isinstance(records, (str, bytes)):
+        raise MemoryAPIError(
+            "MEMORY_CONTROL_EXPORT_INVALID",
+            http_status=503,
+        )
+    sanitized: list[dict[str, object]] = []
+    for record in records:
+        if not isinstance(record, Mapping):
+            raise MemoryAPIError(
+                "MEMORY_CONTROL_EXPORT_INVALID",
+                http_status=503,
+            )
+        sanitized.append(
+            {
+                key: value
+                for key, value in record.items()
+                if isinstance(key, str) and key in _EXPORT_RECORD_FIELDS
+            }
+        )
+    provider = payload.get("provider", "mem0")
+    if not isinstance(provider, str) or not provider or len(provider) > 64:
         raise MemoryAPIError(
             "MEMORY_CONTROL_EXPORT_INVALID",
             http_status=503,
@@ -364,7 +400,11 @@ async def export_memories(request: web.Request) -> web.Response:
         {
             "schema_version": MEMORY_CONTROL_SCHEMA,
             "status": "READY",
-            "export": dict(payload),
+            "export": {
+                "schema_version": "p03.conversation-memory-export.v1",
+                "provider": provider,
+                "records": sanitized,
+            },
         }
     )
 

--- a/tests/control_center/test_memory_api.py
+++ b/tests/control_center/test_memory_api.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from threading import Lock
+
+from aiohttp import CookieJar
+from aiohttp.test_utils import TestClient, TestServer
+
+from control_center.app import AUTH_KEY, create_control_app
+from control_center.auth import CONTROL_CSRF_HEADER
+from control_center.memory_api import mount_memory_api
+from conversation_memory_admin import (
+    ConversationMemoryAdminError,
+    MemoryAdminMutationResult,
+    MemoryAdminMutationStatus,
+    MemoryAdminStatus,
+)
+from conversation_memory_port import ConversationMemoryRecord
+from private_world_ledger import LedgerEvent
+from private_world_port import PrivateWorldSnapshot
+
+
+NOW = datetime(2026, 8, 23, 8, 0, tzinfo=timezone.utc)
+
+
+class FakeLedger:
+    def __init__(self) -> None:
+        self.current = PrivateWorldSnapshot()
+        self.items: list[LedgerEvent] = []
+        self._lock = Lock()
+
+    def snapshot(self) -> PrivateWorldSnapshot:
+        return self.current
+
+    def events(self) -> tuple[LedgerEvent, ...]:
+        return tuple(self.items)
+
+    def apply_once(
+        self,
+        event: LedgerEvent,
+        snapshot: PrivateWorldSnapshot,
+    ) -> bool:
+        with self._lock:
+            if any(
+                row.event_id == event.event_id
+                or row.delivery_id == event.delivery_id
+                for row in self.items
+            ):
+                return False
+            self.items.append(event)
+            self.current = snapshot
+            return True
+
+
+class RecordingMemoryBackend:
+    def __init__(self) -> None:
+        self.record = ConversationMemoryRecord(
+            memory_id="memory-1",
+            text="用户现在住在东京。<script>not executable</script>",
+            user_id="private-user-scope",
+            source_id="reply:letter-1:1",
+            score=0.91,
+            occurred_at=NOW,
+            created_at=NOW,
+            metadata={"manual": False, "actor": "provider"},
+        )
+        self.calls: list[tuple[str, object]] = []
+        self.fail = False
+
+    def _maybe_fail(self) -> None:
+        if self.fail:
+            raise OSError("C:/private/memory/qdrant")
+
+    def list_memories(self, *, query=None, limit=100):
+        self._maybe_fail()
+        self.calls.append(("list", (query, limit)))
+        if query and "东京" not in query:
+            return ()
+        return (self.record,)[:limit]
+
+    def status(self) -> MemoryAdminStatus:
+        self._maybe_fail()
+        return MemoryAdminStatus(
+            "available",
+            "mem0",
+            True,
+            1,
+            2,
+            0,
+        )
+
+    def add(self, text, *, request_id, reason):
+        self._maybe_fail()
+        self.calls.append(("add", (text, request_id, reason)))
+        return MemoryAdminMutationResult(
+            MemoryAdminMutationStatus.APPLIED,
+            request_id,
+            "add",
+            affected_count=1,
+            replacement_memory_id="memory-added",
+        )
+
+    def correct(self, memory_id, corrected_text, *, request_id, reason):
+        self._maybe_fail()
+        self.calls.append(
+            ("correct", (memory_id, corrected_text, request_id, reason))
+        )
+        return MemoryAdminMutationResult(
+            MemoryAdminMutationStatus.APPLIED,
+            request_id,
+            "correct",
+            affected_count=2,
+            target_memory_id=memory_id,
+            replacement_memory_id="memory-corrected",
+        )
+
+    def delete(self, memory_id, *, request_id, reason):
+        self._maybe_fail()
+        self.calls.append(("delete", (memory_id, request_id, reason)))
+        return MemoryAdminMutationResult(
+            MemoryAdminMutationStatus.APPLIED,
+            request_id,
+            "delete",
+            affected_count=1,
+            target_memory_id=memory_id,
+        )
+
+    def clear(self, *, request_id, reason, confirmed):
+        self._maybe_fail()
+        self.calls.append(("clear", (request_id, reason, confirmed)))
+        if not confirmed:
+            raise ConversationMemoryAdminError(
+                "MEMORY_ADMIN_CONFIRMATION_REQUIRED"
+            )
+        return MemoryAdminMutationResult(
+            MemoryAdminMutationStatus.APPLIED,
+            request_id,
+            "clear",
+            affected_count=1,
+        )
+
+    def export(self):
+        self._maybe_fail()
+        return {
+            "schema_version": "p03.conversation-memory-export.v1",
+            "provider": "mem0",
+            "user_id": "private-user-scope",
+            "private_world": "must-not-cross",
+            "provider_config": {"api_key": "must-not-cross"},
+            "records": [
+                {
+                    **self.record.to_prompt_dict(),
+                    "user_id": "private-user-scope",
+                    "metadata": {"private": True},
+                }
+            ],
+        }
+
+
+async def _authenticated_client(
+    backend: RecordingMemoryBackend,
+) -> tuple[TestClient, str, str]:
+    app = create_control_app(FakeLedger())
+    mount_memory_api(app, backend)
+    client = TestClient(
+        TestServer(app),
+        cookie_jar=CookieJar(unsafe=True),
+    )
+    await client.start_server()
+    origin = str(client.make_url("/")).rstrip("/")
+    token = app[AUTH_KEY].issue_bootstrap_token()
+    response = await client.post(
+        "/control/api/session/bootstrap",
+        json={"token": token},
+        headers={"Origin": origin},
+    )
+    assert response.status == 200
+    csrf = (await response.json())["data"]["csrf_token"]
+    return client, origin, csrf
+
+
+def test_memory_status_list_and_search_use_shared_auth_boundary() -> None:
+    async def scenario() -> None:
+        backend = RecordingMemoryBackend()
+        app = create_control_app(FakeLedger())
+        mount_memory_api(app, backend)
+        async with TestClient(TestServer(app)) as unauthenticated:
+            denied = await unauthenticated.get("/control/api/memory/status")
+            assert denied.status == 401
+            assert (await denied.json())["error"]["code"] == (
+                "CONTROL_SESSION_REQUIRED"
+            )
+
+        client, origin, csrf = await _authenticated_client(backend)
+        try:
+            status = await client.get("/control/api/memory/status")
+            assert status.status == 200
+            status_payload = (await status.json())["data"]
+            assert status_payload["provider"] == "mem0"
+            assert status_payload["memory_count"] == 1
+
+            listed = await client.get("/control/api/memory?limit=20")
+            assert listed.status == 200
+            payload = (await listed.json())["data"]
+            assert payload["count"] == 1
+            assert payload["memories"][0]["text"].startswith(
+                "用户现在住在东京"
+            )
+            assert "user_id" not in payload["memories"][0]
+            assert "metadata" not in payload["memories"][0]
+
+            searched = await client.post(
+                "/control/api/memory/search",
+                json={"query": "东京", "limit": 5},
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert searched.status == 200
+            assert (await searched.json())["data"]["count"] == 1
+            assert backend.calls[-1] == ("list", ("东京", 5))
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_memory_mutations_require_csrf_and_delegate_strict_payloads() -> None:
+    async def scenario() -> None:
+        backend = RecordingMemoryBackend()
+        client, origin, csrf = await _authenticated_client(backend)
+        try:
+            missing_csrf = await client.post(
+                "/control/api/memory/manual",
+                json={
+                    "request_id": "memory.add-1",
+                    "text": "用户喜欢黑胶。",
+                    "reason": "用户明确要求记住。",
+                },
+                headers={"Origin": origin},
+            )
+            assert missing_csrf.status == 403
+            assert (await missing_csrf.json())["error"]["code"] == (
+                "CONTROL_CSRF_REQUIRED"
+            )
+
+            added = await client.post(
+                "/control/api/memory/manual",
+                json={
+                    "request_id": "memory.add-1",
+                    "text": "用户喜欢黑胶。",
+                    "reason": "用户明确要求记住。",
+                },
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert added.status == 200
+            assert (await added.json())["data"]["replacement_memory_id"] == (
+                "memory-added"
+            )
+
+            corrected = await client.post(
+                "/control/api/memory/memory-1/correct",
+                json={
+                    "request_id": "memory.correct-1",
+                    "text": "用户现在住在横滨。",
+                    "reason": "用户纠正了居住地。",
+                },
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert corrected.status == 200
+            assert (await corrected.json())["data"]["affected_count"] == 2
+
+            deleted = await client.delete(
+                "/control/api/memory/memory-1",
+                json={
+                    "request_id": "memory.delete-1",
+                    "reason": "用户确认删除错误记忆。",
+                },
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert deleted.status == 200
+            assert (await deleted.json())["data"]["operation"] == "delete"
+
+            unconfirmed = await client.post(
+                "/control/api/memory/clear",
+                json={
+                    "request_id": "memory.clear-1",
+                    "reason": "用户申请清空新对话记忆。",
+                    "confirmed": False,
+                },
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert unconfirmed.status == 409
+            assert (await unconfirmed.json())["error"]["code"] == (
+                "MEMORY_ADMIN_CONFIRMATION_REQUIRED"
+            )
+
+            cleared = await client.post(
+                "/control/api/memory/clear",
+                json={
+                    "request_id": "memory.clear-2",
+                    "reason": "用户确认清空新对话记忆。",
+                    "confirmed": True,
+                },
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert cleared.status == 200
+            assert (await cleared.json())["data"]["operation"] == "clear"
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_memory_export_is_authenticated_and_strips_scope_and_control_fields() -> None:
+    async def scenario() -> None:
+        backend = RecordingMemoryBackend()
+        client, origin, csrf = await _authenticated_client(backend)
+        try:
+            response = await client.post(
+                "/control/api/memory/export",
+                json={},
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert response.status == 200
+            payload = (await response.json())["data"]["export"]
+            assert payload["provider"] == "mem0"
+            assert payload["records"][0]["memory_id"] == "memory-1"
+            encoded = repr(payload)
+            assert "private-user-scope" not in encoded
+            assert "private_world" not in encoded
+            assert "provider_config" not in encoded
+            assert "api_key" not in encoded
+            assert "metadata" not in payload["records"][0]
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_memory_api_rejects_extra_fields_and_returns_path_free_backend_errors() -> None:
+    async def scenario() -> None:
+        backend = RecordingMemoryBackend()
+        client, origin, csrf = await _authenticated_client(backend)
+        try:
+            extra = await client.post(
+                "/control/api/memory/manual",
+                json={
+                    "request_id": "memory.add-extra",
+                    "text": "测试记忆。",
+                    "reason": "测试。",
+                    "private_world": "forbidden",
+                },
+                headers={
+                    "Origin": origin,
+                    CONTROL_CSRF_HEADER: csrf,
+                },
+            )
+            assert extra.status == 400
+            assert (await extra.json())["error"]["code"] == (
+                "CONTROL_BODY_FIELDS_INVALID"
+            )
+
+            backend.fail = True
+            failed = await client.get("/control/api/memory/status")
+            assert failed.status == 503
+            payload = await failed.json()
+            assert payload == {
+                "ok": False,
+                "error": {"code": "MEMORY_CONTROL_UNAVAILABLE"},
+            }
+            assert "C:/private" not in repr(payload)
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Implements the HTTP adapter portion of MEM-06 in #34.

## Scope

- mounts long-term memory administration onto the existing loopback-only, authenticated Control Center;
- reuses the shared session, same-origin, CSRF, no-store, CSP, and error-envelope middleware;
- exposes status, bounded listing, private POST search, manual add, correction, delete, clear, and export routes;
- delegates every operation to the auditable provider-neutral service from #72;
- does not access Qdrant, Mem0 internals, SQLite provider rows, or PrivateWorld directly;
- returns only memory ID, fact text, source reference, domain, bounded score, and timestamps;
- never returns user scope, provider configuration, credentials, arbitrary metadata, or private-world state;
- uses strict exact-field JSON envelopes and bounded limits;
- requires explicit boolean confirmation for clear-all;
- maps provider and audit failures to stable path-free error codes;
- sanitizes exports to the same public memory fields rather than forwarding arbitrary provider payloads.

## Tests

- unauthenticated status denial and authenticated status/list/search;
- memory text remains JSON data and user scope/metadata stay absent;
- mutation CSRF and strict payload enforcement;
- add/correct/delete/clear delegation and confirmation mapping;
- authenticated export with scope/control/config stripping;
- extra-field rejection and path-free backend failure.

## Boundary

This PR mounts no production backend and adds no graphical page. The next runtime slice will construct `ConversationMemoryAdminService` over the same configured Mem0 adapter and mount this API; MEM-07 will add the end-user memory page.