### PR TITLE
docs(client): record audited original client evidence

### DIFF
--- a/docs/P03_ORIGINAL_CLIENT_AUDIT_RESULT_0.0.9.615.md
+++ b/docs/P03_ORIGINAL_CLIENT_AUDIT_RESULT_0.0.9.615.md
@@ -1,0 +1,185 @@
+# P03 原版客户端 0.0.9.615 脱敏审计结果
+
+## 1. 证据状态
+
+本结果来自用户本机原版 `feapp.dat`，由 `tools/audit_original_client.py` 只读生成。公开证据文件：
+
+```text
+docs/evidence/original-client-audit-0.0.9.615.json
+```
+
+已核验：
+
+- `status = AUDITED`；
+- 客户端版本目录提示为 `0.0.9.615`；
+- archive SHA-256 与支持清单完全一致；
+- 主包为 `assets/main-917d29fc.js`；
+- 当前补丁需要的四类锚点均处于预期状态；
+- `safe_to_apply_existing_patch = true`。
+
+因此当前支持清单、隔离复制安装和既有 `toyApiUrl / toyWsUrl + Home -> Collection` 补丁可以继续作为客户端集成基线。
+
+## 2. 已确认的原版导航表面
+
+脱敏报告发现以下命名路由引用：
+
+```text
+Collection
+Feedback
+Home
+Login
+ModeSelect
+Share
+Studio
+Survey
+UserInfo
+```
+
+其中可直接确认：
+
+- `Collection` 是原版信箱入口；
+- `Home` 是原版默认首页；
+- `UserInfo` 是现有用户信息表面；
+- `Studio`、`Survey`、`Feedback` 等属于原版既有页面，不能为了方便擅自挪作陪伴设置页。
+
+`Settings`、`Setting` 和 `Profile` 只在主包中出现为关键词，没有被当前审计识别为命名路由。它们可能是组件、字段、第三方库文本或动态路由，不能据此声明原版存在独立设置页。
+
+## 3. 信件详情结论
+
+报告没有发现名为 `LetterDetail` 的路由引用。
+
+这不等于原版没有信件详情。更可能的情况包括：
+
+- 详情嵌在 `Collection` 页面内部；
+- 使用动态路由或未命名子路由；
+- 详情组件通过状态切换而不是命名导航打开；
+- minified 形式未被当前保守正则识别。
+
+因此 CLIENT-UI-02 不得凭空添加 `LetterDetail` 路由。下一步必须在本机真实打开一封信，记录从列表点击到详情显示过程中使用的原版请求、状态字段和播放器行为。
+
+## 4. 当前信件 wire contract 证据
+
+主包中已发现：
+
+```text
+letter_status  × 4
+reply_content  × 1
+```
+
+未发现：
+
+```text
+reply_text
+reply_video_url
+reply_mode
+media_status
+media_error_code
+```
+
+结论：
+
+1. 原版客户端确实读取 `letter_status` 和 `reply_content`，因此现有后端数值终态映射和 canonical text 字段有真实客户端依据。
+2. 当前不能声称原版主包已经理解独立 `media_status`、精确 `reply_mode` 或 `reply_video_url`。
+3. 视频可能使用其他字段、动态对象、单独播放器包或原版未被正则识别的绑定方式。
+4. 在信件详情接线前，必须先审计 `feplayer.dat`、`webplayer.dat` 以及真实视频信件的网络/播放器行为。
+
+## 5. API 和 action 扫描结论
+
+当前报告中的：
+
+```text
+action_names = []
+toy_api_paths = []
+```
+
+只说明保守扫描没有发现直接字符串形式，不说明原版没有这些调用。主包可能：
+
+- 动态拼接路径；
+- 通过统一 request wrapper 传递 action；
+- 使用压缩后的常量表；
+- 从运行时配置注入地址和接口名。
+
+现有 `getClientConfig` 锚点来自已验证的精确补丁代码，仍然有效；不能用空扫描结果推翻它。
+
+## 6. 原版资源结构
+
+`feapp.dat` 共 36 个成员，其中包括：
+
+```text
+5 个 JavaScript
+3 个 CSS
+1 个 HTML
+8 个 MP4
+16 个 WEBP
+2 个 TTF
+1 个 SVG
+```
+
+这证明原版前端包自身包含页面资源和媒体素材，但不能证明其中 8 个 MP4 是回信播放器素材。文件名和具体内容没有进入脱敏报告，仍需本机人工查看。
+
+## 7. 当前可确定的最小信息架构
+
+### 7.1 `Collection`
+
+优先保持原版信箱主流程：
+
+```text
+写信
+等待状态
+完成状态
+打开原版详情/展开区域
+显示 canonical reply
+显示最终视频
+```
+
+PrivateWorld 候选若与某封信直接相关，应放在该封信的原版详情或紧邻回复的区域，而不是单独管理产品。
+
+### 7.2 `UserInfo`
+
+`UserInfo` 是目前唯一被真实路由证据支持的用户设置候选入口，但其页面结构和可扩展组件尚未确认。
+
+在完成真实页面审计后，才决定是否在其内部增加：
+
+- 长期记忆的查看、纠正和删除；
+- 私人称呼、住所权限和 Local Continuation；
+- 本地模型与媒体状态；
+- 必要配置。
+
+没有确认组件和锚点前，不修改 `UserInfo`。
+
+### 7.3 MiniMax 校准
+
+MiniMax 校准不是日常陪伴能力。即使最终需要图形入口，也只允许放在原版客户端内部的隐藏开发/高级模式，并且必须在真实音频实验开始后再接线。
+
+## 8. 下一步证据顺序
+
+### CLIENT-UI-01C：播放器与详情只读审计
+
+本机审计：
+
+- `feplayer.dat`；
+- `webplayer.dat`；
+- 原版信箱列表点击一封信后的实际页面；
+- 真实或合成视频信件的播放器字段和请求；
+- `UserInfo` 页面结构。
+
+输出继续保持脱敏，不提交原版资源或源码。
+
+### CLIENT-UI-02：最小补丁契约
+
+只有上述证据完成后，确定：
+
+- `Collection` 内的详情扩展点；
+- 原版播放器复用方式；
+- `UserInfo` 内的设置扩展点；
+- 唯一锚点、修改后验证和回滚条件。
+
+## 9. 当前禁止事项
+
+- 不新增独立 Control Center 发布入口；
+- 不猜测 `LetterDetail` 路由；
+- 不把关键词计数当成可复用组件证据；
+- 不假设原版已支持 `media_status` 或 `reply_video_url`；
+- 不在缺少播放器审计时重写视频展示；
+- 不修改 `Studio`、`Survey`、`Feedback` 等无关原版页面；
+- 不用直接 HTTP、CLI 或外部浏览器页面代替产品验收。

--- a/docs/evidence/original-client-audit-0.0.9.615.json
+++ b/docs/evidence/original-client-audit-0.0.9.615.json
@@ -1,0 +1,91 @@
+{
+  "archive": {
+    "compressed_bytes": 27732805,
+    "extension_counts": {
+      ".css": 3,
+      ".html": 1,
+      ".js": 5,
+      ".mp4": 8,
+      ".svg": 1,
+      ".ttf": 2,
+      ".webp": 16
+    },
+    "member_count": 36,
+    "uncompressed_bytes": 40561344
+  },
+  "limitations": [
+    "No route or component is considered reusable from a keyword alone.",
+    "The report contains no JavaScript source or arbitrary UI strings.",
+    "Screens, dialogs, player bindings and stable patch anchors require manual review of the audited version."
+  ],
+  "local_contract_evidence": {
+    "action_names": [],
+    "toy_api_paths": [],
+    "wire_field_counts": {
+      "letter_status": 4,
+      "media_error_code": 0,
+      "media_status": 0,
+      "reply_content": 1,
+      "reply_mode": 0,
+      "reply_text": 0,
+      "reply_video_url": 0
+    }
+  },
+  "main_bundle": {
+    "bytes": 370246,
+    "member": "assets/main-917d29fc.js",
+    "sha256": "c00dedb9a3ff72226b2c8dca81c05e3152de9149113bf6259ca04c415b332d8b"
+  },
+  "navigation_evidence": {
+    "has_collection": true,
+    "has_home": true,
+    "route_references": [
+      "C",
+      "P.name",
+      "f",
+      "f.route",
+      "ye.Collection",
+      "ye.Feedback",
+      "ye.Home",
+      "ye.Login",
+      "ye.ModeSelect",
+      "ye.Share",
+      "ye.Studio",
+      "ye.Survey",
+      "ye.UserInfo"
+    ]
+  },
+  "patch_contract": {
+    "anchor_counts": {
+      "local_endpoint_injection": 1,
+      "mailbox_original": 1,
+      "mailbox_patched": 0,
+      "response_dispatch": 1
+    },
+    "safe_to_apply_existing_patch": true,
+    "state": "official_patch_ready"
+  },
+  "schema_version": "p03.original-client-audit.v1",
+  "source": {
+    "archive_sha256": "53babcf288c7679a57eb4a2647397d951ec450d5fdaea634498286b2ebb8136e",
+    "client_version_hint": "0.0.9.615",
+    "expected_sha256_match": true,
+    "name": "feapp.dat"
+  },
+  "status": "AUDITED",
+  "surface_keyword_counts": {
+    "Collection": 12,
+    "Home": 8,
+    "LetterDetail": 0,
+    "Profile": 9,
+    "Setting": 15,
+    "Settings": 13,
+    "个人": 0,
+    "信件": 0,
+    "信箱": 0,
+    "回信": 0,
+    "视频": 2,
+    "设置": 0,
+    "音乐": 0
+  }
+}

--- a/tests/installer/test_original_client_audit_evidence.py
+++ b/tests/installer/test_original_client_audit_evidence.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EVIDENCE = ROOT / "docs" / "evidence" / "original-client-audit-0.0.9.615.json"
+MANIFEST = ROOT / "installer" / "full-patch-manifest.json"
+
+
+def _load(path: Path) -> dict[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_original_client_audit_matches_supported_manifest() -> None:
+    evidence = _load(EVIDENCE)
+    manifest = _load(MANIFEST)
+    source = evidence["source"]
+    assert isinstance(source, dict)
+
+    assert evidence["schema_version"] == "p03.original-client-audit.v1"
+    assert evidence["status"] == "AUDITED"
+    assert source["name"] == "feapp.dat"
+    assert source["client_version_hint"] == manifest["client_version"]
+    assert source["archive_sha256"] == manifest["feapp_sha256"]
+    assert source["expected_sha256_match"] is True
+
+
+def test_original_client_patch_anchors_are_unique_and_unmodified() -> None:
+    evidence = _load(EVIDENCE)
+    patch = evidence["patch_contract"]
+    assert isinstance(patch, dict)
+    anchors = patch["anchor_counts"]
+    assert isinstance(anchors, dict)
+
+    assert patch["state"] == "official_patch_ready"
+    assert patch["safe_to_apply_existing_patch"] is True
+    assert anchors == {
+        "local_endpoint_injection": 1,
+        "mailbox_original": 1,
+        "mailbox_patched": 0,
+        "response_dispatch": 1,
+    }
+
+
+def test_original_client_evidence_supports_collection_and_user_info_only() -> None:
+    evidence = _load(EVIDENCE)
+    navigation = evidence["navigation_evidence"]
+    assert isinstance(navigation, dict)
+    routes = navigation["route_references"]
+    assert isinstance(routes, list)
+
+    assert navigation["has_home"] is True
+    assert navigation["has_collection"] is True
+    assert "ye.Home" in routes
+    assert "ye.Collection" in routes
+    assert "ye.UserInfo" in routes
+    assert "LetterDetail" not in routes
+    assert "ye.Settings" not in routes
+
+
+def test_original_client_wire_evidence_does_not_claim_media_support() -> None:
+    evidence = _load(EVIDENCE)
+    contract = evidence["local_contract_evidence"]
+    assert isinstance(contract, dict)
+    counts = contract["wire_field_counts"]
+    assert isinstance(counts, dict)
+
+    assert counts["letter_status"] > 0
+    assert counts["reply_content"] > 0
+    assert counts["reply_video_url"] == 0
+    assert counts["media_status"] == 0
+    assert counts["media_error_code"] == 0
+    assert contract["action_names"] == []
+    assert contract["toy_api_paths"] == []
+
+
+def test_original_client_evidence_is_sanitized() -> None:
+    raw = EVIDENCE.read_text(encoding="utf-8")
+    lowered = raw.casefold()
+
+    assert "c:\\" not in lowered
+    assert "d:\\" not in lowered
+    assert "f:\\" not in lowered
+    assert "sk-" not in lowered
+    assert "api_key" not in lowered
+    assert "PRIVATE_FIXTURE_TEXT_SHOULD_NOT_LEAK" not in raw


### PR DESCRIPTION
Implements CLIENT-UI-01B from #35 using the sanitized report generated from the user's supported original `feapp.dat`.

## Confirmed evidence

- archive hash matches the supported `0.0.9.615` manifest exactly;
- the current endpoint and `Home -> Collection` patch anchors each occur exactly once and are safe to apply;
- named route references include `Collection`, `Home`, and `UserInfo`;
- no named `LetterDetail` or `Settings` route is proven;
- the original main bundle contains `letter_status` and `reply_content` references;
- `reply_video_url`, `media_status`, `media_error_code`, and exact reply-mode fields are not proven in the main bundle;
- direct `/toy/...` strings and action names were not found by the conservative scan and are not treated as absence of runtime calls.

## Changes

- adds the sanitized JSON evidence under `docs/evidence/`;
- adds a source-grounded audit result document separating confirmed facts, inferences, and unknowns;
- locks manifest/hash, patch-anchor, route, wire-field, and sanitization expectations in CI;
- keeps CLIENT-UI-02 blocked until player archives and real Collection/UserInfo behavior are audited.

No original archive, JavaScript source, UI string dump, private path, credential, user content, or runtime behavior is added or changed.

Part of #35, #37, and #38.