### PR TITLE
test(client): audit original player archives before media UI changes

### DIFF
--- a/docs/P03_ORIGINAL_PLAYER_AUDIT.md
+++ b/docs/P03_ORIGINAL_PLAYER_AUDIT.md
@@ -1,0 +1,124 @@
+# P03 原版播放器归档审计
+
+## 1. 目的
+
+`feapp.dat` 的首轮脱敏审计已经确认：
+
+- 原版信箱命名路由包含 `Collection`；
+- 用户信息候选入口包含 `UserInfo`；
+- 主包中存在 `letter_status` 和 `reply_content`；
+- 主包中没有证据证明 `reply_video_url`、`media_status`、`media_error_code` 或精确回复模式字段被直接读取；
+- 原版前端还包含独立的 `feplayer.dat` 和 `webplayer.dat`。
+
+因此，在修改原版信件详情或视频播放方式之前，必须先确认两个播放器归档如何接收媒体地址、如何与外层客户端通信、读取哪些字段，以及是否已经存在可复用播放器。
+
+## 2. 产品边界
+
+该审计仍遵循：
+
+```text
+原版 Olivia 客户端是唯一用户产品外壳
+```
+
+审计不能被用来建立：
+
+- 独立浏览器播放器；
+- 第二套视频页面；
+- 绕开原版信件详情的媒体入口；
+- 独立 Control Center；
+- 直接打开生成 MP4 代替原版客户端验收。
+
+## 3. 新增只读工具
+
+```text
+tools/audit_original_players.py
+```
+
+输入是原版版本目录下的：
+
+```text
+resources/feplayer.dat
+resources/webplayer.dat
+```
+
+工具只在内存中读取 ZIP 元数据和有大小上限的 HTML/JavaScript，不会：
+
+- 解压到磁盘；
+- 修改或重打包原版归档；
+- 访问网络；
+- 输出 HTML 或 JavaScript 源码；
+- 输出任意原版文案；
+- 输出绝对路径；
+- 输出完整 URL；
+- 输出凭据或用户内容。
+
+## 4. 报告内容
+
+每个播放器只报告：
+
+- archive SHA-256；
+- 成员数、压缩前后大小和扩展名计数；
+- 直接包含的媒体文件类型计数；
+- 安全的 HTML 入口文件名；
+- 引用的相对 JS/CSS 文件名；
+- JS bundle 文件名、大小和 SHA-256；
+- 直接出现的 `/toy/...` 本地路径；
+- 保守识别的 action 名；
+- allowlist 中的 query key；
+- allowlist 媒体字段出现次数；
+- `postMessage`、`message`、`URLSearchParams` 等通信标记；
+- HLS、DPlayer、Video.js 等已知播放器标记；
+- 外部 URL 只保留 hostname，不保留完整地址。
+
+计数只证明标记存在，不能单独证明具体运行方式。
+
+## 5. 本机执行
+
+在拉取包含该工具的最新 `main` 后运行：
+
+```powershell
+python tools/audit_original_players.py `
+  "<Steam安装目录>\0.0.9.615\resources" `
+  --output original-player-audit.json
+```
+
+只上传生成的：
+
+```text
+original-player-audit.json
+```
+
+不要上传：
+
+- `feplayer.dat`；
+- `webplayer.dat`；
+- 解包文件；
+- HTML/JavaScript 源码；
+- 原版媒体文件。
+
+## 6. 审计后的判断顺序
+
+拿到报告后：
+
+1. 确认 `feplayer` 与 `webplayer` 的 HTML 入口和 JS bundle；
+2. 确认是否使用 query string、`postMessage`、本地 API 或其他 transport；
+3. 确认现有播放器是否原生支持 MP4；
+4. 确认媒体 URL 所需字段；
+5. 再结合原版 `Collection` 内真实点击行为定位信件详情；
+6. 最后才定义最小补丁锚点。
+
+没有报告时，不允许：
+
+- 在后端继续新增未经客户端读取的媒体字段；
+- 猜测 `LetterDetail` 路由；
+- 新增独立播放器页面；
+- 声称原版客户端已经能播放生成视频。
+
+## 7. 完成条件
+
+- 两个播放器归档均生成脱敏报告；
+- 报告不包含源码、绝对路径、私人内容或完整 URL；
+- 播放器入口、transport 和媒体字段的证据已分类为“确认／推断／未知”；
+- 原版播放器接线方案基于证据，而不是关键词猜测；
+- 在确认最小锚点前，不修改原版 UI；
+- `public-smoke`、hardening scan 和 whitespace check 通过。

--- a/tests/installer/test_original_player_audit.py
+++ b/tests/installer/test_original_player_audit.py
@@ -105,6 +105,12 @@ def test_player_audit_reports_binding_metadata_without_source_leakage(tmp_path: 
     assert feplayer["binding_evidence"]["field_counts"]["videoUrl"] == 1
     assert feplayer["binding_evidence"]["transport_marker_counts"]["postMessage"] == 1
     assert feplayer["binding_evidence"]["player_marker_counts"]["Hls"] == 1
+    assert (
+        feplayer["binding_evidence"]["player_marker_counts"][
+            'document.createElement("video")'
+        ]
+        == 1
+    )
     assert feplayer["binding_evidence"]["external_origin_hosts"] == [
         "media.example.invalid"
     ]
@@ -120,7 +126,6 @@ def test_player_audit_reports_binding_metadata_without_source_leakage(tmp_path: 
     assert private_marker not in encoded
     assert "https://media.example.invalid/player" not in encoded
     assert "media.example.invalid" in encoded
-    assert "document.createElement(\"video\")" in encoded
 
 
 def test_player_audit_rejects_missing_or_malformed_archives(tmp_path: Path) -> None:

--- a/tests/installer/test_original_player_audit.py
+++ b/tests/installer/test_original_player_audit.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import zipfile
+
+import pytest
+
+import tools.audit_original_players as audit_module
+from tools.audit_original_players import (
+    OriginalPlayerAuditError,
+    audit_original_players,
+)
+
+
+def _write_archive(
+    path: Path,
+    *,
+    html_name: str,
+    html: str,
+    javascript_name: str,
+    javascript: str,
+    extra: dict[str, str | bytes] | None = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(html_name, html)
+        archive.writestr(javascript_name, javascript)
+        archive.writestr("assets/player.css", "video{display:block}")
+        for name, content in (extra or {}).items():
+            archive.writestr(name, content)
+
+
+def _write_players(resources: Path, *, private_marker: str = "") -> None:
+    _write_archive(
+        resources / "feplayer.dat",
+        html_name="index.html",
+        html=(
+            '<script src="assets/feplayer.js"></script>'
+            '<link href="assets/player.css" rel="stylesheet">'
+        ),
+        javascript_name="assets/feplayer.js",
+        javascript=" ".join(
+            (
+                'document.createElement("video")',
+                "HTMLVideoElement",
+                "postMessage",
+                'new URLSearchParams(location.search).get("video_url")',
+                '"/toy/media/letter/{id}"',
+                'payload.action==="playerReady"',
+                "reply_video_url videoUrl autoplay controls currentTime duration",
+                "Hls hls.js .mp4 .m3u8",
+                "https://media.example.invalid/player",
+                private_marker,
+            )
+        ),
+        extra={"assets/intro.mp4": b"synthetic media fixture"},
+    )
+    _write_archive(
+        resources / "webplayer.dat",
+        html_name="player.html",
+        html='<script src="assets/webplayer.js"></script>',
+        javascript_name="assets/webplayer.js",
+        javascript=" ".join(
+            (
+                "<video",
+                "addEventListener('message'",
+                'new URLSearchParams(location.search).get("video_url")',
+                'new URLSearchParams(location.search).get("letter_id")',
+                "DPlayer video_url poster muted loop",
+                "postMessage .webm .m3u8",
+                private_marker,
+            )
+        ),
+    )
+
+
+def test_player_audit_reports_binding_metadata_without_source_leakage(tmp_path: Path) -> None:
+    private_marker = "PRIVATE_PLAYER_FIXTURE_MUST_NOT_LEAK"
+    resources = tmp_path / "0.0.9.615" / "resources"
+    _write_players(resources, private_marker=private_marker)
+
+    report = audit_original_players(resources)
+
+    assert report["schema_version"] == "p03.original-player-audit.v1"
+    assert report["status"] == "AUDITED"
+    assert report["source"]["client_version_hint"] == "0.0.9.615"
+    assert report["source"]["archive_names"] == ["feplayer.dat", "webplayer.dat"]
+
+    feplayer = report["players"]["feplayer"]
+    assert feplayer["name"] == "feplayer.dat"
+    assert feplayer["archive"]["direct_media_counts"] == {".mp4": 1}
+    assert feplayer["entrypoints"]["html_members"] == ["index.html"]
+    assert feplayer["entrypoints"]["relative_js_css_assets"] == [
+        "assets/feplayer.js",
+        "assets/player.css",
+    ]
+    assert feplayer["entrypoints"]["javascript_bundles"][0]["member"] == "assets/feplayer.js"
+    assert feplayer["binding_evidence"]["local_api_paths"] == [
+        "/toy/media/letter/{id}"
+    ]
+    assert feplayer["binding_evidence"]["action_names"] == ["playerReady"]
+    assert feplayer["binding_evidence"]["query_keys"] == ["video_url"]
+    assert feplayer["binding_evidence"]["field_counts"]["reply_video_url"] == 1
+    assert feplayer["binding_evidence"]["field_counts"]["videoUrl"] == 1
+    assert feplayer["binding_evidence"]["transport_marker_counts"]["postMessage"] == 1
+    assert feplayer["binding_evidence"]["player_marker_counts"]["Hls"] == 1
+    assert feplayer["binding_evidence"]["external_origin_hosts"] == [
+        "media.example.invalid"
+    ]
+
+    webplayer = report["players"]["webplayer"]
+    assert webplayer["entrypoints"]["html_members"] == ["player.html"]
+    assert webplayer["binding_evidence"]["query_keys"] == ["letter_id", "video_url"]
+    assert webplayer["binding_evidence"]["player_marker_counts"]["DPlayer"] == 1
+    assert report["comparison"]["shared_query_keys"] == ["video_url"]
+
+    encoded = json.dumps(report, ensure_ascii=False, sort_keys=True)
+    assert str(tmp_path) not in encoded
+    assert private_marker not in encoded
+    assert "document.createElement" not in encoded
+    assert "https://media.example.invalid/player" not in encoded
+
+
+def test_player_audit_rejects_missing_or_malformed_archives(tmp_path: Path) -> None:
+    resources = tmp_path / "0.0.9.615" / "resources"
+    resources.mkdir(parents=True)
+    (resources / "feplayer.dat").write_bytes(b"not a zip")
+
+    with pytest.raises(OriginalPlayerAuditError) as malformed:
+        audit_original_players(resources)
+    assert malformed.value.code == "PLAYER_ARCHIVE_INVALID"
+
+    (resources / "feplayer.dat").unlink()
+    with pytest.raises(OriginalPlayerAuditError) as missing:
+        audit_original_players(resources)
+    assert missing.value.code == "PLAYER_ARCHIVE_NOT_FOUND"
+
+
+def test_player_audit_rejects_unsafe_archive_members(tmp_path: Path) -> None:
+    resources = tmp_path / "resources"
+    _write_players(resources)
+    with zipfile.ZipFile(resources / "feplayer.dat", "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("index.html", "fixture")
+        archive.writestr("../outside.js", "fixture")
+
+    with pytest.raises(OriginalPlayerAuditError) as unsafe:
+        audit_original_players(resources)
+    assert unsafe.value.code == "PLAYER_ARCHIVE_UNSAFE"
+
+
+def test_player_audit_enforces_per_member_and_total_text_bounds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resources = tmp_path / "resources"
+    _write_players(resources)
+
+    monkeypatch.setattr(audit_module, "MAX_TEXT_MEMBER_BYTES", 4)
+    with pytest.raises(OriginalPlayerAuditError) as member_limit:
+        audit_original_players(resources)
+    assert member_limit.value.code == "PLAYER_TEXT_MEMBER_TOO_LARGE"
+
+    monkeypatch.setattr(audit_module, "MAX_TEXT_MEMBER_BYTES", 1024 * 1024)
+    monkeypatch.setattr(audit_module, "MAX_TOTAL_TEXT_BYTES", 10)
+    with pytest.raises(OriginalPlayerAuditError) as total_limit:
+        audit_original_players(resources)
+    assert total_limit.value.code == "PLAYER_TOTAL_TEXT_TOO_LARGE"
+
+
+def test_player_audit_requires_a_versioned_resources_directory(tmp_path: Path) -> None:
+    with pytest.raises(OriginalPlayerAuditError) as missing:
+        audit_original_players(tmp_path / "missing")
+    assert missing.value.code == "PLAYER_RESOURCES_NOT_FOUND"

--- a/tests/installer/test_original_player_audit.py
+++ b/tests/installer/test_original_player_audit.py
@@ -118,8 +118,9 @@ def test_player_audit_reports_binding_metadata_without_source_leakage(tmp_path: 
     encoded = json.dumps(report, ensure_ascii=False, sort_keys=True)
     assert str(tmp_path) not in encoded
     assert private_marker not in encoded
-    assert "document.createElement" not in encoded
     assert "https://media.example.invalid/player" not in encoded
+    assert "media.example.invalid" in encoded
+    assert "document.createElement(\"video\")" in encoded
 
 
 def test_player_audit_rejects_missing_or_malformed_archives(tmp_path: Path) -> None:

--- a/tools/audit_original_players.py
+++ b/tools/audit_original_players.py
@@ -1,0 +1,421 @@
+"""Audit original Olivia player archives without extracting or modifying them.
+
+The report is intentionally metadata-only. It never emits JavaScript or HTML
+source, arbitrary string literals, absolute paths, credentials, user content,
+or full URLs. It records only hashes, bounded archive metadata, safe relative
+entrypoint names, allowlisted field/transport counts, local ``/toy`` paths, and
+known player-library markers.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath, PureWindowsPath
+import re
+import tempfile
+from typing import Any, Iterable
+from urllib.parse import urlsplit
+import zipfile
+
+
+PLAYER_AUDIT_SCHEMA_VERSION = "p03.original-player-audit.v1"
+PLAYER_ARCHIVES = ("feplayer.dat", "webplayer.dat")
+MAX_ARCHIVE_MEMBERS = 100_000
+MAX_TEXT_MEMBER_BYTES = 64 * 1024 * 1024
+MAX_TOTAL_TEXT_BYTES = 192 * 1024 * 1024
+MAX_LIST_VALUES = 200
+
+_TEXT_SUFFIXES = frozenset({".html", ".js"})
+_MEDIA_SUFFIXES = frozenset(
+    {".mp4", ".webm", ".m3u8", ".mp3", ".wav", ".ogg", ".flac"}
+)
+_SAFE_METADATA_PATH_RE = re.compile(r"^[A-Za-z0-9._/@+-]{1,200}$")
+_LOCAL_API_PATH_RE = re.compile(
+    r"[\"'](/toy/[A-Za-z0-9_./{}:-]{1,160})[\"']"
+)
+_EXTERNAL_URL_RE = re.compile(r"https?://[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]{1,512}")
+_RELATIVE_ASSET_RE = re.compile(
+    r"(?:src|href)\s*=\s*[\"']([^\"']{1,200}\.(?:js|css))(?:\?[^\"']*)?[\"']",
+    flags=re.IGNORECASE,
+)
+_ACTION_RE = re.compile(
+    r"(?:\.action===|[\"']action[\"']\s*:)"
+    r"[\"']([A-Za-z][A-Za-z0-9_.:-]{0,95})[\"']"
+)
+_QUERY_GET_RE = re.compile(
+    r"(?:URLSearchParams\([^)]*\)|searchParams)\.get\([\"']"
+    r"([A-Za-z][A-Za-z0-9_.:-]{0,63})[\"']\)"
+)
+
+_ALLOWLIST_FIELDS = (
+    "reply_video_url",
+    "replyVideoUrl",
+    "video_url",
+    "videoUrl",
+    "media_url",
+    "mediaUrl",
+    "audio_url",
+    "audioUrl",
+    "poster",
+    "autoplay",
+    "controls",
+    "muted",
+    "loop",
+    "currentTime",
+    "duration",
+)
+_ALLOWLIST_QUERY_KEYS = frozenset(
+    {
+        "url",
+        "src",
+        "video",
+        "videoUrl",
+        "video_url",
+        "audio",
+        "audioUrl",
+        "audio_url",
+        "poster",
+        "autoplay",
+        "loop",
+        "muted",
+        "id",
+        "letter_id",
+        "letterId",
+        "mode",
+        "token",
+    }
+)
+_TRANSPORT_MARKERS = (
+    "postMessage",
+    "addEventListener(\"message\"",
+    "addEventListener('message'",
+    "onmessage",
+    "URLSearchParams",
+    "location.search",
+    "location.hash",
+    "window.name",
+    "localStorage",
+    "sessionStorage",
+)
+_PLAYER_MARKERS = (
+    "HTMLVideoElement",
+    "document.createElement(\"video\")",
+    "document.createElement('video')",
+    "<video",
+    "Hls",
+    "hls.js",
+    "mpegts",
+    "flv.js",
+    "dashjs",
+    "videojs",
+    "Video.js",
+    "Artplayer",
+    "DPlayer",
+    "Plyr",
+    "Howler",
+)
+_MEDIA_TEXT_MARKERS = (".mp4", ".webm", ".m3u8", ".mp3", ".wav", ".ogg", ".flac")
+
+
+class OriginalPlayerAuditError(RuntimeError):
+    """Stable audit failure without a machine-specific path or source excerpt."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for block in iter(lambda: stream.read(1 << 20), b""):
+                digest.update(block)
+    except OSError as exc:
+        raise OriginalPlayerAuditError("PLAYER_ARCHIVE_UNREADABLE") from exc
+    return digest.hexdigest()
+
+
+def _safe_member_name(value: str) -> bool:
+    normalized = value.replace("\\", "/")
+    posix = PurePosixPath(normalized)
+    windows = PureWindowsPath(normalized)
+    return bool(normalized) and "\x00" not in normalized and not (
+        posix.is_absolute()
+        or windows.is_absolute()
+        or bool(windows.drive)
+        or any(part in {"", ".", ".."} for part in posix.parts)
+    )
+
+
+def _safe_metadata_path(value: str) -> str | None:
+    normalized = value.replace("\\", "/")
+    if not _safe_member_name(normalized) or not _SAFE_METADATA_PATH_RE.fullmatch(normalized):
+        return None
+    return normalized
+
+
+def _bounded(values: Iterable[str]) -> list[str]:
+    return sorted(set(values))[:MAX_LIST_VALUES]
+
+
+def _read_text_member(archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> str:
+    if info.is_dir() or info.file_size > MAX_TEXT_MEMBER_BYTES:
+        raise OriginalPlayerAuditError("PLAYER_TEXT_MEMBER_TOO_LARGE")
+    try:
+        with archive.open(info) as stream:
+            raw = stream.read(MAX_TEXT_MEMBER_BYTES + 1)
+    except (OSError, RuntimeError, zipfile.BadZipFile) as exc:
+        raise OriginalPlayerAuditError("PLAYER_TEXT_MEMBER_UNREADABLE") from exc
+    if len(raw) > MAX_TEXT_MEMBER_BYTES:
+        raise OriginalPlayerAuditError("PLAYER_TEXT_MEMBER_TOO_LARGE")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise OriginalPlayerAuditError("PLAYER_TEXT_MEMBER_ENCODING_INVALID") from exc
+
+
+def _external_hosts(text: str) -> set[str]:
+    hosts: set[str] = set()
+    for value in _EXTERNAL_URL_RE.findall(text):
+        try:
+            host = urlsplit(value).hostname
+        except ValueError:
+            host = None
+        if host and re.fullmatch(r"[A-Za-z0-9.-]{1,253}", host):
+            hosts.add(host.casefold())
+    return hosts
+
+
+def _version_hint(resources: Path) -> str | None:
+    value = resources.parent.name
+    if re.fullmatch(r"[0-9A-Za-z._-]{1,64}", value):
+        return value
+    return None
+
+
+def _audit_archive(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise OriginalPlayerAuditError("PLAYER_ARCHIVE_NOT_FOUND")
+    archive_sha256 = _sha256_file(path)
+    try:
+        with zipfile.ZipFile(path) as archive:
+            members = archive.infolist()
+            if not members:
+                raise OriginalPlayerAuditError("PLAYER_ARCHIVE_EMPTY")
+            if len(members) > MAX_ARCHIVE_MEMBERS:
+                raise OriginalPlayerAuditError("PLAYER_ARCHIVE_TOO_MANY_MEMBERS")
+            if any(not _safe_member_name(info.filename) for info in members):
+                raise OriginalPlayerAuditError("PLAYER_ARCHIVE_UNSAFE")
+
+            extension_counts: Counter[str] = Counter()
+            direct_media_counts: Counter[str] = Counter()
+            html_entrypoints: list[str] = []
+            javascript_bundles: list[dict[str, object]] = []
+            relative_assets: set[str] = set()
+            local_api_paths: set[str] = set()
+            action_names: set[str] = set()
+            query_keys: set[str] = set()
+            external_hosts: set[str] = set()
+            field_counts = Counter({field: 0 for field in _ALLOWLIST_FIELDS})
+            transport_counts = Counter({marker: 0 for marker in _TRANSPORT_MARKERS})
+            player_marker_counts = Counter({marker: 0 for marker in _PLAYER_MARKERS})
+            media_text_counts = Counter({marker: 0 for marker in _MEDIA_TEXT_MARKERS})
+            total_compressed = 0
+            total_uncompressed = 0
+            total_text_bytes = 0
+
+            for info in members:
+                total_compressed += max(0, int(info.compress_size))
+                total_uncompressed += max(0, int(info.file_size))
+                suffix = PurePosixPath(info.filename).suffix.casefold() or "<none>"
+                extension_counts[suffix] += 1
+                if suffix in _MEDIA_SUFFIXES:
+                    direct_media_counts[suffix] += 1
+                safe_name = _safe_metadata_path(info.filename)
+                if suffix == ".html" and safe_name is not None:
+                    html_entrypoints.append(safe_name)
+                if suffix not in _TEXT_SUFFIXES or info.is_dir():
+                    continue
+                total_text_bytes += int(info.file_size)
+                if total_text_bytes > MAX_TOTAL_TEXT_BYTES:
+                    raise OriginalPlayerAuditError("PLAYER_TOTAL_TEXT_TOO_LARGE")
+                text = _read_text_member(archive, info)
+                if suffix == ".js" and safe_name is not None:
+                    javascript_bundles.append(
+                        {
+                            "member": safe_name,
+                            "bytes": int(info.file_size),
+                            "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                        }
+                    )
+                relative_assets.update(
+                    value
+                    for match in _RELATIVE_ASSET_RE.findall(text)
+                    if (value := _safe_metadata_path(match)) is not None
+                )
+                local_api_paths.update(_LOCAL_API_PATH_RE.findall(text))
+                action_names.update(_ACTION_RE.findall(text))
+                query_keys.update(
+                    value for value in _QUERY_GET_RE.findall(text) if value in _ALLOWLIST_QUERY_KEYS
+                )
+                external_hosts.update(_external_hosts(text))
+                for field in _ALLOWLIST_FIELDS:
+                    field_counts[field] += text.count(field)
+                for marker in _TRANSPORT_MARKERS:
+                    transport_counts[marker] += text.count(marker)
+                for marker in _PLAYER_MARKERS:
+                    player_marker_counts[marker] += text.count(marker)
+                lowered = text.casefold()
+                for marker in _MEDIA_TEXT_MARKERS:
+                    media_text_counts[marker] += lowered.count(marker)
+    except OriginalPlayerAuditError:
+        raise
+    except (OSError, RuntimeError, zipfile.BadZipFile) as exc:
+        raise OriginalPlayerAuditError("PLAYER_ARCHIVE_INVALID") from exc
+
+    return {
+        "name": path.name,
+        "archive_sha256": archive_sha256,
+        "archive": {
+            "member_count": len(members),
+            "compressed_bytes": total_compressed,
+            "uncompressed_bytes": total_uncompressed,
+            "extension_counts": dict(sorted(extension_counts.items())),
+            "direct_media_counts": dict(sorted(direct_media_counts.items())),
+        },
+        "entrypoints": {
+            "html_members": _bounded(html_entrypoints),
+            "relative_js_css_assets": _bounded(relative_assets),
+            "javascript_bundles": sorted(
+                javascript_bundles,
+                key=lambda value: str(value["member"]),
+            )[:MAX_LIST_VALUES],
+        },
+        "binding_evidence": {
+            "local_api_paths": _bounded(local_api_paths),
+            "action_names": _bounded(action_names),
+            "query_keys": _bounded(query_keys),
+            "field_counts": dict(field_counts),
+            "transport_marker_counts": dict(transport_counts),
+            "player_marker_counts": dict(player_marker_counts),
+            "media_text_marker_counts": dict(media_text_counts),
+            "external_origin_hosts": _bounded(external_hosts),
+        },
+    }
+
+
+def audit_original_players(resources_path: str | os.PathLike[str]) -> dict[str, Any]:
+    """Audit both original player archives under one versioned resources folder."""
+
+    resources = Path(resources_path).expanduser()
+    if not resources.is_dir():
+        raise OriginalPlayerAuditError("PLAYER_RESOURCES_NOT_FOUND")
+    players = {
+        name.removesuffix(".dat"): _audit_archive(resources / name)
+        for name in PLAYER_ARCHIVES
+    }
+    return {
+        "schema_version": PLAYER_AUDIT_SCHEMA_VERSION,
+        "status": "AUDITED",
+        "source": {
+            "client_version_hint": _version_hint(resources),
+            "archive_names": list(PLAYER_ARCHIVES),
+        },
+        "players": players,
+        "comparison": {
+            "shared_html_members": sorted(
+                set(players["feplayer"]["entrypoints"]["html_members"])
+                & set(players["webplayer"]["entrypoints"]["html_members"])
+            ),
+            "shared_local_api_paths": sorted(
+                set(players["feplayer"]["binding_evidence"]["local_api_paths"])
+                & set(players["webplayer"]["binding_evidence"]["local_api_paths"])
+            ),
+            "shared_query_keys": sorted(
+                set(players["feplayer"]["binding_evidence"]["query_keys"])
+                & set(players["webplayer"]["binding_evidence"]["query_keys"])
+            ),
+        },
+        "limitations": [
+            "A marker count proves only that the token exists, not how the player uses it.",
+            "The report contains no HTML or JavaScript source and no arbitrary string dump.",
+            "Exact letter-detail wiring still requires review of original-client behavior and bounded patch anchors.",
+        ],
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    temporary: Path | None = None
+    try:
+        path = path.expanduser().resolve()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        encoded = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as stream:
+            stream.write(encoded)
+            temporary = Path(stream.name)
+        os.replace(temporary, path)
+    except OSError as exc:
+        if temporary is not None:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise OriginalPlayerAuditError("PLAYER_AUDIT_OUTPUT_FAILED") from exc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "resources",
+        type=Path,
+        help="path to the original versioned resources directory",
+    )
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    try:
+        report = audit_original_players(args.resources)
+        if args.output is not None:
+            _atomic_write_json(args.output, report)
+            print(
+                json.dumps(
+                    {
+                        "schema_version": PLAYER_AUDIT_SCHEMA_VERSION,
+                        "status": "AUDITED",
+                        "output_name": args.output.name,
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+    except OriginalPlayerAuditError as exc:
+        print(
+            json.dumps(
+                {
+                    "schema_version": PLAYER_AUDIT_SCHEMA_VERSION,
+                    "status": "FAILED",
+                    "error_code": exc.code,
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds the read-only player-archive audit required before changing original-client media UI.

## Scope

- adds `tools/audit_original_players.py` for `feplayer.dat` and `webplayer.dat`;
- reads ZIP metadata and bounded HTML/JS text in memory without extracting or modifying original files;
- reports hashes, extension counts, HTML entrypoints, JS bundle metadata, direct media counts, known player-library markers, query/message transport evidence, local API path counts, and allowlisted media field counts;
- never emits JavaScript source, arbitrary UI strings, absolute paths, credentials, user content, or full URLs;
- adds synthetic tests for both player archives, unsafe members, malformed archives, size bounds, and sanitization;
- documents the original-player audit and keeps media UI work blocked until a sanitized report is reviewed.

No runtime, UI, player, media renderer, or original archive is modified.

Part of #35, #37, and #38.