### PR TITLE
docs(client): record audited original player evidence

### DIFF
--- a/docs/P03_ORIGINAL_PLAYER_AUDIT_RESULT.md
+++ b/docs/P03_ORIGINAL_PLAYER_AUDIT_RESULT.md
@@ -1,0 +1,142 @@
+# P03 原版播放器审计结果（0.0.9.615）
+
+## 1. 证据来源
+
+本结论只基于用户在受支持原版客户端 `0.0.9.615` 上生成的脱敏报告：
+
+```text
+docs/evidence/original-player-audit.0.0.9.615.json
+```
+
+报告没有包含 `feplayer.dat`、`webplayer.dat`、HTML/JavaScript 源码、原版文案、绝对路径或用户数据。
+
+## 2. 可以确认的事实
+
+### 2.1 两个播放器包不是同一个实现
+
+| 项目 | `feplayer.dat` | `webplayer.dat` |
+| --- | ---: | ---: |
+| ZIP 成员 | 1 | 7 |
+| HTML | 1 | 1 |
+| JavaScript | 0 个独立文件 | 4 个独立文件 |
+| CSS | 0 个独立文件 | 2 个独立文件 |
+| 解压后体积 | 5,012 bytes | 596,546 bytes |
+
+两者只共同包含 `index.html`。没有发现共同的本地 API 路径或已识别 query key，因此不能将它们视为可互换播放器，也不能为二者编造一个统一调用契约。
+
+### 2.2 `feplayer.dat` 是内联的原生视频页面
+
+`feplayer.dat` 只包含一个约 5 KB 的 `index.html`，没有独立 JavaScript 或 CSS 文件。
+
+脱敏标记证明其中存在：
+
+- 一个 `<video>` 元素；
+- `URLSearchParams`；
+- `location.search`；
+- autoplay；
+- currentTime；
+- duration；
+- muted。
+
+没有证据证明其中存在：
+
+- 第三方播放器库；
+- `postMessage` 或 message listener；
+- localStorage、sessionStorage、hash 或 window.name 传参；
+- 明文 `/toy/...` API；
+- `reply_video_url`、`video_url`、`videoUrl` 等已知字段；
+- `.mp4`、`.m3u8` 等明文扩展名。
+
+**合理推断：** 它很可能通过 query string 接收某种播放参数，并直接使用浏览器原生视频能力。但报告没有识别出参数名和赋值关系，因此这个推断不能作为补丁锚点。
+
+### 2.3 `webplayer.dat` 是独立的 Vue 前端包
+
+`webplayer.dat` 包含：
+
+```text
+assets/main-752b9fc4.js
+assets/vendor-f724cb1c.js
+assets/vendor-vue-832b0c73.js
+assets/zh-cn-deff0b22.js
+2 个 CSS
+index.html
+```
+
+脱敏标记证明其中存在：
+
+- `URLSearchParams`；
+- `location.search`；
+- autoplay；
+- currentTime；
+- duration；
+- loop；
+- muted；
+- Vue 与 Element 相关资源。
+
+没有发现 Artplayer、DPlayer、Hls.js、Video.js、Plyr、dash.js、flv.js 等已知播放器库标记。也没有发现已知视频字段、本地 API 路径、message transport 或媒体扩展名。
+
+**合理推断：** 它使用 Vue 自行封装播放界面，媒体参数也可能来自 query string。但不能仅因 vendor 名称和 token 计数，断言具体组件、传参键或播放协议。
+
+### 2.4 当前没有证据支持 `reply_video_url`
+
+三份审计现在一致表明：
+
+- `feapp.dat` 主包没有 `reply_video_url`；
+- `feplayer.dat` 没有 `reply_video_url`、`video_url` 或 `videoUrl`；
+- `webplayer.dat` 也没有这些字段。
+
+因此后端返回一个新 `reply_video_url` 字段，不会自动使原版客户端播放视频。必须找到原版主包如何打开播放器，以及它实际构造了什么参数。
+
+### 2.5 无 transport 标记不等于没有外部启动
+
+两个播放器包都没有发现 `postMessage`、message listener、localStorage、sessionStorage 或 window.name。
+
+这排除了若干明显的浏览器内通信候选，但仍不能排除：
+
+- 原版主进程创建播放器窗口并拼接 query string；
+- CEF/Electron/native 层通过启动参数注入 URL；
+- minified 代码间接读取 query 参数；
+- 参数值被编码、缩写或在运行时组装。
+
+## 3. 当前不能做的事
+
+在取得下一层证据前，禁止：
+
+- 新增 `reply_video_url` 后宣称播放器已接通；
+- 猜测 query key 为 `video_url`、`url`、`src` 或其他名称；
+- 修改 `feplayer.dat` 或 `webplayer.dat`；
+- 将 `feplayer` 和 `webplayer` 合并成同一个产品契约；
+- 新建独立视频页面；
+- 绕开原版 Collection 和原版播放器做产品验收。
+
+## 4. 下一步证据
+
+下一项应是**主包与播放器的交叉绑定审计**，只回答：
+
+1. `feapp.dat` 是否引用 `feplayer.dat`、`webplayer.dat` 或对应窗口名称；
+2. 原版主包在什么事件后打开播放器；
+3. 播放器 URL 或启动参数如何构造；
+4. query string 中有哪些受限、可公开的参数键；
+5. 播放器是否由信箱 `Collection` 中的当前信件触发；
+6. 原版正文终态 `letter_status = 4` 与播放器入口之间有什么关系。
+
+该审计仍必须：
+
+- 只读；
+- 不解包到持久目录；
+- 不修改原版文件；
+- 不输出 JavaScript 源码或任意字符串表；
+- 只输出 allowlist 字段、计数、hash 和经过限制的结构证据。
+
+## 5. 当前产品接线结论
+
+现在可冻结为：
+
+```text
+原版 Collection
+  -> 原版信件数据（letter_status + reply_content 已证实）
+  -> 未知的原版播放器启动桥
+  -> feplayer 或 webplayer
+```
+
+下一个补丁目标不是播放器本身，而是先找到并验证“原版信箱如何打开原版播放器”的唯一、可回滚锚点。

--- a/docs/evidence/original-player-audit.0.0.9.615.json
+++ b/docs/evidence/original-player-audit.0.0.9.615.json
@@ -1,0 +1,220 @@
+{
+  "comparison": {
+    "shared_html_members": [
+      "index.html"
+    ],
+    "shared_local_api_paths": [],
+    "shared_query_keys": []
+  },
+  "limitations": [
+    "A marker count proves only that the token exists, not how the player uses it.",
+    "The report contains no HTML or JavaScript source and no arbitrary string dump.",
+    "Exact letter-detail wiring still requires review of original-client behavior and bounded patch anchors."
+  ],
+  "players": {
+    "feplayer": {
+      "archive": {
+        "compressed_bytes": 1362,
+        "direct_media_counts": {},
+        "extension_counts": {
+          ".html": 1
+        },
+        "member_count": 1,
+        "uncompressed_bytes": 5012
+      },
+      "archive_sha256": "0289b883a62c391f0f1d24b6088a7fb07d592a98c5b0f6eff3ab931561be0848",
+      "binding_evidence": {
+        "action_names": [],
+        "external_origin_hosts": [],
+        "field_counts": {
+          "audioUrl": 0,
+          "audio_url": 0,
+          "autoplay": 2,
+          "controls": 0,
+          "currentTime": 1,
+          "duration": 10,
+          "loop": 0,
+          "mediaUrl": 0,
+          "media_url": 0,
+          "muted": 1,
+          "poster": 0,
+          "replyVideoUrl": 0,
+          "reply_video_url": 0,
+          "videoUrl": 0,
+          "video_url": 0
+        },
+        "local_api_paths": [],
+        "media_text_marker_counts": {
+          ".flac": 0,
+          ".m3u8": 0,
+          ".mp3": 0,
+          ".mp4": 0,
+          ".ogg": 0,
+          ".wav": 0,
+          ".webm": 0
+        },
+        "player_marker_counts": {
+          "<video": 1,
+          "Artplayer": 0,
+          "DPlayer": 0,
+          "HTMLVideoElement": 0,
+          "Hls": 0,
+          "Howler": 0,
+          "Plyr": 0,
+          "Video.js": 0,
+          "dashjs": 0,
+          "document.createElement(\"video\")": 0,
+          "document.createElement('video')": 0,
+          "flv.js": 0,
+          "hls.js": 0,
+          "mpegts": 0,
+          "videojs": 0
+        },
+        "query_keys": [],
+        "transport_marker_counts": {
+          "URLSearchParams": 1,
+          "addEventListener(\"message\"": 0,
+          "addEventListener('message'": 0,
+          "localStorage": 0,
+          "location.hash": 0,
+          "location.search": 1,
+          "onmessage": 0,
+          "postMessage": 0,
+          "sessionStorage": 0,
+          "window.name": 0
+        }
+      },
+      "entrypoints": {
+        "html_members": [
+          "index.html"
+        ],
+        "javascript_bundles": [],
+        "relative_js_css_assets": []
+      },
+      "name": "feplayer.dat"
+    },
+    "webplayer": {
+      "archive": {
+        "compressed_bytes": 122473,
+        "direct_media_counts": {},
+        "extension_counts": {
+          ".css": 2,
+          ".html": 1,
+          ".js": 4
+        },
+        "member_count": 7,
+        "uncompressed_bytes": 596546
+      },
+      "archive_sha256": "504b59876af2f04c4902f8c8e6811018d36a2da4394e20cf74f22d13d394b636",
+      "binding_evidence": {
+        "action_names": [],
+        "external_origin_hosts": [
+          "localhost",
+          "vuejs.org",
+          "www.w3.org"
+        ],
+        "field_counts": {
+          "audioUrl": 0,
+          "audio_url": 0,
+          "autoplay": 1,
+          "controls": 0,
+          "currentTime": 4,
+          "duration": 16,
+          "loop": 8,
+          "mediaUrl": 0,
+          "media_url": 0,
+          "muted": 9,
+          "poster": 0,
+          "replyVideoUrl": 0,
+          "reply_video_url": 0,
+          "videoUrl": 0,
+          "video_url": 0
+        },
+        "local_api_paths": [],
+        "media_text_marker_counts": {
+          ".flac": 0,
+          ".m3u8": 0,
+          ".mp3": 0,
+          ".mp4": 0,
+          ".ogg": 0,
+          ".wav": 0,
+          ".webm": 0
+        },
+        "player_marker_counts": {
+          "<video": 0,
+          "Artplayer": 0,
+          "DPlayer": 0,
+          "HTMLVideoElement": 0,
+          "Hls": 0,
+          "Howler": 0,
+          "Plyr": 0,
+          "Video.js": 0,
+          "dashjs": 0,
+          "document.createElement(\"video\")": 0,
+          "document.createElement('video')": 0,
+          "flv.js": 0,
+          "hls.js": 0,
+          "mpegts": 0,
+          "videojs": 0
+        },
+        "query_keys": [],
+        "transport_marker_counts": {
+          "URLSearchParams": 2,
+          "addEventListener(\"message\"": 0,
+          "addEventListener('message'": 0,
+          "localStorage": 0,
+          "location.hash": 0,
+          "location.search": 3,
+          "onmessage": 0,
+          "postMessage": 0,
+          "sessionStorage": 0,
+          "window.name": 0
+        }
+      },
+      "entrypoints": {
+        "html_members": [
+          "index.html"
+        ],
+        "javascript_bundles": [
+          {
+            "bytes": 12837,
+            "member": "assets/main-752b9fc4.js",
+            "sha256": "ef4a71b22251dff74eb622fb699e8bf98f5e90b107f1e181fda8b32b39ddcedd"
+          },
+          {
+            "bytes": 112052,
+            "member": "assets/vendor-f724cb1c.js",
+            "sha256": "101e0227cc76ed70ba23db284c8e9360b57965e590b538290e920006cef1733a"
+          },
+          {
+            "bytes": 23464,
+            "member": "assets/vendor-vue-832b0c73.js",
+            "sha256": "6be009be2f68ca917f8c21e631f4de31f72c2b63ae9a1941d87bd7731b4de8ef"
+          },
+          {
+            "bytes": 33301,
+            "member": "assets/zh-cn-deff0b22.js",
+            "sha256": "d1c5624149ac1f6a5e3ca0dfa11a8c93687711a75ab3446fd4b516a028bc2115"
+          }
+        ],
+        "relative_js_css_assets": [
+          "./assets/index-d7322f11.css",
+          "./assets/main-752b9fc4.js",
+          "./assets/vendor-element-7c8f0743.css",
+          "./assets/vendor-f724cb1c.js",
+          "./assets/vendor-vue-832b0c73.js"
+        ]
+      },
+      "name": "webplayer.dat"
+    }
+  },
+  "schema_version": "p03.original-player-audit.v1",
+  "source": {
+    "archive_names": [
+      "feplayer.dat",
+      "webplayer.dat"
+    ],
+    "client_version_hint": "0.0.9.615"
+  },
+  "status": "AUDITED"
+}

--- a/tests/installer/test_original_player_audit_evidence.py
+++ b/tests/installer/test_original_player_audit_evidence.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EVIDENCE = ROOT / "docs" / "evidence" / "original-player-audit.0.0.9.615.json"
+
+
+def _load() -> dict[str, object]:
+    value = json.loads(EVIDENCE.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_original_player_evidence_is_for_supported_client_and_both_archives() -> None:
+    report = _load()
+
+    assert report["schema_version"] == "p03.original-player-audit.v1"
+    assert report["status"] == "AUDITED"
+    assert report["source"] == {
+        "archive_names": ["feplayer.dat", "webplayer.dat"],
+        "client_version_hint": "0.0.9.615",
+    }
+
+    players = report["players"]
+    assert set(players) == {"feplayer", "webplayer"}
+    assert players["feplayer"]["archive_sha256"] == (
+        "0289b883a62c391f0f1d24b6088a7fb07d592a98c5b0f6eff3ab931561be0848"
+    )
+    assert players["webplayer"]["archive_sha256"] == (
+        "504b59876af2f04c4902f8c8e6811018d36a2da4394e20cf74f22d13d394b636"
+    )
+
+
+def test_original_players_are_distinct_and_share_no_proven_binding_contract() -> None:
+    report = _load()
+    feplayer = report["players"]["feplayer"]
+    webplayer = report["players"]["webplayer"]
+
+    assert feplayer["archive"] == {
+        "compressed_bytes": 1362,
+        "direct_media_counts": {},
+        "extension_counts": {".html": 1},
+        "member_count": 1,
+        "uncompressed_bytes": 5012,
+    }
+    assert feplayer["entrypoints"] == {
+        "html_members": ["index.html"],
+        "javascript_bundles": [],
+        "relative_js_css_assets": [],
+    }
+
+    assert webplayer["archive"]["extension_counts"] == {
+        ".css": 2,
+        ".html": 1,
+        ".js": 4,
+    }
+    assert webplayer["archive"]["member_count"] == 7
+    assert len(webplayer["entrypoints"]["javascript_bundles"]) == 4
+
+    assert report["comparison"] == {
+        "shared_html_members": ["index.html"],
+        "shared_local_api_paths": [],
+        "shared_query_keys": [],
+    }
+
+
+def test_evidence_proves_query_transport_markers_but_not_query_keys_or_reply_fields() -> None:
+    report = _load()
+
+    feplayer = report["players"]["feplayer"]["binding_evidence"]
+    assert feplayer["player_marker_counts"]["<video"] == 1
+    assert feplayer["transport_marker_counts"]["URLSearchParams"] == 1
+    assert feplayer["transport_marker_counts"]["location.search"] == 1
+    assert feplayer["query_keys"] == []
+    assert feplayer["local_api_paths"] == []
+
+    webplayer = report["players"]["webplayer"]["binding_evidence"]
+    assert webplayer["transport_marker_counts"]["URLSearchParams"] == 2
+    assert webplayer["transport_marker_counts"]["location.search"] == 3
+    assert webplayer["query_keys"] == []
+    assert webplayer["local_api_paths"] == []
+
+    for player in (feplayer, webplayer):
+        assert player["field_counts"]["reply_video_url"] == 0
+        assert player["field_counts"]["replyVideoUrl"] == 0
+        assert player["field_counts"]["video_url"] == 0
+        assert player["field_counts"]["videoUrl"] == 0
+        assert player["transport_marker_counts"]["postMessage"] == 0
+        assert player["transport_marker_counts"]["localStorage"] == 0
+        assert player["transport_marker_counts"]["sessionStorage"] == 0
+        assert player["transport_marker_counts"]["window.name"] == 0
+
+
+def test_evidence_is_sanitized_and_contains_no_original_source_dump() -> None:
+    text = EVIDENCE.read_text(encoding="utf-8")
+    lowered = text.casefold()
+
+    assert not re.search(r"[a-z]:[/\\]", text, flags=re.IGNORECASE)
+    assert "document.createelement" not in lowered
+    assert "<script" not in lowered
+    assert "function(" not in lowered
+    assert "=>" not in text
+    assert "api_key" not in lowered
+    assert "bearer " not in lowered
+    assert "sk-" not in lowered
+
+    # Only sanitized host names may remain; no complete external URL is stored.
+    assert "https://" not in lowered
+    assert "http://" not in lowered
+    assert "localhost" in lowered

--- a/tests/installer/test_original_player_audit_evidence.py
+++ b/tests/installer/test_original_player_audit_evidence.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import re
+from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -13,6 +14,22 @@ def _load() -> dict[str, object]:
     value = json.loads(EVIDENCE.read_text(encoding="utf-8"))
     assert isinstance(value, dict)
     return value
+
+
+def _string_values(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        result: list[str] = []
+        for child in value.values():
+            result.extend(_string_values(child))
+        return result
+    if isinstance(value, list):
+        result = []
+        for child in value:
+            result.extend(_string_values(child))
+        return result
+    return []
 
 
 def test_original_player_evidence_is_for_supported_client_and_both_archives() -> None:
@@ -96,14 +113,17 @@ def test_evidence_proves_query_transport_markers_but_not_query_keys_or_reply_fie
 
 
 def test_evidence_is_sanitized_and_contains_no_original_source_dump() -> None:
-    text = EVIDENCE.read_text(encoding="utf-8")
-    lowered = text.casefold()
+    report = _load()
+    values = "\n".join(_string_values(report))
+    lowered = values.casefold()
 
-    assert not re.search(r"[a-z]:[/\\]", text, flags=re.IGNORECASE)
+    # Marker names are approved schema keys. Source fragments must never appear
+    # as report values.
+    assert not re.search(r"[a-z]:[/\\]", values, flags=re.IGNORECASE)
     assert "document.createelement" not in lowered
     assert "<script" not in lowered
     assert "function(" not in lowered
-    assert "=>" not in text
+    assert "=>" not in values
     assert "api_key" not in lowered
     assert "bearer " not in lowered
     assert "sk-" not in lowered


### PR DESCRIPTION
Implements the player-evidence part of CLIENT-UI-01 from #35 using the sanitized report generated from the user's supported original `0.0.9.615` installation.

## Confirmed evidence

- `feplayer.dat` is a one-member, inline HTML player with a native `<video>` marker, `URLSearchParams`, and `location.search`;
- `webplayer.dat` is a distinct Vue/Element bundle with four JavaScript files, two CSS files, and separate playback-state markers;
- the two packages share only `index.html` and have no proven shared query key or local API path;
- neither player exposes `reply_video_url`, `video_url`, `videoUrl`, or a proven local `/toy/...` binding;
- neither report shows `postMessage`, message listeners, local/session storage, hash, or window-name transport;
- marker presence supports query-string configuration as an inference, not a patch anchor;
- adding a backend `reply_video_url` field alone cannot be treated as original-client integration.

## Changes

- adds the sanitized player report under `docs/evidence/`;
- adds a source-grounded result document separating facts, inferences, and prohibited assumptions;
- locks archive hashes, package structure, transport markers, missing fields, and sanitization in CI;
- defines the next evidence target as the original main-bundle-to-player launch bridge.

No original archive, HTML/JavaScript source, private path, credential, user content, UI, player, media renderer, or runtime behavior is changed.

Part of #35, #37, and #38.