### PR TITLE
test(client): audit original main-to-player launch bridge

### DIFF
--- a/docs/P03_ORIGINAL_PLAYER_BRIDGE_AUDIT.md
+++ b/docs/P03_ORIGINAL_PLAYER_BRIDGE_AUDIT.md
@@ -1,0 +1,116 @@
+# P03 原版主包到播放器的交叉绑定审计
+
+## 1. 目的
+
+现有证据已经确认：
+
+- 原版 `feapp.dat` 主包读取 `letter_status` 与 `reply_content`；
+- `feplayer.dat` 和 `webplayer.dat` 都读取 query string；
+- 三个包中都没有已证实的 `reply_video_url`、`video_url` 或 `videoUrl` 契约；
+- 两个播放器并非同一实现。
+
+下一步不能直接修改播放器或添加新字段，而是先确定：
+
+```text
+原版 Collection
+  -> 原版主包中的播放器启动桥
+  -> query / 启动参数
+  -> feplayer 或 webplayer
+```
+
+## 2. 新增只读工具
+
+```text
+tools/audit_original_player_bridge.py
+```
+
+输入是同一受支持版本的：
+
+```text
+feapp.dat
+feplayer.dat
+webplayer.dat
+```
+
+工具只在内存中读取 ZIP 成员，不解压到持久目录，不修改原版文件，也不访问网络。
+
+## 3. 输出范围
+
+报告只包含：
+
+- 三个 archive 的 SHA-256；
+- 受限 HTML/JavaScript 成员名称、大小和 SHA-256；
+- `feplayer`、`webplayer` 等明确技术引用的计数；
+- `window.open`、`loadURL`、`BrowserWindow`、`URLSearchParams` 等固定启动/传参标记的计数；
+- 从 `URLSearchParams` alias、直接 `.searchParams` 和 query template 中提取的参数键；
+- 只含 ASCII、无空格、命中 player/video/media/letter/reply/Collection allowlist 的技术字符串；
+- 每个 player 引用附近窗口的 SHA-256 与固定 marker 集合；
+- 主包和各播放器之间共同 query key 与共同技术字符串。
+
+报告不会输出：
+
+- HTML/JavaScript 源码；
+- 任意字符串表；
+- 原版文案；
+- 完整 URL；
+- 绝对路径；
+- 用户数据；
+- 凭据；
+- context 原文。
+
+## 4. 结果状态
+
+工具只给出结构状态，不直接宣称运行行为：
+
+### `literal_reference_with_query_contract_candidate`
+
+主包存在播放器技术引用，并且与至少一个播放器共享 query key。
+
+这只是候选契约，仍需核验引用上下文唯一性和真实点击行为。
+
+### `literal_reference_without_query_contract`
+
+主包存在播放器引用，但没有找到共同参数键。
+
+可能原因包括：
+
+- 参数名经过压缩或运行时组装；
+- 使用位置参数；
+- native 层补充参数；
+- 当前静态规则仍未覆盖真实写法。
+
+### `no_literal_main_bridge_reference`
+
+主包没有出现 `feplayer` / `webplayer` 明文引用。
+
+此时不能继续猜测前端锚点，下一步应转向受控的原版客户端运行行为或 native-process 调用审计。
+
+## 5. 运行方式
+
+拉取最新 `main` 后，在本机执行：
+
+```powershell
+python tools/audit_original_player_bridge.py `
+  "<Steam安装目录>\0.0.9.615\resources" `
+  --output original-player-bridge-audit.json
+```
+
+只上传生成的 `original-player-bridge-audit.json`。不要上传三个 `.dat`、解包目录或源码片段。
+
+## 6. 后续决策
+
+只有报告证明一个明确候选后，才进入 CLIENT-UI-02：
+
+1. 核验主包引用是否唯一；
+2. 核验它是否位于 Collection 当前信件流程；
+3. 确认播放器类型和参数键；
+4. 定义最小、可回滚、版本哈希绑定的补丁；
+5. 先接通原版视频播放，再讨论设置和管理入口。
+
+在此之前继续冻结：
+
+- standalone Control Center 发布入口；
+- 新视频页面；
+- 新 `LetterDetail` 路由；
+- 对 `reply_video_url` 等字段的未经证实接线；
+- 对播放器 archive 的直接修改。

--- a/tests/installer/test_original_player_bridge_audit.py
+++ b/tests/installer/test_original_player_bridge_audit.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import zipfile
+
+import pytest
+
+from patch_feapp import MAIN_JS
+from tools.audit_original_player_bridge import (
+    OriginalPlayerBridgeAuditError,
+    audit_original_player_bridge,
+)
+
+
+def _write_archive(path: Path, members: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, content in members.items():
+            archive.writestr(name, content)
+
+
+def _make_resources(root: Path, *, private_marker: str = "") -> Path:
+    resources = root / "0.0.9.615" / "resources"
+    _write_archive(
+        resources / "feapp.dat",
+        {
+            MAIN_JS: " ".join(
+                (
+                    "ye.Collection letter_status reply_content",
+                    'const params=new URLSearchParams(location.search);',
+                    'const letter=params.get("letter_id");',
+                    'const target="feplayer.dat?media_id="+encodeURIComponent(letter);',
+                    "window.open(target);",
+                    'const fallback="webplayer.dat";',
+                    'const operation="openVideoPlayer";',
+                    private_marker,
+                )
+            )
+        },
+    )
+    _write_archive(
+        resources / "feplayer.dat",
+        {
+            "index.html": " ".join(
+                (
+                    "<video autoplay muted></video>",
+                    'const query=new URLSearchParams(location.search);',
+                    'const media=query.get("media_id");',
+                    private_marker,
+                )
+            )
+        },
+    )
+    _write_archive(
+        resources / "webplayer.dat",
+        {
+            "index.html": '<script src="assets/main.js"></script>',
+            "assets/main.js": " ".join(
+                (
+                    'const search=new URL(location.href).searchParams;',
+                    'const source=search.get("source_id");',
+                    'const component="videoPlayer";',
+                    private_marker,
+                )
+            ),
+            "assets/vendor-vue.js": "vendor source should be ignored",
+        },
+    )
+    return resources
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _all_string_values(value: object) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        result: list[str] = []
+        for child in value.values():
+            result.extend(_all_string_values(child))
+        return result
+    if isinstance(value, list):
+        result = []
+        for child in value:
+            result.extend(_all_string_values(child))
+        return result
+    return []
+
+
+def test_bridge_audit_correlates_main_and_player_query_contracts(tmp_path: Path) -> None:
+    private_marker = "PRIVATE_FIXTURE_SHOULD_NOT_LEAK"
+    resources = _make_resources(tmp_path, private_marker=private_marker)
+    before = {
+        path.name: _sha256(path)
+        for path in resources.glob("*.dat")
+    }
+
+    report = audit_original_player_bridge(resources)
+
+    assert report["schema_version"] == "p03.original-player-bridge-audit.v1"
+    assert report["status"] == "AUDITED"
+    assert report["source"] == {
+        "client_version_hint": "0.0.9.615",
+        "archive_names": ["feapp.dat", "feplayer.dat", "webplayer.dat"],
+    }
+    assert report["bridge_state"] == "literal_reference_with_query_contract_candidate"
+
+    main = report["main_bundle"]
+    assert main["query_keys"] == ["letter_id", "media_id"]
+    assert main["player_reference_counts"]["feplayer.dat"] == 1
+    assert main["player_reference_counts"]["webplayer.dat"] == 1
+    assert main["launch_marker_counts"]["window.open"] == 1
+    assert main["launch_marker_counts"]["encodeURIComponent"] == 1
+    assert "feplayer.dat?media_id=" in main["technical_literals"]
+    assert "openVideoPlayer" in main["technical_literals"]
+    assert main["player_reference_contexts"]["feplayer.dat"]["contexts"]
+
+    assert report["players"]["feplayer"]["query_keys"] == ["media_id"]
+    assert report["players"]["webplayer"]["query_keys"] == ["source_id"]
+    assert report["correlation"]["feplayer"]["shared_query_keys"] == ["media_id"]
+    assert report["correlation"]["webplayer"]["shared_query_keys"] == []
+
+    after = {
+        path.name: _sha256(path)
+        for path in resources.glob("*.dat")
+    }
+    assert after == before
+
+    values = "\n".join(_all_string_values(report))
+    assert str(tmp_path) not in values
+    assert private_marker not in values
+    assert "const params=" not in values
+    assert "window.open(target)" not in values
+
+
+def test_bridge_audit_detects_generic_query_parsing_without_inventing_keys(
+    tmp_path: Path,
+) -> None:
+    resources = _make_resources(tmp_path)
+    _write_archive(
+        resources / "webplayer.dat",
+        {
+            "index.html": '<script src="assets/main.js"></script>',
+            "assets/main.js": (
+                "const all=Object.fromEntries(new URLSearchParams(location.search));"
+            ),
+        },
+    )
+
+    report = audit_original_player_bridge(resources)
+    webplayer = report["players"]["webplayer"]
+
+    assert webplayer["query_keys"] == []
+    assert webplayer["generic_query_marker_counts"]["Object.fromEntries"] == 1
+    assert webplayer["generic_query_marker_counts"]["URLSearchParams"] == 1
+    assert webplayer["generic_query_marker_counts"]["location.search"] == 1
+
+
+def test_bridge_audit_rejects_missing_malformed_and_unsafe_archives(
+    tmp_path: Path,
+) -> None:
+    resources = tmp_path / "0.0.9.615" / "resources"
+    resources.mkdir(parents=True)
+
+    with pytest.raises(OriginalPlayerBridgeAuditError) as missing:
+        audit_original_player_bridge(resources)
+    assert missing.value.code == "BRIDGE_ARCHIVE_NOT_FOUND"
+
+    (resources / "feapp.dat").write_bytes(b"not a zip")
+    with pytest.raises(OriginalPlayerBridgeAuditError) as malformed:
+        audit_original_player_bridge(resources)
+    assert malformed.value.code == "BRIDGE_ARCHIVE_INVALID"
+
+    _write_archive(resources / "feapp.dat", {MAIN_JS: "fixture"})
+    _write_archive(resources / "feplayer.dat", {"../outside.js": "fixture"})
+    _write_archive(resources / "webplayer.dat", {"index.html": "fixture"})
+    with pytest.raises(OriginalPlayerBridgeAuditError) as unsafe:
+        audit_original_player_bridge(resources)
+    assert unsafe.value.code == "BRIDGE_ARCHIVE_UNSAFE"
+
+
+def test_bridge_audit_report_contains_no_full_urls_or_source_dump(tmp_path: Path) -> None:
+    resources = _make_resources(tmp_path)
+    _write_archive(
+        resources / "webplayer.dat",
+        {
+            "index.html": '<script src="assets/main.js"></script>',
+            "assets/main.js": (
+                'const endpoint="https://private.example.invalid/video";'
+                'const player="videoPlayer";'
+            ),
+        },
+    )
+
+    report = audit_original_player_bridge(resources)
+    encoded = json.dumps(report, ensure_ascii=False, sort_keys=True)
+
+    assert "https://" not in encoded
+    assert "private.example.invalid" not in encoded
+    assert 'const endpoint=' not in encoded
+    assert '"videoPlayer"' in encoded

--- a/tools/audit_original_player_bridge.py
+++ b/tools/audit_original_player_bridge.py
@@ -1,0 +1,451 @@
+"""Audit how the original Olivia frontend may launch its bundled players.
+
+The report is structural and sanitized.  It reads ``feapp.dat``,
+``feplayer.dat`` and ``webplayer.dat`` in memory, but never extracts, modifies,
+or emits source.  Output is restricted to hashes, bounded counts, safe technical
+query keys/literals, and context marker signatures.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath, PureWindowsPath
+import re
+import tempfile
+from typing import Any, Iterable
+import zipfile
+
+from patch_feapp import MAIN_JS
+
+
+BRIDGE_AUDIT_SCHEMA_VERSION = "p03.original-player-bridge-audit.v1"
+PLAYER_ARCHIVES = ("feplayer.dat", "webplayer.dat")
+MAX_ARCHIVE_MEMBERS = 100_000
+MAX_TEXT_MEMBER_BYTES = 128 * 1024 * 1024
+MAX_TOTAL_TEXT_BYTES = 256 * 1024 * 1024
+MAX_LIST_VALUES = 200
+MAX_CONTEXTS_PER_TOKEN = 32
+_CONTEXT_RADIUS = 320
+
+_SAFE_KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]{0,63}$")
+_SAFE_TECH_LITERAL_RE = re.compile(r"^[A-Za-z0-9_./:@?&=+%{}-]{1,160}$")
+_STRING_LITERAL_RE = re.compile(
+    r"(?P<quote>[\"'])(?P<value>[^\"'\\\r\n]{1,160})(?P=quote)"
+)
+_QUERY_TEMPLATE_RE = re.compile(r"(?:\?|&)([A-Za-z][A-Za-z0-9_.:-]{0,63})=")
+_URLSEARCHPARAMS_ALIAS_RE = re.compile(
+    r"(?:^|[^A-Za-z0-9_$])([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*"
+    r"new\s+URLSearchParams\s*\(",
+)
+_SEARCHPARAMS_ALIAS_RE = re.compile(
+    r"(?:^|[^A-Za-z0-9_$])([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*"
+    r"new\s+URL\s*\([^;]{0,512}?\)\.searchParams",
+)
+_DIRECT_QUERY_METHOD_RE = re.compile(
+    r"(?:new\s+URLSearchParams\s*\([^;]{0,512}?\)|"
+    r"[A-Za-z_$][A-Za-z0-9_$]*\.searchParams)\s*\.\s*"
+    r"(?:get|has|set|append|delete)\s*\(\s*[\"']"
+    r"([A-Za-z][A-Za-z0-9_.:-]{0,63})[\"']",
+)
+
+_PLAYER_REFERENCE_TOKENS = (
+    "feplayer.dat",
+    "webplayer.dat",
+    "feplayer",
+    "webplayer",
+)
+_LAUNCH_MARKERS = (
+    "window.open",
+    "loadURL",
+    "loadFile",
+    "BrowserWindow",
+    "webview",
+    "<iframe",
+    "createElement(\"iframe\")",
+    "createElement('iframe')",
+    "URLSearchParams",
+    "Object.fromEntries",
+    "encodeURIComponent",
+    "decodeURIComponent",
+    "location.search",
+    "ipcRenderer",
+    "ipcMain",
+    "postMessage",
+    "invoke(",
+)
+_GENERIC_QUERY_MARKERS = (
+    "Object.fromEntries",
+    ".entries(",
+    ".forEach(",
+    ".keys(",
+    "URLSearchParams",
+    "location.search",
+)
+_CONTEXT_MARKERS = (
+    "ye.Collection",
+    "letter_status",
+    "reply_content",
+    "video",
+    "player",
+    "media",
+    "URLSearchParams",
+    "location.search",
+    "window.open",
+    "loadURL",
+    "loadFile",
+    "BrowserWindow",
+    "webview",
+    "iframe",
+    "postMessage",
+    "ipcRenderer",
+    "invoke(",
+    "encodeURIComponent",
+)
+_TECH_LITERAL_KEYWORDS = (
+    "feplayer",
+    "webplayer",
+    "player",
+    "video",
+    "media",
+    "letter",
+    "reply",
+    "collection",
+)
+
+
+class OriginalPlayerBridgeAuditError(RuntimeError):
+    """Stable audit failure without original source or machine-specific paths."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def _safe_member_name(value: str) -> bool:
+    normalized = value.replace("\\", "/")
+    posix = PurePosixPath(normalized)
+    windows = PureWindowsPath(normalized)
+    return bool(normalized) and "\x00" not in normalized and not (
+        posix.is_absolute()
+        or windows.is_absolute()
+        or bool(windows.drive)
+        or any(part in {"", ".", ".."} for part in posix.parts)
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for block in iter(lambda: stream.read(1 << 20), b""):
+                digest.update(block)
+    except OSError as exc:
+        raise OriginalPlayerBridgeAuditError("BRIDGE_ARCHIVE_UNREADABLE") from exc
+    return digest.hexdigest()
+
+
+def _read_text(archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> str:
+    if info.is_dir() or info.file_size > MAX_TEXT_MEMBER_BYTES:
+        raise OriginalPlayerBridgeAuditError("BRIDGE_TEXT_MEMBER_TOO_LARGE")
+    try:
+        with archive.open(info) as stream:
+            raw = stream.read(MAX_TEXT_MEMBER_BYTES + 1)
+    except (OSError, RuntimeError, zipfile.BadZipFile) as exc:
+        raise OriginalPlayerBridgeAuditError("BRIDGE_TEXT_MEMBER_UNREADABLE") from exc
+    if len(raw) > MAX_TEXT_MEMBER_BYTES:
+        raise OriginalPlayerBridgeAuditError("BRIDGE_TEXT_MEMBER_TOO_LARGE")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise OriginalPlayerBridgeAuditError("BRIDGE_TEXT_MEMBER_ENCODING_INVALID") from exc
+
+
+def _read_archive_texts(
+    path: Path,
+    *,
+    only_member: str | None = None,
+) -> tuple[str, dict[str, str]]:
+    if not path.is_file():
+        raise OriginalPlayerBridgeAuditError("BRIDGE_ARCHIVE_NOT_FOUND")
+    archive_sha256 = _sha256_file(path)
+    texts: dict[str, str] = {}
+    total_text_bytes = 0
+    try:
+        with zipfile.ZipFile(path) as archive:
+            members = archive.infolist()
+            if not members:
+                raise OriginalPlayerBridgeAuditError("BRIDGE_ARCHIVE_EMPTY")
+            if len(members) > MAX_ARCHIVE_MEMBERS:
+                raise OriginalPlayerBridgeAuditError("BRIDGE_ARCHIVE_TOO_MANY_MEMBERS")
+            if any(not _safe_member_name(info.filename) for info in members):
+                raise OriginalPlayerBridgeAuditError("BRIDGE_ARCHIVE_UNSAFE")
+            if only_member is not None:
+                try:
+                    members = [archive.getinfo(only_member)]
+                except KeyError as exc:
+                    raise OriginalPlayerBridgeAuditError(
+                        "BRIDGE_MAIN_BUNDLE_MISSING"
+                    ) from exc
+            for info in members:
+                suffix = PurePosixPath(info.filename).suffix.casefold()
+                if suffix not in {".html", ".js"} or info.is_dir():
+                    continue
+                total_text_bytes += int(info.file_size)
+                if total_text_bytes > MAX_TOTAL_TEXT_BYTES:
+                    raise OriginalPlayerBridgeAuditError("BRIDGE_TOTAL_TEXT_TOO_LARGE")
+                texts[info.filename] = _read_text(archive, info)
+    except OriginalPlayerBridgeAuditError:
+        raise
+    except (OSError, RuntimeError, zipfile.BadZipFile) as exc:
+        raise OriginalPlayerBridgeAuditError("BRIDGE_ARCHIVE_INVALID") from exc
+    return archive_sha256, texts
+
+
+def _application_texts(texts: dict[str, str]) -> dict[str, str]:
+    selected: dict[str, str] = {}
+    for name, text in texts.items():
+        basename = PurePosixPath(name).name.casefold()
+        if basename.startswith(("vendor-", "zh-cn-")):
+            continue
+        selected[name] = text
+    return selected
+
+
+def _query_keys(text: str) -> set[str]:
+    keys = set(_DIRECT_QUERY_METHOD_RE.findall(text))
+    aliases = set(_URLSEARCHPARAMS_ALIAS_RE.findall(text))
+    aliases.update(_SEARCHPARAMS_ALIAS_RE.findall(text))
+    for alias in aliases:
+        pattern = re.compile(
+            rf"(?<![A-Za-z0-9_$]){re.escape(alias)}\s*\.\s*"
+            r"(?:get|has|set|append|delete)\s*\(\s*[\"']"
+            r"([A-Za-z][A-Za-z0-9_.:-]{0,63})[\"']"
+        )
+        keys.update(pattern.findall(text))
+    keys.update(_QUERY_TEMPLATE_RE.findall(text))
+    return {value for value in keys if _SAFE_KEY_RE.fullmatch(value)}
+
+
+def _technical_literals(text: str) -> set[str]:
+    result: set[str] = set()
+    for match in _STRING_LITERAL_RE.finditer(text):
+        value = match.group("value")
+        lowered = value.casefold()
+        if lowered.startswith(("http://", "https://")):
+            continue
+        if not _SAFE_TECH_LITERAL_RE.fullmatch(value):
+            continue
+        if any(keyword in lowered for keyword in _TECH_LITERAL_KEYWORDS):
+            result.add(value)
+    return result
+
+
+def _bounded(values: Iterable[str]) -> list[str]:
+    return sorted(set(values))[:MAX_LIST_VALUES]
+
+
+def _context_signatures(text: str, token: str) -> dict[str, object]:
+    locations = [match.start() for match in re.finditer(re.escape(token), text)]
+    signatures: dict[str, tuple[str, ...]] = {}
+    for offset in locations[:MAX_CONTEXTS_PER_TOKEN]:
+        start = max(0, offset - _CONTEXT_RADIUS)
+        end = min(len(text), offset + len(token) + _CONTEXT_RADIUS)
+        window = text[start:end]
+        digest = hashlib.sha256(window.encode("utf-8")).hexdigest()
+        markers = tuple(
+            marker for marker in _CONTEXT_MARKERS if marker.casefold() in window.casefold()
+        )
+        signatures[digest] = markers
+    return {
+        "count": len(locations),
+        "contexts": [
+            {"sha256": digest, "markers": list(markers)}
+            for digest, markers in sorted(signatures.items())
+        ],
+    }
+
+
+def _scan_bundle(texts: dict[str, str], *, include_contexts: bool) -> dict[str, Any]:
+    application = _application_texts(texts)
+    combined = "\n".join(application.values())
+    query_keys: set[str] = set()
+    technical_literals: set[str] = set()
+    for text in application.values():
+        query_keys.update(_query_keys(text))
+        technical_literals.update(_technical_literals(text))
+
+    result: dict[str, Any] = {
+        "text_members": [
+            {
+                "member": name,
+                "bytes": len(text.encode("utf-8")),
+                "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            }
+            for name, text in sorted(application.items())
+        ],
+        "query_keys": _bounded(query_keys),
+        "technical_literals": _bounded(technical_literals),
+        "launch_marker_counts": {
+            marker: combined.count(marker) for marker in _LAUNCH_MARKERS
+        },
+        "generic_query_marker_counts": {
+            marker: combined.count(marker) for marker in _GENERIC_QUERY_MARKERS
+        },
+    }
+    if include_contexts:
+        result["player_reference_counts"] = {
+            token: combined.casefold().count(token.casefold())
+            for token in _PLAYER_REFERENCE_TOKENS
+        }
+        result["player_reference_contexts"] = {
+            token: _context_signatures(combined.casefold(), token.casefold())
+            for token in _PLAYER_REFERENCE_TOKENS
+            if token.casefold() in combined.casefold()
+        }
+    return result
+
+
+def audit_original_player_bridge(
+    resources_path: str | os.PathLike[str],
+) -> dict[str, Any]:
+    """Audit the original main bundle and both bundled players together."""
+
+    resources = Path(resources_path).expanduser()
+    if not resources.is_dir():
+        raise OriginalPlayerBridgeAuditError("BRIDGE_RESOURCES_NOT_FOUND")
+
+    feapp_sha256, feapp_texts = _read_archive_texts(
+        resources / "feapp.dat",
+        only_member=MAIN_JS,
+    )
+    player_archives: dict[str, dict[str, Any]] = {}
+    for archive_name in PLAYER_ARCHIVES:
+        archive_sha256, texts = _read_archive_texts(resources / archive_name)
+        player_archives[archive_name.removesuffix(".dat")] = {
+            "archive_sha256": archive_sha256,
+            **_scan_bundle(texts, include_contexts=False),
+        }
+
+    main = {
+        "archive_sha256": feapp_sha256,
+        **_scan_bundle(feapp_texts, include_contexts=True),
+    }
+    main_keys = set(main["query_keys"])
+    correlations: dict[str, object] = {}
+    for name, player in player_archives.items():
+        player_keys = set(player["query_keys"])
+        correlations[name] = {
+            "shared_query_keys": sorted(main_keys & player_keys),
+            "shared_technical_literals": sorted(
+                set(main["technical_literals"]) & set(player["technical_literals"])
+            )[:MAX_LIST_VALUES],
+        }
+
+    literal_references = sum(main["player_reference_counts"].values())
+    shared_key_count = sum(
+        len(value["shared_query_keys"]) for value in correlations.values()
+    )
+    if literal_references and shared_key_count:
+        bridge_state = "literal_reference_with_query_contract_candidate"
+    elif literal_references:
+        bridge_state = "literal_reference_without_query_contract"
+    else:
+        bridge_state = "no_literal_main_bridge_reference"
+
+    version_hint = resources.parent.name
+    if not re.fullmatch(r"[0-9A-Za-z._-]{1,64}", version_hint):
+        version_hint = None
+    return {
+        "schema_version": BRIDGE_AUDIT_SCHEMA_VERSION,
+        "status": "AUDITED",
+        "source": {
+            "client_version_hint": version_hint,
+            "archive_names": ["feapp.dat", *PLAYER_ARCHIVES],
+        },
+        "main_bundle": main,
+        "players": player_archives,
+        "correlation": correlations,
+        "bridge_state": bridge_state,
+        "limitations": [
+            "A technical literal or marker count is evidence of presence, not runtime behavior.",
+            "Context hashes and marker sets do not contain source and cannot alone define a patch anchor.",
+            "No player or original-client file is modified or extracted by this audit.",
+            "If the main bundle has no literal player reference, native-process or runtime tracing is still required.",
+        ],
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    temporary: Path | None = None
+    try:
+        path = path.expanduser().resolve()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        encoded = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as stream:
+            stream.write(encoded)
+            temporary = Path(stream.name)
+        os.replace(temporary, path)
+    except OSError as exc:
+        if temporary is not None:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise OriginalPlayerBridgeAuditError("BRIDGE_AUDIT_OUTPUT_FAILED") from exc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "resources",
+        type=Path,
+        help="path to the original versioned resources directory",
+    )
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    try:
+        report = audit_original_player_bridge(args.resources)
+        if args.output is not None:
+            _atomic_write_json(args.output, report)
+            print(
+                json.dumps(
+                    {
+                        "schema_version": BRIDGE_AUDIT_SCHEMA_VERSION,
+                        "status": "AUDITED",
+                        "output_name": args.output.name,
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+    except OriginalPlayerBridgeAuditError as exc:
+        print(
+            json.dumps(
+                {
+                    "schema_version": BRIDGE_AUDIT_SCHEMA_VERSION,
+                    "status": "FAILED",
+                    "error_code": exc.code,
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds the next read-only evidence tool required before modifying original-client media integration.

## Scope

- adds `tools/audit_original_player_bridge.py` for `feapp.dat`, `feplayer.dat`, and `webplayer.dat` together;
- detects bounded literal references to the two original player packages;
- extracts safe query keys from direct URLSearchParams calls, minified aliases, `.searchParams`, and `?key=` templates;
- records fixed launch/transport marker counts and source-free context hashes/marker sets;
- correlates main-bundle query keys and technical literals with each player;
- reports one of three structural states without claiming runtime behavior;
- never extracts or modifies archives and never emits source, arbitrary strings, full URLs, absolute paths, credentials, or user data;
- adds synthetic tests for a proven query-contract candidate, generic query parsing, malformed/unsafe archives, no-source output, and byte-for-byte non-mutation.

## Boundary

This PR adds no UI, no runtime route, no player patch, no new media field, and no standalone Control Center surface. CLIENT-UI-02 remains blocked until the user runs this audit against the supported original installation and the sanitized report is reviewed.

Part of #35, #37, and #38.