### PR TITLE
feat(client): define original mailbox wire contract

### DIFF
--- a/docs/P03_ORIGINAL_CLIENT_LETTER_CONTRACT.md
+++ b/docs/P03_ORIGINAL_CLIENT_LETTER_CONTRACT.md
@@ -1,0 +1,175 @@
+# P03 原版 Olivia 信箱响应契约
+
+## 1. 目的
+
+本文件把本地陪伴后端的内部状态映射到原版 Olivia `0.0.9.615` 的既有信箱契约。它不增加第二套客户端、不新增独立播放器页面，也不要求原版客户端理解本项目自定义字段。
+
+目标链路：
+
+```text
+本地内部状态
+  -> 原版 camelCase 信件字段
+  -> Collection 既有文字／视频回信组件
+```
+
+## 2. 已确认的原版枚举
+
+### 信件状态
+
+```text
+PENDING        = 1
+AUDITING       = 2
+LLM_PROCESSING = 3
+REPLIED        = 4
+FAILED         = 5
+```
+
+### 审核状态
+
+```text
+PENDING  = 1
+PASSED   = 2
+REJECTED = 3
+```
+
+### 回复类型
+
+```text
+NONE     = 0
+TEXT     = 1
+SPEECH   = 2
+MIX_PLAY = 3
+MIX_SVS  = 4
+```
+
+原版 Collection 将 `TEXT` 显示为文字回复，将其他非零回复类型显示为视频回复。
+
+## 3. 已确认的原版字段
+
+### 列表项
+
+```text
+letterId
+isRead
+letterStatus
+auditStatus
+summary
+createdAt
+repliedAt（可选）
+replyType
+```
+
+### 信件详情
+
+```text
+letterId
+isRead
+letterStatus
+auditStatus
+material.stampId（可选）
+material.paperId（可选）
+content
+createdAt
+repliedAt（可选）
+replyText
+replyType
+replyVideoUrl
+```
+
+### 列表响应
+
+```text
+list
+hasMore
+total
+nextCursor
+remainingToday
+```
+
+### 未读响应
+
+```text
+unreadCount
+```
+
+旧的 snake_case 字段只作为本仓库现有测试或内部调用者的兼容别名保留，不作为原版客户端契约。
+
+## 4. 本地三模式映射
+
+| 本地模式 | 媒体状态 | 原版 replyType | 原版表现 |
+| --- | --- | ---: | --- |
+| `text_letter` | 任意 | `TEXT` | 文字回复 |
+| `spoken_video` | `COMPLETED` 且有合法本机 MP4 | `SPEECH` | 视频回复 |
+| `spoken_video` | 等待、处理中或失败 | `TEXT` | 先保留文字正文 |
+| `musical_video` | `COMPLETED` 且有合法本机 MP4 | `MIX_SVS` | 视频回复 |
+| `musical_video` | 等待、处理中或失败 | `TEXT` | 先保留文字正文 |
+
+`musical_video -> MIX_SVS` 是本项目的语义映射决定：该模式包含生成演唱；`MIX_PLAY` 保留给纯演奏语义。
+
+## 5. 正文耐久性
+
+原版只在 `replyType` 为视频类型时使用 `replyVideoUrl`。因此本地后端必须遵守：
+
+```text
+canonical text 完成
+  -> letterStatus = REPLIED
+  -> 媒体尚未完成时 replyType = TEXT
+  -> 媒体完成后 replyType 切为对应视频类型
+```
+
+媒体失败不得把信件状态改回 `FAILED`，也不得清空 `replyText`。原版 Collection 的轮询在媒体完成后会重新读取详情，从文字投影切换到视频投影。
+
+## 6. 媒体 URL 边界
+
+公开给原版客户端的 `replyVideoUrl` 只允许：
+
+```text
+http://127.0.0.1:<port>/toy/media/<safe-name>.mp4
+http://localhost:<port>/toy/media/<safe-name>.mp4
+```
+
+禁止：
+
+- 外部域名；
+- 用户名或密码；
+- query token；
+- fragment；
+- 路径穿越；
+- 非 MP4 文件；
+- 任意本机文件路径。
+
+无合法本机 URL 时降级为文字回复。
+
+## 7. 原版播放器边界
+
+原版信箱视频回复使用 Collection 内现有的 `BaseVideo` 路径。`webplayer` 是另一套与 `uid`、下载进度和播放控制相关的播放器；`feplayer` 使用 `file` 参数。当前书信视频不需要新建播放器路由，也不应把 `webplayer` 或 `feplayer` 强行替换为信件详情组件。
+
+## 8. 实施顺序
+
+### CLIENT-CONTRACT-01
+
+- 新增纯枚举和序列化模块；
+- 锁定字段、状态、回复类型和安全媒体 URL；
+- 不修改运行时。
+
+### CLIENT-CONTRACT-02
+
+- 将列表、详情、未读和发送响应接入纯序列化模块；
+- 同时保留必要的 snake_case 兼容别名；
+- 设置 canonical `repliedAt`；
+- 验证媒体完成前后 `TEXT -> SPEECH/MIX_SVS`。
+
+### CLIENT-CONTRACT-03
+
+- 使用原版客户端真实打开文字、说话视频和音乐视频回复；
+- 验证轮询、详情切换、播放、失败降级和重启恢复。
+
+## 9. 完成条件
+
+- 原版字段全部使用正确 camelCase；
+- 原版状态和回复类型使用正确数值；
+- 文字正文始终可恢复；
+- 视频只有在本机 MP4 完成后才公开；
+- 原版 Collection 不依赖 `media_status`、`reply_mode` 等自定义字段；
+- 没有新增独立客户端、网页或播放器；
+- 公共 CI、hardening scan 和 whitespace check 通过。

--- a/original_client_letter_contract.py
+++ b/original_client_letter_contract.py
@@ -1,0 +1,361 @@
+"""Source-grounded wire contract for the original Olivia mailbox.
+
+The supported 0.0.9.615 client maps camelCase response fields into its
+Collection view.  This module keeps that public contract separate from local
+runtime state and preserves optional snake_case aliases only for existing local
+callers.  It contains no original client assets or source excerpts.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+import re
+import time
+from typing import Iterable, Mapping
+from urllib.parse import urlsplit
+
+
+class OriginalClientLetterStatus(IntEnum):
+    PENDING = 1
+    AUDITING = 2
+    LLM_PROCESSING = 3
+    REPLIED = 4
+    FAILED = 5
+
+
+class OriginalClientAuditStatus(IntEnum):
+    PENDING = 1
+    PASSED = 2
+    REJECTED = 3
+
+
+class OriginalClientReplyType(IntEnum):
+    NONE = 0
+    TEXT = 1
+    SPEECH = 2
+    MIX_PLAY = 3
+    MIX_SVS = 4
+
+
+_INTERNAL_LETTER_STATUS = {
+    "PENDING": OriginalClientLetterStatus.PENDING,
+    "AUDITING": OriginalClientLetterStatus.AUDITING,
+    "PROCESSING": OriginalClientLetterStatus.LLM_PROCESSING,
+    "LLM_PROCESSING": OriginalClientLetterStatus.LLM_PROCESSING,
+    "COMPLETED": OriginalClientLetterStatus.REPLIED,
+    "REPLIED": OriginalClientLetterStatus.REPLIED,
+    "FAILED": OriginalClientLetterStatus.FAILED,
+    "CANCELED": OriginalClientLetterStatus.FAILED,
+    "CANCELLED": OriginalClientLetterStatus.FAILED,
+}
+_INTERNAL_AUDIT_STATUS = {
+    "PENDING": OriginalClientAuditStatus.PENDING,
+    "PASSED": OriginalClientAuditStatus.PASSED,
+    "REJECTED": OriginalClientAuditStatus.REJECTED,
+}
+_MEDIA_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\.mp4$")
+_VIDEO_MODES = frozenset({"spoken_video", "musical_video", "video"})
+
+
+class OriginalClientContractError(ValueError):
+    """Stable contract error used only by pure serializers."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def _now_value(now: float | None) -> float:
+    value = time.time() if now is None else now
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise OriginalClientContractError("ORIGINAL_CLIENT_NOW_INVALID")
+    return float(value)
+
+
+def _published(letter: Mapping[str, object], *, now: float | None) -> bool:
+    deadline = letter.get("reply_not_before", 0.0)
+    if deadline in (None, ""):
+        deadline = 0.0
+    if isinstance(deadline, bool) or not isinstance(deadline, (int, float)):
+        return False
+    return float(deadline) <= _now_value(now)
+
+
+def _letter_status(value: object, *, published: bool) -> int:
+    if not published:
+        return int(OriginalClientLetterStatus.PENDING)
+    if isinstance(value, OriginalClientLetterStatus):
+        return int(value)
+    if type(value) is int:
+        try:
+            return int(OriginalClientLetterStatus(value))
+        except ValueError:
+            return int(OriginalClientLetterStatus.FAILED)
+    normalized = str(value or "").strip().upper()
+    return int(_INTERNAL_LETTER_STATUS.get(normalized, OriginalClientLetterStatus.FAILED))
+
+
+def _audit_status(value: object) -> int:
+    if isinstance(value, OriginalClientAuditStatus):
+        return int(value)
+    if type(value) is int:
+        try:
+            return int(OriginalClientAuditStatus(value))
+        except ValueError:
+            return int(OriginalClientAuditStatus.PASSED)
+    normalized = str(value or "").strip().upper()
+    return int(_INTERNAL_AUDIT_STATUS.get(normalized, OriginalClientAuditStatus.PASSED))
+
+
+def _exact_reply_mode(value: object) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"spoken_video", "musical_video", "text_letter"}:
+        return normalized
+    if normalized == "video":
+        return "musical_video"
+    return "text_letter"
+
+
+def _safe_local_media_url(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        return ""
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return ""
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"127.0.0.1", "localhost"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        return ""
+    try:
+        port = parsed.port
+    except ValueError:
+        return ""
+    if port is None or not 1 <= port <= 65535:
+        return ""
+    prefix = "/toy/media/"
+    if not parsed.path.startswith(prefix):
+        return ""
+    name = parsed.path[len(prefix) :]
+    return value if _MEDIA_NAME.fullmatch(name) else ""
+
+
+def _reply_projection(
+    letter: Mapping[str, object],
+    *,
+    published: bool,
+) -> tuple[int, str, str]:
+    reply_text = str(letter.get("reply_text") or "") if published else ""
+    if not reply_text:
+        return int(OriginalClientReplyType.NONE), "", ""
+
+    mode = _exact_reply_mode(letter.get("reply_mode"))
+    media_status = str(letter.get("media_status") or "").strip().upper()
+    media_url = _safe_local_media_url(letter.get("reply_video_url"))
+    if mode not in _VIDEO_MODES or media_status != "COMPLETED" or not media_url:
+        # Canonical text remains usable while media is pending or unavailable.
+        return int(OriginalClientReplyType.TEXT), reply_text, ""
+    if mode == "spoken_video":
+        return int(OriginalClientReplyType.SPEECH), reply_text, media_url
+    # The local musical-video mode contains generated singing, so the closest
+    # original-client semantic is MIX_SVS rather than instrumental MIX_PLAY.
+    return int(OriginalClientReplyType.MIX_SVS), reply_text, media_url
+
+
+def _required_identifier(letter: Mapping[str, object]) -> str:
+    value = letter.get("letter_id", letter.get("letterId"))
+    if not isinstance(value, str) or not value or len(value) > 256:
+        raise OriginalClientContractError("ORIGINAL_CLIENT_LETTER_ID_INVALID")
+    return value
+
+
+def _timestamp(value: object, *, default: int) -> object:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, (int, float, str)) and value not in (None, ""):
+        return value
+    return default
+
+
+def _material(value: object) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        return {}
+    result: dict[str, object] = {}
+    stamp = value.get("stampId", value.get("stamp_id"))
+    paper = value.get("paperId", value.get("paper_id"))
+    if isinstance(stamp, (str, int)) and not isinstance(stamp, bool):
+        result["stampId"] = stamp
+    if isinstance(paper, (str, int)) and not isinstance(paper, bool):
+        result["paperId"] = paper
+    return result
+
+
+def _summary(letter: Mapping[str, object]) -> str:
+    value = (
+        letter.get("summary")
+        or letter.get("content")
+        or letter.get("reply_text")
+        or ""
+    )
+    return str(value)[:50]
+
+
+def serialize_letter_summary(
+    letter: Mapping[str, object],
+    *,
+    now: float | None = None,
+    include_legacy_aliases: bool = False,
+) -> dict[str, object]:
+    current_time = int(_now_value(now))
+    published = _published(letter, now=now)
+    reply_type, _reply_text, _media_url = _reply_projection(letter, published=published)
+    letter_id = _required_identifier(letter)
+    status = _letter_status(letter.get("letter_status", letter.get("letterStatus")), published=published)
+    audit_status = _audit_status(letter.get("audit_status", letter.get("auditStatus")))
+    created_at = _timestamp(letter.get("created_at", letter.get("createdAt")), default=current_time)
+    payload: dict[str, object] = {
+        "letterId": letter_id,
+        "isRead": 1 if letter.get("is_read", letter.get("isRead", 1)) else 0,
+        "letterStatus": status,
+        "auditStatus": audit_status,
+        "summary": _summary(letter),
+        "createdAt": created_at,
+        "replyType": reply_type,
+    }
+    replied_at = letter.get("replied_at", letter.get("repliedAt"))
+    if replied_at not in (None, ""):
+        payload["repliedAt"] = replied_at
+    if include_legacy_aliases:
+        exact_mode = _exact_reply_mode(letter.get("reply_mode"))
+        payload.update(
+            {
+                "letter_id": letter_id,
+                "is_read": payload["isRead"],
+                "letter_status": status,
+                "audit_status": audit_status,
+                "created_at": created_at,
+                "reply_type": reply_type,
+                "reply_mode": "text" if exact_mode == "text_letter" else "video",
+                "reply_mode_exact": exact_mode,
+                "triage": letter.get("triage", {"status": "unavailable"}),
+            }
+        )
+        if "repliedAt" in payload:
+            payload["replied_at"] = payload["repliedAt"]
+    return payload
+
+
+def serialize_letter_detail(
+    letter: Mapping[str, object],
+    *,
+    now: float | None = None,
+    scope: str = "current",
+    include_legacy_aliases: bool = False,
+) -> dict[str, object]:
+    payload = serialize_letter_summary(
+        letter,
+        now=now,
+        include_legacy_aliases=include_legacy_aliases,
+    )
+    published = _published(letter, now=now)
+    reply_type, reply_text, media_url = _reply_projection(letter, published=published)
+    material = _material(letter.get("material", {}))
+    payload.update(
+        {
+            "material": material,
+            "content": str(letter.get("content") or ""),
+            "replyText": reply_text,
+            "replyType": reply_type,
+            "replyVideoUrl": media_url,
+        }
+    )
+    if include_legacy_aliases:
+        payload.update(
+            {
+                "reply_text": reply_text,
+                "reply_content": reply_text,
+                "reply_type": reply_type,
+                "reply_video_url": media_url,
+                "media_status": letter.get("media_status", "NOT_REQUESTED"),
+                "media_error_code": letter.get("media_error_code"),
+                "scope": scope,
+                "read_only": scope == "legacy",
+            }
+        )
+    return payload
+
+
+def serialize_letter_list(
+    letters: Iterable[Mapping[str, object]],
+    *,
+    remaining_today: int,
+    scope: str,
+    now: float | None = None,
+    include_legacy_aliases: bool = False,
+) -> dict[str, object]:
+    if type(remaining_today) is not int or remaining_today < 0:
+        raise OriginalClientContractError("ORIGINAL_CLIENT_REMAINING_INVALID")
+    serialized = [
+        serialize_letter_summary(
+            letter,
+            now=now,
+            include_legacy_aliases=include_legacy_aliases,
+        )
+        for letter in letters
+    ]
+    payload: dict[str, object] = {
+        "list": serialized,
+        "total": len(serialized),
+        "hasMore": False,
+        "nextCursor": 0,
+        "remainingToday": remaining_today,
+    }
+    if include_legacy_aliases:
+        payload.update(
+            {
+                "has_more": False,
+                "next_cursor": 0,
+                "remaining_today": remaining_today,
+                "scope": scope,
+                "source": "read-only-legacy" if scope == "legacy" else "local-memory",
+                "read_only": scope == "legacy",
+            }
+        )
+    return payload
+
+
+def serialize_unread_count(
+    unread_count: int,
+    *,
+    scope: str,
+    include_legacy_aliases: bool = False,
+) -> dict[str, object]:
+    if type(unread_count) is not int or unread_count < 0:
+        raise OriginalClientContractError("ORIGINAL_CLIENT_UNREAD_INVALID")
+    payload: dict[str, object] = {"unreadCount": unread_count}
+    if include_legacy_aliases:
+        payload.update(
+            {
+                "unread_count": unread_count,
+                "scope": scope,
+                "read_only": scope == "legacy",
+            }
+        )
+    return payload
+
+
+__all__ = [
+    "OriginalClientAuditStatus",
+    "OriginalClientContractError",
+    "OriginalClientLetterStatus",
+    "OriginalClientReplyType",
+    "serialize_letter_detail",
+    "serialize_letter_list",
+    "serialize_letter_summary",
+    "serialize_unread_count",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ py-modules = [
     "local_server",
     "mem0_memory",
     "memory",
+    "original_client_letter_contract",
     "patch_feapp",
     "persona_loader",
     "persona_assembly",

--- a/tests/http/test_original_client_letter_contract.py
+++ b/tests/http/test_original_client_letter_contract.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import pytest
+
+from original_client_letter_contract import (
+    OriginalClientAuditStatus,
+    OriginalClientContractError,
+    OriginalClientLetterStatus,
+    OriginalClientReplyType,
+    serialize_letter_detail,
+    serialize_letter_list,
+    serialize_letter_summary,
+    serialize_unread_count,
+)
+
+
+NOW = 1_800_000_000.0
+
+
+def _letter(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "letter_id": "letter-fixture-001",
+        "content": "这是一封用于原版信箱契约测试的合成来信。",
+        "letter_status": "COMPLETED",
+        "audit_status": 2,
+        "is_read": 1,
+        "created_at": 1_700_000_000,
+        "replied_at": 1_700_000_100,
+        "reply_text": "这是已经通过质量门的合成回复。",
+        "reply_mode": "text_letter",
+        "media_status": "NOT_REQUESTED",
+        "reply_not_before": 0.0,
+        "material": {"stamp_id": "stamp-1", "paperId": "paper-2"},
+    }
+    value.update(overrides)
+    return value
+
+
+def test_original_client_enums_match_supported_bundle() -> None:
+    assert tuple(int(value) for value in OriginalClientLetterStatus) == (1, 2, 3, 4, 5)
+    assert tuple(int(value) for value in OriginalClientAuditStatus) == (1, 2, 3)
+    assert tuple(int(value) for value in OriginalClientReplyType) == (0, 1, 2, 3, 4)
+
+
+def test_pending_publication_hides_reply_and_uses_original_pending_status() -> None:
+    detail = serialize_letter_detail(
+        _letter(reply_not_before=NOW + 60),
+        now=NOW,
+    )
+
+    assert detail == {
+        "letterId": "letter-fixture-001",
+        "isRead": 1,
+        "letterStatus": 1,
+        "auditStatus": 2,
+        "summary": "这是一封用于原版信箱契约测试的合成来信。",
+        "createdAt": 1_700_000_000,
+        "repliedAt": 1_700_000_100,
+        "replyType": 0,
+        "material": {"stampId": "stamp-1", "paperId": "paper-2"},
+        "content": "这是一封用于原版信箱契约测试的合成来信。",
+        "replyText": "",
+        "replyVideoUrl": "",
+    }
+
+
+def test_text_reply_uses_original_text_type() -> None:
+    detail = serialize_letter_detail(_letter(), now=NOW)
+
+    assert detail["letterStatus"] == OriginalClientLetterStatus.REPLIED
+    assert detail["replyType"] == OriginalClientReplyType.TEXT
+    assert detail["replyText"] == "这是已经通过质量门的合成回复。"
+    assert detail["replyVideoUrl"] == ""
+
+
+def test_video_modes_fall_back_to_durable_text_until_media_is_complete() -> None:
+    for mode in ("spoken_video", "musical_video"):
+        detail = serialize_letter_detail(
+            _letter(
+                reply_mode=mode,
+                media_status="PROCESSING",
+                reply_video_url="http://127.0.0.1:8899/toy/media/letter-fixture-001.mp4",
+            ),
+            now=NOW,
+        )
+        assert detail["letterStatus"] == 4
+        assert detail["replyType"] == 1
+        assert detail["replyText"] == "这是已经通过质量门的合成回复。"
+        assert detail["replyVideoUrl"] == ""
+
+
+def test_completed_spoken_video_uses_original_speech_type() -> None:
+    detail = serialize_letter_detail(
+        _letter(
+            reply_mode="spoken_video",
+            media_status="COMPLETED",
+            reply_video_url="http://127.0.0.1:8899/toy/media/letter-fixture-001.mp4",
+        ),
+        now=NOW,
+    )
+
+    assert detail["letterStatus"] == 4
+    assert detail["replyType"] == 2
+    assert detail["replyVideoUrl"] == (
+        "http://127.0.0.1:8899/toy/media/letter-fixture-001.mp4"
+    )
+
+
+def test_completed_musical_video_uses_original_singing_mix_type() -> None:
+    detail = serialize_letter_detail(
+        _letter(
+            reply_mode="musical_video",
+            media_status="COMPLETED",
+            reply_video_url="http://localhost:8899/toy/media/letter-fixture-001.mp4",
+        ),
+        now=NOW,
+    )
+
+    assert detail["replyType"] == 4
+    assert detail["replyVideoUrl"] == (
+        "http://localhost:8899/toy/media/letter-fixture-001.mp4"
+    )
+
+
+def test_untrusted_or_malformed_media_urls_never_reach_original_client() -> None:
+    values = (
+        "https://example.invalid/video.mp4",
+        "http://127.0.0.1:8899/private/video.mp4",
+        "http://127.0.0.1:8899/toy/media/../video.mp4",
+        "http://user:password@127.0.0.1:8899/toy/media/video.mp4",
+        "http://127.0.0.1:8899/toy/media/video.mp4?token=secret",
+        "not-a-url",
+    )
+    for value in values:
+        detail = serialize_letter_detail(
+            _letter(
+                reply_mode="spoken_video",
+                media_status="COMPLETED",
+                reply_video_url=value,
+            ),
+            now=NOW,
+        )
+        assert detail["replyType"] == 1
+        assert detail["replyVideoUrl"] == ""
+
+
+def test_failed_letter_preserves_original_failure_and_audit_enums() -> None:
+    summary = serialize_letter_summary(
+        _letter(
+            letter_status="FAILED",
+            audit_status="REJECTED",
+            reply_text="",
+            replied_at=None,
+        ),
+        now=NOW,
+    )
+
+    assert summary["letterStatus"] == 5
+    assert summary["auditStatus"] == 3
+    assert summary["replyType"] == 0
+    assert "repliedAt" not in summary
+
+
+def test_exact_aggregate_and_unread_names_are_emitted_with_optional_legacy_aliases() -> None:
+    listing = serialize_letter_list(
+        [_letter(), _letter(letter_id="letter-fixture-002", is_read=0)],
+        remaining_today=99,
+        scope="current",
+        now=NOW,
+        include_legacy_aliases=True,
+    )
+    unread = serialize_unread_count(
+        1,
+        scope="current",
+        include_legacy_aliases=True,
+    )
+
+    assert listing["hasMore"] is False
+    assert listing["nextCursor"] == 0
+    assert listing["remainingToday"] == 99
+    assert listing["has_more"] is False
+    assert listing["next_cursor"] == 0
+    assert listing["remaining_today"] == 99
+    assert listing["list"][0]["letterId"] == "letter-fixture-001"
+    assert listing["list"][0]["letter_id"] == "letter-fixture-001"
+    assert unread == {
+        "unreadCount": 1,
+        "unread_count": 1,
+        "scope": "current",
+        "read_only": False,
+    }
+
+
+def test_detail_legacy_aliases_do_not_change_original_fields() -> None:
+    detail = serialize_letter_detail(
+        _letter(
+            reply_mode="spoken_video",
+            media_status="COMPLETED",
+            reply_video_url="http://127.0.0.1:8899/toy/media/letter-fixture-001.mp4",
+        ),
+        now=NOW,
+        include_legacy_aliases=True,
+    )
+
+    assert detail["letterId"] == detail["letter_id"]
+    assert detail["letterStatus"] == detail["letter_status"] == 4
+    assert detail["auditStatus"] == detail["audit_status"] == 2
+    assert detail["replyType"] == detail["reply_type"] == 2
+    assert detail["replyText"] == detail["reply_text"] == detail["reply_content"]
+    assert detail["replyVideoUrl"] == detail["reply_video_url"]
+    assert detail["reply_mode"] == "video"
+    assert detail["reply_mode_exact"] == "spoken_video"
+
+
+def test_contract_rejects_invalid_ids_and_negative_counts() -> None:
+    with pytest.raises(OriginalClientContractError) as invalid_id:
+        serialize_letter_summary(_letter(letter_id=""), now=NOW)
+    assert invalid_id.value.code == "ORIGINAL_CLIENT_LETTER_ID_INVALID"
+
+    with pytest.raises(OriginalClientContractError) as invalid_remaining:
+        serialize_letter_list([], remaining_today=-1, scope="current", now=NOW)
+    assert invalid_remaining.value.code == "ORIGINAL_CLIENT_REMAINING_INVALID"
+
+    with pytest.raises(OriginalClientContractError) as invalid_unread:
+        serialize_unread_count(-1, scope="current")
+    assert invalid_unread.value.code == "ORIGINAL_CLIENT_UNREAD_INVALID"


### PR DESCRIPTION
Implements CLIENT-CONTRACT-01 from the original-client integration plan.

## Source-grounded contract

The supported `0.0.9.615` Collection bundle expects camelCase letter fields and the original numeric enums:

- letter status: pending/auditing/processing/replied/failed = `1..5`;
- audit status: pending/passed/rejected = `1..3`;
- reply type: none/text/speech/mix-play/mix-SVS = `0..4`;
- list/detail fields such as `letterId`, `letterStatus`, `replyText`, `replyType`, and `replyVideoUrl`;
- aggregate fields `hasMore`, `nextCursor`, `remainingToday`, and `unreadCount`.

## Scope

- adds a pure `original_client_letter_contract.py` serializer;
- maps `text_letter` to original text replies;
- maps completed `spoken_video` to original speech video;
- maps completed generated-singing `musical_video` to original MIX_SVS video;
- keeps canonical text visible while media is pending or unavailable;
- exposes a video URL only when it is a safe loopback `/toy/media/*.mp4` URL;
- supports optional snake_case aliases for existing local tests and internal callers;
- documents the contract and packages the module;
- adds tests for every enum, field, fallback, local-media boundary, aggregate name, and invalid input.

## Boundary

This PR does not modify `local_server.py`, the original client archive, any player, media renderer, or UI. CLIENT-CONTRACT-02 will wire this pure contract into list/detail/unread/send responses after this PR passes the protected Windows CI.

Part of #35, #36, #37, and #38.