### PR TITLE
feat(media): add original-player loopback range endpoint

### DIFF
--- a/original_client_media_http.py
+++ b/original_client_media_http.py
@@ -1,0 +1,337 @@
+"""Serve completed reply media to the original Olivia player over loopback HTTP.
+
+The original webplayer can receive a URL-like ``uid`` after its local fallback
+is installed. This module provides the narrow URL and byte-range contract
+needed by a native video element. It does not discover files, mutate letter
+state, or decide whether a reply should be video.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import mimetypes
+import os
+from pathlib import Path
+import re
+from typing import Protocol, runtime_checkable
+from urllib.parse import quote, urlsplit
+
+from aiohttp import web
+
+
+MEDIA_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+MEDIA_PATH = "/toy/media/{media_id}"
+DEFAULT_CHUNK_SIZE = 512 * 1024
+_ALLOWED_SUFFIXES = frozenset({".mp4", ".webm", ".m4v", ".mov"})
+_ALLOWED_CONTENT_TYPES = frozenset(
+    {"video/mp4", "video/webm", "video/quicktime", "video/x-m4v"}
+)
+
+
+class OriginalClientMediaError(RuntimeError):
+    """Stable media-serving failure without a local filesystem path."""
+
+    def __init__(self, code: str, *, status: int) -> None:
+        self.code = code
+        self.status = status
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class ResolvedReplyMedia:
+    media_id: str
+    path: Path
+    content_type: str | None = None
+
+
+@runtime_checkable
+class ReplyMediaResolver(Protocol):
+    def resolve_reply_media(self, media_id: str) -> ResolvedReplyMedia | None: ...
+
+
+@dataclass(frozen=True)
+class FileRange:
+    start: int
+    end: int
+    size: int
+    requested: bool
+
+    @property
+    def length(self) -> int:
+        return self.end - self.start + 1
+
+
+@dataclass(frozen=True)
+class ValidatedMediaFile:
+    media_id: str
+    path: Path
+    size: int
+    modified_ns: int
+    content_type: str
+    etag: str
+
+
+def _media_id(value: object) -> str:
+    if not isinstance(value, str) or not MEDIA_ID_RE.fullmatch(value):
+        raise OriginalClientMediaError("MEDIA_ID_INVALID", status=404)
+    return value
+
+
+def original_webplayer_uid(base_url: str, media_id: str) -> str:
+    """Build the only URL form accepted by the patched original webplayer."""
+
+    identifier = _media_id(media_id)
+    try:
+        parsed = urlsplit(base_url)
+        port = parsed.port
+    except ValueError as exc:
+        raise OriginalClientMediaError("MEDIA_BASE_URL_INVALID", status=500) from exc
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"127.0.0.1", "localhost"}
+        or port is None
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise OriginalClientMediaError("MEDIA_BASE_URL_INVALID", status=500)
+    return (
+        f"http://{parsed.hostname}:{port}/toy/media/"
+        f"{quote(identifier, safe='._:-')}"
+    )
+
+
+def _content_type(path: Path, declared: str | None) -> str:
+    if declared:
+        normalized = declared.strip().casefold()
+        if normalized in _ALLOWED_CONTENT_TYPES:
+            return normalized
+        raise OriginalClientMediaError("MEDIA_CONTENT_TYPE_INVALID", status=500)
+    guessed, _encoding = mimetypes.guess_type(path.name)
+    if guessed in _ALLOWED_CONTENT_TYPES:
+        return guessed
+    raise OriginalClientMediaError("MEDIA_CONTENT_TYPE_INVALID", status=500)
+
+
+def _validated_file(
+    resolver: ReplyMediaResolver,
+    media_root: Path,
+    media_id: str,
+) -> ValidatedMediaFile:
+    try:
+        resolved = resolver.resolve_reply_media(media_id)
+    except (OSError, RuntimeError, ValueError, TypeError) as exc:
+        raise OriginalClientMediaError("MEDIA_RESOLVER_UNAVAILABLE", status=503) from exc
+    if resolved is None:
+        raise OriginalClientMediaError("MEDIA_NOT_FOUND", status=404)
+    if not isinstance(resolved, ResolvedReplyMedia) or resolved.media_id != media_id:
+        raise OriginalClientMediaError("MEDIA_RESOLVER_INVALID", status=503)
+
+    root = media_root.expanduser().resolve()
+    try:
+        path = resolved.path.expanduser().resolve(strict=True)
+        common = os.path.commonpath([str(root), str(path)])
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise OriginalClientMediaError("MEDIA_NOT_FOUND", status=404) from exc
+    if (
+        common != str(root)
+        or not path.is_file()
+        or path.suffix.casefold() not in _ALLOWED_SUFFIXES
+    ):
+        raise OriginalClientMediaError("MEDIA_NOT_FOUND", status=404)
+    try:
+        stat = path.stat()
+    except OSError as exc:
+        raise OriginalClientMediaError("MEDIA_NOT_FOUND", status=404) from exc
+    if stat.st_size <= 0:
+        raise OriginalClientMediaError("MEDIA_NOT_FOUND", status=404)
+
+    content_type = _content_type(path, resolved.content_type)
+    digest = hashlib.sha256(
+        f"{media_id}\0{stat.st_size}\0{stat.st_mtime_ns}".encode("utf-8")
+    ).hexdigest()[:32]
+    return ValidatedMediaFile(
+        media_id=media_id,
+        path=path,
+        size=int(stat.st_size),
+        modified_ns=int(stat.st_mtime_ns),
+        content_type=content_type,
+        etag=f'"{digest}"',
+    )
+
+
+def _parse_range(value: str | None, size: int) -> FileRange:
+    if not value:
+        return FileRange(0, size - 1, size, False)
+    if not value.startswith("bytes=") or "," in value:
+        raise OriginalClientMediaError("MEDIA_RANGE_INVALID", status=416)
+    spec = value[6:].strip()
+    if spec.count("-") != 1:
+        raise OriginalClientMediaError("MEDIA_RANGE_INVALID", status=416)
+    left, right = spec.split("-", 1)
+    try:
+        if left:
+            start = int(left)
+            end = int(right) if right else size - 1
+        elif right:
+            suffix = int(right)
+            if suffix <= 0:
+                raise ValueError
+            suffix = min(suffix, size)
+            start = size - suffix
+            end = size - 1
+        else:
+            raise ValueError
+    except ValueError as exc:
+        raise OriginalClientMediaError("MEDIA_RANGE_INVALID", status=416) from exc
+    if start < 0 or end < start or start >= size:
+        raise OriginalClientMediaError("MEDIA_RANGE_INVALID", status=416)
+    return FileRange(start, min(end, size - 1), size, True)
+
+
+def _headers(media: ValidatedMediaFile, file_range: FileRange) -> dict[str, str]:
+    headers = {
+        "Accept-Ranges": "bytes",
+        "Cache-Control": "private, no-store",
+        "Content-Length": str(file_range.length),
+        "Content-Type": media.content_type,
+        "ETag": media.etag,
+        "X-Content-Type-Options": "nosniff",
+    }
+    if file_range.requested:
+        headers["Content-Range"] = (
+            f"bytes {file_range.start}-{file_range.end}/{file_range.size}"
+        )
+    return headers
+
+
+def _error_response(
+    exc: OriginalClientMediaError,
+    *,
+    size: int | None = None,
+    head: bool = False,
+) -> web.Response:
+    headers = {
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+    }
+    if exc.status == 416:
+        headers["Content-Range"] = f"bytes */{size if size is not None else '*'}"
+    if head:
+        return web.Response(status=exc.status, headers=headers)
+    return web.json_response(
+        {"status": "FAILED", "error_code": exc.code},
+        status=exc.status,
+        headers=headers,
+    )
+
+
+def create_reply_media_handler(
+    *,
+    resolver: ReplyMediaResolver,
+    media_root: str | os.PathLike[str],
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+):
+    """Create an aiohttp GET/HEAD handler without opening a second service."""
+
+    if not isinstance(resolver, ReplyMediaResolver):
+        raise TypeError("a ReplyMediaResolver is required")
+    root = Path(media_root).expanduser().resolve()
+    if chunk_size < 64 * 1024 or chunk_size > 4 * 1024 * 1024:
+        raise ValueError("media chunk size is out of bounds")
+
+    async def handle(request: web.Request) -> web.StreamResponse:
+        media: ValidatedMediaFile | None = None
+        try:
+            identifier = _media_id(request.match_info.get("media_id"))
+            media = _validated_file(resolver, root, identifier)
+            if_none_match = request.headers.get("If-None-Match")
+            if (
+                if_none_match
+                and if_none_match.strip() == media.etag
+                and not request.headers.get("Range")
+            ):
+                return web.Response(
+                    status=304,
+                    headers={
+                        "Cache-Control": "private, no-store",
+                        "ETag": media.etag,
+                        "X-Content-Type-Options": "nosniff",
+                    },
+                )
+            file_range = _parse_range(request.headers.get("Range"), media.size)
+        except OriginalClientMediaError as exc:
+            return _error_response(
+                exc,
+                size=media.size if media is not None else None,
+                head=request.method == "HEAD",
+            )
+
+        status = 206 if file_range.requested else 200
+        headers = _headers(media, file_range)
+        if request.method == "HEAD":
+            return web.Response(status=status, headers=headers)
+
+        try:
+            stream = media.path.open("rb")
+            stream.seek(file_range.start)
+        except OSError:
+            return _error_response(
+                OriginalClientMediaError("MEDIA_READ_FAILED", status=500)
+            )
+
+        response = web.StreamResponse(status=status, headers=headers)
+        try:
+            await response.prepare(request)
+            remaining = file_range.length
+            while remaining:
+                block = stream.read(min(chunk_size, remaining))
+                if not block:
+                    response.force_close()
+                    return response
+                await response.write(block)
+                remaining -= len(block)
+            await response.write_eof()
+            return response
+        except (ConnectionError, OSError, RuntimeError):
+            response.force_close()
+            return response
+        finally:
+            stream.close()
+
+    return handle
+
+
+def mount_reply_media_route(
+    app: web.Application,
+    *,
+    resolver: ReplyMediaResolver,
+    media_root: str | os.PathLike[str],
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+) -> None:
+    """Mount the original-player media route once on the existing local app."""
+
+    if "original_reply_media_mounted" in app:
+        raise RuntimeError("MEDIA_ROUTE_ALREADY_MOUNTED")
+    handler = create_reply_media_handler(
+        resolver=resolver,
+        media_root=media_root,
+        chunk_size=chunk_size,
+    )
+    app["original_reply_media_mounted"] = True
+    app.router.add_get(MEDIA_PATH, handler, allow_head=True)
+
+
+__all__ = [
+    "DEFAULT_CHUNK_SIZE",
+    "MEDIA_PATH",
+    "OriginalClientMediaError",
+    "ReplyMediaResolver",
+    "ResolvedReplyMedia",
+    "create_reply_media_handler",
+    "mount_reply_media_route",
+    "original_webplayer_uid",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ py-modules = [
     "mem0_memory",
     "memory",
     "original_client_letter_contract",
+    "original_client_media_http",
     "patch_feapp",
     "persona_loader",
     "persona_assembly",

--- a/tests/http/test_original_client_media_http.py
+++ b/tests/http/test_original_client_media_http.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+import pytest
+
+from original_client_media_http import (
+    OriginalClientMediaError,
+    ResolvedReplyMedia,
+    mount_reply_media_route,
+    original_webplayer_uid,
+)
+
+
+class MappingResolver:
+    def __init__(self, values: dict[str, ResolvedReplyMedia]) -> None:
+        self.values = values
+        self.requests: list[str] = []
+
+    def resolve_reply_media(self, media_id: str) -> ResolvedReplyMedia | None:
+        self.requests.append(media_id)
+        return self.values.get(media_id)
+
+
+def _client(
+    tmp_path: Path,
+    *,
+    content: bytes = b"0123456789abcdefghijklmnopqrstuvwxyz",
+) -> tuple[web.Application, MappingResolver, Path]:
+    media_root = tmp_path / "media"
+    media_root.mkdir()
+    media = media_root / "reply.mp4"
+    media.write_bytes(content)
+    resolver = MappingResolver(
+        {"letter-1:revision-2": ResolvedReplyMedia("letter-1:revision-2", media)}
+    )
+    app = web.Application()
+    mount_reply_media_route(app, resolver=resolver, media_root=media_root)
+    return app, resolver, media
+
+
+def test_original_webplayer_uid_accepts_only_explicit_loopback_base() -> None:
+    assert original_webplayer_uid(
+        "http://127.0.0.1:8899", "letter-1:revision-2"
+    ) == "http://127.0.0.1:8899/toy/media/letter-1:revision-2"
+    assert original_webplayer_uid(
+        "http://localhost:8899/", "letter.1"
+    ) == "http://localhost:8899/toy/media/letter.1"
+
+    invalid = (
+        "https://127.0.0.1:8899",
+        "http://example.invalid:8899",
+        "http://127.0.0.1",
+        "http://user@127.0.0.1:8899",
+        "http://127.0.0.1:8899/base",
+        "http://127.0.0.1:8899?token=x",
+    )
+    for value in invalid:
+        with pytest.raises(OriginalClientMediaError) as error:
+            original_webplayer_uid(value, "letter-1")
+        assert error.value.code == "MEDIA_BASE_URL_INVALID"
+
+    with pytest.raises(OriginalClientMediaError) as identifier:
+        original_webplayer_uid("http://127.0.0.1:8899", "../reply")
+    assert identifier.value.code == "MEDIA_ID_INVALID"
+
+
+def test_media_route_serves_full_get_head_and_etag(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        app, resolver, media = _client(tmp_path)
+        async with TestClient(TestServer(app)) as client:
+            response = await client.get("/toy/media/letter-1:revision-2")
+            assert response.status == 200
+            assert await response.read() == media.read_bytes()
+            assert response.headers["Accept-Ranges"] == "bytes"
+            assert response.headers["Content-Type"].startswith("video/mp4")
+            assert response.headers["Content-Length"] == str(media.stat().st_size)
+            assert response.headers["Cache-Control"] == "private, no-store"
+            assert response.headers["X-Content-Type-Options"] == "nosniff"
+            etag = response.headers["ETag"]
+
+            head = await client.head("/toy/media/letter-1:revision-2")
+            assert head.status == 200
+            assert await head.read() == b""
+            assert head.headers["ETag"] == etag
+            assert head.headers["Content-Length"] == str(media.stat().st_size)
+
+            unchanged = await client.get(
+                "/toy/media/letter-1:revision-2",
+                headers={"If-None-Match": etag},
+            )
+            assert unchanged.status == 304
+            assert await unchanged.read() == b""
+            assert resolver.requests == [
+                "letter-1:revision-2",
+                "letter-1:revision-2",
+                "letter-1:revision-2",
+            ]
+
+    asyncio.run(scenario())
+
+
+def test_media_route_supports_open_closed_full_and_suffix_ranges(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        app, _resolver, _media = _client(tmp_path, content=b"0123456789")
+        async with TestClient(TestServer(app)) as client:
+            cases = (
+                ("bytes=2-5", b"2345", "bytes 2-5/10"),
+                ("bytes=7-", b"789", "bytes 7-9/10"),
+                ("bytes=-3", b"789", "bytes 7-9/10"),
+                ("bytes=8-99", b"89", "bytes 8-9/10"),
+                ("bytes=0-9", b"0123456789", "bytes 0-9/10"),
+            )
+            for requested, expected, content_range in cases:
+                response = await client.get(
+                    "/toy/media/letter-1:revision-2",
+                    headers={"Range": requested},
+                )
+                assert response.status == 206
+                assert await response.read() == expected
+                assert response.headers["Content-Range"] == content_range
+                assert response.headers["Content-Length"] == str(len(expected))
+
+    asyncio.run(scenario())
+
+
+def test_media_route_rejects_invalid_ranges_and_unknown_ids(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        app, _resolver, _media = _client(tmp_path, content=b"0123456789")
+        async with TestClient(TestServer(app)) as client:
+            for value in (
+                "items=0-1",
+                "bytes=",
+                "bytes=9-2",
+                "bytes=20-",
+                "bytes=0-1,3-4",
+            ):
+                response = await client.get(
+                    "/toy/media/letter-1:revision-2",
+                    headers={"Range": value},
+                )
+                assert response.status == 416
+                assert (await response.json())["error_code"] == "MEDIA_RANGE_INVALID"
+                assert response.headers["Content-Range"] == "bytes */10"
+
+            missing = await client.get("/toy/media/unknown")
+            assert missing.status == 404
+            assert (await missing.json()) == {
+                "status": "FAILED",
+                "error_code": "MEDIA_NOT_FOUND",
+            }
+
+            malformed = await client.get("/toy/media/..%2Freply")
+            assert malformed.status in {404, 405}
+
+    asyncio.run(scenario())
+
+
+def test_media_route_confines_resolved_files_to_media_root(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        media_root = tmp_path / "media"
+        media_root.mkdir()
+        outside = tmp_path / "outside.mp4"
+        outside.write_bytes(b"private")
+        resolver = MappingResolver({"outside": ResolvedReplyMedia("outside", outside)})
+        app = web.Application()
+        mount_reply_media_route(app, resolver=resolver, media_root=media_root)
+
+        async with TestClient(TestServer(app)) as client:
+            response = await client.get("/toy/media/outside")
+            assert response.status == 404
+            payload = await response.json()
+            assert payload["error_code"] == "MEDIA_NOT_FOUND"
+            assert str(outside) not in str(payload)
+
+    asyncio.run(scenario())
+
+
+def test_media_route_rejects_empty_non_video_and_invalid_resolver_results(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        media_root = tmp_path / "media"
+        media_root.mkdir()
+        empty = media_root / "empty.mp4"
+        empty.write_bytes(b"")
+        text = media_root / "reply.txt"
+        text.write_text("not media", encoding="utf-8")
+
+        class InvalidResolver:
+            def resolve_reply_media(self, media_id: str):
+                if media_id == "empty":
+                    return ResolvedReplyMedia("empty", empty)
+                if media_id == "text":
+                    return ResolvedReplyMedia("text", text)
+                if media_id == "wrong":
+                    return ResolvedReplyMedia("different", empty)
+                raise OSError("private path")
+
+        app = web.Application()
+        mount_reply_media_route(app, resolver=InvalidResolver(), media_root=media_root)
+        async with TestClient(TestServer(app)) as client:
+            for media_id in ("empty", "text"):
+                response = await client.get(f"/toy/media/{media_id}")
+                assert response.status == 404
+                assert (await response.json())["error_code"] == "MEDIA_NOT_FOUND"
+
+            wrong = await client.get("/toy/media/wrong")
+            assert wrong.status == 503
+            assert (await wrong.json())["error_code"] == "MEDIA_RESOLVER_INVALID"
+
+            failed = await client.get("/toy/media/failed")
+            assert failed.status == 503
+            payload = await failed.json()
+            assert payload["error_code"] == "MEDIA_RESOLVER_UNAVAILABLE"
+            assert "private path" not in str(payload)
+
+    asyncio.run(scenario())
+
+
+def test_media_route_mounts_once_and_validates_chunk_size(tmp_path: Path) -> None:
+    media_root = tmp_path / "media"
+    media_root.mkdir()
+    resolver = MappingResolver({})
+    app = web.Application()
+    mount_reply_media_route(app, resolver=resolver, media_root=media_root)
+
+    with pytest.raises(RuntimeError, match="MEDIA_ROUTE_ALREADY_MOUNTED"):
+        mount_reply_media_route(app, resolver=resolver, media_root=media_root)
+
+    other = web.Application()
+    with pytest.raises(ValueError, match="chunk size"):
+        mount_reply_media_route(
+            other,
+            resolver=resolver,
+            media_root=media_root,
+            chunk_size=1024,
+        )


### PR DESCRIPTION
Implements the second CLIENT-MEDIA slice under the original-client-only boundary.

## Scope

- adds a narrow loopback URL builder for the patched original webplayer;
- serves completed reply videos at `/toy/media/{media_id}` from the existing local aiohttp application;
- supports GET, HEAD, ETag, full responses, single byte ranges, open ranges, suffix ranges, and 206/416 contracts required by native video seeking;
- streams files in bounded chunks rather than loading a full video into memory;
- confines resolver results to an explicit media root and approved video suffix/content types;
- returns only stable error codes and never exposes filesystem paths;
- rejects external/non-loopback base URLs, credentials, fragments, invalid IDs, multiple ranges, empty files, symlink/path escapes, and malformed resolver results;
- packages the module for installed runtime use;
- is synchronized with the latest protected `main`, including the isolated original-webplayer patch.

## Tests

- loopback UID construction and rejection boundaries;
- full GET, HEAD, ETag, and cache behavior;
- closed, open, suffix, clipped, and full byte ranges;
- invalid ranges and unknown IDs;
- root confinement and non-video/empty files;
- resolver failures, duplicate mounting, and chunk bounds.

## Boundary

This PR adds the reusable serving contract only. It does not yet mount the route in `local_server.py`, expose a media UID in original letter responses, change the original UI, or enable standalone Control Center UI. Those remain separate reviewable changes.

Part of #35, #37, and #38.