### PR TITLE
feat(client): add companion management shell inside original settings

### DIFF
--- a/docs/P03_ORIGINAL_CLIENT_COMPANION_SETTINGS.md
+++ b/docs/P03_ORIGINAL_CLIENT_COMPANION_SETTINGS.md
@@ -1,0 +1,109 @@
+# P03 原版客户端内陪伴设置入口
+
+## 1. 决策
+
+原版 Olivia 客户端继续作为唯一用户产品外壳。
+
+陪伴系统的长期记忆和 PrivateWorld 管理入口放入原版 `/settings` 页面，不创建：
+
+- 独立浏览器 Control Center；
+- 第二套桌面客户端；
+- 新的前端路由；
+- iframe；
+- 要求普通用户执行的 CLI。
+
+## 2. 原版依据
+
+受支持客户端 `0.0.9.615` 已确认存在：
+
+```text
+/settings  -> SettingsView
+Collection -> 原版信箱
+webplayer  -> 原版视频播放链
+```
+
+`SettingsView` 已有 `tp-settings-item` 分区，以及 `button`、`link`、`switch`、`select` 等现有交互形式。因此本地陪伴入口只在该页面追加一个同结构分区。
+
+## 3. 本 PR 的范围
+
+新增：
+
+```text
+patch_companion_settings.py
+```
+
+它在隔离安装副本的 `feapp.dat` 中：
+
+1. 核验唯一的原版主模块标签；
+2. 保持 `assets/main-917d29fc.js` 及其他既有资源逐字节不变；
+3. 只修改 `index.html`；
+4. 新增一个仓库自有的本地 bootstrap；
+5. 在 `/settings` 中追加“本地陪伴”分区；
+6. 在原版窗口内打开“长期记忆 / 私人世界”弹层外壳；
+7. 只允许连接显式的 `127.0.0.1` 或 `localhost` HTTP 端口；
+8. 失败时恢复修改前的归档。
+
+## 4. 用户界面边界
+
+入口沿用原版设置页已有样式类：
+
+```text
+tp-settings-item
+text-text-body
+text-title-m
+text-label-l
+rounded-full
+border-grey-5
+```
+
+弹层：
+
+- 留在原版窗口内；
+- 可通过关闭按钮、背景点击或 Escape 退出；
+- 使用语义化 dialog / tab / tabpanel；
+- 不加载外部脚本、字体或页面；
+- 不在此 PR 中复制 Memory 或 PrivateWorld 业务逻辑。
+
+## 5. 后端契约
+
+本 PR 只预留只读状态路径：
+
+```text
+GET /toy/companion/status
+```
+
+如果该路径尚未接线，界面显示“本机陪伴服务暂不可用”，不会伪造成功。
+
+后续 PR 依次接入：
+
+```text
+CLIENT-SETTINGS-02  状态与只读数据 API
+CLIENT-SETTINGS-03  长期记忆查看、纠正和删除
+CLIENT-SETTINGS-04  PrivateWorld 快照、候选和受控修改
+CLIENT-SETTINGS-05  安装器接线与原版客户端真实验收
+```
+
+所有写操作必须继续经过现有 Memory Service、PrivateWorld Command Service、Reducer 和 Ledger，前端不能直接写 SQLite 或 Qdrant。
+
+## 6. 安全与回滚
+
+- 只补丁隔离安装副本；
+- 独立保留 `feapp.dat.companion.orig`；
+- ZIP 成员路径必须安全；
+- 原版主模块缺失或锚点不唯一时停止；
+- 重复运行保持幂等；
+- API 地址变化时停止，不静默改写既有安装；
+- 原有成员除 `index.html` 外必须保持相同哈希；
+- 新 bootstrap 不包含 iframe、`window.open` 或外部 URL；
+- 任一验证失败时恢复开始前的归档。
+
+## 7. 完成条件
+
+- 真实 `0.0.9.615` 原版归档可通过补丁验证；
+- 原版主模块 SHA-256 保持不变；
+- 设置入口只在 `/settings` 出现；
+- 不创建新路由或独立页面；
+- 同一配置重复执行不重复注入；
+- 非 loopback API 地址全部拒绝；
+- 备份、回滚和归档安全测试通过；
+- `public-smoke` 与 hardening scan 通过。

--- a/patch_companion_settings.py
+++ b/patch_companion_settings.py
@@ -1,0 +1,638 @@
+"""Add a bounded companion panel to the supported Olivia settings view.
+
+The patch only changes a staged ``feapp.dat`` archive. It keeps the client main
+module byte-for-byte intact, inserts one local bootstrap script into
+``index.html``, and rolls the archive back if any validation step fails.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import os
+from pathlib import Path, PurePosixPath, PureWindowsPath
+import re
+import shutil
+import tempfile
+from urllib.parse import urlsplit
+import zipfile
+
+
+INDEX_MEMBER = "index.html"
+MAIN_MODULE_MEMBER = "assets/main-917d29fc.js"
+BOOTSTRAP_MEMBER = "assets/olivia-companion-settings.js"
+PATCH_MARKER = "data-olivia-companion-settings"
+PATCH_SCHEMA_VERSION = "p03.original-settings-shell.v1"
+MAX_ARCHIVE_MEMBERS = 100_000
+MAX_TEXT_MEMBER_BYTES = 64 * 1024 * 1024
+
+_MODULE_SCRIPT_RE = re.compile(
+    r"<script\b"
+    r"(?=[^>]*\btype\s*=\s*([\"'])module\1)"
+    r"(?=[^>]*\bsrc\s*=\s*([\"'])\./assets/main-917d29fc\.js\2)"
+    r"[^>]*>\s*</script>",
+    flags=re.IGNORECASE,
+)
+_MARKER_TAG_RE = re.compile(
+    r"<script\b[^>]*\bdata-olivia-companion-settings="
+    r"([\"'])p03\.original-settings-shell\.v1\1[^>]*>",
+    flags=re.IGNORECASE,
+)
+_API_BASE_RE = re.compile(
+    r"\bdata-api-base=([\"'])(?P<value>[^\"']+)\1",
+    flags=re.IGNORECASE,
+)
+
+_BOOTSTRAP_JAVASCRIPT = r'''(() => {
+  "use strict";
+
+  const loader = document.currentScript;
+  const rawApiBase = loader && loader.dataset ? loader.dataset.apiBase : "";
+  const ROOT_ATTR = "data-olivia-companion-settings-root";
+  const DIALOG_ATTR = "data-olivia-companion-settings-dialog";
+  const STATUS_PATH = "/toy/companion/status";
+
+  const parseApiBase = (value) => {
+    let url;
+    try {
+      url = new URL(value);
+    } catch (_error) {
+      return null;
+    }
+    const loopback = url.hostname === "127.0.0.1" || url.hostname === "localhost";
+    if (
+      url.protocol !== "http:" ||
+      !loopback ||
+      !url.port ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash ||
+      (url.pathname !== "/" && url.pathname !== "")
+    ) {
+      return null;
+    }
+    return url;
+  };
+
+  const apiBase = parseApiBase(rawApiBase);
+  if (!apiBase) {
+    return;
+  }
+
+  const text = (tag, value, className) => {
+    const element = document.createElement(tag);
+    element.textContent = value;
+    if (className) {
+      element.className = className;
+    }
+    return element;
+  };
+
+  const button = (label, onClick) => {
+    const element = document.createElement("button");
+    element.type = "button";
+    element.textContent = label;
+    element.className = "px-6 py-2.5 rounded-full border border-grey-5 text-text-body text-label-m font-medium cursor-pointer hover:bg-surface-1 transition-colors";
+    element.addEventListener("click", onClick);
+    return element;
+  };
+
+  const isSettingsRoute = () => {
+    const route = `${window.location.pathname} ${window.location.hash}`;
+    return /(?:^|[\/#])settings(?:[\/?#]|$)/i.test(route);
+  };
+
+  const removeShell = () => {
+    document.querySelector(`[${ROOT_ATTR}]`)?.remove();
+    document.querySelector(`[${DIALOG_ATTR}]`)?.remove();
+  };
+
+  const statusMessage = (node, value) => {
+    node.textContent = value;
+    node.dataset.state = value === "本机陪伴服务可用。" ? "available" : "unavailable";
+  };
+
+  const loadStatus = async (node) => {
+    statusMessage(node, "正在连接本机陪伴服务……");
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 3000);
+    try {
+      const endpoint = new URL(STATUS_PATH, apiBase);
+      const response = await fetch(endpoint, {
+        method: "GET",
+        cache: "no-store",
+        credentials: "omit",
+        headers: { "Accept": "application/json" },
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error("unavailable");
+      }
+      const payload = await response.json();
+      if (!payload || payload.status !== "READY") {
+        throw new Error("unavailable");
+      }
+      statusMessage(node, "本机陪伴服务可用。");
+    } catch (_error) {
+      statusMessage(node, "本机陪伴服务暂不可用。");
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  };
+
+  const openDialog = () => {
+    document.querySelector(`[${DIALOG_ATTR}]`)?.remove();
+
+    const backdrop = document.createElement("div");
+    backdrop.setAttribute(DIALOG_ATTR, "");
+    backdrop.style.position = "fixed";
+    backdrop.style.inset = "0";
+    backdrop.style.zIndex = "2147483000";
+    backdrop.style.display = "grid";
+    backdrop.style.placeItems = "center";
+    backdrop.style.padding = "40px";
+    backdrop.style.background = "rgba(0, 0, 0, 0.62)";
+
+    const dialog = document.createElement("section");
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("aria-modal", "true");
+    dialog.setAttribute("aria-labelledby", "olivia-companion-dialog-title");
+    dialog.style.width = "min(760px, calc(100vw - 80px))";
+    dialog.style.maxHeight = "calc(100vh - 80px)";
+    dialog.style.overflow = "auto";
+    dialog.style.borderRadius = "16px";
+    dialog.style.padding = "28px";
+    dialog.style.background = "var(--el-bg-color, #202124)";
+    dialog.style.boxShadow = "0 24px 80px rgba(0, 0, 0, 0.45)";
+
+    const header = document.createElement("div");
+    header.style.display = "flex";
+    header.style.alignItems = "center";
+    header.style.justifyContent = "space-between";
+    header.style.gap = "24px";
+
+    const heading = text("h2", "本地陪伴", "text-text-title text-headline-m");
+    heading.id = "olivia-companion-dialog-title";
+    heading.style.margin = "0";
+
+    const close = button("关闭", () => backdrop.remove());
+    header.append(heading, close);
+
+    const status = text(
+      "p",
+      "正在连接本机陪伴服务……",
+      "text-text-secondary text-body-m font-regular"
+    );
+    status.setAttribute("aria-live", "polite");
+    status.style.margin = "20px 0";
+
+    const tabs = document.createElement("div");
+    tabs.setAttribute("role", "tablist");
+    tabs.style.display = "flex";
+    tabs.style.gap = "12px";
+    tabs.style.marginBottom = "18px";
+
+    const panels = document.createElement("div");
+    const definitions = [
+      {
+        id: "memory",
+        label: "长期记忆",
+        description: "查看、纠正或删除林离在新对话中形成的本地记忆。",
+      },
+      {
+        id: "private-world",
+        label: "私人世界",
+        description: "管理关系边界、私人称呼、住所权限和本地世界线。",
+      },
+    ];
+
+    const showPanel = (id) => {
+      for (const tab of tabs.querySelectorAll('[role="tab"]')) {
+        const active = tab.dataset.panelId === id;
+        tab.setAttribute("aria-selected", active ? "true" : "false");
+        tab.style.background = active ? "rgba(255,255,255,0.12)" : "transparent";
+      }
+      for (const panel of panels.querySelectorAll('[role="tabpanel"]')) {
+        panel.hidden = panel.dataset.panelId !== id;
+      }
+    };
+
+    for (const definition of definitions) {
+      const tab = button(definition.label, () => showPanel(definition.id));
+      tab.setAttribute("role", "tab");
+      tab.dataset.panelId = definition.id;
+      tab.setAttribute("aria-controls", `olivia-companion-panel-${definition.id}`);
+      tabs.append(tab);
+
+      const panel = document.createElement("section");
+      panel.id = `olivia-companion-panel-${definition.id}`;
+      panel.dataset.panelId = definition.id;
+      panel.dataset.oliviaCompanionPanel = definition.id;
+      panel.setAttribute("role", "tabpanel");
+      panel.style.padding = "18px";
+      panel.style.borderRadius = "12px";
+      panel.style.background = "rgba(255,255,255,0.06)";
+      panel.append(
+        text("h3", definition.label, "text-text-title text-title-m"),
+        text("p", definition.description, "text-text-secondary text-body-m font-regular")
+      );
+      panels.append(panel);
+    }
+
+    dialog.append(header, status, tabs, panels);
+    backdrop.append(dialog);
+    backdrop.addEventListener("click", (event) => {
+      if (event.target === backdrop) {
+        backdrop.remove();
+      }
+    });
+    backdrop.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        backdrop.remove();
+      }
+    });
+    document.body.append(backdrop);
+    showPanel("memory");
+    close.focus();
+    loadStatus(status);
+  };
+
+  const findSettingsContainer = () => {
+    for (const main of document.querySelectorAll("main")) {
+      const sections = main.querySelectorAll(".tp-settings-item");
+      if (sections.length) {
+        return sections[sections.length - 1].parentElement;
+      }
+    }
+    return null;
+  };
+
+  const mountShell = () => {
+    if (!isSettingsRoute()) {
+      removeShell();
+      return;
+    }
+    if (document.querySelector(`[${ROOT_ATTR}]`)) {
+      return;
+    }
+    const container = findSettingsContainer();
+    if (!container) {
+      return;
+    }
+
+    const section = document.createElement("div");
+    section.setAttribute(ROOT_ATTR, "");
+    section.className = "tp-settings-item";
+
+    const title = text("div", "本地陪伴", "text-text-body text-title-m");
+    const row = document.createElement("div");
+    row.className = "flex items-center justify-between px-0 py-3 rounded-3";
+
+    const copy = document.createElement("div");
+    copy.className = "flex flex-col gap-0 flex-1 min-w-0";
+    copy.append(
+      text("div", "记忆与私人世界", "text-text-body text-label-l"),
+      text(
+        "div",
+        "在 Olivia 客户端内管理本地连续性。",
+        "text-text-secondary text-body-m font-regular"
+      )
+    );
+
+    row.append(copy, button("打开", openDialog));
+    section.append(title, row);
+    container.append(section);
+  };
+
+  let scheduled = false;
+  const schedule = () => {
+    if (scheduled) {
+      return;
+    }
+    scheduled = true;
+    window.requestAnimationFrame(() => {
+      scheduled = false;
+      mountShell();
+    });
+  };
+
+  const observer = new MutationObserver(schedule);
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+  window.addEventListener("hashchange", schedule);
+  window.addEventListener("popstate", schedule);
+  schedule();
+})();
+'''
+
+
+class CompanionSettingsPatchError(RuntimeError):
+    """Stable archive patch failure."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for block in iter(lambda: stream.read(1 << 20), b""):
+                digest.update(block)
+    except OSError as exc:
+        raise CompanionSettingsPatchError("COMPANION_ARCHIVE_UNREADABLE") from exc
+    return digest.hexdigest()
+
+
+def validate_api_base(value: str | None) -> str:
+    if not value:
+        raise CompanionSettingsPatchError("COMPANION_API_BASE_REQUIRED")
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError as exc:
+        raise CompanionSettingsPatchError("COMPANION_API_BASE_INVALID") from exc
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"127.0.0.1", "localhost"}
+        or port is None
+        or not 1 <= port <= 65535
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise CompanionSettingsPatchError("COMPANION_API_BASE_INVALID")
+    return f"http://{parsed.hostname}:{port}/"
+
+
+def _safe_member_path(root: Path, member_name: str) -> Path:
+    normalized = member_name.replace("\\", "/")
+    posix = PurePosixPath(normalized)
+    windows = PureWindowsPath(normalized)
+    if (
+        not normalized
+        or "\x00" in normalized
+        or posix.is_absolute()
+        or windows.is_absolute()
+        or bool(windows.drive)
+        or any(part in {"", ".", ".."} for part in posix.parts)
+    ):
+        raise CompanionSettingsPatchError("COMPANION_ARCHIVE_UNSAFE")
+    target = (root / Path(*posix.parts)).resolve()
+    if os.path.commonpath([str(root), str(target)]) != str(root):
+        raise CompanionSettingsPatchError("COMPANION_ARCHIVE_UNSAFE")
+    return target
+
+
+def _validate_archive(path: Path) -> None:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            members = archive.infolist()
+            if not members:
+                raise CompanionSettingsPatchError("COMPANION_ARCHIVE_EMPTY")
+            if len(members) > MAX_ARCHIVE_MEMBERS:
+                raise CompanionSettingsPatchError("COMPANION_ARCHIVE_TOO_MANY_MEMBERS")
+            for info in members:
+                _safe_member_path(path.parent.resolve(), info.filename)
+    except CompanionSettingsPatchError:
+        raise
+    except (OSError, RuntimeError, zipfile.BadZipFile) as exc:
+        raise CompanionSettingsPatchError("COMPANION_ARCHIVE_INVALID") from exc
+
+
+def _safe_extract(archive: zipfile.ZipFile, root: Path) -> None:
+    for info in archive.infolist():
+        target = _safe_member_path(root, info.filename)
+        if info.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with archive.open(info) as source, target.open("wb") as destination:
+                shutil.copyfileobj(source, destination)
+        except OSError as exc:
+            raise CompanionSettingsPatchError("COMPANION_ARCHIVE_UNREADABLE") from exc
+
+
+def _member_hashes(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    try:
+        with zipfile.ZipFile(path) as archive:
+            for info in archive.infolist():
+                if info.is_dir():
+                    continue
+                result[info.filename] = hashlib.sha256(archive.read(info)).hexdigest()
+    except (KeyError, OSError, RuntimeError, zipfile.BadZipFile) as exc:
+        raise CompanionSettingsPatchError("COMPANION_ARCHIVE_UNREADABLE") from exc
+    return result
+
+
+def _atomic_copy(source: Path, destination: Path) -> None:
+    temporary = destination.with_name(destination.name + ".tmp")
+    try:
+        shutil.copy2(source, temporary)
+        os.replace(temporary, destination)
+    except OSError as exc:
+        raise CompanionSettingsPatchError("COMPANION_BACKUP_FAILED") from exc
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _ensure_backup(feapp: Path) -> Path:
+    backup = Path(str(feapp) + ".companion.orig")
+    if backup.exists():
+        _validate_archive(backup)
+    else:
+        _atomic_copy(feapp, backup)
+    return backup
+
+
+def _read_text(path: Path, code: str) -> str:
+    try:
+        if path.stat().st_size > MAX_TEXT_MEMBER_BYTES:
+            raise CompanionSettingsPatchError(code)
+        return path.read_text(encoding="utf-8")
+    except CompanionSettingsPatchError:
+        raise
+    except (OSError, UnicodeError) as exc:
+        raise CompanionSettingsPatchError(code) from exc
+
+
+def _patch_index(root: Path, api_base: str) -> str:
+    index = root / INDEX_MEMBER
+    main_module = root / MAIN_MODULE_MEMBER
+    bootstrap = root / BOOTSTRAP_MEMBER
+    if not index.is_file():
+        raise CompanionSettingsPatchError("COMPANION_INDEX_MISSING")
+    if not main_module.is_file():
+        raise CompanionSettingsPatchError("COMPANION_MAIN_MODULE_MISSING")
+    source = _read_text(index, "COMPANION_INDEX_UNREADABLE")
+
+    marker_count = source.count(PATCH_MARKER)
+    if marker_count == 1:
+        if not bootstrap.is_file():
+            raise CompanionSettingsPatchError("COMPANION_PATCH_INCOMPLETE")
+        tag = _MARKER_TAG_RE.search(source)
+        api_match = _API_BASE_RE.search(tag.group(0) if tag else "")
+        if not tag or not api_match:
+            raise CompanionSettingsPatchError("COMPANION_PATCH_INCOMPLETE")
+        if html.unescape(api_match.group("value")) != api_base:
+            raise CompanionSettingsPatchError("COMPANION_API_BASE_MISMATCH")
+        if _read_text(bootstrap, "COMPANION_BOOTSTRAP_UNREADABLE") != _BOOTSTRAP_JAVASCRIPT:
+            raise CompanionSettingsPatchError("COMPANION_PATCH_INCOMPLETE")
+        return "ALREADY_PATCHED"
+    if marker_count or bootstrap.exists():
+        raise CompanionSettingsPatchError("COMPANION_PATCH_INCOMPLETE")
+
+    matches = list(_MODULE_SCRIPT_RE.finditer(source))
+    if len(matches) != 1:
+        raise CompanionSettingsPatchError("COMPANION_MODULE_ANCHOR_INVALID")
+    match = matches[0]
+    tag = (
+        '<script src="./assets/olivia-companion-settings.js" '
+        f'{PATCH_MARKER}="{PATCH_SCHEMA_VERSION}" '
+        f'data-api-base="{html.escape(api_base, quote=True)}"></script>'
+    )
+    patched = source[: match.end()] + "\n  " + tag + source[match.end() :]
+    if patched.count(PATCH_MARKER) != 1:
+        raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED")
+    bootstrap.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        index.write_text(patched, encoding="utf-8")
+        bootstrap.write_text(_BOOTSTRAP_JAVASCRIPT, encoding="utf-8")
+    except OSError as exc:
+        raise CompanionSettingsPatchError("COMPANION_PATCH_WRITE_FAILED") from exc
+    return "PATCHED"
+
+
+def _repack(root: Path, destination: Path) -> None:
+    temporary = destination.with_name(destination.name + ".tmp")
+    try:
+        with zipfile.ZipFile(temporary, "w", zipfile.ZIP_DEFLATED) as archive:
+            for path in sorted(root.rglob("*")):
+                if path.is_file():
+                    archive.write(path, path.relative_to(root).as_posix())
+        _validate_archive(temporary)
+        os.replace(temporary, destination)
+    except CompanionSettingsPatchError:
+        raise
+    except (OSError, RuntimeError, zipfile.BadZipFile) as exc:
+        raise CompanionSettingsPatchError("COMPANION_REPACK_FAILED") from exc
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _verify_archive(
+    path: Path,
+    *,
+    api_base: str,
+    original_hashes: dict[str, str],
+) -> None:
+    patched_hashes = _member_hashes(path)
+    if set(patched_hashes) != set(original_hashes) | {BOOTSTRAP_MEMBER}:
+        raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED")
+    for name, digest in original_hashes.items():
+        if name == INDEX_MEMBER:
+            continue
+        if patched_hashes.get(name) != digest:
+            raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED")
+    try:
+        with zipfile.ZipFile(path) as archive:
+            index = archive.read(INDEX_MEMBER).decode("utf-8")
+            bootstrap = archive.read(BOOTSTRAP_MEMBER).decode("utf-8")
+    except (KeyError, OSError, UnicodeError, zipfile.BadZipFile) as exc:
+        raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED") from exc
+    required = (
+        'data-olivia-companion-settings="p03.original-settings-shell.v1"',
+        f'data-api-base="{html.escape(api_base, quote=True)}"',
+    )
+    bootstrap_required = (
+        'const STATUS_PATH = "/toy/companion/status";',
+        'data-olivia-companion-settings-root',
+        'panel.dataset.oliviaCompanionPanel',
+        '长期记忆',
+        '私人世界',
+        'new MutationObserver',
+    )
+    if (
+        any(value not in index for value in required)
+        or any(value not in bootstrap for value in bootstrap_required)
+        or "<iframe" in bootstrap.casefold()
+        or "window.open" in bootstrap
+    ):
+        raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED")
+
+
+def patch_companion_settings(
+    feapp_path: str | os.PathLike[str],
+    api_base: str | None,
+    *,
+    work_root: str | os.PathLike[str] | None = None,
+) -> dict[str, str]:
+    """Patch one staged client archive and preserve every existing asset."""
+
+    feapp = Path(feapp_path).expanduser().resolve()
+    normalized_api_base = validate_api_base(api_base)
+    if not feapp.is_file():
+        raise CompanionSettingsPatchError("COMPANION_ARCHIVE_NOT_FOUND")
+    _validate_archive(feapp)
+    original_hashes = _member_hashes(feapp)
+    source_sha256 = sha256_file(feapp)
+    backup = _ensure_backup(feapp)
+    backup_sha256 = sha256_file(backup)
+    sandbox = Path(work_root or feapp.parent).expanduser().resolve()
+    if not sandbox.is_dir():
+        raise CompanionSettingsPatchError("COMPANION_WORK_ROOT_NOT_FOUND")
+
+    with tempfile.TemporaryDirectory(prefix=".patch-companion-settings-", dir=sandbox) as name:
+        temporary_root = Path(name)
+        rollback = temporary_root / "rollback.dat"
+        _atomic_copy(feapp, rollback)
+        try:
+            unpacked = temporary_root / "unpacked"
+            with zipfile.ZipFile(feapp) as archive:
+                _safe_extract(archive, unpacked)
+            status = _patch_index(unpacked, normalized_api_base)
+            if status == "PATCHED":
+                output = temporary_root / "patched.dat"
+                _repack(unpacked, output)
+                os.replace(output, feapp)
+            _verify_archive(
+                feapp,
+                api_base=normalized_api_base,
+                original_hashes=original_hashes,
+            )
+        except Exception:
+            _atomic_copy(rollback, feapp)
+            raise
+
+    return {
+        "schema_version": PATCH_SCHEMA_VERSION,
+        "status": status,
+        "source_sha256": source_sha256,
+        "backup_sha256": backup_sha256,
+        "patched_sha256": sha256_file(feapp),
+        "backup_name": backup.name,
+    }
+
+
+__all__ = [
+    "BOOTSTRAP_MEMBER",
+    "CompanionSettingsPatchError",
+    "INDEX_MEMBER",
+    "MAIN_MODULE_MEMBER",
+    "PATCH_MARKER",
+    "PATCH_SCHEMA_VERSION",
+    "patch_companion_settings",
+    "sha256_file",
+    "validate_api_base",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ py-modules = [
     "memory",
     "original_client_letter_contract",
     "original_client_media_http",
+    "patch_companion_settings",
     "patch_feapp",
     "persona_loader",
     "persona_assembly",

--- a/tests/installer/test_patch_companion_settings.py
+++ b/tests/installer/test_patch_companion_settings.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import zipfile
+
+import pytest
+
+from patch_companion_settings import (
+    BOOTSTRAP_MEMBER,
+    CompanionSettingsPatchError,
+    INDEX_MEMBER,
+    MAIN_MODULE_MEMBER,
+    PATCH_MARKER,
+    patch_companion_settings,
+    validate_api_base,
+)
+
+
+INDEX = """<!doctype html>
+<html><head>
+<script type="module" crossorigin src="./assets/main-917d29fc.js"></script>
+<link rel="stylesheet" href="./assets/index.css">
+</head><body><div id="app"></div></body></html>
+"""
+
+
+def _archive(
+    path: Path,
+    *,
+    index: str = INDEX,
+    main: bytes = b"synthetic-main-module",
+    extra: dict[str, bytes] | None = None,
+) -> Path:
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(INDEX_MEMBER, index)
+        archive.writestr(MAIN_MODULE_MEMBER, main)
+        archive.writestr("assets/index.css", b"body{display:block}")
+        for name, value in (extra or {}).items():
+            archive.writestr(name, value)
+    return path
+
+
+def _members(path: Path) -> dict[str, bytes]:
+    with zipfile.ZipFile(path) as archive:
+        return {
+            info.filename: archive.read(info)
+            for info in archive.infolist()
+            if not info.is_dir()
+        }
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_patch_adds_one_settings_shell_and_preserves_existing_assets(tmp_path: Path) -> None:
+    path = _archive(tmp_path / "feapp.dat")
+    before = _members(path)
+    source_hash = _sha(path)
+
+    result = patch_companion_settings(path, "http://127.0.0.1:8899", work_root=tmp_path)
+
+    after = _members(path)
+    assert result["status"] == "PATCHED"
+    assert result["source_sha256"] == source_hash
+    assert result["backup_name"] == "feapp.dat.companion.orig"
+    assert _sha(tmp_path / result["backup_name"]) == source_hash
+    assert set(after) == set(before) | {BOOTSTRAP_MEMBER}
+    for name, value in before.items():
+        if name != INDEX_MEMBER:
+            assert after[name] == value
+    index = after[INDEX_MEMBER].decode()
+    bootstrap = after[BOOTSTRAP_MEMBER].decode()
+    assert index.count(PATCH_MARKER) == 1
+    assert 'data-api-base="http://127.0.0.1:8899/"' in index
+    assert "data-olivia-companion-settings-root" in bootstrap
+    assert 'const STATUS_PATH = "/toy/companion/status";' in bootstrap
+    assert "长期记忆" in bootstrap
+    assert "私人世界" in bootstrap
+    assert "MutationObserver" in bootstrap
+    assert "<iframe" not in bootstrap.casefold()
+    assert "window.open" not in bootstrap
+    assert "http://" not in bootstrap
+    assert "https://" not in bootstrap
+
+
+def test_patch_is_idempotent_for_the_same_api_base(tmp_path: Path) -> None:
+    path = _archive(tmp_path / "feapp.dat")
+    first = patch_companion_settings(path, "http://localhost:8899", work_root=tmp_path)
+    first_hash = _sha(path)
+
+    second = patch_companion_settings(path, "http://localhost:8899/", work_root=tmp_path)
+
+    assert first["status"] == "PATCHED"
+    assert second["status"] == "ALREADY_PATCHED"
+    assert _sha(path) == first_hash
+    assert _members(path)[INDEX_MEMBER].decode().count(PATCH_MARKER) == 1
+
+
+def test_repatch_with_a_different_api_base_is_rejected_without_mutation(tmp_path: Path) -> None:
+    path = _archive(tmp_path / "feapp.dat")
+    patch_companion_settings(path, "http://127.0.0.1:8899", work_root=tmp_path)
+    before = path.read_bytes()
+
+    with pytest.raises(CompanionSettingsPatchError) as error:
+        patch_companion_settings(path, "http://127.0.0.1:8900", work_root=tmp_path)
+
+    assert error.value.code == "COMPANION_API_BASE_MISMATCH"
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        "",
+        "https://127.0.0.1:8899",
+        "http://example.invalid:8899",
+        "http://127.0.0.1",
+        "http://user@127.0.0.1:8899",
+        "http://127.0.0.1:8899/base",
+        "http://127.0.0.1:8899?token=x",
+        "http://127.0.0.1:8899/#fragment",
+    ],
+)
+def test_api_base_requires_an_explicit_loopback_http_port(value: str | None) -> None:
+    with pytest.raises(CompanionSettingsPatchError):
+        validate_api_base(value)
+
+
+def test_missing_or_duplicate_module_anchor_rolls_back(tmp_path: Path) -> None:
+    cases = (
+        INDEX.replace(
+            '<script type="module" crossorigin src="./assets/main-917d29fc.js"></script>',
+            "",
+        ),
+        INDEX.replace(
+            '<script type="module" crossorigin src="./assets/main-917d29fc.js"></script>',
+            '<script type="module" crossorigin src="./assets/main-917d29fc.js"></script>' * 2,
+        ),
+    )
+    for number, index in enumerate(cases):
+        path = _archive(tmp_path / f"case-{number}.dat", index=index)
+        before = path.read_bytes()
+        with pytest.raises(CompanionSettingsPatchError) as error:
+            patch_companion_settings(path, "http://127.0.0.1:8899", work_root=tmp_path)
+        assert error.value.code == "COMPANION_MODULE_ANCHOR_INVALID"
+        assert path.read_bytes() == before
+
+
+def test_missing_main_module_and_incomplete_patch_are_rejected(tmp_path: Path) -> None:
+    missing = tmp_path / "missing-main.dat"
+    with zipfile.ZipFile(missing, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(INDEX_MEMBER, INDEX)
+    with pytest.raises(CompanionSettingsPatchError) as missing_error:
+        patch_companion_settings(missing, "http://127.0.0.1:8899", work_root=tmp_path)
+    assert missing_error.value.code == "COMPANION_MAIN_MODULE_MISSING"
+
+    incomplete = _archive(
+        tmp_path / "incomplete.dat",
+        index=INDEX.replace(
+            "</head>",
+            '<script data-olivia-companion-settings="p03.original-settings-shell.v1" '
+            'data-api-base="http://127.0.0.1:8899/"></script></head>',
+        ),
+    )
+    with pytest.raises(CompanionSettingsPatchError) as incomplete_error:
+        patch_companion_settings(incomplete, "http://127.0.0.1:8899", work_root=tmp_path)
+    assert incomplete_error.value.code == "COMPANION_PATCH_INCOMPLETE"
+
+
+def test_unsafe_archive_member_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "unsafe.dat"
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(INDEX_MEMBER, INDEX)
+        archive.writestr(MAIN_MODULE_MEMBER, b"main")
+        archive.writestr("../outside.js", b"escape")
+
+    with pytest.raises(CompanionSettingsPatchError) as error:
+        patch_companion_settings(path, "http://127.0.0.1:8899", work_root=tmp_path)
+
+    assert error.value.code == "COMPANION_ARCHIVE_UNSAFE"
+
+
+def test_existing_backup_is_never_overwritten(tmp_path: Path) -> None:
+    path = _archive(tmp_path / "feapp.dat")
+    backup = _archive(tmp_path / "feapp.dat.companion.orig", main=b"first-backup")
+    backup_before = backup.read_bytes()
+
+    patch_companion_settings(path, "http://127.0.0.1:8899", work_root=tmp_path)
+
+    assert backup.read_bytes() == backup_before


### PR DESCRIPTION
Implements CLIENT-SETTINGS-01 under the original-client-only product boundary.

## Source-grounded placement

The supported Olivia `0.0.9.615` bundle has a real `/settings` route and an existing `SettingsView` built from `tp-settings-item` sections. This PR reuses that surface instead of creating a standalone browser Control Center, second desktop app, new route, or iframe.

## Scope

- adds a safe patcher for the staged `feapp.dat` in the isolated install;
- keeps `assets/main-917d29fc.js` and every existing member except `index.html` byte-for-byte unchanged;
- injects one repository-owned local bootstrap asset;
- appends a native-styled “本地陪伴” section only while the original `/settings` route is active;
- opens an in-window dialog shell with “长期记忆” and “私人世界” tabs;
- reserves only `GET /toy/companion/status` and reports unavailable honestly until the backend slice lands;
- accepts only explicit loopback HTTP bases with a port;
- adds a separate backup, idempotency, archive safety, member-hash verification, and full rollback;
- packages the patcher and documents the remaining sequential slices.

## Validation

- 16 synthetic patch and rollback tests;
- direct local validation against the supplied `0.0.9.615` archive:
  - source hash matched the pinned archive;
  - the archive gained exactly one bootstrap member;
  - the original main bundle SHA-256 remained `c00dedb9a3ff72226b2c8dca81c05e3152de9149113bf6259ca04c415b332d8b`;
- no iframe, `window.open`, external page, or standalone user entry;
- hardening scan passes.

## Boundary

This PR does not expose or mutate Memory or PrivateWorld data, does not alter Collection or webplayer behavior, and is not yet wired into the installer. CLIENT-SETTINGS-02 will add a narrow provider-neutral backend contract before any mutation UI is enabled.

Part of #35, #37, and #38.