### PR TITLE
feat(client): adapt existing companion services to original settings

### DIFF
--- a/docs/P03_ORIGINAL_CLIENT_COMPANION_SERVICE_ADAPTER.md
+++ b/docs/P03_ORIGINAL_CLIENT_COMPANION_SERVICE_ADAPTER.md
@@ -1,0 +1,113 @@
+# P03 原版设置页陪伴 Service Adapter
+
+## 1. 目标
+
+将仓库中已经存在的长期记忆、PrivateWorld 和候选存储接入原版 Olivia `/settings` 的只读接口，不再实现第二套记忆、关系或存储逻辑。
+
+```text
+原版 /settings
+  -> original_client_companion_api.py
+  -> OriginalClientCompanionServiceBackend
+  -> 现有 Service / Ledger / Candidate Store
+```
+
+## 2. 复用边界
+
+Adapter 只接受三个可选端口：
+
+- Memory Admin Read Port；
+- PrivateWorld Read Port；
+- Candidate Read Port。
+
+它不导入或直接操作：
+
+- sqlite3；
+- Qdrant；
+- Mem0 内部对象；
+- PrivateWorld Reducer；
+- Command payload；
+- 原始模型响应。
+
+长期记忆继续由 `ConversationMemoryAdminService` 管理；PrivateWorld 继续由现有 Ledger / Command Service / Control API 管理；候选继续由 `SQLitePrivateWorldCandidateStore` 管理。
+
+## 3. 状态规则
+
+每个能力独立报告：
+
+```text
+available
+degraded
+unavailable
+disabled
+```
+
+- 服务未配置：`disabled`；
+- 服务状态可读：沿用服务自身状态；
+- 单个服务失败：只将该能力标记为 `unavailable`；
+- 其他能力不受影响；
+- 不以数据库文件存在代替能力可用性。
+
+## 4. 长期记忆映射
+
+只从 `ConversationMemoryRecord` 映射：
+
+```text
+memory_id
+text
+source_id
+created_at
+score（可选）
+```
+
+时间优先使用 provider creation time；缺失时使用 exchange occurrence time。两者都缺失时拒绝该读取，不能伪造时间。
+
+不输出：
+
+- user_id；
+- metadata 全量；
+- embedding；
+- provider 原始对象；
+- system prompt；
+- PrivateWorld 数据。
+
+## 5. PrivateWorld 映射
+
+Adapter 只接受现有 Control API 的受限 snapshot：
+
+- version；
+- relationship stage；
+- 五个定性等级；
+- nickname permissions；
+- home access；
+- continuation facts 与 awareness。
+
+即使上游意外附加隐藏分数、路径或调试字段，Adapter 也不会复制这些字段到原版客户端响应。
+
+## 6. 候选映射
+
+只读取：
+
+```text
+status = pending
+now = timezone-aware current time
+```
+
+只输出：
+
+- candidate ID；
+- boundary / conflict / repair 类型；
+- 简短说明；
+- 创建和过期时间。
+
+不输出 confidence、source letter、reply revision 或决策审计。
+
+## 7. 后续顺序
+
+```text
+CLIENT-SETTINGS-04  在生产本机服务中装配并挂载只读接口
+CLIENT-SETTINGS-05  在原版设置弹层显示真实数据
+CLIENT-SETTINGS-06  增加明确确认后的受控写操作
+CLIENT-SETTINGS-07  安装器接线与原版客户端验收
+```
+
+本 PR 不修改 `local_server.py`，也不启用任何写操作。

--- a/original_client_companion_backend.py
+++ b/original_client_companion_backend.py
@@ -1,0 +1,399 @@
+"""Adapt existing memory and PrivateWorld services to the original settings API.
+
+The adapter owns no extraction, retrieval, reduction, decision, or persistence
+logic. It maps already-bounded service results into the transport dataclasses
+used by the patched original Olivia settings view.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Protocol, runtime_checkable
+
+from conversation_memory_admin import MemoryAdminStatus
+from conversation_memory_port import ConversationMemoryRecord
+from original_client_companion_api import (
+    CompanionCandidateSummary,
+    CompanionCapability,
+    CompanionContinuationSummary,
+    CompanionMemorySummary,
+    CompanionPrivateWorldSummary,
+    CompanionReadStatus,
+    OriginalClientCompanionReadBackend,
+)
+from private_world_candidates import (
+    CandidateStatus,
+    PrivateWorldCandidate,
+)
+
+
+_RELATIONSHIP_FIELDS = (
+    "familiarity",
+    "trust",
+    "comfort",
+    "closeness",
+    "tension",
+)
+_LEVELS = frozenset({"unknown", "low", "medium", "high"})
+_HOME_ACCESS = frozenset(
+    {"no_access", "visit_access", "errand_access", "domestic_access"}
+)
+_AWARENESS = frozenset({"control_only", "pending", "character_known"})
+
+
+class OriginalClientCompanionBackendError(RuntimeError):
+    """Stable adapter failure with no provider or storage detail."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@runtime_checkable
+class MemoryAdminReadPort(Protocol):
+    def status(self) -> MemoryAdminStatus: ...
+
+    def list_memories(
+        self,
+        *,
+        query: str | None = None,
+        limit: int = 100,
+    ) -> Sequence[ConversationMemoryRecord]: ...
+
+
+@runtime_checkable
+class PrivateWorldReadPort(Protocol):
+    def snapshot(self) -> Mapping[str, object]: ...
+
+
+@runtime_checkable
+class CandidateReadPort(Protocol):
+    def list_candidates(
+        self,
+        *,
+        status: CandidateStatus | None = None,
+        now: datetime | None = None,
+    ) -> Sequence[PrivateWorldCandidate]: ...
+
+
+def _capability_failure(code: str) -> CompanionCapability:
+    return CompanionCapability("unavailable", reason_code=code)
+
+
+def _aware_now(value: datetime) -> datetime:
+    if (
+        not isinstance(value, datetime)
+        or value.tzinfo is None
+        or value.utcoffset() is None
+    ):
+        raise OriginalClientCompanionBackendError("COMPANION_TIME_INVALID")
+    return value
+
+
+def _mapping(value: object, *, code: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise OriginalClientCompanionBackendError(code)
+    return value
+
+
+def _sequence(value: object, *, code: str) -> Sequence[object]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise OriginalClientCompanionBackendError(code)
+    return value
+
+
+def _text(value: object, *, code: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise OriginalClientCompanionBackendError(code)
+    return value.strip()
+
+
+def _integer(value: object, *, code: str, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise OriginalClientCompanionBackendError(code)
+    return value
+
+
+def _memory_timestamp(record: ConversationMemoryRecord) -> str:
+    value = record.created_at or record.occurred_at
+    if value is None or value.tzinfo is None or value.utcoffset() is None:
+        raise OriginalClientCompanionBackendError(
+            "COMPANION_MEMORY_TIME_UNAVAILABLE"
+        )
+    return value.isoformat()
+
+
+class OriginalClientCompanionServiceBackend(OriginalClientCompanionReadBackend):
+    """Read adapter over optional services already owned by the local runtime."""
+
+    def __init__(
+        self,
+        *,
+        memory_admin: MemoryAdminReadPort | None = None,
+        private_world: PrivateWorldReadPort | None = None,
+        candidates: CandidateReadPort | None = None,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        for value, protocol, name in (
+            (memory_admin, MemoryAdminReadPort, "memory admin"),
+            (private_world, PrivateWorldReadPort, "PrivateWorld read port"),
+            (candidates, CandidateReadPort, "candidate read port"),
+        ):
+            if value is not None and not isinstance(value, protocol):
+                raise TypeError(f"{name} is invalid")
+        self._memory_admin = memory_admin
+        self._private_world = private_world
+        self._candidates = candidates
+        self._now = now or (lambda: datetime.now(timezone.utc))
+
+    def _memory_status(self) -> CompanionCapability:
+        if self._memory_admin is None:
+            return CompanionCapability(
+                "disabled",
+                reason_code="COMPANION_MEMORY_DISABLED",
+            )
+        try:
+            status = self._memory_admin.status()
+            if not isinstance(status, MemoryAdminStatus):
+                raise TypeError("invalid memory status")
+            count = (
+                status.memory_count
+                if status.status in {"available", "degraded"}
+                else None
+            )
+            return CompanionCapability(
+                status.status,
+                reason_code=status.reason_code,
+                count=count,
+            )
+        except (OSError, RuntimeError, TypeError, ValueError):
+            return _capability_failure("COMPANION_MEMORY_UNAVAILABLE")
+
+    def _private_world_status(self) -> CompanionCapability:
+        if self._private_world is None:
+            return CompanionCapability(
+                "disabled",
+                reason_code="COMPANION_PRIVATE_WORLD_DISABLED",
+            )
+        try:
+            self.private_world_summary()
+            return CompanionCapability("available")
+        except (OSError, RuntimeError, TypeError, ValueError):
+            return _capability_failure("COMPANION_PRIVATE_WORLD_UNAVAILABLE")
+
+    def _candidate_status(self) -> CompanionCapability:
+        if self._candidates is None:
+            return CompanionCapability(
+                "disabled",
+                reason_code="COMPANION_CANDIDATES_DISABLED",
+            )
+        try:
+            values = self._pending_candidates()
+            return CompanionCapability("available", count=len(values))
+        except (OSError, RuntimeError, TypeError, ValueError):
+            return _capability_failure("COMPANION_CANDIDATES_UNAVAILABLE")
+
+    def read_status(self) -> CompanionReadStatus:
+        return CompanionReadStatus(
+            memory=self._memory_status(),
+            private_world=self._private_world_status(),
+            candidates=self._candidate_status(),
+        )
+
+    def list_memories(
+        self,
+        *,
+        query: str | None,
+        limit: int,
+    ) -> tuple[CompanionMemorySummary, ...]:
+        if self._memory_admin is None:
+            raise OriginalClientCompanionBackendError(
+                "COMPANION_MEMORY_DISABLED"
+            )
+        if type(limit) is not int or not 1 <= limit <= 100:
+            raise OriginalClientCompanionBackendError(
+                "COMPANION_MEMORY_LIMIT_INVALID"
+            )
+        try:
+            records = tuple(
+                self._memory_admin.list_memories(query=query, limit=limit)
+            )
+        except Exception as exc:
+            raise OriginalClientCompanionBackendError(
+                "COMPANION_MEMORY_UNAVAILABLE"
+            ) from exc
+        if len(records) > limit or any(
+            not isinstance(record, ConversationMemoryRecord)
+            for record in records
+        ):
+            raise OriginalClientCompanionBackendError(
+                "COMPANION_MEMORY_INVALID"
+            )
+        return tuple(
+            CompanionMemorySummary(
+                memory_id=record.memory_id,
+                text=record.text,
+                source_id=record.source_id,
+                created_at=_memory_timestamp(record),
+                score=record.score,
+            )
+            for record in records
+        )
+
+    def private_world_summary(self) -> CompanionPrivateWorldSummary:
+        if self._private_world is None:
+            raise OriginalClientCompanionBackendError(
+                "COMPANION_PRIVATE_WORLD_DISABLED"
+            )
+        try:
+            payload = _mapping(
+                self._private_world.snapshot(),
+                code="COMPANION_PRIVATE_WORLD_INVALID",
+            )
+            levels_raw = _mapping(
+                payload.get("levels"),
+                code="COMPANION_PRIVATE_WORLD_INVALID",
+            )
+            if set(levels_raw) != set(_RELATIONSHIP_FIELDS):
+                raise OriginalClientCompanionBackendError(
+                    "COMPANION_PRIVATE_WORLD_INVALID"
+                )
+            levels = {
+                name: _text(
+                    levels_raw[name],
+                    code="COMPANION_PRIVATE_WORLD_INVALID",
+                )
+                for name in _RELATIONSHIP_FIELDS
+            }
+            if any(value not in _LEVELS for value in levels.values()):
+                raise OriginalClientCompanionBackendError(
+                    "COMPANION_PRIVATE_WORLD_INVALID"
+                )
+
+            nicknames_raw = _sequence(
+                payload.get("nickname_permissions", ()),
+                code="COMPANION_PRIVATE_WORLD_INVALID",
+            )
+            nicknames = tuple(
+                _text(value, code="COMPANION_PRIVATE_WORLD_INVALID")
+                for value in nicknames_raw
+            )
+
+            facts_raw = _sequence(
+                payload.get("continuation_facts", ()),
+                code="COMPANION_PRIVATE_WORLD_INVALID",
+            )
+            facts: list[CompanionContinuationSummary] = []
+            for raw in facts_raw:
+                item = _mapping(
+                    raw,
+                    code="COMPANION_PRIVATE_WORLD_INVALID",
+                )
+                awareness = _text(
+                    item.get("awareness"),
+                    code="COMPANION_PRIVATE_WORLD_INVALID",
+                )
+                if awareness not in _AWARENESS:
+                    raise OriginalClientCompanionBackendError(
+                        "COMPANION_PRIVATE_WORLD_INVALID"
+                    )
+                facts.append(
+                    CompanionContinuationSummary(
+                        fact_id=_text(
+                            item.get("fact_id"),
+                            code="COMPANION_PRIVATE_WORLD_INVALID",
+                        ),
+                        statement=_text(
+                            item.get("statement"),
+                            code="COMPANION_PRIVATE_WORLD_INVALID",
+                        ),
+                        awareness=awareness,
+                    )
+                )
+
+            home_access = _text(
+                payload.get("home_access"),
+                code="COMPANION_PRIVATE_WORLD_INVALID",
+            )
+            if home_access not in _HOME_ACCESS:
+                raise OriginalClientCompanionBackendError(
+                    "COMPANION_PRIVATE_WORLD_INVALID"
+                )
+
+            return CompanionPrivateWorldSummary(
+                version=_integer(
+                    payload.get("version"),
+                    code="COMPANION_PRIVATE_WORLD_INVALID",
+                ),
+                relationship_stage=_text(
+                    payload.get("relationship_stage"),
+                    code="COMPANION_PRIVATE_WORLD_INVALID",
+                ),
+                levels=levels,
+                nickname_permissions=nicknames,
+                home_access=home_access,
+                continuation_facts=tuple(facts),
+            )
+        except OriginalClientCompanionBackendError:
+            raise
+        except Exception as exc:
+            raise OriginalClientCompanionBackendError(
+                "COMPANION_PRIVATE_WORLD_UNAVAILABLE"
+            ) from exc
+
+    def _pending_candidates(self) -> tuple[PrivateWorldCandidate, ...]:
+        if self._candidates is None:
+            raise OriginalClientCompanionBackendError(
+                "COMPANION_CANDIDATES_DISABLED"
+            )
+        now = _aware_now(self._now())
+        try:
+            values = tuple(
+                self._candidates.list_candidates(
+                    status=CandidateStatus.PENDING,
+                    now=now,
+                )
+            )
+        except Exception as exc:
+            raise OriginalClientCompanionBackendError(
+                "COMPANION_CANDIDATES_UNAVAILABLE"
+            ) from exc
+        if any(
+            not isinstance(value, PrivateWorldCandidate)
+            or value.status is not CandidateStatus.PENDING
+            for value in values
+        ):
+            raise OriginalClientCompanionBackendError(
+                "COMPANION_CANDIDATES_INVALID"
+            )
+        return values
+
+    def list_candidates(
+        self,
+        *,
+        limit: int,
+    ) -> tuple[CompanionCandidateSummary, ...]:
+        if type(limit) is not int or not 1 <= limit <= 100:
+            raise OriginalClientCompanionBackendError(
+                "COMPANION_CANDIDATE_LIMIT_INVALID"
+            )
+        return tuple(
+            CompanionCandidateSummary(
+                candidate_id=value.candidate_id,
+                candidate_type=value.candidate_type.value,
+                summary=value.summary,
+                created_at=value.created_at.isoformat(),
+                expires_at=value.expires_at.isoformat(),
+            )
+            for value in self._pending_candidates()[:limit]
+        )
+
+
+__all__ = [
+    "CandidateReadPort",
+    "MemoryAdminReadPort",
+    "OriginalClientCompanionBackendError",
+    "OriginalClientCompanionServiceBackend",
+    "PrivateWorldReadPort",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ py-modules = [
     "mem0_memory",
     "memory",
     "original_client_companion_api",
+    "original_client_companion_backend",
     "original_client_letter_contract",
     "original_client_media_http",
     "patch_companion_settings",

--- a/tests/http/test_original_client_companion_backend.py
+++ b/tests/http/test_original_client_companion_backend.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import inspect
+from pathlib import Path
+
+import pytest
+
+from conversation_memory_admin import MemoryAdminStatus
+from conversation_memory_port import ConversationMemoryRecord
+from original_client_companion_backend import (
+    OriginalClientCompanionBackendError,
+    OriginalClientCompanionServiceBackend,
+)
+from private_world_candidates import (
+    CandidateStatus,
+    CandidateType,
+    PrivateWorldCandidate,
+)
+
+
+NOW = datetime(2026, 8, 23, 10, 30, tzinfo=timezone.utc)
+
+
+class MemoryAdminFixture:
+    def __init__(self) -> None:
+        self.requests: list[tuple[str | None, int]] = []
+
+    def status(self) -> MemoryAdminStatus:
+        return MemoryAdminStatus(
+            status="available",
+            provider="mem0",
+            enabled=True,
+            memory_count=2,
+            audit_count=0,
+            pending_correction_count=0,
+        )
+
+    def list_memories(
+        self,
+        *,
+        query: str | None = None,
+        limit: int = 100,
+    ):
+        self.requests.append((query, limit))
+        return (
+            ConversationMemoryRecord(
+                memory_id="memory.1",
+                text="用户喜欢雨天散步。",
+                user_id="local-user",
+                source_id="reply:letter-1:1",
+                created_at=NOW,
+                score=0.9,
+            ),
+            ConversationMemoryRecord(
+                memory_id="memory.2",
+                text="用户计划九月去云南。",
+                user_id="local-user",
+                source_id="reply:letter-2:1",
+                occurred_at=NOW,
+            ),
+        )[:limit]
+
+
+class PrivateWorldFixture:
+    def snapshot(self):
+        return {
+            "schema_version": "p03.private-world-control.v1",
+            "version": 8,
+            "relationship_stage": "trusted_friend",
+            "levels": {
+                "familiarity": "medium",
+                "trust": "high",
+                "comfort": "medium",
+                "closeness": "medium",
+                "tension": "low",
+            },
+            "nickname_permissions": ["小河豚"],
+            "home_access": "visit_access",
+            "continuation_facts": [
+                {
+                    "fact_id": "continuation.yunnan",
+                    "statement": "林离正在准备云南采风。",
+                    "awareness": "character_known",
+                }
+            ],
+            "hidden_scores": {"trust": 88, "comfort": 72},
+            "database_path": "C:/private/private_world.sqlite3",
+        }
+
+
+class CandidateFixture:
+    def __init__(self) -> None:
+        self.calls: list[tuple[CandidateStatus | None, datetime | None]] = []
+
+    def list_candidates(
+        self,
+        *,
+        status: CandidateStatus | None = None,
+        now: datetime | None = None,
+    ):
+        self.calls.append((status, now))
+        return (
+            PrivateWorldCandidate(
+                candidate_id="candidate.repair.1",
+                source_letter_id="letter-1",
+                source_reply_revision=1,
+                candidate_type=CandidateType.REPAIR,
+                summary="双方完成了一次明确修复。",
+                confidence=0.98,
+                status=CandidateStatus.PENDING,
+                created_at=NOW,
+                expires_at=datetime(
+                    2026,
+                    8,
+                    30,
+                    10,
+                    30,
+                    tzinfo=timezone.utc,
+                ),
+            ),
+        )
+
+
+def test_adapter_maps_existing_services_without_hidden_state() -> None:
+    memory = MemoryAdminFixture()
+    world = PrivateWorldFixture()
+    candidates = CandidateFixture()
+    backend = OriginalClientCompanionServiceBackend(
+        memory_admin=memory,
+        private_world=world,
+        candidates=candidates,
+        now=lambda: NOW,
+    )
+
+    status = backend.read_status()
+    assert status.memory.to_dict() == {"state": "available", "count": 2}
+    assert status.private_world.to_dict() == {"state": "available"}
+    assert status.candidates.to_dict() == {"state": "available", "count": 1}
+
+    memories = backend.list_memories(query="雨天", limit=2)
+    assert memory.requests == [("雨天", 2)]
+    assert [value.created_at for value in memories] == [NOW.isoformat()] * 2
+    assert memories[0].score == 0.9
+
+    summary = backend.private_world_summary().to_dict()
+    assert summary["version"] == 8
+    assert summary["levels"]["trust"] == "high"
+    assert summary["nickname_permissions"] == ["小河豚"]
+    assert summary["continuation_facts"][0]["awareness"] == "character_known"
+    serialized = repr(summary)
+    assert "hidden_scores" not in serialized
+    assert "database_path" not in serialized
+    assert "88" not in serialized
+
+    pending = backend.list_candidates(limit=5)
+    assert candidates.calls[-1] == (CandidateStatus.PENDING, NOW)
+    assert pending[0].candidate_type == "repair"
+    candidate_payload = pending[0].to_dict()
+    assert "confidence" not in candidate_payload
+    assert "source_letter_id" not in candidate_payload
+
+
+def test_absent_services_are_independently_disabled() -> None:
+    backend = OriginalClientCompanionServiceBackend(now=lambda: NOW)
+
+    status = backend.read_status().to_dict()["capabilities"]
+    assert status == {
+        "memory": {
+            "state": "disabled",
+            "reason_code": "COMPANION_MEMORY_DISABLED",
+        },
+        "private_world": {
+            "state": "disabled",
+            "reason_code": "COMPANION_PRIVATE_WORLD_DISABLED",
+        },
+        "candidates": {
+            "state": "disabled",
+            "reason_code": "COMPANION_CANDIDATES_DISABLED",
+        },
+    }
+
+    with pytest.raises(OriginalClientCompanionBackendError) as memory_error:
+        backend.list_memories(query=None, limit=10)
+    assert memory_error.value.code == "COMPANION_MEMORY_DISABLED"
+
+    with pytest.raises(OriginalClientCompanionBackendError) as world_error:
+        backend.private_world_summary()
+    assert world_error.value.code == "COMPANION_PRIVATE_WORLD_DISABLED"
+
+    with pytest.raises(OriginalClientCompanionBackendError) as candidate_error:
+        backend.list_candidates(limit=10)
+    assert candidate_error.value.code == "COMPANION_CANDIDATES_DISABLED"
+
+
+def test_service_failures_degrade_only_the_affected_capability() -> None:
+    class FailingMemory(MemoryAdminFixture):
+        def status(self) -> MemoryAdminStatus:
+            raise OSError("private memory path")
+
+    class FailingCandidates(CandidateFixture):
+        def list_candidates(self, *, status=None, now=None):
+            raise OSError("private candidate path")
+
+    backend = OriginalClientCompanionServiceBackend(
+        memory_admin=FailingMemory(),
+        private_world=PrivateWorldFixture(),
+        candidates=FailingCandidates(),
+        now=lambda: NOW,
+    )
+
+    capabilities = backend.read_status().to_dict()["capabilities"]
+    assert capabilities["memory"] == {
+        "state": "unavailable",
+        "reason_code": "COMPANION_MEMORY_UNAVAILABLE",
+    }
+    assert capabilities["private_world"] == {"state": "available"}
+    assert capabilities["candidates"] == {
+        "state": "unavailable",
+        "reason_code": "COMPANION_CANDIDATES_UNAVAILABLE",
+    }
+
+
+def test_invalid_provider_records_do_not_gain_invented_fields() -> None:
+    class UndatedMemory(MemoryAdminFixture):
+        def list_memories(self, *, query=None, limit=100):
+            return (
+                ConversationMemoryRecord(
+                    memory_id="memory.undated",
+                    text="没有时间字段的记忆。",
+                    user_id="local-user",
+                    source_id="reply:undated:1",
+                ),
+            )
+
+    backend = OriginalClientCompanionServiceBackend(
+        memory_admin=UndatedMemory(),
+        now=lambda: NOW,
+    )
+    with pytest.raises(OriginalClientCompanionBackendError) as error:
+        backend.list_memories(query=None, limit=10)
+    assert error.value.code == "COMPANION_MEMORY_TIME_UNAVAILABLE"
+
+    class InvalidWorld(PrivateWorldFixture):
+        def snapshot(self):
+            payload = dict(super().snapshot())
+            payload["levels"] = {"trust": "high"}
+            return payload
+
+    invalid_world = OriginalClientCompanionServiceBackend(
+        private_world=InvalidWorld(),
+        now=lambda: NOW,
+    )
+    with pytest.raises(OriginalClientCompanionBackendError) as world_error:
+        invalid_world.private_world_summary()
+    assert world_error.value.code == "COMPANION_PRIVATE_WORLD_INVALID"
+
+
+def test_adapter_uses_services_instead_of_storage_implementations() -> None:
+    module = __import__("original_client_companion_backend")
+    source = inspect.getsource(module).casefold()
+    forbidden = (
+        "import sqlite3",
+        "qdrant",
+        "sqlite3.connect",
+        ".execute(",
+        ".cursor(",
+    )
+    assert not any(value in source for value in forbidden)
+
+    module_path = Path(module.__file__ or "")
+    assert module_path.name == "original_client_companion_backend.py"


### PR DESCRIPTION
Implements CLIENT-SETTINGS-03 after the bounded original-settings read contract.

## Scope

- adds `OriginalClientCompanionServiceBackend`, a provider-neutral adapter over the existing services;
- accepts optional Memory Admin, PrivateWorld read, and Candidate read ports;
- maps `ConversationMemoryRecord` without exposing user IDs, full metadata, embeddings, provider objects, prompts, or PrivateWorld data;
- uses provider creation time and falls back to the exchange occurrence time; records with no real time are rejected rather than assigned an invented timestamp;
- accepts only the existing PrivateWorld Control snapshot and copies its qualitative levels, permissions, and continuation facts;
- ignores any unexpected hidden scores, paths, or debug fields in the upstream mapping;
- reads only pending, non-expired relationship candidates and omits confidence, source-letter IDs, reply revisions, and decision audit;
- reports Memory, PrivateWorld, and Candidate capability states independently, so one failed service does not make the others look unavailable;
- contains no SQLite, Qdrant, Mem0-internal, reducer, or command-payload implementation;
- packages and documents the adapter.

## Tests

- complete service mapping and timestamp fallback;
- hidden-score/path field exclusion;
- pending-candidate filtering and field minimization;
- independently disabled services;
- independently unavailable services;
- rejection of undated memory and malformed PrivateWorld summaries;
- source scan proving the adapter does not reach storage implementations.

## Boundary

This PR does not mount any route in `local_server.py`, render data in the original UI, or enable mutations. CLIENT-SETTINGS-04 will assemble configured services and mount the already-reviewed read API on the existing local application.

Part of #33, #34, #35, and #38.