### PR TITLE
feat(client): mount companion reads in the original-client runtime

### DIFF
--- a/docs/P03_ORIGINAL_CLIENT_COMPANION_RUNTIME.md
+++ b/docs/P03_ORIGINAL_CLIENT_COMPANION_RUNTIME.md
@@ -1,0 +1,126 @@
+# P03 原版客户端陪伴读取运行时
+
+## 1. 目标
+
+把已经合入的原版设置弹窗、只读 HTTP Contract 和现有 Memory / PrivateWorld Service 真正接到同一个本机进程中。
+
+发布运行结构：
+
+```text
+原版 Olivia 客户端
+  -> /toy/letter/* 等既有本机接口
+  -> /toy/companion/* 原版设置读取接口
+  -> 同一个 127.0.0.1 aiohttp 进程
+```
+
+不启动独立浏览器 Control Center，不增加第二个用户服务器，也不要求用户运行 CLI。
+
+## 2. 入口
+
+安装后的启动器不再直接执行：
+
+```text
+local_server.py
+```
+
+而是执行：
+
+```text
+original_client_server.py
+```
+
+`original_client_server.py` 会：
+
+1. 导入既有 `local_server` 业务运行时；
+2. 复用同一个 Memory Adapter、PrivateWorld Ledger 和候选数据库；
+3. 先注册 `/toy/companion/*`；
+4. 最后注册原有 catch-all toy API handler；
+5. 在同一个 `127.0.0.1:8899` 监听器上运行。
+
+原有 `/health`、信箱、生成、媒体和其他 toy API 仍由 `local_server.handler` 处理。
+
+## 3. 长期记忆接线
+
+运行时从现有 `MemoryPromptBuilder` 读取已经用于 Persona 检索的 `ConversationMemoryPort`，再构造：
+
+```text
+ConversationMemoryAdminService
+```
+
+审计文件位于本机数据根目录：
+
+```text
+<data>/memory/memory_admin_audit.sqlite3
+```
+
+该审计不记录记忆正文。当前 PR 只把读取能力挂进原版设置接口；纠正、删除等写操作仍是后续独立 PR。
+
+缺少本机数据根、Mem0 未启用或管理服务无法初始化时，长期记忆能力显示为 disabled/unavailable，不影响信箱和普通回信。
+
+## 4. PrivateWorld 接线
+
+运行时复用 `local_server` 已经持有的同一个 `PrivateWorldPort`，只把 `PrivateWorldSnapshot` 投影为：
+
+- 关系阶段；
+- familiarity / trust / comfort / closeness / tension 的 low / medium / high；
+- 已授权称呼；
+- 住所权限；
+- Local Continuation 与 awareness。
+
+不会返回隐藏的 0–100 数值。
+
+候选读取复用同一个 PrivateWorld SQLite 文件中的 `SQLitePrivateWorldCandidateStore`。不会复制第二份候选数据库，也不会在本 PR 中批准或拒绝候选。
+
+## 5. 路由优先级
+
+既有 `local_server` 使用 catch-all 路由，因此挂载顺序必须固定：
+
+```text
+1. /toy/companion/status
+2. /toy/companion/memory
+3. /toy/companion/private-world
+4. /toy/companion/private-world/candidates
+5. /{tail:.*} 既有 toy API
+```
+
+如果顺序反过来，catch-all 会截获原版设置请求。本顺序由测试锁定。
+
+## 6. 安全边界
+
+- 只监听 loopback；
+- 只接受运行时注入的原版前端 HTTPS Origin，或显式 loopback 开发 Origin；
+- 不硬编码或联系外部原版服务器；
+- 返回 `Cache-Control: no-store`；
+- 后端错误不返回路径、数据库名、provider payload 或凭据；
+- Memory、PrivateWorld 和候选读取分别降级；
+- 任一可选能力失败时，原有 toy API 继续工作。
+
+## 7. 本 PR 不包含
+
+- 在原版弹窗中渲染记忆列表和 PrivateWorld 详情；
+- 记忆纠正、删除；
+- 称呼、住所权限和 Local Continuation 修改；
+- 候选批准、拒绝；
+- 原版信箱 camelCase Contract 的生产接线；
+- 安装器应用 `patch_companion_settings.py`；
+- 删除 standalone Control Center 代码。
+
+## 8. 验收
+
+- 原版设置四个 GET 路由在同一进程可访问；
+- `/health` 和既有 toy API 仍进入原 handler；
+- Memory、PrivateWorld、候选复用已有 Service/Store；
+- PrivateWorld 输出没有隐藏数值；
+- 可选服务缺失时只显示 disabled/unavailable；
+- 启动器执行 `original_client_server.py`；
+- 缺少该入口时安装运行明确失败为 `PATCH_PAYLOAD_INCOMPLETE`；
+- Windows public-smoke、hardening scan 和 whitespace check 通过。
+
+## 9. 后续顺序
+
+```text
+CLIENT-SETTINGS-05  原版设置弹窗渲染真实只读数据
+CLIENT-SETTINGS-06  原版内受控写操作
+CLIENT-INSTALL-01   安装器自动应用设置与播放器补丁
+CLIENT-CONTRACT-02  原版 Collection 数据格式生产接线
+```

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -78,6 +78,12 @@ def _backend_executable() -> Path:
     return candidate if candidate.is_file() else Path(sys.executable)
 
 
+def _backend_entrypoint(backend: Path) -> Path:
+    """Use the one process that mounts toy API and original in-client settings."""
+
+    return backend / "original_client_server.py"
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--install-root", type=Path, required=True)
@@ -86,7 +92,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     root = args.install_root.expanduser().resolve()
     backend = root / "local_backend"
-    if not (backend / "local_server.py").is_file():
+    entrypoint = _backend_entrypoint(backend)
+    if not (backend / "local_server.py").is_file() or not entrypoint.is_file():
         print("PATCH_PAYLOAD_INCOMPLETE")
         return 2
     if args.health_only:
@@ -128,7 +135,7 @@ def main(argv: list[str] | None = None) -> int:
     server = None
     if not _health(args.port):
         detached = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) | getattr(subprocess, "DETACHED_PROCESS", 0)
-        server = subprocess.Popen([str(_backend_executable()), str(backend / "local_server.py")], cwd=backend, env=environment, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, creationflags=detached)
+        server = subprocess.Popen([str(_backend_executable()), str(entrypoint)], cwd=backend, env=environment, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, creationflags=detached)
         deadline = time.monotonic() + 20
         while time.monotonic() < deadline and server.poll() is None:
             if _health(args.port):

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -49,7 +49,7 @@ class OriginalClientServerError(RuntimeError):
 
 
 class PrivateWorldControlReadAdapter:
-    """Project one typed snapshot into the qualitative original-settings view."""
+    """Project typed PrivateWorld state into the qualitative settings view."""
 
     def __init__(self, port: PrivateWorldPort) -> None:
         if not isinstance(port, PrivateWorldPort):

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -1,0 +1,286 @@
+"""Run the original Olivia local backend with its in-client companion settings.
+
+The original client remains the only user-facing shell.  This module mounts the
+bounded Memory / PrivateWorld read API before the existing catch-all toy API
+handler, then launches both surfaces in one loopback-only aiohttp process.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from aiohttp import web
+
+from conversation_memory_admin import (
+    ConversationMemoryAdminError,
+    ConversationMemoryAdminService,
+)
+from conversation_memory_port import ConversationMemoryPort
+from original_client_companion_api import mount_original_companion_read_api
+from original_client_companion_backend import (
+    OriginalClientCompanionServiceBackend,
+)
+from private_world_candidates import (
+    PrivateWorldCandidateError,
+    SQLitePrivateWorldCandidateStore,
+)
+from private_world_ledger import LedgerWriteError
+from private_world_port import PrivateWorldPort, PrivateWorldSnapshot
+from private_world_projection import project_private_world
+from private_world_runtime import resolve_private_world_database
+
+
+FallbackHandler = Callable[[web.Request], Awaitable[web.StreamResponse]]
+_RUNTIME_KEY = web.AppKey("original_client.server_runtime", object)
+_MEMORY_ADMIN_FILENAME = "memory_admin_audit.sqlite3"
+
+
+class OriginalClientServerError(RuntimeError):
+    """Stable assembly failure without a path or provider payload."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+class PrivateWorldControlReadAdapter:
+    """Project one typed snapshot into the qualitative original-settings view."""
+
+    def __init__(self, port: PrivateWorldPort) -> None:
+        if not isinstance(port, PrivateWorldPort):
+            raise TypeError("a PrivateWorld port is required")
+        self._port = port
+
+    def snapshot(self) -> Mapping[str, object]:
+        try:
+            snapshot = self._port.snapshot()
+        except Exception as exc:
+            raise OriginalClientServerError(
+                "COMPANION_PRIVATE_WORLD_UNAVAILABLE"
+            ) from exc
+        if not isinstance(snapshot, PrivateWorldSnapshot):
+            raise OriginalClientServerError(
+                "COMPANION_PRIVATE_WORLD_INVALID"
+            )
+        projected = project_private_world(snapshot)
+        behavior = projected.behavior.to_dict()
+        return {
+            "version": snapshot.version,
+            "relationship_stage": behavior["relationship_stage"],
+            "levels": {
+                name: behavior[name]
+                for name in (
+                    "familiarity",
+                    "trust",
+                    "comfort",
+                    "closeness",
+                    "tension",
+                )
+            },
+            "nickname_permissions": list(snapshot.nickname_permissions),
+            "home_access": snapshot.home_access.value,
+            "continuation_facts": [
+                fact.to_dict() for fact in snapshot.continuation_facts
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class OriginalClientServerRuntime:
+    app: web.Application
+    backend: OriginalClientCompanionServiceBackend
+    memory_admin: ConversationMemoryAdminService | None
+    private_world_read: PrivateWorldControlReadAdapter | None
+    candidate_store: SQLitePrivateWorldCandidateStore | None
+
+    def public_status(self) -> dict[str, object]:
+        """Return component presence only; never paths, content, or hidden scores."""
+
+        return {
+            "status": "available",
+            "network_scope": "loopback",
+            "original_client_only": True,
+            "memory_admin_mounted": self.memory_admin is not None,
+            "private_world_mounted": self.private_world_read is not None,
+            "candidate_store_mounted": self.candidate_store is not None,
+        }
+
+
+def create_original_client_server_runtime(
+    fallback_handler: FallbackHandler,
+    *,
+    memory_admin: ConversationMemoryAdminService | None = None,
+    private_world: PrivateWorldPort | None = None,
+    candidates: SQLitePrivateWorldCandidateStore | None = None,
+    trusted_origins: Sequence[str] = (),
+) -> OriginalClientServerRuntime:
+    """Mount companion reads before the existing catch-all toy API handler."""
+
+    if not callable(fallback_handler):
+        raise TypeError("a fallback request handler is required")
+    private_read = (
+        PrivateWorldControlReadAdapter(private_world)
+        if private_world is not None
+        else None
+    )
+    backend = OriginalClientCompanionServiceBackend(
+        memory_admin=memory_admin,
+        private_world=private_read,
+        candidates=candidates,
+    )
+    app = web.Application()
+    mount_original_companion_read_api(
+        app,
+        backend,
+        trusted_origins=tuple(trusted_origins),
+    )
+    # Keep this last.  The original server intentionally owns a catch-all route.
+    app.router.add_route("*", "/{tail:.*}", fallback_handler)
+    runtime = OriginalClientServerRuntime(
+        app,
+        backend,
+        memory_admin,
+        private_read,
+        candidates,
+    )
+    app[_RUNTIME_KEY] = runtime
+    return runtime
+
+
+def _absolute_data_root(environ: Mapping[str, str]) -> Path | None:
+    raw = str(environ.get("OLIVIA_LOCAL_DATA_ROOT", "")).strip()
+    if not raw:
+        return None
+    path = Path(raw).expanduser()
+    if not path.is_absolute() or path.exists() and not path.is_dir():
+        return None
+    return path.resolve()
+
+
+def _configured_memory_admin(
+    server_module: ModuleType | Any,
+    environ: Mapping[str, str],
+) -> ConversationMemoryAdminService | None:
+    root = _absolute_data_root(environ)
+    builder = getattr(
+        getattr(server_module, "letters_adapter", None),
+        "memory_prompt_builder",
+        None,
+    )
+    memory = getattr(builder, "conversation_memory", None)
+    if root is None or not isinstance(memory, ConversationMemoryPort):
+        return None
+    user_id = getattr(builder, "conversation_memory_user_id", "local-user")
+    try:
+        return ConversationMemoryAdminService(
+            memory,
+            root / "memory" / _MEMORY_ADMIN_FILENAME,
+            user_id=str(user_id),
+        )
+    except (
+        ConversationMemoryAdminError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        return None
+
+
+def _configured_private_world(
+    server_module: ModuleType | Any,
+    environ: Mapping[str, str],
+) -> tuple[PrivateWorldPort | None, SQLitePrivateWorldCandidateStore | None]:
+    if getattr(server_module, "private_world_committer", None) is None:
+        return None, None
+    port = getattr(server_module, "private_world_port", None)
+    if not isinstance(port, PrivateWorldPort):
+        return None, None
+
+    path, _reason, enabled = resolve_private_world_database(environ)
+    if not enabled or path is None or not path.is_file():
+        return port, None
+    try:
+        candidates = SQLitePrivateWorldCandidateStore(path)
+    except (
+        PrivateWorldCandidateError,
+        LedgerWriteError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        candidates = None
+    return port, candidates
+
+
+def create_configured_original_client_server_runtime(
+    *,
+    server_module: ModuleType | Any | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> OriginalClientServerRuntime:
+    """Assemble configured services already owned by the local reply runtime."""
+
+    if server_module is None:
+        import local_server as server_module
+
+    values = os.environ if environ is None else environ
+    fallback = getattr(server_module, "handler", None)
+    origins = tuple(
+        getattr(server_module, "TRUSTED_FRONTEND_ORIGINS", ())
+    )
+    memory_admin = _configured_memory_admin(server_module, values)
+    private_world, candidates = _configured_private_world(
+        server_module,
+        values,
+    )
+    return create_original_client_server_runtime(
+        fallback,
+        memory_admin=memory_admin,
+        private_world=private_world,
+        candidates=candidates,
+        trusted_origins=origins,
+    )
+
+
+def main() -> int:
+    """Launch one loopback process for the original client and companion reads."""
+
+    import local_server
+
+    local_server.recover_pending_private_world()
+    runtime = create_configured_original_client_server_runtime(
+        server_module=local_server,
+    )
+    local_server._safe_log(
+        "server_start",
+        host="127.0.0.1",
+        port=local_server.PORT,
+        companion_settings=True,
+    )
+    web.run_app(
+        runtime.app,
+        host="127.0.0.1",
+        port=local_server.PORT,
+        access_log=None,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "OriginalClientServerError",
+    "OriginalClientServerRuntime",
+    "PrivateWorldControlReadAdapter",
+    "create_configured_original_client_server_runtime",
+    "create_original_client_server_runtime",
+    "main",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ py-modules = [
     "original_client_companion_backend",
     "original_client_letter_contract",
     "original_client_media_http",
+    "original_client_server",
     "patch_companion_settings",
     "patch_feapp",
     "persona_loader",

--- a/tests/http/test_original_client_server.py
+++ b/tests/http/test_original_client_server.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from conversation_memory_admin import MemoryAdminStatus
+from conversation_memory_port import (
+    ConversationMemoryRecord,
+    NullConversationMemoryPort,
+)
+from original_client_server import (
+    create_configured_original_client_server_runtime,
+    create_original_client_server_runtime,
+)
+from private_world_candidates import (
+    CandidateStatus,
+    CandidateType,
+    PrivateWorldCandidate,
+)
+from private_world_ledger import SQLitePrivateWorldLedger
+from private_world_port import (
+    ContinuationAwareness,
+    HomeAccess,
+    LocalContinuationFact,
+    PrivateWorldSnapshot,
+)
+
+
+TRUSTED_ORIGIN = "https://client.example"
+
+
+class MemoryAdminFixture:
+    def status(self) -> MemoryAdminStatus:
+        return MemoryAdminStatus(
+            "available",
+            "fixture",
+            True,
+            1,
+            0,
+            0,
+        )
+
+    def list_memories(self, *, query=None, limit=100):
+        assert query in {None, "东京"}
+        assert 1 <= limit <= 100
+        return (
+            ConversationMemoryRecord(
+                "memory.fixture.1",
+                "用户现在住在东京北区。",
+                "local-user",
+                "reply.fixture.1",
+                score=0.9,
+                created_at=datetime(2026, 8, 23, tzinfo=timezone.utc),
+            ),
+        )
+
+
+class PrivateWorldFixture:
+    def __init__(self) -> None:
+        self._snapshot = PrivateWorldSnapshot(
+            version=7,
+            familiarity=72,
+            trust=88,
+            comfort=65,
+            closeness=55,
+            tension=10,
+            relationship_stage="close",
+            nickname_permissions=("小河豚",),
+            home_access=HomeAccess.VISIT_ACCESS,
+            continuation_facts=(
+                LocalContinuationFact(
+                    "trip.yunnan",
+                    "林离已经决定去云南采风。",
+                    ContinuationAwareness.CHARACTER_KNOWN,
+                ),
+            ),
+        )
+
+    def snapshot(self) -> PrivateWorldSnapshot:
+        return self._snapshot
+
+    def control_view(self):
+        return self._snapshot.control_view()
+
+    def character_view(self):
+        return self._snapshot.character_view()
+
+
+class CandidateFixture:
+    def list_candidates(self, *, status=None, now=None):
+        assert status is CandidateStatus.PENDING
+        assert now is not None
+        created = datetime(2026, 8, 23, 1, 0, tzinfo=timezone.utc)
+        return (
+            PrivateWorldCandidate(
+                "candidate.fixture.1",
+                "letter.fixture.1",
+                1,
+                CandidateType.REPAIR,
+                "这次交流可能构成关系修复。",
+                0.8,
+                CandidateStatus.PENDING,
+                created,
+                created + timedelta(days=7),
+            ),
+        )
+
+
+async def _fallback(request: web.Request) -> web.Response:
+    return web.json_response(
+        {"fallback": request.path},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+def test_companion_routes_precede_existing_catch_all_and_return_real_data() -> None:
+    async def scenario() -> None:
+        runtime = create_original_client_server_runtime(
+            _fallback,
+            memory_admin=MemoryAdminFixture(),
+            private_world=PrivateWorldFixture(),
+            candidates=CandidateFixture(),
+            trusted_origins=(TRUSTED_ORIGIN,),
+        )
+        async with TestClient(TestServer(runtime.app)) as client:
+            status = await client.get(
+                "/toy/companion/status",
+                headers={"Origin": TRUSTED_ORIGIN},
+            )
+            assert status.status == 200
+            status_payload = await status.json()
+            assert status_payload["capabilities"]["memory"] == {
+                "state": "available",
+                "count": 1,
+            }
+            assert status_payload["capabilities"]["private_world"] == {
+                "state": "available"
+            }
+            assert status_payload["capabilities"]["candidates"] == {
+                "state": "available",
+                "count": 1,
+            }
+
+            memories = await client.get(
+                "/toy/companion/memory?query=%E4%B8%9C%E4%BA%AC&limit=5",
+                headers={"Origin": TRUSTED_ORIGIN},
+            )
+            assert memories.status == 200
+            memory_payload = await memories.json()
+            assert memory_payload["memories"][0]["text"] == "用户现在住在东京北区。"
+            assert "user_id" not in memory_payload["memories"][0]
+
+            private_world = await client.get(
+                "/toy/companion/private-world",
+                headers={"Origin": TRUSTED_ORIGIN},
+            )
+            assert private_world.status == 200
+            private_payload = await private_world.json()
+            assert private_payload["version"] == 7
+            assert private_payload["relationship_stage"] == "close"
+            assert private_payload["levels"] == {
+                "familiarity": "high",
+                "trust": "high",
+                "comfort": "medium",
+                "closeness": "medium",
+                "tension": "low",
+            }
+            assert private_payload["nickname_permissions"] == ["小河豚"]
+            assert private_payload["home_access"] == "visit_access"
+            for hidden in ("familiarity", "trust", "comfort", "closeness", "tension"):
+                assert hidden not in {
+                    key for key in private_payload if key != "levels"
+                }
+
+            candidates = await client.get(
+                "/toy/companion/private-world/candidates?limit=5",
+                headers={"Origin": TRUSTED_ORIGIN},
+            )
+            assert candidates.status == 200
+            candidate_payload = await candidates.json()
+            assert candidate_payload["candidates"] == [
+                {
+                    "candidate_id": "candidate.fixture.1",
+                    "candidate_type": "repair",
+                    "summary": "这次交流可能构成关系修复。",
+                    "created_at": "2026-08-23T01:00:00+00:00",
+                    "expires_at": "2026-08-30T01:00:00+00:00",
+                }
+            ]
+
+            fallback = await client.get("/health")
+            assert fallback.status == 200
+            assert await fallback.json() == {"fallback": "/health"}
+
+    asyncio.run(scenario())
+
+
+def test_configured_runtime_reuses_existing_memory_and_private_world_storage(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        root = tmp_path / "data"
+        root.mkdir()
+        database = root / "private_world" / "private_world.sqlite3"
+        ledger = SQLitePrivateWorldLedger(database)
+        builder = SimpleNamespace(
+            conversation_memory=NullConversationMemoryPort(),
+            conversation_memory_user_id="local-user",
+        )
+        server = SimpleNamespace(
+            handler=_fallback,
+            letters_adapter=SimpleNamespace(memory_prompt_builder=builder),
+            private_world_port=ledger,
+            private_world_committer=object(),
+            TRUSTED_FRONTEND_ORIGINS=frozenset({TRUSTED_ORIGIN}),
+        )
+        runtime = create_configured_original_client_server_runtime(
+            server_module=server,
+            environ={
+                "OLIVIA_LOCAL_DATA_ROOT": str(root),
+                "OLIVIA_PRIVATE_WORLD_ENABLED": "1",
+                "OLIVIA_PRIVATE_WORLD_DB": str(database),
+            },
+        )
+
+        assert runtime.memory_admin is not None
+        assert runtime.private_world_read is not None
+        assert runtime.candidate_store is not None
+        assert (root / "memory" / "memory_admin_audit.sqlite3").is_file()
+        assert runtime.public_status() == {
+            "status": "available",
+            "network_scope": "loopback",
+            "original_client_only": True,
+            "memory_admin_mounted": True,
+            "private_world_mounted": True,
+            "candidate_store_mounted": True,
+        }
+
+        async with TestClient(TestServer(runtime.app)) as client:
+            response = await client.get(
+                "/toy/companion/status",
+                headers={"Origin": TRUSTED_ORIGIN},
+            )
+            assert response.status == 200
+            payload = await response.json()
+            assert payload["capabilities"]["memory"]["state"] == "disabled"
+            assert payload["capabilities"]["private_world"]["state"] == "available"
+            assert payload["capabilities"]["candidates"] == {
+                "state": "available",
+                "count": 0,
+            }
+
+    asyncio.run(scenario())
+
+
+def test_configured_runtime_degrades_optional_services_without_losing_toy_api(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        server = SimpleNamespace(
+            handler=_fallback,
+            letters_adapter=SimpleNamespace(
+                memory_prompt_builder=SimpleNamespace(
+                    conversation_memory=None,
+                    conversation_memory_user_id="local-user",
+                )
+            ),
+            private_world_port=None,
+            private_world_committer=None,
+            TRUSTED_FRONTEND_ORIGINS=frozenset({TRUSTED_ORIGIN}),
+        )
+        runtime = create_configured_original_client_server_runtime(
+            server_module=server,
+            environ={"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path / "missing")},
+        )
+        async with TestClient(TestServer(runtime.app)) as client:
+            status = await client.get(
+                "/toy/companion/status",
+                headers={"Origin": TRUSTED_ORIGIN},
+            )
+            payload = await status.json()
+            assert payload["capabilities"]["memory"]["state"] == "disabled"
+            assert payload["capabilities"]["private_world"]["state"] == "disabled"
+            assert payload["capabilities"]["candidates"]["state"] == "disabled"
+
+            fallback = await client.get("/toy/signIn")
+            assert fallback.status == 200
+            assert await fallback.json() == {"fallback": "/toy/signIn"}
+
+    asyncio.run(scenario())

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import installer.start_local as start_local
+
+
+def _installation(tmp_path: Path, *, with_entrypoint: bool = True) -> Path:
+    root = tmp_path / "installed"
+    backend = root / "local_backend"
+    (backend / "installer").mkdir(parents=True)
+    (backend / "local_server.py").write_text("# fixture", encoding="utf-8")
+    if with_entrypoint:
+        (backend / "original_client_server.py").write_text(
+            "# fixture",
+            encoding="utf-8",
+        )
+    (backend / "installer" / "full-patch-manifest.json").write_text(
+        json.dumps({"client_version": "0.0.9.615"}),
+        encoding="utf-8",
+    )
+    client = root / "app" / "0.0.9.615" / "Olivia.exe"
+    client.parent.mkdir(parents=True)
+    client.write_bytes(b"fixture")
+    return root
+
+
+def test_launcher_starts_combined_server_before_original_client(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    root = _installation(tmp_path)
+    health = iter((False, True, True))
+    commands: list[list[str]] = []
+    client_commands: list[list[str]] = []
+
+    class Process:
+        @staticmethod
+        def poll():
+            return None
+
+    def popen(command, **_kwargs):
+        commands.append([str(value) for value in command])
+        return Process()
+
+    def call(command, **_kwargs):
+        client_commands.append([str(value) for value in command])
+        return 0
+
+    monkeypatch.setattr(start_local, "_health", lambda _port: next(health))
+    monkeypatch.setattr(
+        start_local,
+        "_backend_executable",
+        lambda: Path("pythonw-fixture.exe"),
+    )
+    monkeypatch.setattr(start_local.subprocess, "Popen", popen)
+    monkeypatch.setattr(start_local.subprocess, "call", call)
+
+    result = start_local.main(["--install-root", str(root), "--port", "8899"])
+
+    assert result == 0
+    assert commands == [
+        [
+            "pythonw-fixture.exe",
+            str(root / "local_backend" / "original_client_server.py"),
+        ]
+    ]
+    assert client_commands[0][0].endswith("Olivia.exe")
+    assert not commands[0][1].endswith("local_server.py")
+
+
+def test_launcher_refuses_payload_without_combined_entrypoint(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    root = _installation(tmp_path, with_entrypoint=False)
+
+    assert start_local.main(["--install-root", str(root)]) == 2
+    assert capsys.readouterr().out.strip() == "PATCH_PAYLOAD_INCOMPLETE"

--- a/tests/installer/test_private_world_default.py
+++ b/tests/installer/test_private_world_default.py
@@ -15,6 +15,10 @@ def test_start_local_configures_private_world_under_install_data(
     backend = root / "local_backend"
     backend.mkdir(parents=True)
     (backend / "local_server.py").write_text("# synthetic", encoding="utf-8")
+    (backend / "original_client_server.py").write_text(
+        "# synthetic",
+        encoding="utf-8",
+    )
     client = root / "app" / "synthetic" / "Olivia.exe"
     client.parent.mkdir(parents=True)
     client.write_bytes(b"synthetic")


### PR DESCRIPTION
Implements CLIENT-SETTINGS-04 after #84 and #85.

## Scope

- adds `original_client_server.py`, the one loopback process launched for the original Olivia client;
- mounts `/toy/companion/status`, `/memory`, `/private-world`, and `/private-world/candidates` before the existing `local_server` catch-all route;
- reuses the exact `ConversationMemoryPort` already owned by `MemoryPromptBuilder` and wraps it with the existing `ConversationMemoryAdminService`;
- writes only the content-free memory-admin audit under the configured local data root;
- reuses the exact existing PrivateWorld port and projects its typed snapshot to qualitative levels without exposing 0–100 scores;
- opens the existing PrivateWorld SQLite file through `SQLitePrivateWorldCandidateStore` for pending reads rather than creating a second database;
- keeps Memory, PrivateWorld, and candidates independently optional so their failure does not remove `/health`, mailbox, generation, or media routes;
- updates the Windows launcher to start `original_client_server.py` instead of directly executing the catch-all module;
- requires both runtime files to exist before launch and packages the new entrypoint.

## Tests

- companion routes win over the existing catch-all and return real bounded data;
- memory user scope and PrivateWorld hidden numbers stay absent;
- the existing `/health`/toy handler remains reachable;
- configured runtime reuses one memory service, one ledger, and one candidate store;
- optional services degrade independently;
- the installed launcher starts the combined runtime and refuses an incomplete payload.

## Boundary

This PR does not yet render the returned lists in the original settings dialog, enable mutations, apply the settings patch from the installer, or wire the original Collection camelCase serializer. Those remain separate small PRs from the latest protected main.

Part of #33, #34, #35, #37, and #38.