### PR TITLE
feat(client): show companion data inside original settings

### DIFF
--- a/docs/P03_ORIGINAL_CLIENT_COMPANION_READ_UI.md
+++ b/docs/P03_ORIGINAL_CLIENT_COMPANION_READ_UI.md
@@ -1,0 +1,106 @@
+# P03 原版设置页陪伴只读界面
+
+## 1. 目标
+
+在原版 Olivia `/settings` 的“本地陪伴”弹窗中显示已经接入同一进程的真实数据：
+
+- 长期记忆状态、列表与搜索；
+- PrivateWorld 定性关系状态；
+- 已授权称呼与住所权限；
+- Local Continuation 及其 awareness；
+- 待确认的关系建议。
+
+用户不打开外部浏览器，不使用独立 Control Center，也不运行 CLI。
+
+## 2. 接口
+
+界面只调用四个 GET 接口：
+
+```text
+/toy/companion/status
+/toy/companion/memory
+/toy/companion/private-world
+/toy/companion/private-world/candidates
+```
+
+本 PR 不发出 POST、PUT、PATCH 或 DELETE 请求。
+
+## 3. 长期记忆
+
+长期记忆面板显示：
+
+- 能力是否可用；
+- 当前记录数量；
+- 最多 50 条记忆正文；
+- 本机创建时间；
+- 最多 500 字符的搜索词。
+
+界面不显示 memory ID、source ID、user scope、向量、完整 metadata、provider 配置或系统提示词。
+
+所有记忆正文使用 `textContent` 写入 DOM。记忆内容不能生成 HTML、脚本或原版组件。
+
+## 4. PrivateWorld
+
+PrivateWorld 面板只显示：
+
+- 关系阶段；
+- 熟悉、信任、自在、亲近、紧张的低／中／高；
+- 已授权私人称呼；
+- 住所权限；
+- Local Continuation 正文与 awareness；
+- 待确认关系建议的类型、摘要和时间。
+
+不显示：
+
+- 隐藏的 0–100 数值；
+- 候选置信度；
+- 来源信件与回复版本；
+- command、decision 或审计 ID；
+- 数据库路径和内部错误。
+
+关系建议在本 PR 中只能查看，不能批准或拒绝。
+
+## 5. 失败与降级
+
+四类数据分别降级：
+
+- Memory 不可用时，只显示长期记忆暂不可用；
+- PrivateWorld 不可用时，不影响 Memory；
+- 候选不可用时，不影响 PrivateWorld 摘要；
+- 整体状态接口不可用时，两个面板都显示暂不可用；
+- 任何设置读取失败都不影响 Collection、文字回信或媒体播放。
+
+## 6. 客户端补丁升级
+
+原版主 JavaScript 继续保持字节不变。补丁只管理：
+
+```text
+index.html 中唯一的本地脚本标签
+assets/olivia-companion-settings.js
+```
+
+已经存在旧版 repository-owned bootstrap 时：
+
+1. 验证脚本路径、标记和 API base；
+2. 只替换本项目拥有的 bootstrap 与版本属性；
+3. 保留原版主包和其他资源；
+4. 失败时恢复修改前归档；
+5. API base 不一致时拒绝更新。
+
+## 7. 安全边界
+
+- API base 必须是带端口的 loopback HTTP；
+- 无 iframe、外部窗口、外部脚本、字体或分析服务；
+- 无 `innerHTML`、`document.write`、`eval` 或动态 Function；
+- 所有数据以文本节点显示；
+- 请求 `no-store`，不带浏览器凭据；
+- 搜索和列表数量有固定上限；
+- Node.js 语法检查在可用环境中执行。
+
+## 8. 后续
+
+```text
+CLIENT-SETTINGS-06  记忆纠正/删除与候选批准/拒绝
+CLIENT-INSTALL-01   安装器自动应用原版设置补丁
+CLIENT-CONTRACT-02  Collection 数据格式生产接线
+```

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -1,0 +1,649 @@
+"""Self-contained script injected into the original Olivia settings surface."""
+
+from __future__ import annotations
+
+
+SETTINGS_UI_VERSION = "p03.original-settings-read.v1"
+
+BOOTSTRAP_JAVASCRIPT = r'''(() => {
+  "use strict";
+
+  const loader = document.currentScript;
+  const rawApiBase = loader && loader.dataset ? loader.dataset.apiBase : "";
+  const ROOT_ATTR = "data-olivia-companion-settings-root";
+  const DIALOG_ATTR = "data-olivia-companion-settings-dialog";
+  const STATUS_PATH = "/toy/companion/status";
+  const MEMORY_PATH = "/toy/companion/memory";
+  const PRIVATE_WORLD_PATH = "/toy/companion/private-world";
+  const CANDIDATES_PATH = "/toy/companion/private-world/candidates";
+
+  const parseApiBase = (value) => {
+    let url;
+    try {
+      url = new URL(value);
+    } catch (_error) {
+      return null;
+    }
+    const loopback = url.hostname === "127.0.0.1" || url.hostname === "localhost";
+    if (
+      url.protocol !== "http:" ||
+      !loopback ||
+      !url.port ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash ||
+      (url.pathname !== "/" && url.pathname !== "")
+    ) {
+      return null;
+    }
+    return url;
+  };
+
+  const apiBase = parseApiBase(rawApiBase);
+  if (!apiBase) {
+    return;
+  }
+
+  const text = (tag, value, className) => {
+    const element = document.createElement(tag);
+    element.textContent = value;
+    if (className) {
+      element.className = className;
+    }
+    return element;
+  };
+
+  const button = (label, onClick) => {
+    const element = document.createElement("button");
+    element.type = "button";
+    element.textContent = label;
+    element.className = "px-6 py-2.5 rounded-full border border-grey-5 text-text-body text-label-m font-medium cursor-pointer hover:bg-surface-1 transition-colors";
+    element.addEventListener("click", onClick);
+    return element;
+  };
+
+  const card = () => {
+    const element = document.createElement("article");
+    element.style.padding = "14px";
+    element.style.borderRadius = "10px";
+    element.style.background = "rgba(255,255,255,0.06)";
+    element.style.display = "grid";
+    element.style.gap = "8px";
+    return element;
+  };
+
+  const stack = () => {
+    const element = document.createElement("div");
+    element.style.display = "grid";
+    element.style.gap = "10px";
+    return element;
+  };
+
+  const field = (label, value) => {
+    const row = document.createElement("div");
+    row.style.display = "grid";
+    row.style.gridTemplateColumns = "minmax(110px, 0.7fr) minmax(0, 1.3fr)";
+    row.style.gap = "12px";
+    row.append(
+      text("span", label, "text-text-secondary text-body-m font-regular"),
+      text("span", value, "text-text-body text-body-m font-medium")
+    );
+    return row;
+  };
+
+  const formatTime = (value) => {
+    if (typeof value !== "string" || !value) {
+      return "";
+    }
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      return "";
+    }
+    try {
+      return parsed.toLocaleString("zh-CN", { hour12: false });
+    } catch (_error) {
+      return value;
+    }
+  };
+
+  const stateLabels = {
+    available: "可用",
+    degraded: "部分可用",
+    unavailable: "暂不可用",
+    disabled: "未启用",
+  };
+
+  const levelLabels = {
+    unknown: "未知",
+    low: "低",
+    medium: "中",
+    high: "高",
+  };
+
+  const stageLabels = {
+    unknown: "尚未确认",
+    acquaintance: "认识",
+    familiar: "熟悉",
+    close: "亲近",
+  };
+
+  const homeLabels = {
+    no_access: "未授权",
+    visit_access: "可到访",
+    errand_access: "可代办日常事项",
+    domestic_access: "可参与居家日常",
+  };
+
+  const awarenessLabels = {
+    control_only: "仅本机记录",
+    pending: "等待确认",
+    character_known: "林离已经知道",
+  };
+
+  const candidateLabels = {
+    boundary_respected: "边界被尊重",
+    conflict: "发生冲突",
+    repair: "完成修复",
+  };
+
+  const capabilityState = (value) => {
+    const state = value && typeof value.state === "string" ? value.state : "unavailable";
+    return Object.hasOwn(stateLabels, state) ? state : "unavailable";
+  };
+
+  const requestJson = async (path, params = {}) => {
+    const endpoint = new URL(path, apiBase);
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== null && value !== undefined && value !== "") {
+        endpoint.searchParams.set(key, String(value));
+      }
+    }
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 5000);
+    try {
+      const response = await fetch(endpoint, {
+        method: "GET",
+        cache: "no-store",
+        credentials: "omit",
+        headers: { "Accept": "application/json" },
+        signal: controller.signal,
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload || payload.status !== "READY") {
+        throw new Error("unavailable");
+      }
+      return payload;
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  };
+
+  const renderUnavailable = (panel, state, label) => {
+    panel.replaceChildren(
+      text("h3", label, "text-text-title text-title-m"),
+      text(
+        "p",
+        `${label}${state === "disabled" ? "未启用。" : "暂时不可用。"}`,
+        "text-text-secondary text-body-m font-regular"
+      )
+    );
+  };
+
+  const renderMemories = (list, memories) => {
+    list.replaceChildren();
+    if (!Array.isArray(memories) || memories.length === 0) {
+      list.append(
+        text("p", "暂无长期记忆。", "text-text-secondary text-body-m font-regular")
+      );
+      return;
+    }
+    for (const memory of memories) {
+      if (!memory || typeof memory.text !== "string") {
+        continue;
+      }
+      const item = card();
+      item.append(text("p", memory.text, "text-text-body text-body-m font-regular"));
+      const created = formatTime(memory.created_at);
+      if (created) {
+        item.append(
+          text("p", created, "text-text-secondary text-caption-m font-regular")
+        );
+      }
+      list.append(item);
+    }
+    if (!list.childElementCount) {
+      list.append(
+        text("p", "暂无可显示的长期记忆。", "text-text-secondary text-body-m font-regular")
+      );
+    }
+  };
+
+  const renderMemoryPanel = async (panel, capability) => {
+    const state = capabilityState(capability);
+    if (state === "disabled" || state === "unavailable") {
+      renderUnavailable(panel, state, "长期记忆");
+      return;
+    }
+
+    const heading = text("h3", "长期记忆", "text-text-title text-title-m");
+    const summary = text(
+      "p",
+      `状态：${stateLabels[state]}${Number.isInteger(capability.count) ? `，共 ${capability.count} 条` : ""}`,
+      "text-text-secondary text-body-m font-regular"
+    );
+    const controls = document.createElement("div");
+    controls.style.display = "flex";
+    controls.style.gap = "10px";
+    controls.style.alignItems = "center";
+
+    const input = document.createElement("input");
+    input.type = "search";
+    input.maxLength = 500;
+    input.placeholder = "搜索长期记忆";
+    input.setAttribute("aria-label", "搜索长期记忆");
+    input.className = "flex-1 min-w-0 rounded-3 border border-grey-5 bg-transparent px-4 py-2.5 text-text-body text-body-m";
+
+    const resultState = text(
+      "p",
+      "正在读取长期记忆……",
+      "text-text-secondary text-body-m font-regular"
+    );
+    resultState.setAttribute("aria-live", "polite");
+    const list = stack();
+
+    const load = async () => {
+      resultState.textContent = "正在读取长期记忆……";
+      list.replaceChildren();
+      try {
+        const payload = await requestJson(MEMORY_PATH, {
+          query: input.value.trim(),
+          limit: 50,
+        });
+        renderMemories(list, payload.memories);
+        resultState.textContent = input.value.trim()
+          ? `搜索结果：${Array.isArray(payload.memories) ? payload.memories.length : 0} 条`
+          : "已读取本机长期记忆。";
+      } catch (_error) {
+        resultState.textContent = "长期记忆暂时无法读取。";
+      }
+    };
+
+    const search = button("搜索", load);
+    controls.append(input, search);
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        load();
+      }
+    });
+
+    panel.replaceChildren(heading, summary, controls, resultState, list);
+    await load();
+  };
+
+  const renderPrivateSummary = (container, payload) => {
+    const levels = payload && payload.levels && typeof payload.levels === "object"
+      ? payload.levels
+      : {};
+    const nicknames = Array.isArray(payload.nickname_permissions)
+      ? payload.nickname_permissions.filter((value) => typeof value === "string")
+      : [];
+    container.append(
+      field("关系阶段", stageLabels[payload.relationship_stage] || "尚未确认"),
+      field("熟悉程度", levelLabels[levels.familiarity] || "未知"),
+      field("信任", levelLabels[levels.trust] || "未知"),
+      field("自在程度", levelLabels[levels.comfort] || "未知"),
+      field("亲近程度", levelLabels[levels.closeness] || "未知"),
+      field("紧张程度", levelLabels[levels.tension] || "未知"),
+      field("私人称呼", nicknames.length ? nicknames.join("、") : "未授权"),
+      field("住所权限", homeLabels[payload.home_access] || "未授权")
+    );
+
+    const continuationTitle = text(
+      "h4",
+      "本地世界线",
+      "text-text-title text-label-l font-medium"
+    );
+    continuationTitle.style.marginTop = "8px";
+    container.append(continuationTitle);
+    const facts = Array.isArray(payload.continuation_facts)
+      ? payload.continuation_facts
+      : [];
+    if (!facts.length) {
+      container.append(
+        text("p", "暂无本地世界线记录。", "text-text-secondary text-body-m font-regular")
+      );
+      return;
+    }
+    const factList = stack();
+    for (const fact of facts) {
+      if (!fact || typeof fact.statement !== "string") {
+        continue;
+      }
+      const item = card();
+      item.append(
+        text("p", fact.statement, "text-text-body text-body-m font-regular"),
+        text(
+          "p",
+          awarenessLabels[fact.awareness] || "状态未知",
+          "text-text-secondary text-caption-m font-regular"
+        )
+      );
+      factList.append(item);
+    }
+    container.append(factList);
+  };
+
+  const renderCandidateList = (container, payload, capability) => {
+    const state = capabilityState(capability);
+    const title = text(
+      "h4",
+      "待确认的关系建议",
+      "text-text-title text-label-l font-medium"
+    );
+    title.style.marginTop = "14px";
+    container.append(title);
+    if (state === "disabled" || state === "unavailable") {
+      container.append(
+        text(
+          "p",
+          `关系建议${state === "disabled" ? "未启用。" : "暂时不可用。"}`,
+          "text-text-secondary text-body-m font-regular"
+        )
+      );
+      return;
+    }
+    const candidates = payload && Array.isArray(payload.candidates)
+      ? payload.candidates
+      : [];
+    if (!candidates.length) {
+      container.append(
+        text("p", "暂无待确认建议。", "text-text-secondary text-body-m font-regular")
+      );
+      return;
+    }
+    const list = stack();
+    for (const candidate of candidates) {
+      if (!candidate || typeof candidate.summary !== "string") {
+        continue;
+      }
+      const item = card();
+      item.append(
+        text(
+          "h5",
+          candidateLabels[candidate.candidate_type] || "关系建议",
+          "text-text-title text-label-l font-medium"
+        ),
+        text("p", candidate.summary, "text-text-body text-body-m font-regular")
+      );
+      const created = formatTime(candidate.created_at);
+      if (created) {
+        item.append(
+          text("p", created, "text-text-secondary text-caption-m font-regular")
+        );
+      }
+      list.append(item);
+    }
+    container.append(list);
+  };
+
+  const renderPrivateWorldPanel = async (panel, privateCapability, candidateCapability) => {
+    const privateState = capabilityState(privateCapability);
+    const heading = text("h3", "私人世界", "text-text-title text-title-m");
+    const summary = text(
+      "p",
+      `状态：${stateLabels[privateState]}`,
+      "text-text-secondary text-body-m font-regular"
+    );
+    const content = stack();
+    panel.replaceChildren(heading, summary, content);
+
+    let privatePayload = null;
+    if (privateState !== "disabled" && privateState !== "unavailable") {
+      try {
+        privatePayload = await requestJson(PRIVATE_WORLD_PATH);
+        renderPrivateSummary(content, privatePayload);
+      } catch (_error) {
+        content.append(
+          text("p", "私人世界暂时无法读取。", "text-text-secondary text-body-m font-regular")
+        );
+      }
+    } else {
+      content.append(
+        text(
+          "p",
+          `私人世界${privateState === "disabled" ? "未启用。" : "暂时不可用。"}`,
+          "text-text-secondary text-body-m font-regular"
+        )
+      );
+    }
+
+    let candidatePayload = null;
+    const candidateState = capabilityState(candidateCapability);
+    if (candidateState !== "disabled" && candidateState !== "unavailable") {
+      try {
+        candidatePayload = await requestJson(CANDIDATES_PATH, { limit: 50 });
+      } catch (_error) {
+        candidatePayload = null;
+      }
+    }
+    renderCandidateList(content, candidatePayload, candidateCapability);
+  };
+
+  const loadDialogData = async (statusNode, panels) => {
+    statusNode.textContent = "正在连接本机陪伴服务……";
+    try {
+      const payload = await requestJson(STATUS_PATH);
+      const capabilities = payload.capabilities && typeof payload.capabilities === "object"
+        ? payload.capabilities
+        : {};
+      statusNode.textContent = "本机陪伴服务已连接。";
+      statusNode.dataset.state = "available";
+      await Promise.allSettled([
+        renderMemoryPanel(panels.memory, capabilities.memory),
+        renderPrivateWorldPanel(
+          panels.privateWorld,
+          capabilities.private_world,
+          capabilities.candidates
+        ),
+      ]);
+    } catch (_error) {
+      statusNode.textContent = "本机陪伴服务暂不可用。";
+      statusNode.dataset.state = "unavailable";
+      renderUnavailable(panels.memory, "unavailable", "长期记忆");
+      renderUnavailable(panels.privateWorld, "unavailable", "私人世界");
+    }
+  };
+
+  const isSettingsRoute = () => {
+    const route = `${window.location.pathname} ${window.location.hash}`;
+    return /(?:^|[\/#])settings(?:[\/?#]|$)/i.test(route);
+  };
+
+  const removeShell = () => {
+    document.querySelector(`[${ROOT_ATTR}]`)?.remove();
+    document.querySelector(`[${DIALOG_ATTR}]`)?.remove();
+  };
+
+  const openDialog = () => {
+    document.querySelector(`[${DIALOG_ATTR}]`)?.remove();
+
+    const backdrop = document.createElement("div");
+    backdrop.setAttribute(DIALOG_ATTR, "");
+    backdrop.style.position = "fixed";
+    backdrop.style.inset = "0";
+    backdrop.style.zIndex = "2147483000";
+    backdrop.style.display = "grid";
+    backdrop.style.placeItems = "center";
+    backdrop.style.padding = "40px";
+    backdrop.style.background = "rgba(0, 0, 0, 0.62)";
+
+    const dialog = document.createElement("section");
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("aria-modal", "true");
+    dialog.setAttribute("aria-labelledby", "olivia-companion-dialog-title");
+    dialog.style.width = "min(820px, calc(100vw - 80px))";
+    dialog.style.maxHeight = "calc(100vh - 80px)";
+    dialog.style.overflow = "auto";
+    dialog.style.borderRadius = "16px";
+    dialog.style.padding = "28px";
+    dialog.style.background = "var(--el-bg-color, #202124)";
+    dialog.style.boxShadow = "0 24px 80px rgba(0, 0, 0, 0.45)";
+
+    const header = document.createElement("div");
+    header.style.display = "flex";
+    header.style.alignItems = "center";
+    header.style.justifyContent = "space-between";
+    header.style.gap = "24px";
+
+    const heading = text("h2", "本地陪伴", "text-text-title text-headline-m");
+    heading.id = "olivia-companion-dialog-title";
+    heading.style.margin = "0";
+    const close = button("关闭", () => backdrop.remove());
+    header.append(heading, close);
+
+    const status = text(
+      "p",
+      "正在连接本机陪伴服务……",
+      "text-text-secondary text-body-m font-regular"
+    );
+    status.setAttribute("aria-live", "polite");
+    status.style.margin = "20px 0";
+
+    const tabs = document.createElement("div");
+    tabs.setAttribute("role", "tablist");
+    tabs.style.display = "flex";
+    tabs.style.gap = "12px";
+    tabs.style.marginBottom = "18px";
+
+    const panels = document.createElement("div");
+    const panelNodes = {};
+    const definitions = [
+      { id: "memory", label: "长期记忆", key: "memory" },
+      { id: "private-world", label: "私人世界", key: "privateWorld" },
+    ];
+
+    const showPanel = (id) => {
+      for (const tab of tabs.querySelectorAll('[role="tab"]')) {
+        const active = tab.dataset.panelId === id;
+        tab.setAttribute("aria-selected", active ? "true" : "false");
+        tab.style.background = active ? "rgba(255,255,255,0.12)" : "transparent";
+      }
+      for (const panel of panels.querySelectorAll('[role="tabpanel"]')) {
+        panel.hidden = panel.dataset.panelId !== id;
+      }
+    };
+
+    for (const definition of definitions) {
+      const tab = button(definition.label, () => showPanel(definition.id));
+      tab.setAttribute("role", "tab");
+      tab.dataset.panelId = definition.id;
+      tab.setAttribute("aria-controls", `olivia-companion-panel-${definition.id}`);
+      tabs.append(tab);
+
+      const panel = document.createElement("section");
+      panel.id = `olivia-companion-panel-${definition.id}`;
+      panel.dataset.panelId = definition.id;
+      panel.dataset.oliviaCompanionPanel = definition.id;
+      panel.setAttribute("role", "tabpanel");
+      panel.style.padding = "18px";
+      panel.style.borderRadius = "12px";
+      panel.style.background = "rgba(255,255,255,0.06)";
+      panel.style.display = "grid";
+      panel.style.gap = "14px";
+      panel.append(
+        text("h3", definition.label, "text-text-title text-title-m"),
+        text("p", "正在读取……", "text-text-secondary text-body-m font-regular")
+      );
+      panelNodes[definition.key] = panel;
+      panels.append(panel);
+    }
+
+    dialog.append(header, status, tabs, panels);
+    backdrop.append(dialog);
+    backdrop.addEventListener("click", (event) => {
+      if (event.target === backdrop) {
+        backdrop.remove();
+      }
+    });
+    backdrop.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        backdrop.remove();
+      }
+    });
+    document.body.append(backdrop);
+    showPanel("memory");
+    close.focus();
+    loadDialogData(status, panelNodes);
+  };
+
+  const findSettingsContainer = () => {
+    for (const main of document.querySelectorAll("main")) {
+      const sections = main.querySelectorAll(".tp-settings-item");
+      if (sections.length) {
+        return sections[sections.length - 1].parentElement;
+      }
+    }
+    return null;
+  };
+
+  const mountShell = () => {
+    if (!isSettingsRoute()) {
+      removeShell();
+      return;
+    }
+    if (document.querySelector(`[${ROOT_ATTR}]`)) {
+      return;
+    }
+    const container = findSettingsContainer();
+    if (!container) {
+      return;
+    }
+
+    const section = document.createElement("div");
+    section.setAttribute(ROOT_ATTR, "");
+    section.className = "tp-settings-item";
+
+    const title = text("div", "本地陪伴", "text-text-body text-title-m");
+    const row = document.createElement("div");
+    row.className = "flex items-center justify-between px-0 py-3 rounded-3";
+
+    const copy = document.createElement("div");
+    copy.className = "flex flex-col gap-0 flex-1 min-w-0";
+    copy.append(
+      text("div", "记忆与私人世界", "text-text-body text-label-l"),
+      text(
+        "div",
+        "在 Olivia 客户端内查看本地连续性。",
+        "text-text-secondary text-body-m font-regular"
+      )
+    );
+
+    row.append(copy, button("打开", openDialog));
+    section.append(title, row);
+    container.append(section);
+  };
+
+  let scheduled = false;
+  const schedule = () => {
+    if (scheduled) {
+      return;
+    }
+    scheduled = true;
+    window.requestAnimationFrame(() => {
+      scheduled = false;
+      mountShell();
+    });
+  };
+
+  const observer = new MutationObserver(schedule);
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+  window.addEventListener("hashchange", schedule);
+  window.addEventListener("popstate", schedule);
+  schedule();
+})();
+'''
+
+
+__all__ = ["BOOTSTRAP_JAVASCRIPT", "SETTINGS_UI_VERSION"]

--- a/patch_companion_settings.py
+++ b/patch_companion_settings.py
@@ -195,6 +195,17 @@ def _read_text(path: Path, code: str) -> str:
         raise CompanionSettingsPatchError(code) from exc
 
 
+def _normalize_newlines(value: str) -> str:
+    return value.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _write_utf8(path: Path, value: str) -> None:
+    try:
+        path.write_bytes(value.encode("utf-8"))
+    except OSError as exc:
+        raise CompanionSettingsPatchError("COMPANION_PATCH_WRITE_FAILED") from exc
+
+
 def _managed_tag(api_base: str) -> str:
     return (
         '<script src="./assets/olivia-companion-settings.js" '
@@ -225,7 +236,8 @@ def _patch_existing(
     )
     ui_match = _UI_VERSION_RE.search(tag.group(0))
     if (
-        current_script == BOOTSTRAP_JAVASCRIPT
+        _normalize_newlines(current_script)
+        == _normalize_newlines(BOOTSTRAP_JAVASCRIPT)
         and ui_match
         and html.unescape(ui_match.group("value")) == SETTINGS_UI_VERSION
     ):
@@ -233,14 +245,9 @@ def _patch_existing(
 
     managed = _managed_tag(api_base)
     updated = source[: tag.start()] + managed + source[tag.end() :]
-    try:
-        (bootstrap.parent.parent / INDEX_MEMBER).write_text(
-            updated,
-            encoding="utf-8",
-        )
-        bootstrap.write_text(BOOTSTRAP_JAVASCRIPT, encoding="utf-8")
-    except OSError as exc:
-        raise CompanionSettingsPatchError("COMPANION_PATCH_WRITE_FAILED") from exc
+    index = bootstrap.parent.parent / INDEX_MEMBER
+    _write_utf8(index, updated)
+    _write_utf8(bootstrap, BOOTSTRAP_JAVASCRIPT)
     return "PATCHED"
 
 
@@ -273,11 +280,8 @@ def _patch_index(root: Path, api_base: str) -> str:
     if patched.count(PATCH_MARKER) != 1:
         raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED")
     bootstrap.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        index.write_text(patched, encoding="utf-8")
-        bootstrap.write_text(BOOTSTRAP_JAVASCRIPT, encoding="utf-8")
-    except OSError as exc:
-        raise CompanionSettingsPatchError("COMPANION_PATCH_WRITE_FAILED") from exc
+    _write_utf8(index, patched)
+    _write_utf8(bootstrap, BOOTSTRAP_JAVASCRIPT)
     return "PATCHED"
 
 
@@ -352,7 +356,8 @@ def _verify_archive(
         any(value not in index for value in required)
         or any(value not in bootstrap for value in bootstrap_required)
         or any(value in bootstrap for value in forbidden)
-        or bootstrap != BOOTSTRAP_JAVASCRIPT
+        or _normalize_newlines(bootstrap)
+        != _normalize_newlines(BOOTSTRAP_JAVASCRIPT)
     ):
         raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED")
 

--- a/patch_companion_settings.py
+++ b/patch_companion_settings.py
@@ -1,7 +1,7 @@
 """Add a bounded companion panel to the supported Olivia settings view.
 
 The patch only changes a staged ``feapp.dat`` archive. It keeps the client main
-module byte-for-byte intact, inserts one local bootstrap script into
+module byte-for-byte intact, inserts one repository-owned local script into
 ``index.html``, and rolls the archive back if any validation step fails.
 """
 
@@ -16,6 +16,11 @@ import shutil
 import tempfile
 from urllib.parse import urlsplit
 import zipfile
+
+from original_client_settings_ui import (
+    BOOTSTRAP_JAVASCRIPT,
+    SETTINGS_UI_VERSION,
+)
 
 
 INDEX_MEMBER = "index.html"
@@ -42,288 +47,14 @@ _API_BASE_RE = re.compile(
     r"\bdata-api-base=([\"'])(?P<value>[^\"']+)\1",
     flags=re.IGNORECASE,
 )
-
-_BOOTSTRAP_JAVASCRIPT = r'''(() => {
-  "use strict";
-
-  const loader = document.currentScript;
-  const rawApiBase = loader && loader.dataset ? loader.dataset.apiBase : "";
-  const ROOT_ATTR = "data-olivia-companion-settings-root";
-  const DIALOG_ATTR = "data-olivia-companion-settings-dialog";
-  const STATUS_PATH = "/toy/companion/status";
-
-  const parseApiBase = (value) => {
-    let url;
-    try {
-      url = new URL(value);
-    } catch (_error) {
-      return null;
-    }
-    const loopback = url.hostname === "127.0.0.1" || url.hostname === "localhost";
-    if (
-      url.protocol !== "http:" ||
-      !loopback ||
-      !url.port ||
-      url.username ||
-      url.password ||
-      url.search ||
-      url.hash ||
-      (url.pathname !== "/" && url.pathname !== "")
-    ) {
-      return null;
-    }
-    return url;
-  };
-
-  const apiBase = parseApiBase(rawApiBase);
-  if (!apiBase) {
-    return;
-  }
-
-  const text = (tag, value, className) => {
-    const element = document.createElement(tag);
-    element.textContent = value;
-    if (className) {
-      element.className = className;
-    }
-    return element;
-  };
-
-  const button = (label, onClick) => {
-    const element = document.createElement("button");
-    element.type = "button";
-    element.textContent = label;
-    element.className = "px-6 py-2.5 rounded-full border border-grey-5 text-text-body text-label-m font-medium cursor-pointer hover:bg-surface-1 transition-colors";
-    element.addEventListener("click", onClick);
-    return element;
-  };
-
-  const isSettingsRoute = () => {
-    const route = `${window.location.pathname} ${window.location.hash}`;
-    return /(?:^|[\/#])settings(?:[\/?#]|$)/i.test(route);
-  };
-
-  const removeShell = () => {
-    document.querySelector(`[${ROOT_ATTR}]`)?.remove();
-    document.querySelector(`[${DIALOG_ATTR}]`)?.remove();
-  };
-
-  const statusMessage = (node, value) => {
-    node.textContent = value;
-    node.dataset.state = value === "本机陪伴服务可用。" ? "available" : "unavailable";
-  };
-
-  const loadStatus = async (node) => {
-    statusMessage(node, "正在连接本机陪伴服务……");
-    const controller = new AbortController();
-    const timeout = window.setTimeout(() => controller.abort(), 3000);
-    try {
-      const endpoint = new URL(STATUS_PATH, apiBase);
-      const response = await fetch(endpoint, {
-        method: "GET",
-        cache: "no-store",
-        credentials: "omit",
-        headers: { "Accept": "application/json" },
-        signal: controller.signal,
-      });
-      if (!response.ok) {
-        throw new Error("unavailable");
-      }
-      const payload = await response.json();
-      if (!payload || payload.status !== "READY") {
-        throw new Error("unavailable");
-      }
-      statusMessage(node, "本机陪伴服务可用。");
-    } catch (_error) {
-      statusMessage(node, "本机陪伴服务暂不可用。");
-    } finally {
-      window.clearTimeout(timeout);
-    }
-  };
-
-  const openDialog = () => {
-    document.querySelector(`[${DIALOG_ATTR}]`)?.remove();
-
-    const backdrop = document.createElement("div");
-    backdrop.setAttribute(DIALOG_ATTR, "");
-    backdrop.style.position = "fixed";
-    backdrop.style.inset = "0";
-    backdrop.style.zIndex = "2147483000";
-    backdrop.style.display = "grid";
-    backdrop.style.placeItems = "center";
-    backdrop.style.padding = "40px";
-    backdrop.style.background = "rgba(0, 0, 0, 0.62)";
-
-    const dialog = document.createElement("section");
-    dialog.setAttribute("role", "dialog");
-    dialog.setAttribute("aria-modal", "true");
-    dialog.setAttribute("aria-labelledby", "olivia-companion-dialog-title");
-    dialog.style.width = "min(760px, calc(100vw - 80px))";
-    dialog.style.maxHeight = "calc(100vh - 80px)";
-    dialog.style.overflow = "auto";
-    dialog.style.borderRadius = "16px";
-    dialog.style.padding = "28px";
-    dialog.style.background = "var(--el-bg-color, #202124)";
-    dialog.style.boxShadow = "0 24px 80px rgba(0, 0, 0, 0.45)";
-
-    const header = document.createElement("div");
-    header.style.display = "flex";
-    header.style.alignItems = "center";
-    header.style.justifyContent = "space-between";
-    header.style.gap = "24px";
-
-    const heading = text("h2", "本地陪伴", "text-text-title text-headline-m");
-    heading.id = "olivia-companion-dialog-title";
-    heading.style.margin = "0";
-
-    const close = button("关闭", () => backdrop.remove());
-    header.append(heading, close);
-
-    const status = text(
-      "p",
-      "正在连接本机陪伴服务……",
-      "text-text-secondary text-body-m font-regular"
-    );
-    status.setAttribute("aria-live", "polite");
-    status.style.margin = "20px 0";
-
-    const tabs = document.createElement("div");
-    tabs.setAttribute("role", "tablist");
-    tabs.style.display = "flex";
-    tabs.style.gap = "12px";
-    tabs.style.marginBottom = "18px";
-
-    const panels = document.createElement("div");
-    const definitions = [
-      {
-        id: "memory",
-        label: "长期记忆",
-        description: "查看、纠正或删除林离在新对话中形成的本地记忆。",
-      },
-      {
-        id: "private-world",
-        label: "私人世界",
-        description: "管理关系边界、私人称呼、住所权限和本地世界线。",
-      },
-    ];
-
-    const showPanel = (id) => {
-      for (const tab of tabs.querySelectorAll('[role="tab"]')) {
-        const active = tab.dataset.panelId === id;
-        tab.setAttribute("aria-selected", active ? "true" : "false");
-        tab.style.background = active ? "rgba(255,255,255,0.12)" : "transparent";
-      }
-      for (const panel of panels.querySelectorAll('[role="tabpanel"]')) {
-        panel.hidden = panel.dataset.panelId !== id;
-      }
-    };
-
-    for (const definition of definitions) {
-      const tab = button(definition.label, () => showPanel(definition.id));
-      tab.setAttribute("role", "tab");
-      tab.dataset.panelId = definition.id;
-      tab.setAttribute("aria-controls", `olivia-companion-panel-${definition.id}`);
-      tabs.append(tab);
-
-      const panel = document.createElement("section");
-      panel.id = `olivia-companion-panel-${definition.id}`;
-      panel.dataset.panelId = definition.id;
-      panel.dataset.oliviaCompanionPanel = definition.id;
-      panel.setAttribute("role", "tabpanel");
-      panel.style.padding = "18px";
-      panel.style.borderRadius = "12px";
-      panel.style.background = "rgba(255,255,255,0.06)";
-      panel.append(
-        text("h3", definition.label, "text-text-title text-title-m"),
-        text("p", definition.description, "text-text-secondary text-body-m font-regular")
-      );
-      panels.append(panel);
-    }
-
-    dialog.append(header, status, tabs, panels);
-    backdrop.append(dialog);
-    backdrop.addEventListener("click", (event) => {
-      if (event.target === backdrop) {
-        backdrop.remove();
-      }
-    });
-    backdrop.addEventListener("keydown", (event) => {
-      if (event.key === "Escape") {
-        backdrop.remove();
-      }
-    });
-    document.body.append(backdrop);
-    showPanel("memory");
-    close.focus();
-    loadStatus(status);
-  };
-
-  const findSettingsContainer = () => {
-    for (const main of document.querySelectorAll("main")) {
-      const sections = main.querySelectorAll(".tp-settings-item");
-      if (sections.length) {
-        return sections[sections.length - 1].parentElement;
-      }
-    }
-    return null;
-  };
-
-  const mountShell = () => {
-    if (!isSettingsRoute()) {
-      removeShell();
-      return;
-    }
-    if (document.querySelector(`[${ROOT_ATTR}]`)) {
-      return;
-    }
-    const container = findSettingsContainer();
-    if (!container) {
-      return;
-    }
-
-    const section = document.createElement("div");
-    section.setAttribute(ROOT_ATTR, "");
-    section.className = "tp-settings-item";
-
-    const title = text("div", "本地陪伴", "text-text-body text-title-m");
-    const row = document.createElement("div");
-    row.className = "flex items-center justify-between px-0 py-3 rounded-3";
-
-    const copy = document.createElement("div");
-    copy.className = "flex flex-col gap-0 flex-1 min-w-0";
-    copy.append(
-      text("div", "记忆与私人世界", "text-text-body text-label-l"),
-      text(
-        "div",
-        "在 Olivia 客户端内管理本地连续性。",
-        "text-text-secondary text-body-m font-regular"
-      )
-    );
-
-    row.append(copy, button("打开", openDialog));
-    section.append(title, row);
-    container.append(section);
-  };
-
-  let scheduled = false;
-  const schedule = () => {
-    if (scheduled) {
-      return;
-    }
-    scheduled = true;
-    window.requestAnimationFrame(() => {
-      scheduled = false;
-      mountShell();
-    });
-  };
-
-  const observer = new MutationObserver(schedule);
-  observer.observe(document.documentElement, { childList: true, subtree: true });
-  window.addEventListener("hashchange", schedule);
-  window.addEventListener("popstate", schedule);
-  schedule();
-})();
-'''
+_BOOTSTRAP_SOURCE_RE = re.compile(
+    r"\bsrc=([\"'])\./assets/olivia-companion-settings\.js\1",
+    flags=re.IGNORECASE,
+)
+_UI_VERSION_RE = re.compile(
+    r"\bdata-ui-version=([\"'])(?P<value>[^\"']+)\1",
+    flags=re.IGNORECASE,
+)
 
 
 class CompanionSettingsPatchError(RuntimeError):
@@ -464,6 +195,55 @@ def _read_text(path: Path, code: str) -> str:
         raise CompanionSettingsPatchError(code) from exc
 
 
+def _managed_tag(api_base: str) -> str:
+    return (
+        '<script src="./assets/olivia-companion-settings.js" '
+        f'{PATCH_MARKER}="{PATCH_SCHEMA_VERSION}" '
+        f'data-ui-version="{SETTINGS_UI_VERSION}" '
+        f'data-api-base="{html.escape(api_base, quote=True)}"></script>'
+    )
+
+
+def _patch_existing(
+    source: str,
+    bootstrap: Path,
+    api_base: str,
+) -> str:
+    if not bootstrap.is_file():
+        raise CompanionSettingsPatchError("COMPANION_PATCH_INCOMPLETE")
+    tag = _MARKER_TAG_RE.search(source)
+    api_match = _API_BASE_RE.search(tag.group(0) if tag else "")
+    source_match = _BOOTSTRAP_SOURCE_RE.search(tag.group(0) if tag else "")
+    if not tag or not api_match or not source_match:
+        raise CompanionSettingsPatchError("COMPANION_PATCH_INCOMPLETE")
+    if html.unescape(api_match.group("value")) != api_base:
+        raise CompanionSettingsPatchError("COMPANION_API_BASE_MISMATCH")
+
+    current_script = _read_text(
+        bootstrap,
+        "COMPANION_BOOTSTRAP_UNREADABLE",
+    )
+    ui_match = _UI_VERSION_RE.search(tag.group(0))
+    if (
+        current_script == BOOTSTRAP_JAVASCRIPT
+        and ui_match
+        and html.unescape(ui_match.group("value")) == SETTINGS_UI_VERSION
+    ):
+        return "ALREADY_PATCHED"
+
+    managed = _managed_tag(api_base)
+    updated = source[: tag.start()] + managed + source[tag.end() :]
+    try:
+        (bootstrap.parent.parent / INDEX_MEMBER).write_text(
+            updated,
+            encoding="utf-8",
+        )
+        bootstrap.write_text(BOOTSTRAP_JAVASCRIPT, encoding="utf-8")
+    except OSError as exc:
+        raise CompanionSettingsPatchError("COMPANION_PATCH_WRITE_FAILED") from exc
+    return "PATCHED"
+
+
 def _patch_index(root: Path, api_base: str) -> str:
     index = root / INDEX_MEMBER
     main_module = root / MAIN_MODULE_MEMBER
@@ -476,17 +256,7 @@ def _patch_index(root: Path, api_base: str) -> str:
 
     marker_count = source.count(PATCH_MARKER)
     if marker_count == 1:
-        if not bootstrap.is_file():
-            raise CompanionSettingsPatchError("COMPANION_PATCH_INCOMPLETE")
-        tag = _MARKER_TAG_RE.search(source)
-        api_match = _API_BASE_RE.search(tag.group(0) if tag else "")
-        if not tag or not api_match:
-            raise CompanionSettingsPatchError("COMPANION_PATCH_INCOMPLETE")
-        if html.unescape(api_match.group("value")) != api_base:
-            raise CompanionSettingsPatchError("COMPANION_API_BASE_MISMATCH")
-        if _read_text(bootstrap, "COMPANION_BOOTSTRAP_UNREADABLE") != _BOOTSTRAP_JAVASCRIPT:
-            raise CompanionSettingsPatchError("COMPANION_PATCH_INCOMPLETE")
-        return "ALREADY_PATCHED"
+        return _patch_existing(source, bootstrap, api_base)
     if marker_count or bootstrap.exists():
         raise CompanionSettingsPatchError("COMPANION_PATCH_INCOMPLETE")
 
@@ -494,18 +264,18 @@ def _patch_index(root: Path, api_base: str) -> str:
     if len(matches) != 1:
         raise CompanionSettingsPatchError("COMPANION_MODULE_ANCHOR_INVALID")
     match = matches[0]
-    tag = (
-        '<script src="./assets/olivia-companion-settings.js" '
-        f'{PATCH_MARKER}="{PATCH_SCHEMA_VERSION}" '
-        f'data-api-base="{html.escape(api_base, quote=True)}"></script>'
+    patched = (
+        source[: match.end()]
+        + "\n  "
+        + _managed_tag(api_base)
+        + source[match.end() :]
     )
-    patched = source[: match.end()] + "\n  " + tag + source[match.end() :]
     if patched.count(PATCH_MARKER) != 1:
         raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED")
     bootstrap.parent.mkdir(parents=True, exist_ok=True)
     try:
         index.write_text(patched, encoding="utf-8")
-        bootstrap.write_text(_BOOTSTRAP_JAVASCRIPT, encoding="utf-8")
+        bootstrap.write_text(BOOTSTRAP_JAVASCRIPT, encoding="utf-8")
     except OSError as exc:
         raise CompanionSettingsPatchError("COMPANION_PATCH_WRITE_FAILED") from exc
     return "PATCHED"
@@ -541,7 +311,7 @@ def _verify_archive(
     if set(patched_hashes) != set(original_hashes) | {BOOTSTRAP_MEMBER}:
         raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED")
     for name, digest in original_hashes.items():
-        if name == INDEX_MEMBER:
+        if name in {INDEX_MEMBER, BOOTSTRAP_MEMBER}:
             continue
         if patched_hashes.get(name) != digest:
             raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED")
@@ -553,21 +323,36 @@ def _verify_archive(
         raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED") from exc
     required = (
         'data-olivia-companion-settings="p03.original-settings-shell.v1"',
+        f'data-ui-version="{SETTINGS_UI_VERSION}"',
         f'data-api-base="{html.escape(api_base, quote=True)}"',
     )
     bootstrap_required = (
         'const STATUS_PATH = "/toy/companion/status";',
-        'data-olivia-companion-settings-root',
-        'panel.dataset.oliviaCompanionPanel',
-        '长期记忆',
-        '私人世界',
-        'new MutationObserver',
+        'const MEMORY_PATH = "/toy/companion/memory";',
+        'const PRIVATE_WORLD_PATH = "/toy/companion/private-world";',
+        'const CANDIDATES_PATH = "/toy/companion/private-world/candidates";',
+        "data-olivia-companion-settings-root",
+        "panel.dataset.oliviaCompanionPanel",
+        "长期记忆",
+        "私人世界",
+        "待确认的关系建议",
+        "new MutationObserver",
+        "replaceChildren",
+    )
+    forbidden = (
+        "<iframe",
+        "window.open",
+        "innerHTML",
+        'method: "POST"',
+        'method: "PUT"',
+        'method: "DELETE"',
+        "eval(",
     )
     if (
         any(value not in index for value in required)
         or any(value not in bootstrap for value in bootstrap_required)
-        or "<iframe" in bootstrap.casefold()
-        or "window.open" in bootstrap
+        or any(value in bootstrap for value in forbidden)
+        or bootstrap != BOOTSTRAP_JAVASCRIPT
     ):
         raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED")
 
@@ -593,7 +378,10 @@ def patch_companion_settings(
     if not sandbox.is_dir():
         raise CompanionSettingsPatchError("COMPANION_WORK_ROOT_NOT_FOUND")
 
-    with tempfile.TemporaryDirectory(prefix=".patch-companion-settings-", dir=sandbox) as name:
+    with tempfile.TemporaryDirectory(
+        prefix=".patch-companion-settings-",
+        dir=sandbox,
+    ) as name:
         temporary_root = Path(name)
         rollback = temporary_root / "rollback.dat"
         _atomic_copy(feapp, rollback)
@@ -617,6 +405,7 @@ def patch_companion_settings(
 
     return {
         "schema_version": PATCH_SCHEMA_VERSION,
+        "ui_version": SETTINGS_UI_VERSION,
         "status": status,
         "source_sha256": source_sha256,
         "backup_sha256": backup_sha256,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ py-modules = [
     "original_client_letter_contract",
     "original_client_media_http",
     "original_client_server",
+    "original_client_settings_ui",
     "patch_companion_settings",
     "patch_feapp",
     "persona_loader",

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -13,13 +13,13 @@ from original_client_settings_ui import (
 
 def test_original_settings_read_ui_has_fixed_bounded_contract() -> None:
     assert SETTINGS_UI_VERSION == "p03.original-settings-read.v1"
-    for path in (
-        "/toy/companion/status",
-        "/toy/companion/memory",
-        "/toy/companion/private-world",
-        "/toy/companion/private-world/candidates",
+    for declaration in (
+        'const STATUS_PATH = "/toy/companion/status";',
+        'const MEMORY_PATH = "/toy/companion/memory";',
+        'const PRIVATE_WORLD_PATH = "/toy/companion/private-world";',
+        'const CANDIDATES_PATH = "/toy/companion/private-world/candidates";',
     ):
-        assert BOOTSTRAP_JAVASCRIPT.count(path) == 1
+        assert BOOTSTRAP_JAVASCRIPT.count(declaration) == 1
     assert 'method: "GET"' in BOOTSTRAP_JAVASCRIPT
     assert "limit: 50" in BOOTSTRAP_JAVASCRIPT
     assert "input.maxLength = 500" in BOOTSTRAP_JAVASCRIPT
@@ -63,10 +63,10 @@ def test_original_settings_read_ui_javascript_is_parseable() -> None:
         pytest.skip("Node.js is not installed")
     result = subprocess.run(
         [node, "--check", "-"],
-        input=BOOTSTRAP_JAVASCRIPT,
-        text=True,
+        input=BOOTSTRAP_JAVASCRIPT.encode("utf-8"),
         capture_output=True,
         timeout=20,
         check=False,
     )
-    assert result.returncode == 0, result.stderr or result.stdout
+    output = (result.stderr or result.stdout).decode("utf-8", errors="replace")
+    assert result.returncode == 0, output

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+from original_client_settings_ui import (
+    BOOTSTRAP_JAVASCRIPT,
+    SETTINGS_UI_VERSION,
+)
+
+
+def test_original_settings_read_ui_has_fixed_bounded_contract() -> None:
+    assert SETTINGS_UI_VERSION == "p03.original-settings-read.v1"
+    for path in (
+        "/toy/companion/status",
+        "/toy/companion/memory",
+        "/toy/companion/private-world",
+        "/toy/companion/private-world/candidates",
+    ):
+        assert BOOTSTRAP_JAVASCRIPT.count(path) == 1
+    assert 'method: "GET"' in BOOTSTRAP_JAVASCRIPT
+    assert "limit: 50" in BOOTSTRAP_JAVASCRIPT
+    assert "input.maxLength = 500" in BOOTSTRAP_JAVASCRIPT
+    assert "Promise.allSettled" in BOOTSTRAP_JAVASCRIPT
+
+
+def test_original_settings_read_ui_renders_untrusted_data_as_text_only() -> None:
+    source = BOOTSTRAP_JAVASCRIPT
+    assert "textContent" in source
+    assert "replaceChildren" in source
+    for forbidden in (
+        "innerHTML",
+        "outerHTML",
+        "insertAdjacentHTML",
+        "document.write",
+        "eval(",
+        "new Function",
+        "window.open",
+        "<iframe",
+        'method: "POST"',
+        'method: "PUT"',
+        'method: "PATCH"',
+        'method: "DELETE"',
+        "memory_id",
+        "source_id",
+        "user_id",
+        "database_path",
+        "api_key",
+        "0–100",
+        "批准",
+        "拒绝",
+    ):
+        assert forbidden not in source
+    assert "http://" not in source
+    assert "https://" not in source
+
+
+def test_original_settings_read_ui_javascript_is_parseable() -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is not installed")
+    result = subprocess.run(
+        [node, "--check", "-"],
+        input=BOOTSTRAP_JAVASCRIPT,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/installer/test_patch_companion_settings.py
+++ b/tests/installer/test_patch_companion_settings.py
@@ -6,6 +6,10 @@ import zipfile
 
 import pytest
 
+from original_client_settings_ui import (
+    BOOTSTRAP_JAVASCRIPT,
+    SETTINGS_UI_VERSION,
+)
 from patch_companion_settings import (
     BOOTSTRAP_MEMBER,
     CompanionSettingsPatchError,
@@ -54,15 +58,22 @@ def _sha(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def test_patch_adds_one_settings_shell_and_preserves_existing_assets(tmp_path: Path) -> None:
+def test_patch_adds_read_only_settings_data_and_preserves_existing_assets(
+    tmp_path: Path,
+) -> None:
     path = _archive(tmp_path / "feapp.dat")
     before = _members(path)
     source_hash = _sha(path)
 
-    result = patch_companion_settings(path, "http://127.0.0.1:8899", work_root=tmp_path)
+    result = patch_companion_settings(
+        path,
+        "http://127.0.0.1:8899",
+        work_root=tmp_path,
+    )
 
     after = _members(path)
     assert result["status"] == "PATCHED"
+    assert result["ui_version"] == SETTINGS_UI_VERSION
     assert result["source_sha256"] == source_hash
     assert result["backup_name"] == "feapp.dat.companion.orig"
     assert _sha(tmp_path / result["backup_name"]) == source_hash
@@ -70,41 +81,110 @@ def test_patch_adds_one_settings_shell_and_preserves_existing_assets(tmp_path: P
     for name, value in before.items():
         if name != INDEX_MEMBER:
             assert after[name] == value
+
     index = after[INDEX_MEMBER].decode()
     bootstrap = after[BOOTSTRAP_MEMBER].decode()
     assert index.count(PATCH_MARKER) == 1
     assert 'data-api-base="http://127.0.0.1:8899/"' in index
-    assert "data-olivia-companion-settings-root" in bootstrap
-    assert 'const STATUS_PATH = "/toy/companion/status";' in bootstrap
-    assert "长期记忆" in bootstrap
-    assert "私人世界" in bootstrap
+    assert f'data-ui-version="{SETTINGS_UI_VERSION}"' in index
+    for path_value in (
+        "/toy/companion/status",
+        "/toy/companion/memory",
+        "/toy/companion/private-world",
+        "/toy/companion/private-world/candidates",
+    ):
+        assert path_value in bootstrap
+    for visible_text in (
+        "长期记忆",
+        "私人世界",
+        "待确认的关系建议",
+        "搜索长期记忆",
+        "本地世界线",
+    ):
+        assert visible_text in bootstrap
     assert "MutationObserver" in bootstrap
+    assert "replaceChildren" in bootstrap
+    assert 'method: "GET"' in bootstrap
     assert "<iframe" not in bootstrap.casefold()
     assert "window.open" not in bootstrap
+    assert "innerHTML" not in bootstrap
+    assert 'method: "POST"' not in bootstrap
+    assert 'method: "PUT"' not in bootstrap
+    assert 'method: "DELETE"' not in bootstrap
     assert "http://" not in bootstrap
     assert "https://" not in bootstrap
 
 
 def test_patch_is_idempotent_for_the_same_api_base(tmp_path: Path) -> None:
     path = _archive(tmp_path / "feapp.dat")
-    first = patch_companion_settings(path, "http://localhost:8899", work_root=tmp_path)
+    first = patch_companion_settings(
+        path,
+        "http://localhost:8899",
+        work_root=tmp_path,
+    )
     first_hash = _sha(path)
 
-    second = patch_companion_settings(path, "http://localhost:8899/", work_root=tmp_path)
+    second = patch_companion_settings(
+        path,
+        "http://localhost:8899/",
+        work_root=tmp_path,
+    )
 
     assert first["status"] == "PATCHED"
     assert second["status"] == "ALREADY_PATCHED"
+    assert second["ui_version"] == SETTINGS_UI_VERSION
     assert _sha(path) == first_hash
     assert _members(path)[INDEX_MEMBER].decode().count(PATCH_MARKER) == 1
 
 
-def test_repatch_with_a_different_api_base_is_rejected_without_mutation(tmp_path: Path) -> None:
+def test_repository_owned_bootstrap_is_upgraded_without_touching_main_module(
+    tmp_path: Path,
+) -> None:
+    legacy_tag = (
+        '<script src="./assets/olivia-companion-settings.js" '
+        'data-olivia-companion-settings="p03.original-settings-shell.v1" '
+        'data-api-base="http://127.0.0.1:8899/"></script>'
+    )
+    legacy_index = INDEX.replace("</head>", legacy_tag + "</head>")
+    path = _archive(
+        tmp_path / "feapp.dat",
+        index=legacy_index,
+        extra={BOOTSTRAP_MEMBER: b"legacy repository-owned bootstrap"},
+    )
+    before_main = _members(path)[MAIN_MODULE_MEMBER]
+
+    result = patch_companion_settings(
+        path,
+        "http://127.0.0.1:8899",
+        work_root=tmp_path,
+    )
+
+    after = _members(path)
+    assert result["status"] == "PATCHED"
+    assert after[MAIN_MODULE_MEMBER] == before_main
+    assert after[BOOTSTRAP_MEMBER].decode() == BOOTSTRAP_JAVASCRIPT
+    index = after[INDEX_MEMBER].decode()
+    assert f'data-ui-version="{SETTINGS_UI_VERSION}"' in index
+    assert index.count(PATCH_MARKER) == 1
+
+
+def test_repatch_with_a_different_api_base_is_rejected_without_mutation(
+    tmp_path: Path,
+) -> None:
     path = _archive(tmp_path / "feapp.dat")
-    patch_companion_settings(path, "http://127.0.0.1:8899", work_root=tmp_path)
+    patch_companion_settings(
+        path,
+        "http://127.0.0.1:8899",
+        work_root=tmp_path,
+    )
     before = path.read_bytes()
 
     with pytest.raises(CompanionSettingsPatchError) as error:
-        patch_companion_settings(path, "http://127.0.0.1:8900", work_root=tmp_path)
+        patch_companion_settings(
+            path,
+            "http://127.0.0.1:8900",
+            work_root=tmp_path,
+        )
 
     assert error.value.code == "COMPANION_API_BASE_MISMATCH"
     assert path.read_bytes() == before
@@ -124,7 +204,9 @@ def test_repatch_with_a_different_api_base_is_rejected_without_mutation(tmp_path
         "http://127.0.0.1:8899/#fragment",
     ],
 )
-def test_api_base_requires_an_explicit_loopback_http_port(value: str | None) -> None:
+def test_api_base_requires_an_explicit_loopback_http_port(
+    value: str | None,
+) -> None:
     with pytest.raises(CompanionSettingsPatchError):
         validate_api_base(value)
 
@@ -137,24 +219,35 @@ def test_missing_or_duplicate_module_anchor_rolls_back(tmp_path: Path) -> None:
         ),
         INDEX.replace(
             '<script type="module" crossorigin src="./assets/main-917d29fc.js"></script>',
-            '<script type="module" crossorigin src="./assets/main-917d29fc.js"></script>' * 2,
+            '<script type="module" crossorigin src="./assets/main-917d29fc.js"></script>'
+            * 2,
         ),
     )
     for number, index in enumerate(cases):
         path = _archive(tmp_path / f"case-{number}.dat", index=index)
         before = path.read_bytes()
         with pytest.raises(CompanionSettingsPatchError) as error:
-            patch_companion_settings(path, "http://127.0.0.1:8899", work_root=tmp_path)
+            patch_companion_settings(
+                path,
+                "http://127.0.0.1:8899",
+                work_root=tmp_path,
+            )
         assert error.value.code == "COMPANION_MODULE_ANCHOR_INVALID"
         assert path.read_bytes() == before
 
 
-def test_missing_main_module_and_incomplete_patch_are_rejected(tmp_path: Path) -> None:
+def test_missing_main_module_and_incomplete_patch_are_rejected(
+    tmp_path: Path,
+) -> None:
     missing = tmp_path / "missing-main.dat"
     with zipfile.ZipFile(missing, "w", zipfile.ZIP_DEFLATED) as archive:
         archive.writestr(INDEX_MEMBER, INDEX)
     with pytest.raises(CompanionSettingsPatchError) as missing_error:
-        patch_companion_settings(missing, "http://127.0.0.1:8899", work_root=tmp_path)
+        patch_companion_settings(
+            missing,
+            "http://127.0.0.1:8899",
+            work_root=tmp_path,
+        )
     assert missing_error.value.code == "COMPANION_MAIN_MODULE_MISSING"
 
     incomplete = _archive(
@@ -166,7 +259,11 @@ def test_missing_main_module_and_incomplete_patch_are_rejected(tmp_path: Path) -
         ),
     )
     with pytest.raises(CompanionSettingsPatchError) as incomplete_error:
-        patch_companion_settings(incomplete, "http://127.0.0.1:8899", work_root=tmp_path)
+        patch_companion_settings(
+            incomplete,
+            "http://127.0.0.1:8899",
+            work_root=tmp_path,
+        )
     assert incomplete_error.value.code == "COMPANION_PATCH_INCOMPLETE"
 
 
@@ -178,16 +275,27 @@ def test_unsafe_archive_member_is_rejected(tmp_path: Path) -> None:
         archive.writestr("../outside.js", b"escape")
 
     with pytest.raises(CompanionSettingsPatchError) as error:
-        patch_companion_settings(path, "http://127.0.0.1:8899", work_root=tmp_path)
+        patch_companion_settings(
+            path,
+            "http://127.0.0.1:8899",
+            work_root=tmp_path,
+        )
 
     assert error.value.code == "COMPANION_ARCHIVE_UNSAFE"
 
 
 def test_existing_backup_is_never_overwritten(tmp_path: Path) -> None:
     path = _archive(tmp_path / "feapp.dat")
-    backup = _archive(tmp_path / "feapp.dat.companion.orig", main=b"first-backup")
+    backup = _archive(
+        tmp_path / "feapp.dat.companion.orig",
+        main=b"first-backup",
+    )
     backup_before = backup.read_bytes()
 
-    patch_companion_settings(path, "http://127.0.0.1:8899", work_root=tmp_path)
+    patch_companion_settings(
+        path,
+        "http://127.0.0.1:8899",
+        work_root=tmp_path,
+    )
 
     assert backup.read_bytes() == backup_before


### PR DESCRIPTION
Implements CLIENT-SETTINGS-05 after #86.

## Scope

- upgrades the repository-owned bootstrap inside the original Olivia `/settings` surface;
- reads the already-mounted status, Memory, PrivateWorld, and pending-candidate GET endpoints;
- renders long-term memory state, bounded list, creation time, and local search inside the original dialog;
- renders qualitative relationship stage and levels, authorized nicknames, home access, Local Continuation, and pending candidate summaries;
- keeps candidate review read-only in this slice;
- inserts all backend and memory text with `textContent` / DOM nodes only;
- contains no iframe, external window, external asset, HTML injection, dynamic code evaluation, or write request;
- keeps the original main module byte-for-byte unchanged;
- safely upgrades an earlier repository-owned settings bootstrap after verifying its path, marker, and loopback API base;
- preserves rollback, backup, archive safety, idempotency, and API-base mismatch refusal.

## Tests

- all four bounded paths and visible sections;
- GET-only request contract and list/query bounds;
- exclusion of user scope, internal identifiers, hidden numbers, credentials, and mutation controls;
- no dangerous DOM or code execution APIs;
- Node.js syntax validation when available;
- fresh patch, exact retry, managed bootstrap upgrade, rollback, unsafe archive, and backup preservation.

## Boundary

This PR does not enable memory correction/deletion, PrivateWorld direct edits, candidate approve/reject, installer activation, or Collection wire-contract mounting. The original Olivia client remains the only user-facing shell.

Part of #33, #34, #35, #37, and #38.