### PR TITLE
feat(installer): activate original settings and webplayer patches

### DIFF
--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -6,18 +6,60 @@
 
 1. 将发布 ZIP 解压到任意目录。
 2. 双击 `INSTALL.cmd`。它始终使用 `%LOCALAPPDATA%` 下受管的 Python 3.12 embeddable runtime；首次使用会显示 Python.org 固定来源、SHA-256 和 PSF 许可证，并在明确同意后下载。安装器从 Steam AppID `4532590` 的 appmanifest 自动发现正版目录。
-3. 安装成功后双击 `START.cmd`。它只启动隔离副本的本地 HTTP server，再直接启动隔离副本的 `0.0.9.615\Olivia.exe`，并使用安装目录下的独立 profile。
+3. 安装成功后双击 `START.cmd`。它只启动一个监听 `127.0.0.1` 的本机服务，再直接启动隔离副本的 `0.0.9.615\Olivia.exe`，并使用安装目录下的独立 profile。长期记忆、PrivateWorld 和媒体接口都挂在同一个进程中。
 4. 首次配置可双击 `CONFIGURE.cmd`：API key 输入不回显，并以当前 Windows 用户 DPAPI 加密保存到 `data\config`；也可选择自己的参考音频/视频导入 `data\third-party\reference`。这些文件不进入补丁包。
 5. 卸载双击 `UNINSTALL.cmd`。受控卸载只删除安装器自己写入的 `app`、`local_backend`、启动脚本和 marker，保留 `data`、`logs`、`third-party`。
 
-安装前会校验客户端版本 `0.0.9.615` 与 `feapp.dat` SHA-256；校验不匹配或目标目录已有未知内容时停止。补丁会在隔离副本中保留 `feapp.dat.orig`，正版 Steam 目录不会产生备份、补丁或写入。
+## 原版客户端补丁
+
+安装前同时校验：
+
+```text
+客户端版本：0.0.9.615
+feapp.dat SHA-256：
+53babcf288c7679a57eb4a2647397d951ec450d5fdaea634498286b2ebb8136e
+
+webplayer.dat SHA-256：
+504b59876af2f04c4902f8c8e6811018d36a2da4394e20cf74f22d13d394b636
+```
+
+任一文件缺失或哈希不匹配时，安装在写入目标目录前停止。
+
+安装器只在隔离副本中按顺序执行：
+
+```text
+feapp.dat
+  1. toyApiUrl / toyWsUrl 指向本机服务
+  2. 默认进入原版 Collection
+  3. 在原版 Settings 内加入“本地陪伴”界面
+
+webplayer.dat
+  4. 保留原版 uid 播放路径
+  5. 只为明确的 loopback /toy/media/ 地址启用本机视频播放
+```
+
+原版主包之外，设置界面只增加一个仓库自有 bootstrap；原版 `assets/main-917d29fc.js` 的业务代码除既有端点和 Collection 锚点外不做模糊替换。播放器的普通原版路径继续加载未修改的原模块。
+
+隔离副本保留：
+
+```text
+feapp.dat.orig
+feapp.dat.companion.orig
+webplayer.dat.orig
+```
+
+正版 Steam 目录不会产生备份、补丁或写入。任何补丁、验证或重打包步骤失败时，整个未完成安装目录会被删除，不留下部分可用的客户端。
+
+已有旧 marker 但缺少原版设置或 webplayer 本机媒体标记时，不会伪装成“已经安装”；安装器会停止并要求先按受控流程处理旧安装。
 
 ## 当前能力边界
 
+- 原版 UI：用户日常只打开原版 Olivia。原版 Settings 内可读取长期记忆、PrivateWorld 和待确认建议；不发布独立浏览器 Control Center 或第二个桌面入口。
 - 文字回信：接入 main 的本地 HTTP 契约；LLM 未配置时返回真实 `UNAVAILABLE`，不伪造成功。
-- 视频回信、音乐视频：已迁入情绪分流、普通视频 delivery、LatentSync、音乐内容/渲染与 MiniMax Music 3 worker 的调用边界；实际 TTS、视觉、分离和音乐模型均为外部依赖。高情绪来信进入串行后台媒体任务，依赖缺失时明确返回 `UNAVAILABLE`，不会伪造媒体 URL。
+- 视频回信、音乐视频：已迁入情绪分流、普通视频 delivery、LatentSync、音乐内容/渲染与 MiniMax Music 3 worker 的调用边界；实际 TTS、视觉、分离和音乐模型均为外部依赖。依赖缺失时明确返回 `UNAVAILABLE`，不会伪造媒体 URL。完成的本机 MP4 通过原版 webplayer 播放。
 - Live：暂停，manifest 标记为 `UNAVAILABLE_PAUSED`，不会注入 Live 入口。
 - 第三方 Python/runtime/model：不随补丁分发。请使用 `docs/THIRD_PARTY_DOWNLOADS.md` 的官方来源页；下载清单默认空、下载器默认 dry-run，必须明确接受许可证后才允许写入仓库外 data root。
 
 embeddable Python 仅解决解释器获取；`aiohttp`、TTS、视觉、音频分离和音乐模型仍需按第三方下载清单单独准备。缺失时 `START.cmd` / 本地 health 会报告不可用原因；不会自动下载未固定来源、许可证或 SHA-256 的内容。用户 API key 只从启动进程环境或 `CONFIGURE.cmd` 生成的当前用户 DPAPI 文件读取，不写入安装包或日志；DPAPI 解密值只存在于后端子进程环境中。
+
 启动时若没有 `OLIVIA_LLM_API_KEY`、`DEEPSEEK_API_KEY` 或 `OPENAI_API_KEY`，命令行会明确提示未配置，不能把 safe-static 回退误认为真实模型回信。

--- a/installer/full-patch-manifest.json
+++ b/installer/full-patch-manifest.json
@@ -3,7 +3,8 @@
   "steam_app_id": "4532590",
   "client_version": "0.0.9.615",
   "feapp_sha256": "53babcf288c7679a57eb4a2647397d951ec450d5fdaea634498286b2ebb8136e",
+  "webplayer_sha256": "504b59876af2f04c4902f8c8e6811018d36a2da4394e20cf74f22d13d394b636",
   "patch_mode": "isolated-copy",
   "live_status": "UNAVAILABLE_PAUSED",
-  "media_status": "VIDEO_AND_MUSIC_REPLY_BOUNDARIES_PRESENT_PROVIDER_DOWNLOAD_REQUIRED"
+  "media_status": "ORIGINAL_WEBPLAYER_LOCAL_VIDEO_AND_MUSIC_REPLY_BOUNDARIES_PRESENT_PROVIDER_DOWNLOAD_REQUIRED"
 }

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -10,18 +10,64 @@ import shutil
 from pathlib import Path
 from typing import Any, Iterable
 
+from patch_companion_settings import patch_companion_settings
 from patch_feapp import patch_feapp
+from patch_webplayer import patch_webplayer
 
 APP_ID = "4532590"
 MANIFEST_SCHEMA = "olivia.full-patch.v2"
 MARKER_NAME = ".olivia-full-patch.json"
-OWNED_PATHS = ("app", "local_backend", "START.cmd", "CONFIGURE.cmd", "UNINSTALL.cmd", MARKER_NAME)
+OWNED_PATHS = (
+    "app",
+    "local_backend",
+    "START.cmd",
+    "CONFIGURE.cmd",
+    "UNINSTALL.cmd",
+    MARKER_NAME,
+)
 PRESERVED_PATHS = ("data", "logs", "third-party")
-PAYLOAD_DIRS = ("asr", "contracts", "installer", "media_state", "tools", "tts", "linli_character")
+PAYLOAD_DIRS = (
+    "asr",
+    "contracts",
+    "installer",
+    "media_state",
+    "tools",
+    "tts",
+    "linli_character",
+)
 PAYLOAD_EXTRA_DIRS = ("runtime/visual",)
 PAYLOAD_SUFFIXES = {".py", ".json", ".toml", ".ini", ".txt", ".ps1", ".patch"}
-PAYLOAD_ROOT_FILES = {"local_server.py", "patch_feapp.py", "http_contract.py", "llm_gateway.py", "memory.py", "memory_port.py", "memory_prompt.py", "local_memory.py", "persona_provider.py", "reply_orchestrator.py", "third_party_manifest.example.json", "third_party_manifest.schema.json"}
-PAYLOAD_EXCLUDED_ROOT_FILES = {"letter_pairs.json", "memory_store.json", "llm_config.json"}
+PAYLOAD_ROOT_FILES = {
+    "local_server.py",
+    "original_client_server.py",
+    "original_client_settings_ui.py",
+    "patch_companion_settings.py",
+    "patch_feapp.py",
+    "patch_webplayer.py",
+    "http_contract.py",
+    "llm_gateway.py",
+    "memory.py",
+    "memory_port.py",
+    "memory_prompt.py",
+    "local_memory.py",
+    "persona_provider.py",
+    "reply_orchestrator.py",
+    "third_party_manifest.example.json",
+    "third_party_manifest.schema.json",
+}
+PAYLOAD_REQUIRED_ROOT_FILES = {
+    "local_server.py",
+    "original_client_server.py",
+    "original_client_settings_ui.py",
+    "patch_companion_settings.py",
+    "patch_feapp.py",
+    "patch_webplayer.py",
+}
+PAYLOAD_EXCLUDED_ROOT_FILES = {
+    "letter_pairs.json",
+    "memory_store.json",
+    "llm_config.json",
+}
 
 
 class PatchInstallError(RuntimeError):
@@ -36,6 +82,12 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _valid_sha256(value: object) -> bool:
+    return isinstance(value, str) and bool(
+        re.fullmatch(r"[0-9a-fA-F]{64}", value)
+    )
+
+
 def _load_json(path: Path, code: str) -> dict[str, Any]:
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
@@ -47,11 +99,28 @@ def _load_json(path: Path, code: str) -> dict[str, Any]:
 
 
 def load_manifest(path: str | os.PathLike[str]) -> dict[str, Any]:
-    value = _load_json(Path(path).expanduser().resolve(), "PATCH_MANIFEST_INVALID")
-    required = {"schema_version", "steam_app_id", "client_version", "feapp_sha256", "patch_mode", "live_status", "media_status"}
-    if set(value) != required or value["schema_version"] != MANIFEST_SCHEMA or value["steam_app_id"] != APP_ID:
-        raise PatchInstallError("PATCH_MANIFEST_INVALID")
-    if not isinstance(value["feapp_sha256"], str) or not re.fullmatch(r"[0-9a-fA-F]{64}", value["feapp_sha256"]):
+    value = _load_json(
+        Path(path).expanduser().resolve(),
+        "PATCH_MANIFEST_INVALID",
+    )
+    required = {
+        "schema_version",
+        "steam_app_id",
+        "client_version",
+        "feapp_sha256",
+        "webplayer_sha256",
+        "patch_mode",
+        "live_status",
+        "media_status",
+    }
+    if (
+        set(value) != required
+        or value["schema_version"] != MANIFEST_SCHEMA
+        or value["steam_app_id"] != APP_ID
+        or value["patch_mode"] != "isolated-copy"
+        or not _valid_sha256(value["feapp_sha256"])
+        or not _valid_sha256(value["webplayer_sha256"])
+    ):
         raise PatchInstallError("PATCH_MANIFEST_INVALID")
     return value
 
@@ -59,14 +128,25 @@ def load_manifest(path: str | os.PathLike[str]) -> dict[str, Any]:
 def _steam_roots_from_vdf(steam_root: Path) -> list[Path]:
     roots = [steam_root]
     try:
-        text = (steam_root / "steamapps" / "libraryfolders.vdf").read_text(encoding="utf-8", errors="replace")
+        text = (
+            steam_root / "steamapps" / "libraryfolders.vdf"
+        ).read_text(encoding="utf-8", errors="replace")
     except OSError:
         return roots
-    roots.extend(Path(match.group(1).replace("\\\\", "\\")) for match in re.finditer(r'"path"\s+"([^"]+)"', text, flags=re.IGNORECASE))
+    roots.extend(
+        Path(match.group(1).replace("\\\\", "\\"))
+        for match in re.finditer(
+            r'"path"\s+"([^"]+)"',
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
     return roots
 
 
-def discover_steam_install(library_roots: Iterable[Path] | None = None) -> Path:
+def discover_steam_install(
+    library_roots: Iterable[Path] | None = None,
+) -> Path:
     """Find AppID 4532590 from Steam registry/manifests without fixed drives."""
 
     roots = [Path(root) for root in (library_roots or [])]
@@ -74,11 +154,18 @@ def discover_steam_install(library_roots: Iterable[Path] | None = None) -> Path:
         try:
             import winreg
 
-            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\Valve\Steam") as key:
+            with winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Valve\Steam",
+            ) as key:
                 roots.append(Path(winreg.QueryValueEx(key, "SteamPath")[0]))
         except (ImportError, OSError):
             pass
-        roots.extend(Path(f"{drive}:/steam") for drive in "CDEFGHIJKLMNOPQRSTUVWXYZ" if Path(f"{drive}:/steam").is_dir())
+        roots.extend(
+            Path(f"{drive}:/steam")
+            for drive in "CDEFGHIJKLMNOPQRSTUVWXYZ"
+            if Path(f"{drive}:/steam").is_dir()
+        )
     expanded: list[Path] = []
     for root in roots:
         expanded.extend(_steam_roots_from_vdf(root.expanduser().resolve()))
@@ -93,24 +180,46 @@ def discover_steam_install(library_roots: Iterable[Path] | None = None) -> Path:
             text = manifest.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        match = re.search(r'"installdir"\s+"([^"]+)"', text, flags=re.IGNORECASE)
+        match = re.search(
+            r'"installdir"\s+"([^"]+)"',
+            text,
+            flags=re.IGNORECASE,
+        )
         if match:
-            candidate = (root / "steamapps" / "common" / match.group(1)).resolve()
+            candidate = (
+                root / "steamapps" / "common" / match.group(1)
+            ).resolve()
             if candidate.is_dir():
                 return candidate
     raise PatchInstallError("OFFICIAL_INSTALL_NOT_FOUND")
 
 
-def validate_official_source(source: str | os.PathLike[str], manifest: dict[str, Any]) -> tuple[str, Path]:
+def validate_official_source(
+    source: str | os.PathLike[str],
+    manifest: dict[str, Any],
+) -> tuple[str, Path, Path]:
     root = Path(source).expanduser().resolve()
     version = str(manifest["client_version"])
-    required = (root / "launcher.exe", root / version / "Olivia.exe", root / version / "resources" / "feapp.dat")
+    version_root = root / version
+    resources = version_root / "resources"
+    required = (
+        root / "launcher.exe",
+        version_root / "Olivia.exe",
+        resources / "feapp.dat",
+        resources / "webplayer.dat",
+    )
     if not all(path.is_file() for path in required):
         raise PatchInstallError("OFFICIAL_INSTALL_NOT_FOUND")
-    feapp = required[-1]
-    if _sha256(feapp).lower() != str(manifest["feapp_sha256"]).lower():
+    feapp = required[2]
+    webplayer = required[3]
+    if (
+        _sha256(feapp).lower()
+        != str(manifest["feapp_sha256"]).lower()
+        or _sha256(webplayer).lower()
+        != str(manifest["webplayer_sha256"]).lower()
+    ):
         raise PatchInstallError("UNSUPPORTED_OFFICIAL_VERSION")
-    return version, feapp
+    return version, feapp, webplayer
 
 
 def _copy_file(source: Path, destination: Path) -> None:
@@ -122,31 +231,50 @@ def _ignore_official_copy(directory: str, names: list[str]) -> set[str]:
     """Exclude repository/evidence caches that are never runtime assets."""
 
     excluded = {".git", ".evidence", ".pytest_cache", "__pycache__"}
-    return {name for name in names if name in excluded or name.endswith(".pyc")}
+    return {
+        name
+        for name in names
+        if name in excluded or name.endswith(".pyc")
+    }
 
 
 def _is_non_runtime_payload_file(name: str) -> bool:
     lowered = name.lower()
     return (
         lowered == "pytest.ini"
-        or (lowered.startswith("requirements-dev") and lowered.endswith(".txt"))
+        or (
+            lowered.startswith("requirements-dev")
+            and lowered.endswith(".txt")
+        )
         or (lowered.startswith("test_") and lowered.endswith(".py"))
     )
 
 
 def _ignore_payload_copy(directory: str, names: list[str]) -> set[str]:
     excluded = _ignore_official_copy(directory, names)
-    excluded.update(name for name in names if _is_non_runtime_payload_file(name))
+    excluded.update(
+        name for name in names if _is_non_runtime_payload_file(name)
+    )
     return excluded
 
 
-def copy_project_payload(payload_root: Path, destination: Path) -> list[str]:
+def copy_project_payload(
+    payload_root: Path,
+    destination: Path,
+) -> list[str]:
     """Copy project source/config scripts, never original or model payloads."""
 
     copied: list[str] = []
     destination.mkdir(parents=True, exist_ok=True)
     for child in payload_root.iterdir():
-        if child.name in {".git", ".github", ".evidence", ".venv", "tests", "docs"}:
+        if child.name in {
+            ".git",
+            ".github",
+            ".evidence",
+            ".venv",
+            "tests",
+            "docs",
+        }:
             continue
         if child.is_file() and (
             child.name in PAYLOAD_EXCLUDED_ROOT_FILES
@@ -155,23 +283,43 @@ def copy_project_payload(payload_root: Path, destination: Path) -> list[str]:
             continue
         target = destination / child.name
         if child.is_dir() and child.name in PAYLOAD_DIRS:
-            shutil.copytree(child, target, dirs_exist_ok=True, ignore=_ignore_payload_copy)
+            shutil.copytree(
+                child,
+                target,
+                dirs_exist_ok=True,
+                ignore=_ignore_payload_copy,
+            )
             copied.append(child.name + "/")
-        elif child.is_file() and (child.name in PAYLOAD_ROOT_FILES or child.suffix.lower() in PAYLOAD_SUFFIXES):
+        elif child.is_file() and (
+            child.name in PAYLOAD_ROOT_FILES
+            or child.suffix.lower() in PAYLOAD_SUFFIXES
+        ):
             _copy_file(child, target)
             copied.append(child.name)
     for relative in PAYLOAD_EXTRA_DIRS:
         source_dir = payload_root / Path(*relative.split("/"))
         if source_dir.is_dir():
             target_dir = destination / Path(*relative.split("/"))
-            shutil.copytree(source_dir, target_dir, dirs_exist_ok=True, ignore=_ignore_payload_copy)
+            shutil.copytree(
+                source_dir,
+                target_dir,
+                dirs_exist_ok=True,
+                ignore=_ignore_payload_copy,
+            )
             copied.append(relative + "/")
-    if not (destination / "local_server.py").is_file() or not (destination / "patch_feapp.py").is_file():
+    if any(
+        not (destination / name).is_file()
+        for name in PAYLOAD_REQUIRED_ROOT_FILES
+    ):
         raise PatchInstallError("PATCH_PAYLOAD_INCOMPLETE")
     return sorted(copied)
 
 
-def copy_official_runtime(source: Path, destination: Path, version: str) -> list[str]:
+def copy_official_runtime(
+    source: Path,
+    destination: Path,
+    version: str,
+) -> list[str]:
     """Copy only the Steam client runtime, never repository files beside it."""
 
     destination.mkdir(parents=True, exist_ok=True)
@@ -180,7 +328,11 @@ def copy_official_runtime(source: Path, destination: Path, version: str) -> list
     if not launcher.is_file() or not version_root.is_dir():
         raise PatchInstallError("OFFICIAL_INSTALL_NOT_FOUND")
     _copy_file(launcher, destination / "launcher.exe")
-    shutil.copytree(version_root, destination / version, ignore=_ignore_official_copy)
+    shutil.copytree(
+        version_root,
+        destination / version,
+        ignore=_ignore_official_copy,
+    )
     return ["launcher.exe", version + "/"]
 
 
@@ -201,40 +353,132 @@ def _write_start_scripts(root: Path, port: int) -> None:
 
 def _read_marker(path: Path) -> dict[str, Any]:
     marker = _load_json(path, "PATCH_MARKER_INVALID")
-    if marker.get("schema_version") != "olivia.full-patch.install.v2" or marker.get("owned_root") != str(path.parent.resolve()):
+    if (
+        marker.get("schema_version") != "olivia.full-patch.install.v2"
+        or marker.get("owned_root") != str(path.parent.resolve())
+    ):
         raise PatchInstallError("PATCH_MARKER_INVALID")
     return marker
 
 
-def install_full_patch(official_source: str | os.PathLike[str], destination: str | os.PathLike[str], payload_root: str | os.PathLike[str], manifest_path: str | os.PathLike[str], *, port: int = 8899) -> dict[str, Any]:
+def _marker_matches_current_install(
+    marker: dict[str, Any],
+    manifest: dict[str, Any],
+) -> bool:
+    return (
+        marker.get("official_feapp_sha256")
+        == manifest["feapp_sha256"]
+        and marker.get("official_webplayer_sha256")
+        == manifest["webplayer_sha256"]
+        and marker.get("original_client_only") is True
+        and marker.get("companion_settings_embedded") is True
+        and marker.get("webplayer_local_media") is True
+    )
+
+
+def install_full_patch(
+    official_source: str | os.PathLike[str],
+    destination: str | os.PathLike[str],
+    payload_root: str | os.PathLike[str],
+    manifest_path: str | os.PathLike[str],
+    *,
+    port: int = 8899,
+) -> dict[str, Any]:
     manifest = load_manifest(manifest_path)
     source = Path(official_source).expanduser().resolve()
     target = Path(destination).expanduser().resolve()
     payload = Path(payload_root).expanduser().resolve()
-    version, _source_feapp = validate_official_source(source, manifest)
+    version, _source_feapp, _source_webplayer = validate_official_source(
+        source,
+        manifest,
+    )
     if target == source or target in source.parents or source in target.parents:
         raise PatchInstallError("INSTALL_ROOT_OVERLAPS_OFFICIAL")
     marker_path = target / MARKER_NAME
     if target.exists():
-        if marker_path.is_file() and _read_marker(marker_path).get("official_feapp_sha256") == manifest["feapp_sha256"]:
-            return {"status": "ALREADY_INSTALLED", **_read_marker(marker_path)}
+        if marker_path.is_file():
+            marker = _read_marker(marker_path)
+            if _marker_matches_current_install(marker, manifest):
+                return {"status": "ALREADY_INSTALLED", **marker}
         raise PatchInstallError("INSTALL_ROOT_ALREADY_EXISTS")
     target.parent.mkdir(parents=True, exist_ok=True)
-    # Copy directly into the final external target.  Windows can deny an
-    # atomic directory rename after a large Steam copy (antivirus/indexing); a
-    # failed run is still removed by the exact-target rollback below.
     staging = target
     try:
-        copied_runtime = copy_official_runtime(source, staging / "app", version)
+        copied_runtime = copy_official_runtime(
+            source,
+            staging / "app",
+            version,
+        )
         copied = copy_project_payload(payload, staging / "local_backend")
-        feapp = staging / "app" / version / "resources" / "feapp.dat"
+        resources = staging / "app" / version / "resources"
+        feapp = resources / "feapp.dat"
+        webplayer = resources / "webplayer.dat"
+        if (
+            _sha256(feapp).lower()
+            != str(manifest["feapp_sha256"]).lower()
+            or _sha256(webplayer).lower()
+            != str(manifest["webplayer_sha256"]).lower()
+        ):
+            raise PatchInstallError("STAGED_COPY_VERIFICATION_FAILED")
         if not 1 <= port <= 65535:
             raise PatchInstallError("INVALID_PORT")
-        patch = patch_feapp(feapp, f"ws://127.0.0.1:{port}/ws", work_root=feapp.parent)
+
+        base_http = f"http://127.0.0.1:{port}"
+        endpoint_patch = patch_feapp(
+            feapp,
+            f"ws://127.0.0.1:{port}/ws",
+            work_root=resources,
+        )
+        settings_patch = patch_companion_settings(
+            feapp,
+            base_http,
+            work_root=resources,
+        )
+        player_patch = patch_webplayer(
+            webplayer,
+            work_root=resources,
+        )
+
         _write_start_scripts(staging, port)
         (staging / "data").mkdir()
-        marker = {"schema_version": "olivia.full-patch.install.v2", "steam_app_id": APP_ID, "client_version": version, "official_source": str(source), "owned_root": str(target), "official_feapp_sha256": manifest["feapp_sha256"], "patched_feapp_sha256": _sha256(feapp), "backup_feapp_sha256": patch["backup_sha256"], "port": port, "owned_paths": list(OWNED_PATHS), "preserved_paths": list(PRESERVED_PATHS), "runtime_entries": copied_runtime, "payload_entries": copied, "live_status": manifest["live_status"], "media_status": manifest["media_status"]}
-        (staging / MARKER_NAME).write_text(json.dumps(marker, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+        marker = {
+            "schema_version": "olivia.full-patch.install.v2",
+            "steam_app_id": APP_ID,
+            "client_version": version,
+            "official_source": str(source),
+            "owned_root": str(target),
+            "official_feapp_sha256": manifest["feapp_sha256"],
+            "patched_feapp_sha256": _sha256(feapp),
+            "backup_feapp_sha256": endpoint_patch["backup_sha256"],
+            "companion_backup_feapp_sha256": settings_patch[
+                "backup_sha256"
+            ],
+            "companion_settings_status": settings_patch["status"],
+            "companion_settings_ui_version": settings_patch["ui_version"],
+            "official_webplayer_sha256": manifest["webplayer_sha256"],
+            "patched_webplayer_sha256": _sha256(webplayer),
+            "backup_webplayer_sha256": player_patch["backup_sha256"],
+            "webplayer_patch_status": player_patch["status"],
+            "original_client_only": True,
+            "companion_settings_embedded": True,
+            "webplayer_local_media": True,
+            "port": port,
+            "owned_paths": list(OWNED_PATHS),
+            "preserved_paths": list(PRESERVED_PATHS),
+            "runtime_entries": copied_runtime,
+            "payload_entries": copied,
+            "live_status": manifest["live_status"],
+            "media_status": manifest["media_status"],
+        }
+        (staging / MARKER_NAME).write_text(
+            json.dumps(
+                marker,
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
     except Exception:
         if staging.exists():
             shutil.rmtree(staging)
@@ -242,13 +486,21 @@ def install_full_patch(official_source: str | os.PathLike[str], destination: str
     return {"status": "INSTALLED", **marker}
 
 
-def uninstall_full_patch(installation: str | os.PathLike[str], *, apply: bool = False) -> dict[str, Any]:
+def uninstall_full_patch(
+    installation: str | os.PathLike[str],
+    *,
+    apply: bool = False,
+) -> dict[str, Any]:
     root = Path(installation).expanduser().resolve()
     marker_path = root / MARKER_NAME
     if not root.is_dir() or not marker_path.is_file():
         raise PatchInstallError("PATCH_MARKER_NOT_FOUND")
     marker = _read_marker(marker_path)
-    plan = {"status": "UNINSTALLED" if apply else "DRY_RUN", "owned_paths": list(marker.get("owned_paths", OWNED_PATHS)), "preserved_paths": list(PRESERVED_PATHS)}
+    plan = {
+        "status": "UNINSTALLED" if apply else "DRY_RUN",
+        "owned_paths": list(marker.get("owned_paths", OWNED_PATHS)),
+        "preserved_paths": list(PRESERVED_PATHS),
+    }
     if not apply:
         return plan
     for name in marker.get("owned_paths", OWNED_PATHS):

--- a/tests/installer/test_original_player_audit_evidence.py
+++ b/tests/installer/test_original_player_audit_evidence.py
@@ -7,7 +7,13 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[2]
-EVIDENCE = ROOT / "docs" / "evidence" / "original-player-audit.0.0.9.615.json"
+EVIDENCE = (
+    ROOT
+    / "docs"
+    / "evidence"
+    / "original-player-audit.0.0.9.615.json"
+)
+MANIFEST = ROOT / "installer" / "full-patch-manifest.json"
 
 
 def _load() -> dict[str, object]:
@@ -49,6 +55,16 @@ def test_original_player_evidence_is_for_supported_client_and_both_archives() ->
     )
     assert players["webplayer"]["archive_sha256"] == (
         "504b59876af2f04c4902f8c8e6811018d36a2da4394e20cf74f22d13d394b636"
+    )
+
+
+def test_installer_pins_the_audited_supported_webplayer() -> None:
+    report = _load()
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    assert manifest["client_version"] == report["source"]["client_version_hint"]
+    assert manifest["webplayer_sha256"] == (
+        report["players"]["webplayer"]["archive_sha256"]
     )
 
 

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -11,12 +11,18 @@ from pathlib import Path
 import pytest
 
 from installer.full_patch import (
+    PAYLOAD_REQUIRED_ROOT_FILES,
     PatchInstallError,
+    copy_project_payload,
     discover_steam_install,
     install_full_patch,
     uninstall_full_patch,
 )
-from installer.start_local import _client_command, _client_environment, _client_executable
+from installer.start_local import (
+    _client_command,
+    _client_environment,
+    _client_executable,
+)
 
 
 def _sha256(path: Path) -> str:
@@ -51,13 +57,20 @@ def test_install_entrypoint_is_parseable_by_windows_powershell() -> None:
 
 def test_published_powershell_scripts_are_utf8_bom_safe() -> None:
     repo_root = Path(__file__).parents[2]
-    for relative in (Path("installer") / "Install.ps1", Path("tools") / "Install-ThirdParty.ps1"):
+    for relative in (
+        Path("installer") / "Install.ps1",
+        Path("tools") / "Install-ThirdParty.ps1",
+    ):
         raw = (repo_root / relative).read_bytes()
-        assert raw.startswith(b"\xef\xbb\xbf"), f"{relative} must be UTF-8 BOM for Windows PowerShell 5.1"
+        assert raw.startswith(
+            b"\xef\xbb\xbf"
+        ), f"{relative} must be UTF-8 BOM for Windows PowerShell 5.1"
         raw.decode("utf-8-sig")
 
 
-def test_install_cmd_preserves_paths_with_spaces_for_windows_powershell(tmp_path: Path) -> None:
+def test_install_cmd_preserves_paths_with_spaces_for_windows_powershell(
+    tmp_path: Path,
+) -> None:
     if os.name != "nt":
         pytest.skip("cmd.exe is only available on Windows")
 
@@ -66,19 +79,30 @@ def test_install_cmd_preserves_paths_with_spaces_for_windows_powershell(tmp_path
     package.mkdir()
     (package / "installer").mkdir()
     shutil.copy2(repo_root / "INSTALL.cmd", package / "INSTALL.cmd")
-    (package / "installer" / "Install.ps1").write_text("# fixture", encoding="utf-8")
+    (package / "installer" / "Install.ps1").write_text(
+        "# fixture",
+        encoding="utf-8",
+    )
     capture = package / "captured-powershell-arguments.txt"
     (package / "powershell.cmd").write_text(
-        '@echo off\n'
+        "@echo off\n"
         f'>"{capture}" echo %*\n'
-        'exit /b 0\n',
+        "exit /b 0\n",
         encoding="ascii",
     )
 
     env = os.environ.copy()
     env["PATH"] = str(package) + os.pathsep + env.get("PATH", "")
     result = subprocess.run(
-        [os.environ.get("COMSPEC", r"C:\Windows\System32\cmd.exe"), "/d", "/c", "call INSTALL.cmd"],
+        [
+            os.environ.get(
+                "COMSPEC",
+                r"C:\Windows\System32\cmd.exe",
+            ),
+            "/d",
+            "/c",
+            "call INSTALL.cmd",
+        ],
         cwd=package,
         env=env,
         capture_output=True,
@@ -92,10 +116,12 @@ def test_install_cmd_preserves_paths_with_spaces_for_windows_powershell(tmp_path
     assert f'-File "{package}\\.\\installer\\Install.ps1"' in args
     assert f'-PayloadRoot "{package}\\."' in args
     assert "-Destination" in args
-    assert "Install.ps1\" -PayloadRoot" in args
+    assert 'Install.ps1" -PayloadRoot' in args
 
 
-def test_start_local_matches_first_party_client_launch_contract(tmp_path: Path) -> None:
+def test_start_local_matches_first_party_client_launch_contract(
+    tmp_path: Path,
+) -> None:
     client = tmp_path / "app" / "0.0.9.615" / "Olivia.exe"
     local = tmp_path / "profile" / "Local"
     roaming = tmp_path / "profile" / "Roaming"
@@ -119,28 +145,66 @@ def test_start_local_matches_first_party_client_launch_contract(tmp_path: Path) 
     assert "SteamGameId" not in environment
 
 
-def _make_official(root: Path) -> tuple[Path, str]:
+def _make_official(root: Path) -> tuple[Path, str, str]:
     version_root = root / "0.0.9.615"
     resources = version_root / "resources"
     resources.mkdir(parents=True)
     (root / "launcher.exe").write_bytes(b"official launcher fixture")
-    (root / "letter_pairs.json").write_text("synthetic user letters", encoding="utf-8")
-    (root / "memory_store.json").write_text("synthetic user memory", encoding="utf-8")
-    (root / "llm_config.json").write_text('{"api_key":"synthetic"}', encoding="utf-8")
+    (root / "letter_pairs.json").write_text(
+        "synthetic user letters",
+        encoding="utf-8",
+    )
+    (root / "memory_store.json").write_text(
+        "synthetic user memory",
+        encoding="utf-8",
+    )
+    (root / "llm_config.json").write_text(
+        '{"api_key":"synthetic"}',
+        encoding="utf-8",
+    )
     (version_root / "Olivia.exe").write_bytes(b"official client fixture")
+
     javascript = (
         "prefix "
         "He=e=>new Promise((t,n)=>{try{"
         ',"query.response":no(a)}}),t(c)},onFailure:\'suffix\' '
-        '!z.isNew||N?(await t.replace({name:ye.Home}),await h(z.uid.toString(),z.modelGatewayToken||"",!1))'
+        '!z.isNew||N?(await t.replace({name:ye.Home}),'
+        'await h(z.uid.toString(),z.modelGatewayToken||"",!1))'
     )
-    archive = resources / "feapp.dat"
-    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as output:
+    feapp = resources / "feapp.dat"
+    with zipfile.ZipFile(feapp, "w", zipfile.ZIP_DEFLATED) as output:
+        output.writestr(
+            "index.html",
+            "<!doctype html><html><head>"
+            '<script type="module" crossorigin '
+            'src="./assets/main-917d29fc.js"></script>'
+            '<link rel="stylesheet" href="./assets/index.css">'
+            "</head><body><div id=\"app\"></div></body></html>",
+        )
         output.writestr("assets/main-917d29fc.js", javascript)
-    return root, _sha256(archive)
+        output.writestr("assets/index.css", "body{display:block}")
+
+    webplayer = resources / "webplayer.dat"
+    with zipfile.ZipFile(webplayer, "w", zipfile.ZIP_DEFLATED) as output:
+        output.writestr(
+            "index.html",
+            "<!doctype html><html><head>"
+            '<script type="module" crossorigin '
+            'src="./assets/main-752b9fc4.js"></script>'
+            "</head><body><div id=\"app\"></div></body></html>",
+        )
+        output.writestr(
+            "assets/main-752b9fc4.js",
+            "console.log('synthetic original player')",
+        )
+    return root, _sha256(feapp), _sha256(webplayer)
 
 
-def _write_manifest(path: Path, feapp_sha256: str) -> Path:
+def _write_manifest(
+    path: Path,
+    feapp_sha256: str,
+    webplayer_sha256: str,
+) -> Path:
     path.write_text(
         json.dumps(
             {
@@ -148,9 +212,10 @@ def _write_manifest(path: Path, feapp_sha256: str) -> Path:
                 "steam_app_id": "4532590",
                 "client_version": "0.0.9.615",
                 "feapp_sha256": feapp_sha256,
+                "webplayer_sha256": webplayer_sha256,
                 "patch_mode": "isolated-copy",
                 "live_status": "UNAVAILABLE_PAUSED",
-                "media_status": "TEXT_ONLY_MAIN_BASELINE",
+                "media_status": "ORIGINAL_WEBPLAYER_LOCAL_VIDEO",
             }
         ),
         encoding="utf-8",
@@ -160,24 +225,32 @@ def _write_manifest(path: Path, feapp_sha256: str) -> Path:
 
 def _make_payload(repo_root: Path, root: Path) -> Path:
     root.mkdir()
-    shutil.copy2(repo_root / "local_server.py", root / "local_server.py")
-    shutil.copy2(repo_root / "patch_feapp.py", root / "patch_feapp.py")
+    for name in PAYLOAD_REQUIRED_ROOT_FILES:
+        shutil.copy2(repo_root / name, root / name)
     shutil.copytree(repo_root / "installer", root / "installer")
     return root
 
 
-def test_copy_payload_excludes_non_runtime_project_files(tmp_path: Path) -> None:
-    from installer.full_patch import copy_project_payload
-
+def test_copy_payload_excludes_non_runtime_project_files(
+    tmp_path: Path,
+) -> None:
     source = tmp_path / "payload"
     destination = tmp_path / "installed" / "local_backend"
     source.mkdir()
-    for name in ("local_server.py", "patch_feapp.py", "dynamic_renderer.py"):
+    for name in PAYLOAD_REQUIRED_ROOT_FILES | {"dynamic_renderer.py"}:
         (source / name).write_text("# fixture", encoding="utf-8")
-    for name in ("test_fixture.py", "pytest.ini", "requirements-dev.txt", "requirements-dev-extra.txt"):
+    for name in (
+        "test_fixture.py",
+        "pytest.ini",
+        "requirements-dev.txt",
+        "requirements-dev-extra.txt",
+    ):
         (source / name).write_text("fixture", encoding="utf-8")
     (source / ".evidence").mkdir()
-    (source / ".evidence" / "capture.json").write_text("{}", encoding="utf-8")
+    (source / ".evidence" / "capture.json").write_text(
+        "{}",
+        encoding="utf-8",
+    )
     (source / "__pycache__").mkdir()
     (source / "__pycache__" / "fixture.pyc").write_bytes(b"pyc")
 
@@ -185,36 +258,118 @@ def test_copy_payload_excludes_non_runtime_project_files(tmp_path: Path) -> None
 
     assert "dynamic_renderer.py" in copied
     assert (destination / "dynamic_renderer.py").is_file()
-    for name in ("test_fixture.py", "pytest.ini", "requirements-dev.txt", "requirements-dev-extra.txt"):
+    for name in PAYLOAD_REQUIRED_ROOT_FILES:
+        assert name in copied
+        assert (destination / name).is_file()
+    for name in (
+        "test_fixture.py",
+        "pytest.ini",
+        "requirements-dev.txt",
+        "requirements-dev-extra.txt",
+    ):
         assert name not in copied
         assert not (destination / name).exists()
     assert not (destination / ".evidence").exists()
     assert not (destination / "__pycache__").exists()
 
 
+def test_copy_payload_rejects_missing_original_client_runtime(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "payload"
+    source.mkdir()
+    for name in PAYLOAD_REQUIRED_ROOT_FILES - {"original_client_server.py"}:
+        (source / name).write_text("# fixture", encoding="utf-8")
+
+    with pytest.raises(PatchInstallError, match="PATCH_PAYLOAD_INCOMPLETE"):
+        copy_project_payload(source, tmp_path / "destination")
+
+
 @pytest.fixture
-def fixture_inputs(tmp_path: Path) -> tuple[Path, Path, Path, str]:
-    official, digest = _make_official(tmp_path / "official")
+def fixture_inputs(
+    tmp_path: Path,
+) -> tuple[Path, Path, Path, str, str]:
+    official, feapp_digest, webplayer_digest = _make_official(
+        tmp_path / "official"
+    )
     repo_root = Path(__file__).parents[2]
     payload = _make_payload(repo_root, tmp_path / "payload")
-    manifest = _write_manifest(tmp_path / "manifest.json", digest)
-    return official, payload, manifest, digest
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        feapp_digest,
+        webplayer_digest,
+    )
+    return (
+        official,
+        payload,
+        manifest,
+        feapp_digest,
+        webplayer_digest,
+    )
 
 
-def test_install_isolated_copy_patches_only_staged_client(fixture_inputs, tmp_path: Path):
-    official, payload, manifest, digest = fixture_inputs
-    source_feapp = official / "0.0.9.615" / "resources" / "feapp.dat"
-    source_bytes = source_feapp.read_bytes()
-    result = install_full_patch(official, tmp_path / "installed", payload, manifest)
+def test_install_isolated_copy_activates_original_client_surfaces(
+    fixture_inputs,
+    tmp_path: Path,
+) -> None:
+    official, payload, manifest, feapp_digest, webplayer_digest = fixture_inputs
+    resources = official / "0.0.9.615" / "resources"
+    source_feapp = resources / "feapp.dat"
+    source_webplayer = resources / "webplayer.dat"
+    source_feapp_bytes = source_feapp.read_bytes()
+    source_webplayer_bytes = source_webplayer.read_bytes()
+
+    result = install_full_patch(
+        official,
+        tmp_path / "installed",
+        payload,
+        manifest,
+    )
     installed = tmp_path / "installed"
 
     assert result["status"] == "INSTALLED"
-    assert source_feapp.read_bytes() == source_bytes
-    assert _sha256(source_feapp) == digest
-    patched = installed / "app" / "0.0.9.615" / "resources" / "feapp.dat"
-    assert _sha256(patched) != digest
-    assert _sha256(Path(str(patched) + ".orig")) == digest
-    assert (installed / "local_backend" / "patch_feapp.py").is_file()
+    assert result["original_client_only"] is True
+    assert result["companion_settings_embedded"] is True
+    assert result["webplayer_local_media"] is True
+    assert result["companion_settings_status"] == "PATCHED"
+    assert result["webplayer_patch_status"] == "PATCHED"
+
+    assert source_feapp.read_bytes() == source_feapp_bytes
+    assert source_webplayer.read_bytes() == source_webplayer_bytes
+    assert _sha256(source_feapp) == feapp_digest
+    assert _sha256(source_webplayer) == webplayer_digest
+
+    installed_resources = (
+        installed / "app" / "0.0.9.615" / "resources"
+    )
+    patched_feapp = installed_resources / "feapp.dat"
+    patched_webplayer = installed_resources / "webplayer.dat"
+    assert _sha256(patched_feapp) != feapp_digest
+    assert _sha256(patched_webplayer) != webplayer_digest
+    assert _sha256(Path(str(patched_feapp) + ".orig")) == feapp_digest
+    assert _sha256(Path(str(patched_webplayer) + ".orig")) == webplayer_digest
+    assert result["companion_backup_feapp_sha256"] == _sha256(
+        Path(str(patched_feapp) + ".companion.orig")
+    )
+
+    with zipfile.ZipFile(patched_feapp) as archive:
+        names = set(archive.namelist())
+        index = archive.read("index.html").decode("utf-8")
+        main = archive.read("assets/main-917d29fc.js").decode("utf-8")
+    assert "assets/olivia-companion-settings.js" in names
+    assert "data-olivia-companion-settings" in index
+    assert "data-ui-version=\"p03.original-settings-read.v1\"" in index
+    assert "toyApiUrl" in main
+    assert "await t.replace({name:ye.Collection})" in main
+
+    with zipfile.ZipFile(patched_webplayer) as archive:
+        names = set(archive.namelist())
+        index = archive.read("index.html").decode("utf-8")
+    assert "assets/olivia-local-media-bootstrap.js" in names
+    assert "data-olivia-local-media-bootstrap" in index
+
+    for name in PAYLOAD_REQUIRED_ROOT_FILES:
+        assert (installed / "local_backend" / name).is_file()
     assert not (installed / "app" / "letter_pairs.json").exists()
     assert not (installed / "app" / "memory_store.json").exists()
     assert not (installed / "app" / "llm_config.json").exists()
@@ -222,35 +377,69 @@ def test_install_isolated_copy_patches_only_staged_client(fixture_inputs, tmp_pa
     assert not (installed / "local_backend" / "memory_store.json").exists()
     assert not (installed / "local_backend" / "llm_config.json").exists()
     assert (installed / "CONFIGURE.cmd").is_file()
-    assert "installer\\start_local.py" in (installed / "START.cmd").read_text(encoding="utf-8")
-    assert "runtime\\python-3.12.10-embed-amd64\\python.exe" in (installed / "START.cmd").read_text(encoding="utf-8")
+    start = (installed / "START.cmd").read_text(encoding="utf-8")
+    assert "installer\\start_local.py" in start
+    assert "runtime\\python-3.12.10-embed-amd64\\python.exe" in start
     uninstall = (installed / "UNINSTALL.cmd").read_text(encoding="utf-8")
     assert "installer\\uninstall.py" in uninstall
     assert "installer_main" not in uninstall
     for script in (installed / "START.cmd", installed / "UNINSTALL.cmd"):
-        text = script.read_text(encoding="utf-8").lower()
-        assert "d:/" not in text and "f:/" not in text and "sk-" not in text
+        value = script.read_text(encoding="utf-8").lower()
+        assert "d:/" not in value
+        assert "f:/" not in value
+        assert "sk-" not in value
 
 
-def test_install_is_idempotent_and_unknown_target_is_not_overwritten(fixture_inputs, tmp_path: Path):
-    official, payload, manifest, _ = fixture_inputs
+def test_install_is_idempotent_and_unknown_target_is_not_overwritten(
+    fixture_inputs,
+    tmp_path: Path,
+) -> None:
+    official, payload, manifest, _feapp, _webplayer = fixture_inputs
     target = tmp_path / "installed"
     first = install_full_patch(official, target, payload, manifest)
     assert first["status"] == "INSTALLED"
-    assert install_full_patch(official, target, payload, manifest)["status"] == "ALREADY_INSTALLED"
+    assert install_full_patch(
+        official,
+        target,
+        payload,
+        manifest,
+    )["status"] == "ALREADY_INSTALLED"
 
     unknown = tmp_path / "unknown"
     unknown.mkdir()
     (unknown / "user-file.txt").write_text("keep", encoding="utf-8")
     with pytest.raises(PatchInstallError, match="INSTALL_ROOT_ALREADY_EXISTS"):
         install_full_patch(official, unknown, payload, manifest)
-    assert (unknown / "user-file.txt").read_text(encoding="utf-8") == "keep"
+    assert (
+        unknown / "user-file.txt"
+    ).read_text(encoding="utf-8") == "keep"
 
 
-def test_install_rejects_bad_source_hash_before_target_write(fixture_inputs, tmp_path: Path):
-    official, payload, manifest, _ = fixture_inputs
+def test_incomplete_old_marker_is_not_treated_as_current_install(
+    fixture_inputs,
+    tmp_path: Path,
+) -> None:
+    official, payload, manifest, _feapp, _webplayer = fixture_inputs
+    target = tmp_path / "installed"
+    install_full_patch(official, target, payload, manifest)
+    marker_path = target / ".olivia-full-patch.json"
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    marker["companion_settings_embedded"] = False
+    marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+    with pytest.raises(PatchInstallError, match="INSTALL_ROOT_ALREADY_EXISTS"):
+        install_full_patch(official, target, payload, manifest)
+
+
+@pytest.mark.parametrize("field", ["feapp_sha256", "webplayer_sha256"])
+def test_install_rejects_bad_source_hash_before_target_write(
+    fixture_inputs,
+    tmp_path: Path,
+    field: str,
+) -> None:
+    official, payload, manifest, _feapp, _webplayer = fixture_inputs
     bad = json.loads(manifest.read_text(encoding="utf-8"))
-    bad["feapp_sha256"] = "0" * 64
+    bad[field] = "0" * 64
     manifest.write_text(json.dumps(bad), encoding="utf-8")
     target = tmp_path / "installed"
     with pytest.raises(PatchInstallError, match="UNSUPPORTED_OFFICIAL_VERSION"):
@@ -258,41 +447,59 @@ def test_install_rejects_bad_source_hash_before_target_write(fixture_inputs, tmp
     assert not target.exists()
 
 
-def test_install_rejects_official_source_overlap(fixture_inputs, tmp_path: Path):
-    official, payload, manifest, _ = fixture_inputs
+def test_install_rejects_official_source_overlap(
+    fixture_inputs,
+) -> None:
+    official, payload, manifest, _feapp, _webplayer = fixture_inputs
     with pytest.raises(PatchInstallError, match="INSTALL_ROOT_OVERLAPS_OFFICIAL"):
         install_full_patch(official, official / "nested", payload, manifest)
 
 
-def test_discovery_uses_appmanifest_without_fixed_drive(tmp_path: Path):
+def test_discovery_uses_appmanifest_without_fixed_drive(tmp_path: Path) -> None:
     steam = tmp_path / "Steam"
     official = steam / "steamapps" / "common" / "BSide Olivia Lin Test"
     _make_official(official)
     apps = steam / "steamapps"
     apps.mkdir(exist_ok=True)
-    (apps / "appmanifest_4532590.acf").write_text('"installdir" "BSide Olivia Lin Test"', encoding="utf-8")
+    (apps / "appmanifest_4532590.acf").write_text(
+        '"installdir" "BSide Olivia Lin Test"',
+        encoding="utf-8",
+    )
     assert discover_steam_install([steam]) == official.resolve()
 
 
-def test_uninstall_is_dry_run_then_removes_only_owned_paths(fixture_inputs, tmp_path: Path):
-    official, payload, manifest, _ = fixture_inputs
+def test_uninstall_is_dry_run_then_removes_only_owned_paths(
+    fixture_inputs,
+    tmp_path: Path,
+) -> None:
+    official, payload, manifest, _feapp, _webplayer = fixture_inputs
     target = tmp_path / "installed"
     install_full_patch(official, target, payload, manifest)
-    (target / "data" / "letters.json").write_text("user data", encoding="utf-8")
+    (target / "data" / "letters.json").write_text(
+        "user data",
+        encoding="utf-8",
+    )
     (target / "logs").mkdir()
     (target / "third-party").mkdir()
     assert uninstall_full_patch(target)["status"] == "DRY_RUN"
     assert (target / "app").is_dir()
     assert uninstall_full_patch(target, apply=True)["status"] == "UNINSTALLED"
     assert not (target / "app").exists()
-    assert (target / "data" / "letters.json").read_text(encoding="utf-8") == "user data"
+    assert (
+        target / "data" / "letters.json"
+    ).read_text(encoding="utf-8") == "user data"
     assert (target / "third-party").is_dir()
 
 
-def test_start_resolves_isolated_client_and_never_launcher(fixture_inputs, tmp_path: Path):
-    official, payload, manifest, _ = fixture_inputs
+def test_start_resolves_isolated_client_and_never_launcher(
+    fixture_inputs,
+    tmp_path: Path,
+) -> None:
+    official, payload, manifest, _feapp, _webplayer = fixture_inputs
     target = tmp_path / "installed"
     install_full_patch(official, target, payload, manifest)
-    assert _client_executable(target) == target / "app" / "0.0.9.615" / "Olivia.exe"
+    assert _client_executable(target) == (
+        target / "app" / "0.0.9.615" / "Olivia.exe"
+    )
     start = (target / "START.cmd").read_text(encoding="utf-8")
     assert "launcher.exe" not in start.lower()


### PR DESCRIPTION
Implements CLIENT-INSTALL-01 after #86 and #87.

## Scope

- pins the audited original `webplayer.dat` hash alongside the supported `feapp.dat` hash;
- validates both original archives before creating the isolated installation;
- requires the combined original-client server, settings UI, and all three safe patchers in the runtime payload;
- applies the supported isolated-copy patches in order:
  1. local `toyApiUrl` / `toyWsUrl` and default original `Collection`;
  2. the repository-owned “本地陪伴” interface inside original Settings;
  3. the original webplayer local `/toy/media/` fallback;
- never changes the Steam source directory and verifies the copied hashes again before patching;
- records separate original, patched, and backup hashes for feapp, the managed settings layer, and webplayer;
- refuses to call an older incomplete marker “already installed” when original Settings or webplayer activation is missing;
- deletes the entire incomplete target on any copy, patch, repack, or verification failure;
- keeps the original Olivia client as the only user-facing entry and starts the one combined loopback runtime from #86.

## Tests

- synthetic source archives for both feapp and webplayer;
- source byte-for-byte preservation;
- endpoint, Collection, original Settings, and local-player activation in the staged copy;
- exact backup hashes and managed marker fields;
- manifest/source mismatch for either archive;
- incomplete runtime payload refusal;
- old incomplete marker refusal;
- idempotent current install, overlap protection, uninstall preservation, discovery, and isolated launch.

## Boundary

This PR does not add a second UI, enable write operations, finish the Collection camelCase runtime serializer, download models, or claim real media generation has been accepted. It makes the already-reviewed original-client surfaces part of the normal isolated installer.

Part of #35, #37, and #38.