### PR TITLE
feat(client): compose original settings read runtime

### DIFF
--- a/control_center/original_client_runtime.py
+++ b/control_center/original_client_runtime.py
@@ -1,0 +1,215 @@
+"""Composition-only bridge for the original Olivia companion settings surface.
+
+The original client remains the sole user-facing shell.  This module does not
+open a socket, create an application, render a browser page, or access storage.
+It only combines the already-reviewed original-client HTTP contract with the
+already-reviewed service adapter and mounts them on an existing aiohttp app.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+import inspect
+from typing import Iterable
+
+from aiohttp import web
+
+
+_BACKEND_CLASS = "OriginalClientCompanionServiceBackend"
+_BACKEND_MODULES = (
+    "original_client_companion_backend",
+    "original_client_companion_service_backend",
+    "original_client_companion_services",
+)
+_MOUNT_NAMES = (
+    "mount_original_client_companion_api",
+    "mount_original_companion_read_api",
+    "mount_companion_read_api",
+    "mount_companion_api",
+)
+
+
+class OriginalClientRuntimeCompositionError(RuntimeError):
+    """Stable composition error without service or filesystem details."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class OriginalClientCompanionRuntime:
+    """Objects mounted into one existing local application."""
+
+    backend: object
+    trusted_origins: tuple[str, ...]
+
+
+def _load_backend_class() -> type:
+    matches: list[type] = []
+    for module_name in _BACKEND_MODULES:
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:
+            if exc.name == module_name:
+                continue
+            raise OriginalClientRuntimeCompositionError(
+                "ORIGINAL_COMPANION_BACKEND_IMPORT_FAILED"
+            ) from exc
+        candidate = getattr(module, _BACKEND_CLASS, None)
+        if isinstance(candidate, type):
+            matches.append(candidate)
+    if len(matches) != 1:
+        raise OriginalClientRuntimeCompositionError(
+            "ORIGINAL_COMPANION_BACKEND_UNAVAILABLE"
+        )
+    return matches[0]
+
+
+def _load_mount_function():
+    try:
+        module = importlib.import_module("original_client_companion_api")
+    except ModuleNotFoundError as exc:
+        raise OriginalClientRuntimeCompositionError(
+            "ORIGINAL_COMPANION_API_UNAVAILABLE"
+        ) from exc
+    matches = [
+        getattr(module, name)
+        for name in _MOUNT_NAMES
+        if callable(getattr(module, name, None))
+    ]
+    if len(matches) != 1:
+        discovered = [
+            value
+            for name, value in vars(module).items()
+            if name.startswith("mount_")
+            and "companion" in name
+            and callable(value)
+        ]
+        matches = discovered
+    if len(matches) != 1:
+        raise OriginalClientRuntimeCompositionError(
+            "ORIGINAL_COMPANION_MOUNT_UNAVAILABLE"
+        )
+    return matches[0]
+
+
+def _semantic_service(name: str, services: dict[str, object | None]) -> object | None:
+    normalized = name.casefold()
+    if "memory" in normalized:
+        return services["memory"]
+    if "candidate" in normalized:
+        return services["candidates"]
+    if "private" in normalized or "world" in normalized:
+        return services["private_world"]
+    raise OriginalClientRuntimeCompositionError(
+        "ORIGINAL_COMPANION_BACKEND_SIGNATURE_UNSUPPORTED"
+    )
+
+
+def _build_backend(
+    *,
+    memory_service: object | None,
+    private_world_service: object | None,
+    candidate_service: object | None,
+) -> object:
+    backend_class = _load_backend_class()
+    signature = inspect.signature(backend_class)
+    services = {
+        "memory": memory_service,
+        "private_world": private_world_service,
+        "candidates": candidate_service,
+    }
+    kwargs: dict[str, object | None] = {}
+    for name, parameter in signature.parameters.items():
+        if parameter.kind in {
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        }:
+            continue
+        try:
+            kwargs[name] = _semantic_service(name, services)
+        except OriginalClientRuntimeCompositionError:
+            if parameter.default is inspect.Parameter.empty:
+                raise
+    try:
+        return backend_class(**kwargs)
+    except (TypeError, ValueError) as exc:
+        raise OriginalClientRuntimeCompositionError(
+            "ORIGINAL_COMPANION_BACKEND_INVALID"
+        ) from exc
+
+
+def _mount(
+    app: web.Application,
+    backend: object,
+    trusted_origins: tuple[str, ...],
+) -> None:
+    mount = _load_mount_function()
+    signature = inspect.signature(mount)
+    kwargs: dict[str, object] = {}
+    positional: list[object] = []
+    for name, parameter in signature.parameters.items():
+        normalized = name.casefold()
+        value: object
+        if normalized in {"app", "application"}:
+            value = app
+        elif "backend" in normalized or "provider" in normalized:
+            value = backend
+        elif "origin" in normalized:
+            value = trusted_origins
+        elif parameter.default is not inspect.Parameter.empty:
+            continue
+        else:
+            raise OriginalClientRuntimeCompositionError(
+                "ORIGINAL_COMPANION_MOUNT_SIGNATURE_UNSUPPORTED"
+            )
+        if parameter.kind is inspect.Parameter.POSITIONAL_ONLY:
+            positional.append(value)
+        else:
+            kwargs[name] = value
+    try:
+        mount(*positional, **kwargs)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise OriginalClientRuntimeCompositionError(
+            "ORIGINAL_COMPANION_MOUNT_FAILED"
+        ) from exc
+
+
+def mount_original_client_companion_runtime(
+    app: web.Application,
+    *,
+    memory_service: object | None = None,
+    private_world_service: object | None = None,
+    candidate_service: object | None = None,
+    trusted_origins: Iterable[str] = (),
+) -> OriginalClientCompanionRuntime:
+    """Mount existing companion services on an existing loopback app.
+
+    Passing ``None`` keeps a capability honestly disabled.  The supplied
+    service objects remain the owners of reads, reduction, persistence, and
+    candidate decisions; this function never reaches into their storage.
+    """
+
+    if not isinstance(app, web.Application):
+        raise TypeError("an aiohttp application is required")
+    origins = tuple(trusted_origins)
+    if any(not isinstance(value, str) or not value for value in origins):
+        raise ValueError("trusted origins must be non-empty strings")
+    if len(set(origins)) != len(origins):
+        raise ValueError("trusted origins must be unique")
+    backend = _build_backend(
+        memory_service=memory_service,
+        private_world_service=private_world_service,
+        candidate_service=candidate_service,
+    )
+    _mount(app, backend, origins)
+    return OriginalClientCompanionRuntime(backend=backend, trusted_origins=origins)
+
+
+__all__ = [
+    "OriginalClientCompanionRuntime",
+    "OriginalClientRuntimeCompositionError",
+    "mount_original_client_companion_runtime",
+]

--- a/tests/control_center/test_original_client_runtime.py
+++ b/tests/control_center/test_original_client_runtime.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import asyncio
+
+from aiohttp.test_utils import TestClient, TestServer
+import pytest
+
+from control_center.original_client_runtime import (
+    OriginalClientRuntimeCompositionError,
+    mount_original_client_companion_runtime,
+)
+from original_client_companion_api import STATUS_PATH
+
+
+def test_runtime_mounts_disabled_capabilities_on_existing_loopback_app() -> None:
+    async def scenario() -> None:
+        from aiohttp import web
+
+        app = web.Application()
+        runtime = mount_original_client_companion_runtime(app)
+        assert runtime.backend is not None
+        assert runtime.trusted_origins == ()
+
+        async with TestClient(TestServer(app)) as client:
+            origin = str(client.make_url("/")).rstrip("/")
+            response = await client.get(STATUS_PATH, headers={"Origin": origin})
+            assert response.status == 200
+            payload = await response.json()
+            assert payload["status"] == "READY"
+            assert payload["capabilities"]["memory"]["state"] == "disabled"
+            assert payload["capabilities"]["private_world"]["state"] == "disabled"
+            assert payload["capabilities"]["candidates"]["state"] == "disabled"
+            assert response.headers["Cache-Control"] == "no-store"
+            assert response.headers["Access-Control-Allow-Origin"] == origin
+
+    asyncio.run(scenario())
+
+
+def test_runtime_keeps_external_origin_outside_original_client_boundary() -> None:
+    async def scenario() -> None:
+        from aiohttp import web
+
+        app = web.Application()
+        mount_original_client_companion_runtime(app)
+        async with TestClient(TestServer(app)) as client:
+            response = await client.get(
+                STATUS_PATH,
+                headers={"Origin": "https://example.invalid"},
+            )
+            assert response.status == 403
+            payload = await response.json()
+            assert payload["error_code"] == "COMPANION_ORIGIN_FORBIDDEN"
+            assert "Access-Control-Allow-Origin" not in response.headers
+
+    asyncio.run(scenario())
+
+
+def test_runtime_accepts_explicit_original_client_origin() -> None:
+    async def scenario() -> None:
+        from aiohttp import web
+
+        app = web.Application()
+        origin = "https://original-client.invalid"
+        mount_original_client_companion_runtime(
+            app,
+            trusted_origins=(origin,),
+        )
+        async with TestClient(TestServer(app)) as client:
+            response = await client.get(STATUS_PATH, headers={"Origin": origin})
+            assert response.status == 200
+            assert response.headers["Access-Control-Allow-Origin"] == origin
+
+    asyncio.run(scenario())
+
+
+def test_runtime_rejects_duplicate_origins_and_duplicate_mount() -> None:
+    from aiohttp import web
+
+    app = web.Application()
+    with pytest.raises(ValueError):
+        mount_original_client_companion_runtime(
+            app,
+            trusted_origins=("https://client.invalid", "https://client.invalid"),
+        )
+
+    mount_original_client_companion_runtime(app)
+    with pytest.raises(OriginalClientRuntimeCompositionError) as duplicate:
+        mount_original_client_companion_runtime(app)
+    assert duplicate.value.code == "ORIGINAL_COMPANION_MOUNT_FAILED"
+
+
+def test_runtime_opens_no_socket_and_creates_no_second_application(monkeypatch) -> None:
+    from aiohttp import web
+
+    app = web.Application()
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("composition must not open a listener")
+
+    monkeypatch.setattr(web, "run_app", forbidden)
+    runtime = mount_original_client_companion_runtime(app)
+    assert runtime.backend is not None


### PR DESCRIPTION
Superseded by the already merged original-client runtime and installer composition in #86 and #88.

This branch adds reflective import/signature discovery for a read runtime that now has a direct, source-grounded implementation in `original_client_server.py`. Keeping it would create a second composition path and unnecessary architecture. No code from this PR is required.