### PR TITLE
feat(client): mount original settings mutations in local runtime

### DIFF
--- a/control_center/original_client_mutation_runtime.py
+++ b/control_center/original_client_mutation_runtime.py
@@ -1,0 +1,179 @@
+"""Compose original-client mutations from services already mounted for reads.
+
+The module walks a small, bounded process-local object graph to locate the
+existing auditable Memory Admin and typed candidate-decision services.  It does
+not construct providers, open storage, create an application, or start a
+listener.  The original Olivia client remains the only user-facing shell.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import fields, is_dataclass
+import inspect
+from types import ModuleType
+from typing import Iterable, Mapping
+
+from aiohttp import web
+
+from control_center.original_client_mutation_services import (
+    OriginalClientCompanionMutationServiceBackend,
+)
+from original_client_companion_mutation_api import (
+    mount_original_client_companion_mutation_api,
+)
+
+
+_MEMORY_CORRECT = frozenset(
+    {"correct_memory", "correct", "replace_memory", "replace"}
+)
+_MEMORY_DELETE = frozenset(
+    {"delete_memory", "delete", "remove_memory", "remove"}
+)
+_CANDIDATE_DECIDE = frozenset(
+    {"decide_candidate", "decide", "record_decision"}
+)
+_MAX_GRAPH_NODES = 256
+_MAX_GRAPH_DEPTH = 5
+
+
+class OriginalClientMutationRuntimeError(RuntimeError):
+    """Stable composition failure without storage or provider details."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def _callable_names(value: object) -> frozenset[str]:
+    names: set[str] = set()
+    for name in dir(value):
+        if name.startswith("_"):
+            continue
+        try:
+            candidate = getattr(value, name)
+        except Exception:
+            continue
+        if callable(candidate):
+            names.add(name)
+    return frozenset(names)
+
+
+def _is_memory_service(value: object) -> bool:
+    names = _callable_names(value)
+    return bool(names & _MEMORY_CORRECT) and bool(names & _MEMORY_DELETE)
+
+
+def _is_candidate_service(value: object) -> bool:
+    names = _callable_names(value)
+    return bool(names & _CANDIDATE_DECIDE)
+
+
+def _children(value: object) -> tuple[object, ...]:
+    if isinstance(value, Mapping):
+        return tuple(value.values())
+    if isinstance(value, (tuple, list, set, frozenset, deque)):
+        return tuple(value)
+    if is_dataclass(value) and not isinstance(value, type):
+        children: list[object] = []
+        for field in fields(value):
+            try:
+                children.append(getattr(value, field.name))
+            except Exception:
+                continue
+        return tuple(children)
+    namespace = getattr(value, "__dict__", None)
+    if isinstance(namespace, dict):
+        return tuple(
+            item
+            for name, item in namespace.items()
+            if not name.startswith("__")
+        )
+    return ()
+
+
+def _walk(roots: Iterable[object]) -> tuple[object, ...]:
+    queue = deque((value, 0) for value in roots)
+    seen: set[int] = set()
+    values: list[object] = []
+    while queue:
+        value, depth = queue.popleft()
+        if value is None or isinstance(
+            value,
+            (str, bytes, bytearray, int, float, bool, ModuleType, type),
+        ):
+            continue
+        if inspect.isroutine(value):
+            continue
+        identity = id(value)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        values.append(value)
+        if len(values) > _MAX_GRAPH_NODES:
+            raise OriginalClientMutationRuntimeError(
+                "ORIGINAL_COMPANION_RUNTIME_GRAPH_TOO_LARGE"
+            )
+        if depth >= _MAX_GRAPH_DEPTH:
+            continue
+        for child in _children(value):
+            queue.append((child, depth + 1))
+    return tuple(values)
+
+
+def _unique_service(
+    values: tuple[object, ...],
+    predicate,
+    *,
+    code: str,
+) -> object | None:
+    matches = [value for value in values if predicate(value)]
+    identities = {id(value) for value in matches}
+    if len(identities) > 1:
+        raise OriginalClientMutationRuntimeError(code)
+    return matches[0] if matches else None
+
+
+def mount_original_client_companion_mutations_from_app(
+    app: web.Application,
+    *,
+    trusted_origins: tuple[str, ...] = (),
+    extra_roots: Iterable[object] = (),
+) -> OriginalClientCompanionMutationServiceBackend:
+    """Discover existing services and mount mutations on the same application."""
+
+    if not isinstance(app, web.Application):
+        raise TypeError("an aiohttp application is required")
+    roots = tuple(app.values()) + tuple(extra_roots)
+    values = _walk(roots)
+    memory_service = _unique_service(
+        values,
+        _is_memory_service,
+        code="ORIGINAL_COMPANION_MEMORY_SERVICE_AMBIGUOUS",
+    )
+    candidate_service = _unique_service(
+        values,
+        _is_candidate_service,
+        code="ORIGINAL_COMPANION_CANDIDATE_SERVICE_AMBIGUOUS",
+    )
+    backend = OriginalClientCompanionMutationServiceBackend(
+        memory_service=memory_service,
+        candidate_service=candidate_service,
+    )
+    try:
+        mount_original_client_companion_mutation_api(
+            app,
+            backend,
+            trusted_origins=trusted_origins,
+        )
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise OriginalClientMutationRuntimeError(
+            "ORIGINAL_COMPANION_MUTATION_MOUNT_FAILED"
+        ) from exc
+    return backend
+
+
+__all__ = [
+    "OriginalClientMutationRuntimeError",
+    "mount_original_client_companion_mutations_from_app",
+]

--- a/tests/control_center/test_original_client_mutation_runtime.py
+++ b/tests/control_center/test_original_client_mutation_runtime.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from aiohttp.test_utils import TestClient, TestServer
+import pytest
+
+from control_center.original_client_mutation_runtime import (
+    OriginalClientMutationRuntimeError,
+    mount_original_client_companion_mutations_from_app,
+)
+from original_client_companion_mutation_api import (
+    CONFIRM_HEADER,
+    CONFIRM_VALUE,
+    MEMORY_DELETE_PATH,
+)
+
+
+class MemoryService:
+    def __init__(self) -> None:
+        self.deleted: list[str] = []
+
+    def correct_memory(self, **kwargs):
+        return {
+            "status": "applied",
+            "request_id": kwargs["request_id"],
+            "affected_count": 2,
+        }
+
+    def delete_memory(self, **kwargs):
+        self.deleted.append(kwargs["memory_id"])
+        return {
+            "status": "applied",
+            "request_id": kwargs["request_id"],
+            "affected_count": 1,
+        }
+
+
+class CandidateService:
+    def decide_candidate(self, **kwargs):
+        return {
+            "status": "committed",
+            "request_id": kwargs["request_id"],
+            "affected_count": 1,
+        }
+
+
+@dataclass
+class RuntimeOwner:
+    memory: object | None = None
+    candidate: object | None = None
+
+
+def test_runtime_discovers_existing_services_in_bounded_app_graph() -> None:
+    async def scenario() -> None:
+        from aiohttp import web
+
+        app = web.Application()
+        memory = MemoryService()
+        app[web.AppKey("fixture_owner", object)] = RuntimeOwner(
+            memory=memory,
+            candidate=CandidateService(),
+        )
+        mount_original_client_companion_mutations_from_app(app)
+
+        async with TestClient(TestServer(app)) as client:
+            origin = str(client.make_url("/")).rstrip("/")
+            response = await client.post(
+                MEMORY_DELETE_PATH,
+                json={
+                    "memory_id": "memory.fixture.1",
+                    "request_id": "request.memory.delete.1",
+                    "reason": "用户确认删除。",
+                },
+                headers={"Origin": origin, CONFIRM_HEADER: CONFIRM_VALUE},
+            )
+            assert response.status == 200
+            assert (await response.json())["status"] == "APPLIED"
+            assert memory.deleted == ["memory.fixture.1"]
+
+    asyncio.run(scenario())
+
+
+def test_runtime_mounts_honest_unavailable_endpoints_without_services() -> None:
+    async def scenario() -> None:
+        from aiohttp import web
+
+        app = web.Application()
+        mount_original_client_companion_mutations_from_app(app)
+        async with TestClient(TestServer(app)) as client:
+            origin = str(client.make_url("/")).rstrip("/")
+            response = await client.post(
+                MEMORY_DELETE_PATH,
+                json={
+                    "memory_id": "memory.fixture.1",
+                    "request_id": "request.memory.delete.1",
+                    "reason": "用户确认删除。",
+                },
+                headers={"Origin": origin, CONFIRM_HEADER: CONFIRM_VALUE},
+            )
+            assert response.status == 503
+            assert (await response.json())["error_code"] == "MEMORY_MUTATION_DISABLED"
+
+    asyncio.run(scenario())
+
+
+def test_runtime_accepts_explicit_extra_root_without_storing_it_on_app() -> None:
+    from aiohttp import web
+
+    app = web.Application()
+    memory = MemoryService()
+    backend = mount_original_client_companion_mutations_from_app(
+        app,
+        extra_roots=(RuntimeOwner(memory=memory),),
+    )
+    assert backend is not None
+    assert all(value is not memory for value in app.values())
+
+
+def test_runtime_rejects_ambiguous_services() -> None:
+    from aiohttp import web
+
+    app = web.Application()
+    with pytest.raises(OriginalClientMutationRuntimeError) as error:
+        mount_original_client_companion_mutations_from_app(
+            app,
+            extra_roots=(MemoryService(), MemoryService()),
+        )
+    assert error.value.code == "ORIGINAL_COMPANION_MEMORY_SERVICE_AMBIGUOUS"
+
+
+def test_runtime_opens_no_socket_and_creates_no_second_application(monkeypatch) -> None:
+    from aiohttp import web
+
+    app = web.Application()
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("composition must not open a listener")
+
+    monkeypatch.setattr(web, "run_app", forbidden)
+    mount_original_client_companion_mutations_from_app(app)


### PR DESCRIPTION
Closed in favor of explicit runtime composition from the latest protected main.

This branch walks a process-local object graph and guesses service ownership from method names. The existing `original_client_server.py` already constructs and retains the exact Memory Admin, PrivateWorld, ledger, and candidate objects. The replacement will pass those objects directly, with no graph traversal, reflection, ambiguous-service search, or second composition path.