### PR TITLE
feat(client): mount direct original settings mutations

### DIFF
--- a/original_client_companion_mutation_backend.py
+++ b/original_client_companion_mutation_backend.py
@@ -1,0 +1,223 @@
+"""Direct service adapter for mutations initiated inside original Olivia.
+
+The adapter calls the repository's existing auditable services by their explicit
+public methods.  It contains no method guessing, signature reflection, object
+graph traversal, storage implementation, reducer, or second command path.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from control_center.private_world_candidate_api import (
+    CandidateAPIError,
+    CandidateDecisionRequest,
+    CandidateDecisionResult,
+)
+from conversation_memory_admin import (
+    ConversationMemoryAdminError,
+    MemoryAdminMutationResult,
+    MemoryAdminMutationStatus,
+)
+from original_client_companion_mutation_api import (
+    CompanionMutationResult,
+    OriginalClientCompanionMutationError,
+)
+
+
+@runtime_checkable
+class MemoryAdminMutationService(Protocol):
+    def correct(
+        self,
+        memory_id: str,
+        corrected_text: str,
+        *,
+        request_id: str,
+        reason: str,
+    ) -> MemoryAdminMutationResult: ...
+
+    def delete(
+        self,
+        memory_id: str,
+        *,
+        request_id: str,
+        reason: str,
+    ) -> MemoryAdminMutationResult: ...
+
+
+@runtime_checkable
+class CandidateDecisionService(Protocol):
+    def decide(
+        self,
+        request: CandidateDecisionRequest,
+    ) -> CandidateDecisionResult: ...
+
+
+def _memory_error(exc: ConversationMemoryAdminError) -> OriginalClientCompanionMutationError:
+    code = exc.code
+    if code == "MEMORY_ADMIN_REQUEST_CONFLICT":
+        status = 409
+    elif "INVALID" in code or "REQUIRED" in code:
+        status = 400
+    else:
+        status = 503
+    return OriginalClientCompanionMutationError(code, status=status)
+
+
+def _candidate_error(exc: CandidateAPIError) -> OriginalClientCompanionMutationError:
+    status = int(getattr(exc, "http_status", 400))
+    if status not in {400, 403, 404, 409, 413, 415, 503}:
+        status = 503
+    return OriginalClientCompanionMutationError(exc.code, status=status)
+
+
+def _memory_result(result: MemoryAdminMutationResult) -> CompanionMutationResult:
+    if not isinstance(result, MemoryAdminMutationResult):
+        raise OriginalClientCompanionMutationError(
+            "MEMORY_MUTATION_RESULT_INVALID",
+            status=503,
+        )
+    statuses = {
+        MemoryAdminMutationStatus.APPLIED: "APPLIED",
+        MemoryAdminMutationStatus.DUPLICATE: "DUPLICATE",
+        MemoryAdminMutationStatus.NOOP: "NOOP",
+    }
+    return CompanionMutationResult(
+        request_id=result.request_id,
+        status=statuses[result.status],
+        affected_count=result.affected_count,
+    )
+
+
+def _candidate_result(
+    result: CandidateDecisionResult,
+    *,
+    request_id: str,
+) -> CompanionMutationResult:
+    if not isinstance(result, CandidateDecisionResult):
+        raise OriginalClientCompanionMutationError(
+            "CANDIDATE_MUTATION_RESULT_INVALID",
+            status=503,
+        )
+    statuses = {
+        "approved": ("APPLIED", 1),
+        "rejected": ("APPLIED", 1),
+        "duplicate": ("DUPLICATE", 0),
+        "expired": ("REJECTED", 0),
+    }
+    try:
+        status, affected_count = statuses[result.status]
+    except KeyError as exc:
+        raise OriginalClientCompanionMutationError(
+            "CANDIDATE_MUTATION_RESULT_INVALID",
+            status=503,
+        ) from exc
+    return CompanionMutationResult(
+        request_id=request_id,
+        status=status,
+        affected_count=affected_count,
+        reason_code=result.reason_code,
+    )
+
+
+class DirectOriginalClientCompanionMutationBackend:
+    """Map the original Settings transport to the canonical services."""
+
+    def __init__(
+        self,
+        *,
+        memory_admin: MemoryAdminMutationService | None = None,
+        candidate_decisions: CandidateDecisionService | None = None,
+    ) -> None:
+        if memory_admin is not None and not isinstance(
+            memory_admin,
+            MemoryAdminMutationService,
+        ):
+            raise TypeError("an explicit Memory Admin service is required")
+        if candidate_decisions is not None and not isinstance(
+            candidate_decisions,
+            CandidateDecisionService,
+        ):
+            raise TypeError("an explicit candidate decision service is required")
+        self.memory_admin = memory_admin
+        self.candidate_decisions = candidate_decisions
+
+    def correct_memory(
+        self,
+        *,
+        memory_id: str,
+        replacement_text: str,
+        request_id: str,
+        reason: str,
+    ) -> CompanionMutationResult:
+        if self.memory_admin is None:
+            raise OriginalClientCompanionMutationError(
+                "MEMORY_MUTATION_DISABLED",
+                status=503,
+            )
+        try:
+            result = self.memory_admin.correct(
+                memory_id,
+                replacement_text,
+                request_id=request_id,
+                reason=reason,
+            )
+        except ConversationMemoryAdminError as exc:
+            raise _memory_error(exc) from exc
+        return _memory_result(result)
+
+    def delete_memory(
+        self,
+        *,
+        memory_id: str,
+        request_id: str,
+        reason: str,
+    ) -> CompanionMutationResult:
+        if self.memory_admin is None:
+            raise OriginalClientCompanionMutationError(
+                "MEMORY_MUTATION_DISABLED",
+                status=503,
+            )
+        try:
+            result = self.memory_admin.delete(
+                memory_id,
+                request_id=request_id,
+                reason=reason,
+            )
+        except ConversationMemoryAdminError as exc:
+            raise _memory_error(exc) from exc
+        return _memory_result(result)
+
+    def decide_candidate(
+        self,
+        *,
+        candidate_id: str,
+        decision: str,
+        request_id: str,
+        reason: str,
+        decided_at: str,
+    ) -> CompanionMutationResult:
+        if self.candidate_decisions is None:
+            raise OriginalClientCompanionMutationError(
+                "CANDIDATE_MUTATION_DISABLED",
+                status=503,
+            )
+        try:
+            request = CandidateDecisionRequest(
+                candidate_id=candidate_id,
+                decision=decision,
+                request_id=request_id,
+                reason=reason,
+                decided_at=decided_at,
+            )
+            result = self.candidate_decisions.decide(request)
+        except CandidateAPIError as exc:
+            raise _candidate_error(exc) from exc
+        return _candidate_result(result, request_id=request_id)
+
+
+__all__ = [
+    "CandidateDecisionService",
+    "DirectOriginalClientCompanionMutationBackend",
+    "MemoryAdminMutationService",
+]

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -35,6 +35,7 @@ from original_client_companion_mutation_api import (
 )
 from original_client_companion_mutation_backend import (
     DirectOriginalClientCompanionMutationBackend,
+    MemoryAdminMutationService,
 )
 from private_world_candidates import (
     PrivateWorldCandidateError,
@@ -148,8 +149,13 @@ def create_original_client_server_runtime(
         private_world=private_read,
         candidates=candidates,
     )
+    mutation_memory = (
+        memory_admin
+        if isinstance(memory_admin, MemoryAdminMutationService)
+        else None
+    )
     mutation_backend = DirectOriginalClientCompanionMutationBackend(
-        memory_admin=memory_admin,
+        memory_admin=mutation_memory,
         candidate_decisions=candidate_decisions,
     )
     app = web.Application()

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -1,8 +1,9 @@
 """Run the original Olivia local backend with its in-client companion settings.
 
 The original client remains the only user-facing shell.  This module mounts the
-bounded Memory / PrivateWorld read API before the existing catch-all toy API
-handler, then launches both surfaces in one loopback-only aiohttp process.
+bounded Memory / PrivateWorld read and explicit-mutation APIs before the
+existing catch-all toy API handler, then launches every surface in one
+loopback-only aiohttp process.
 """
 
 from __future__ import annotations
@@ -16,6 +17,10 @@ from typing import Any
 
 from aiohttp import web
 
+from control_center.private_world_candidate_api import CandidateReviewBackend
+from control_center.private_world_candidate_backend import (
+    SQLiteCandidateReviewBackend,
+)
 from conversation_memory_admin import (
     ConversationMemoryAdminError,
     ConversationMemoryAdminService,
@@ -25,14 +30,21 @@ from original_client_companion_api import mount_original_companion_read_api
 from original_client_companion_backend import (
     OriginalClientCompanionServiceBackend,
 )
+from original_client_companion_mutation_api import (
+    mount_original_client_companion_mutation_api,
+)
+from original_client_companion_mutation_backend import (
+    DirectOriginalClientCompanionMutationBackend,
+)
 from private_world_candidates import (
     PrivateWorldCandidateError,
     SQLitePrivateWorldCandidateStore,
 )
-from private_world_ledger import LedgerWriteError
+from private_world_ledger import LedgerWriteError, SQLitePrivateWorldLedger
 from private_world_port import PrivateWorldPort, PrivateWorldSnapshot
 from private_world_projection import project_private_world
 from private_world_runtime import resolve_private_world_database
+from private_world_service import PrivateWorldCommandService
 
 
 FallbackHandler = Callable[[web.Request], Awaitable[web.StreamResponse]]
@@ -97,6 +109,8 @@ class OriginalClientServerRuntime:
     memory_admin: ConversationMemoryAdminService | None
     private_world_read: PrivateWorldControlReadAdapter | None
     candidate_store: SQLitePrivateWorldCandidateStore | None
+    candidate_decisions: CandidateReviewBackend | None
+    mutation_backend: DirectOriginalClientCompanionMutationBackend
 
     def public_status(self) -> dict[str, object]:
         """Return component presence only; never paths, content, or hidden scores."""
@@ -117,9 +131,10 @@ def create_original_client_server_runtime(
     memory_admin: ConversationMemoryAdminService | None = None,
     private_world: PrivateWorldPort | None = None,
     candidates: SQLitePrivateWorldCandidateStore | None = None,
+    candidate_decisions: CandidateReviewBackend | None = None,
     trusted_origins: Sequence[str] = (),
 ) -> OriginalClientServerRuntime:
-    """Mount companion reads before the existing catch-all toy API handler."""
+    """Mount companion reads and explicit mutations before the toy catch-all."""
 
     if not callable(fallback_handler):
         raise TypeError("a fallback request handler is required")
@@ -133,11 +148,21 @@ def create_original_client_server_runtime(
         private_world=private_read,
         candidates=candidates,
     )
+    mutation_backend = DirectOriginalClientCompanionMutationBackend(
+        memory_admin=memory_admin,
+        candidate_decisions=candidate_decisions,
+    )
     app = web.Application()
+    origins = tuple(trusted_origins)
     mount_original_companion_read_api(
         app,
         backend,
-        trusted_origins=tuple(trusted_origins),
+        trusted_origins=origins,
+    )
+    mount_original_client_companion_mutation_api(
+        app,
+        mutation_backend,
+        trusted_origins=origins,
     )
     # Keep this last.  The original server intentionally owns a catch-all route.
     app.router.add_route("*", "/{tail:.*}", fallback_handler)
@@ -147,6 +172,8 @@ def create_original_client_server_runtime(
         memory_admin,
         private_read,
         candidates,
+        candidate_decisions,
+        mutation_backend,
     )
     app[_RUNTIME_KEY] = runtime
     return runtime
@@ -195,16 +222,21 @@ def _configured_memory_admin(
 def _configured_private_world(
     server_module: ModuleType | Any,
     environ: Mapping[str, str],
-) -> tuple[PrivateWorldPort | None, SQLitePrivateWorldCandidateStore | None]:
-    if getattr(server_module, "private_world_committer", None) is None:
-        return None, None
+) -> tuple[
+    PrivateWorldPort | None,
+    SQLitePrivateWorldCandidateStore | None,
+    CandidateReviewBackend | None,
+]:
+    committer = getattr(server_module, "private_world_committer", None)
+    if committer is None:
+        return None, None, None
     port = getattr(server_module, "private_world_port", None)
     if not isinstance(port, PrivateWorldPort):
-        return None, None
+        return None, None, None
 
     path, _reason, enabled = resolve_private_world_database(environ)
     if not enabled or path is None or not path.is_file():
-        return port, None
+        return port, None, None
     try:
         candidates = SQLitePrivateWorldCandidateStore(path)
     except (
@@ -215,8 +247,26 @@ def _configured_private_world(
         TypeError,
         ValueError,
     ):
-        candidates = None
-    return port, candidates
+        return port, None, None
+
+    candidate_decisions: CandidateReviewBackend | None = None
+    ledger = getattr(committer, "ledger", None)
+    if isinstance(ledger, SQLitePrivateWorldLedger):
+        try:
+            candidate_decisions = SQLiteCandidateReviewBackend(
+                candidates,
+                PrivateWorldCommandService(ledger),
+            )
+        except (
+            PrivateWorldCandidateError,
+            LedgerWriteError,
+            OSError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+        ):
+            candidate_decisions = None
+    return port, candidates, candidate_decisions
 
 
 def create_configured_original_client_server_runtime(
@@ -235,7 +285,7 @@ def create_configured_original_client_server_runtime(
         getattr(server_module, "TRUSTED_FRONTEND_ORIGINS", ())
     )
     memory_admin = _configured_memory_admin(server_module, values)
-    private_world, candidates = _configured_private_world(
+    private_world, candidates, candidate_decisions = _configured_private_world(
         server_module,
         values,
     )
@@ -244,12 +294,13 @@ def create_configured_original_client_server_runtime(
         memory_admin=memory_admin,
         private_world=private_world,
         candidates=candidates,
+        candidate_decisions=candidate_decisions,
         trusted_origins=origins,
     )
 
 
 def main() -> int:
-    """Launch one loopback process for the original client and companion reads."""
+    """Launch one loopback process for the original client and companion APIs."""
 
     import local_server
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ py-modules = [
     "memory",
     "original_client_companion_api",
     "original_client_companion_backend",
+    "original_client_companion_mutation_api",
+    "original_client_companion_mutation_backend",
     "original_client_letter_contract",
     "original_client_media_http",
     "original_client_server",

--- a/tests/http/test_original_client_companion_mutation_backend.py
+++ b/tests/http/test_original_client_companion_mutation_backend.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from control_center.private_world_candidate_api import (
+    CandidateAPIError,
+    CandidateDecisionRequest,
+    CandidateDecisionResult,
+)
+from conversation_memory_admin import (
+    ConversationMemoryAdminError,
+    MemoryAdminMutationResult,
+    MemoryAdminMutationStatus,
+)
+from original_client_companion_mutation_api import (
+    OriginalClientCompanionMutationError,
+)
+from original_client_companion_mutation_backend import (
+    DirectOriginalClientCompanionMutationBackend,
+)
+
+
+class MemoryAdminFixture:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+
+    def correct(
+        self,
+        memory_id: str,
+        corrected_text: str,
+        *,
+        request_id: str,
+        reason: str,
+    ) -> MemoryAdminMutationResult:
+        self.calls.append(
+            (
+                "correct",
+                (memory_id, corrected_text),
+                {"request_id": request_id, "reason": reason},
+            )
+        )
+        return MemoryAdminMutationResult(
+            MemoryAdminMutationStatus.APPLIED,
+            request_id,
+            "correct",
+            affected_count=2,
+            target_memory_id=memory_id,
+            replacement_memory_id="memory.corrected.1",
+        )
+
+    def delete(
+        self,
+        memory_id: str,
+        *,
+        request_id: str,
+        reason: str,
+    ) -> MemoryAdminMutationResult:
+        self.calls.append(
+            (
+                "delete",
+                (memory_id,),
+                {"request_id": request_id, "reason": reason},
+            )
+        )
+        return MemoryAdminMutationResult(
+            MemoryAdminMutationStatus.NOOP,
+            request_id,
+            "delete",
+            target_memory_id=memory_id,
+        )
+
+
+class CandidateDecisionFixture:
+    def __init__(self, status: str = "approved") -> None:
+        self.status = status
+        self.requests: list[CandidateDecisionRequest] = []
+
+    def decide(
+        self,
+        request: CandidateDecisionRequest,
+    ) -> CandidateDecisionResult:
+        self.requests.append(request)
+        return CandidateDecisionResult(
+            candidate_id=request.candidate_id,
+            decision=request.decision,
+            status=self.status,
+            reason_code=(
+                "PRIVATE_WORLD_CANDIDATE_DECISION_DUPLICATE"
+                if self.status == "duplicate"
+                else "PRIVATE_WORLD_CANDIDATE_APPROVED"
+                if request.decision == "approve"
+                else "PRIVATE_WORLD_CANDIDATE_REJECTED"
+            ),
+        )
+
+
+def test_memory_operations_call_exact_existing_service_methods() -> None:
+    memory = MemoryAdminFixture()
+    backend = DirectOriginalClientCompanionMutationBackend(memory_admin=memory)
+
+    corrected = backend.correct_memory(
+        memory_id="memory.fixture.1",
+        replacement_text="用户现在住在东京北区。",
+        request_id="request.memory.correct.1",
+        reason="用户明确纠正。",
+    )
+    deleted = backend.delete_memory(
+        memory_id="memory.fixture.2",
+        request_id="request.memory.delete.1",
+        reason="用户明确删除。",
+    )
+
+    assert corrected.status == "APPLIED"
+    assert corrected.affected_count == 2
+    assert deleted.status == "NOOP"
+    assert deleted.affected_count == 0
+    assert memory.calls == [
+        (
+            "correct",
+            ("memory.fixture.1", "用户现在住在东京北区。"),
+            {
+                "request_id": "request.memory.correct.1",
+                "reason": "用户明确纠正。",
+            },
+        ),
+        (
+            "delete",
+            ("memory.fixture.2",),
+            {
+                "request_id": "request.memory.delete.1",
+                "reason": "用户明确删除。",
+            },
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("decision", "service_status", "public_status", "affected"),
+    [
+        ("approve", "approved", "APPLIED", 1),
+        ("reject", "rejected", "APPLIED", 1),
+        ("approve", "duplicate", "DUPLICATE", 0),
+    ],
+)
+def test_candidate_decision_constructs_exact_existing_request(
+    decision: str,
+    service_status: str,
+    public_status: str,
+    affected: int,
+) -> None:
+    candidates = CandidateDecisionFixture(service_status)
+    backend = DirectOriginalClientCompanionMutationBackend(
+        candidate_decisions=candidates
+    )
+
+    result = backend.decide_candidate(
+        candidate_id="candidate.fixture.1",
+        decision=decision,
+        request_id="request.candidate.decision.1",
+        reason="用户明确确认。",
+        decided_at="2026-08-23T12:00:00+00:00",
+    )
+
+    assert result.status == public_status
+    assert result.affected_count == affected
+    assert len(candidates.requests) == 1
+    request = candidates.requests[0]
+    assert request == CandidateDecisionRequest(
+        candidate_id="candidate.fixture.1",
+        decision=decision,
+        request_id="request.candidate.decision.1",
+        reason="用户明确确认。",
+        decided_at="2026-08-23T12:00:00+00:00",
+    )
+
+
+def test_missing_services_are_independently_unavailable() -> None:
+    backend = DirectOriginalClientCompanionMutationBackend()
+
+    with pytest.raises(OriginalClientCompanionMutationError) as memory_error:
+        backend.delete_memory(
+            memory_id="memory.fixture.1",
+            request_id="request.memory.delete.1",
+            reason="用户明确删除。",
+        )
+    assert memory_error.value.code == "MEMORY_MUTATION_DISABLED"
+    assert memory_error.value.status == 503
+
+    with pytest.raises(OriginalClientCompanionMutationError) as candidate_error:
+        backend.decide_candidate(
+            candidate_id="candidate.fixture.1",
+            decision="approve",
+            request_id="request.candidate.decision.1",
+            reason="用户明确确认。",
+            decided_at="2026-08-23T12:00:00+00:00",
+        )
+    assert candidate_error.value.code == "CANDIDATE_MUTATION_DISABLED"
+    assert candidate_error.value.status == 503
+
+
+def test_domain_errors_remain_stable_and_path_free() -> None:
+    class FailingMemory(MemoryAdminFixture):
+        def delete(self, *args, **kwargs):
+            raise ConversationMemoryAdminError("MEMORY_ADMIN_REQUEST_CONFLICT")
+
+    class FailingCandidate(CandidateDecisionFixture):
+        def decide(self, request: CandidateDecisionRequest):
+            raise CandidateAPIError(
+                "PRIVATE_WORLD_CANDIDATE_NOT_FOUND",
+                http_status=404,
+            )
+
+    backend = DirectOriginalClientCompanionMutationBackend(
+        memory_admin=FailingMemory(),
+        candidate_decisions=FailingCandidate(),
+    )
+    with pytest.raises(OriginalClientCompanionMutationError) as memory_error:
+        backend.delete_memory(
+            memory_id="memory.fixture.1",
+            request_id="request.memory.delete.1",
+            reason="用户明确删除。",
+        )
+    assert memory_error.value.code == "MEMORY_ADMIN_REQUEST_CONFLICT"
+    assert memory_error.value.status == 409
+
+    with pytest.raises(OriginalClientCompanionMutationError) as candidate_error:
+        backend.decide_candidate(
+            candidate_id="candidate.fixture.1",
+            decision="approve",
+            request_id="request.candidate.decision.1",
+            reason="用户明确确认。",
+            decided_at="2026-08-23T12:00:00+00:00",
+        )
+    assert candidate_error.value.code == "PRIVATE_WORLD_CANDIDATE_NOT_FOUND"
+    assert candidate_error.value.status == 404
+    assert "path" not in str(candidate_error.value).casefold()
+
+
+def test_backend_has_no_dynamic_discovery_surface() -> None:
+    import inspect
+    import original_client_companion_mutation_backend as module
+
+    source = inspect.getsource(module)
+    for forbidden in (
+        "inspect.signature",
+        "importlib.import_module",
+        "__dict__",
+        "dir(",
+        "get_type_hints",
+        "deque(",
+    ):
+        assert forbidden not in source

--- a/tests/http/test_original_client_server_mutations.py
+++ b/tests/http/test_original_client_server_mutations.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from control_center.private_world_candidate_api import (
+    CandidateDecisionRequest,
+    CandidateDecisionResult,
+)
+from control_center.private_world_candidate_backend import (
+    SQLiteCandidateReviewBackend,
+)
+from conversation_memory_admin import (
+    MemoryAdminMutationResult,
+    MemoryAdminMutationStatus,
+    MemoryAdminStatus,
+)
+from conversation_memory_port import NullConversationMemoryPort
+from original_client_companion_mutation_api import (
+    CONFIRM_HEADER,
+    CONFIRM_VALUE,
+)
+from original_client_server import (
+    create_configured_original_client_server_runtime,
+    create_original_client_server_runtime,
+)
+from private_world_delivery import PrivateWorldDeliveryCommitter
+from private_world_ledger import SQLitePrivateWorldLedger
+
+
+TRUSTED_ORIGIN = "https://client.example"
+
+
+async def _fallback(request: web.Request) -> web.Response:
+    return web.json_response({"fallback": request.path})
+
+
+class MemoryAdminFixture:
+    def __init__(self) -> None:
+        self.corrected: list[tuple[str, str, str, str]] = []
+        self.deleted: list[tuple[str, str, str]] = []
+
+    def status(self) -> MemoryAdminStatus:
+        return MemoryAdminStatus("available", "fixture", True, 0, 0, 0)
+
+    def list_memories(self, *, query=None, limit=100):
+        return ()
+
+    def correct(
+        self,
+        memory_id: str,
+        corrected_text: str,
+        *,
+        request_id: str,
+        reason: str,
+    ) -> MemoryAdminMutationResult:
+        self.corrected.append((memory_id, corrected_text, request_id, reason))
+        return MemoryAdminMutationResult(
+            MemoryAdminMutationStatus.APPLIED,
+            request_id,
+            "correct",
+            affected_count=2,
+            target_memory_id=memory_id,
+            replacement_memory_id="memory.corrected.1",
+        )
+
+    def delete(
+        self,
+        memory_id: str,
+        *,
+        request_id: str,
+        reason: str,
+    ) -> MemoryAdminMutationResult:
+        self.deleted.append((memory_id, request_id, reason))
+        return MemoryAdminMutationResult(
+            MemoryAdminMutationStatus.APPLIED,
+            request_id,
+            "delete",
+            affected_count=1,
+            target_memory_id=memory_id,
+        )
+
+
+class CandidateDecisionFixture:
+    def __init__(self) -> None:
+        self.requests: list[CandidateDecisionRequest] = []
+
+    def decide(
+        self,
+        request: CandidateDecisionRequest,
+    ) -> CandidateDecisionResult:
+        self.requests.append(request)
+        return CandidateDecisionResult(
+            candidate_id=request.candidate_id,
+            decision=request.decision,
+            status="approved" if request.decision == "approve" else "rejected",
+            reason_code=(
+                "PRIVATE_WORLD_CANDIDATE_APPROVED"
+                if request.decision == "approve"
+                else "PRIVATE_WORLD_CANDIDATE_REJECTED"
+            ),
+        )
+
+
+def test_original_runtime_mounts_direct_memory_and_candidate_mutations() -> None:
+    async def scenario() -> None:
+        memory = MemoryAdminFixture()
+        candidates = CandidateDecisionFixture()
+        runtime = create_original_client_server_runtime(
+            _fallback,
+            memory_admin=memory,
+            candidate_decisions=candidates,
+            trusted_origins=(TRUSTED_ORIGIN,),
+        )
+        async with TestClient(TestServer(runtime.app)) as client:
+            missing_confirmation = await client.post(
+                "/toy/companion/memory/delete",
+                json={
+                    "memory_id": "memory.fixture.1",
+                    "request_id": "request.memory.delete.1",
+                    "reason": "用户明确删除。",
+                },
+                headers={"Origin": TRUSTED_ORIGIN},
+            )
+            assert missing_confirmation.status == 403
+            assert (await missing_confirmation.json())["error_code"] == (
+                "COMPANION_CONFIRMATION_REQUIRED"
+            )
+
+            corrected = await client.post(
+                "/toy/companion/memory/correct",
+                json={
+                    "memory_id": "memory.fixture.1",
+                    "replacement_text": "用户现在住在东京北区。",
+                    "request_id": "request.memory.correct.1",
+                    "reason": "用户明确纠正。",
+                },
+                headers={
+                    "Origin": TRUSTED_ORIGIN,
+                    CONFIRM_HEADER: CONFIRM_VALUE,
+                },
+            )
+            assert corrected.status == 200
+            assert (await corrected.json())["status"] == "APPLIED"
+
+            deleted = await client.post(
+                "/toy/companion/memory/delete",
+                json={
+                    "memory_id": "memory.fixture.2",
+                    "request_id": "request.memory.delete.1",
+                    "reason": "用户明确删除。",
+                },
+                headers={
+                    "Origin": TRUSTED_ORIGIN,
+                    CONFIRM_HEADER: CONFIRM_VALUE,
+                },
+            )
+            assert deleted.status == 200
+            assert (await deleted.json())["affected_count"] == 1
+
+            approved = await client.post(
+                "/toy/companion/private-world/candidates/candidate.fixture.1/approve",
+                json={
+                    "request_id": "request.candidate.approve.1",
+                    "reason": "用户明确确认。",
+                    "decided_at": "2026-08-23T12:00:00+00:00",
+                },
+                headers={
+                    "Origin": TRUSTED_ORIGIN,
+                    CONFIRM_HEADER: CONFIRM_VALUE,
+                },
+            )
+            assert approved.status == 200
+            assert (await approved.json())["status"] == "APPLIED"
+
+            fallback = await client.get("/health")
+            assert fallback.status == 200
+            assert await fallback.json() == {"fallback": "/health"}
+
+        assert memory.corrected == [
+            (
+                "memory.fixture.1",
+                "用户现在住在东京北区。",
+                "request.memory.correct.1",
+                "用户明确纠正。",
+            )
+        ]
+        assert memory.deleted == [
+            (
+                "memory.fixture.2",
+                "request.memory.delete.1",
+                "用户明确删除。",
+            )
+        ]
+        assert candidates.requests == [
+            CandidateDecisionRequest(
+                candidate_id="candidate.fixture.1",
+                decision="approve",
+                request_id="request.candidate.approve.1",
+                reason="用户明确确认。",
+                decided_at="2026-08-23T12:00:00+00:00",
+            )
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_configured_runtime_reuses_existing_private_world_ledger_for_decisions(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        root = tmp_path / "data"
+        root.mkdir()
+        database = root / "private_world" / "private_world.sqlite3"
+        ledger = SQLitePrivateWorldLedger(database)
+        server = SimpleNamespace(
+            handler=_fallback,
+            letters_adapter=SimpleNamespace(
+                memory_prompt_builder=SimpleNamespace(
+                    conversation_memory=NullConversationMemoryPort(),
+                    conversation_memory_user_id="local-user",
+                )
+            ),
+            private_world_port=ledger,
+            private_world_committer=PrivateWorldDeliveryCommitter(ledger),
+            TRUSTED_FRONTEND_ORIGINS=frozenset({TRUSTED_ORIGIN}),
+        )
+        runtime = create_configured_original_client_server_runtime(
+            server_module=server,
+            environ={
+                "OLIVIA_LOCAL_DATA_ROOT": str(root),
+                "OLIVIA_PRIVATE_WORLD_ENABLED": "1",
+                "OLIVIA_PRIVATE_WORLD_DB": str(database),
+            },
+        )
+        assert isinstance(
+            runtime.candidate_decisions,
+            SQLiteCandidateReviewBackend,
+        )
+        assert runtime.candidate_decisions.command_service._ledger is ledger
+
+        async with TestClient(TestServer(runtime.app)) as client:
+            missing = await client.post(
+                "/toy/companion/private-world/candidates/candidate.missing.1/approve",
+                json={
+                    "request_id": "request.candidate.missing.1",
+                    "reason": "用户明确确认。",
+                    "decided_at": "2026-08-23T12:00:00+00:00",
+                },
+                headers={
+                    "Origin": TRUSTED_ORIGIN,
+                    CONFIRM_HEADER: CONFIRM_VALUE,
+                },
+            )
+            assert missing.status == 404
+            assert (await missing.json())["error_code"] == (
+                "PRIVATE_WORLD_CANDIDATE_NOT_FOUND"
+            )
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Implements the first production mutation slice after #90 from the latest protected `main`.

## Scope

- adds a direct adapter from the original Settings mutation transport to the repository's existing explicit services:
  - `ConversationMemoryAdminService.correct()`;
  - `ConversationMemoryAdminService.delete()`;
  - `SQLiteCandidateReviewBackend.decide()`;
- preserves the existing Memory audit, correction ordering, candidate idempotency, typed PrivateWorld command service, reducer, and ledger behavior;
- mounts the mutation API on the same `original_client_server.py` aiohttp application before the existing toy catch-all;
- reuses the exact PrivateWorld ledger already owned by `PrivateWorldDeliveryCommitter` when constructing candidate decisions;
- keeps read-only fixtures and missing services honestly mutation-disabled;
- adds no method-name guessing, signature introspection, object-graph traversal, second application, second listener, browser page, or standalone Control Center entry;
- packages the #90 transport module and the direct adapter for the installed runtime.

## Validation

- exact Memory Admin method calls and result mapping;
- exact typed candidate decision request construction;
- explicit-confirmation transport through the combined original-client runtime;
- independent disabled/error behavior;
- same-ledger candidate command assembly;
- toy API catch-all remains reachable;
- source regression excludes reflective discovery machinery.

## Supersedes

- #91: reflective method/signature adapter;
- #92: process object-graph service discovery.

Both were closed rather than merged because the actual service contracts are already explicit.

## Boundary

This PR does not add buttons to the original Settings dialog and does not add direct nickname/home/continuation commands. The next PR will expose only memory correction/deletion and candidate approve/reject in the existing original-client dialog, then refresh its read-only data.

Part of #33, #34, #35, and #38.