### PR TITLE
fix(client): publish original Collection wire contract at runtime

### DIFF
--- a/original_client_server.py
+++ b/original_client_server.py
@@ -1,15 +1,16 @@
 """Run the original Olivia local backend with its in-client companion settings.
 
 The original client remains the only user-facing shell.  This module mounts the
-bounded Memory / PrivateWorld read and explicit-mutation APIs before the
-existing catch-all toy API handler, then launches every surface in one
-loopback-only aiohttp process.
+bounded Memory / PrivateWorld read and explicit-mutation APIs plus the original
+Collection wire adapter before the existing catch-all toy API handler, then
+launches every surface in one loopback-only aiohttp process.
 """
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
+import json
 import os
 from pathlib import Path
 from types import ModuleType
@@ -37,6 +38,13 @@ from original_client_companion_mutation_backend import (
     DirectOriginalClientCompanionMutationBackend,
     MemoryAdminMutationService,
 )
+from original_client_letter_contract import (
+    OriginalClientContractError,
+    serialize_letter_detail,
+    serialize_letter_list,
+    serialize_letter_summary,
+    serialize_unread_count,
+)
 from private_world_candidates import (
     PrivateWorldCandidateError,
     SQLitePrivateWorldCandidateStore,
@@ -49,7 +57,9 @@ from private_world_service import PrivateWorldCommandService
 
 
 FallbackHandler = Callable[[web.Request], Awaitable[web.StreamResponse]]
+LetterCollection = Callable[[str], Sequence[Mapping[str, object]]]
 _RUNTIME_KEY = web.AppKey("original_client.server_runtime", object)
+_MAILBOX_MOUNTED_KEY = web.AppKey("original_client.mailbox_wire_mounted", bool)
 _MEMORY_ADMIN_FILENAME = "memory_admin_audit.sqlite3"
 
 
@@ -103,6 +113,173 @@ class PrivateWorldControlReadAdapter:
         }
 
 
+def _response_payload(response: web.StreamResponse) -> dict[str, object] | None:
+    if not isinstance(response, web.Response):
+        return None
+    body = response.body
+    if isinstance(body, str):
+        raw = body.encode("utf-8")
+    elif isinstance(body, (bytes, bytearray, memoryview)):
+        raw = bytes(body)
+    else:
+        return None
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _replace_response_payload(
+    response: web.Response,
+    payload: Mapping[str, object],
+    *,
+    status: int | None = None,
+) -> web.Response:
+    encoded = json.dumps(
+        dict(payload),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    response.headers.pop("Content-Length", None)
+    response.body = encoded
+    response.headers["Content-Type"] = "application/json; charset=utf-8"
+    if status is not None:
+        response.set_status(status)
+    return response
+
+
+def _mailbox_failure(response: web.Response) -> web.Response:
+    return _replace_response_payload(
+        response,
+        {
+            "code": 503,
+            "message": "ORIGINAL_CLIENT_MAILBOX_UNAVAILABLE",
+            "data": {
+                "status": "UNAVAILABLE",
+                "error_code": "ORIGINAL_CLIENT_MAILBOX_UNAVAILABLE",
+            },
+        },
+        status=503,
+    )
+
+
+def _find_letter(
+    values: Sequence[Mapping[str, object]],
+    letter_id: object,
+) -> Mapping[str, object] | None:
+    if not isinstance(letter_id, str) or not letter_id:
+        return None
+    for value in values:
+        if value.get("letter_id", value.get("letterId")) == letter_id:
+            return value
+    return None
+
+
+def _non_negative_int(value: object, *, default: int) -> int:
+    return value if type(value) is int and value >= 0 else default
+
+
+def _adapt_mailbox_payload(
+    request: web.Request,
+    payload: dict[str, object],
+    letter_collection: LetterCollection,
+) -> dict[str, object]:
+    path = request.path.rstrip("/")
+    data = payload.get("data")
+    if not isinstance(data, Mapping):
+        return payload
+    scope = request.query.get("scope", "current")
+
+    if path == "/toy/letter/list" and payload.get("code") == 0:
+        letters = tuple(letter_collection(scope))
+        remaining = _non_negative_int(
+            data.get("remaining_today", data.get("remainingToday")),
+            default=99 if scope == "current" else 0,
+        )
+        payload["data"] = serialize_letter_list(
+            letters,
+            remaining_today=remaining,
+            scope=scope,
+            include_legacy_aliases=True,
+        )
+        return payload
+
+    if path == "/toy/letter/unread_count" and payload.get("code") == 0:
+        letters = tuple(letter_collection(scope))
+        unread = sum(1 for letter in letters if not letter.get("is_read", 1))
+        payload["data"] = serialize_unread_count(
+            unread,
+            scope=scope,
+            include_legacy_aliases=True,
+        )
+        return payload
+
+    if path == "/toy/letter/detail" and payload.get("code") == 0:
+        letter_id = data.get("letter_id", data.get("letterId"))
+        letter = _find_letter(tuple(letter_collection(scope)), letter_id)
+        if letter is None:
+            return payload
+        payload["data"] = serialize_letter_detail(
+            letter,
+            scope=scope,
+            include_legacy_aliases=True,
+        )
+        return payload
+
+    if path == "/toy/letter/send":
+        letter_id = data.get("letter_id", data.get("letterId"))
+        letter = _find_letter(tuple(letter_collection("current")), letter_id)
+        if letter is None:
+            return payload
+        original = serialize_letter_summary(
+            letter,
+            include_legacy_aliases=True,
+        )
+        merged = dict(data)
+        merged.update(original)
+        payload["data"] = merged
+    return payload
+
+
+def mount_original_mailbox_wire_adapter(
+    app: web.Application,
+    fallback_handler: FallbackHandler,
+    letter_collection: LetterCollection,
+) -> None:
+    """Expose the existing letter runtime through the audited Collection schema."""
+
+    if not isinstance(app, web.Application):
+        raise TypeError("an aiohttp application is required")
+    if not callable(fallback_handler) or not callable(letter_collection):
+        raise TypeError("mailbox fallback and letter collection are required")
+    if app.get(_MAILBOX_MOUNTED_KEY, False):
+        raise RuntimeError("ORIGINAL_CLIENT_MAILBOX_ALREADY_MOUNTED")
+
+    async def adapted(request: web.Request) -> web.StreamResponse:
+        response = await fallback_handler(request)
+        if not isinstance(response, web.Response):
+            return response
+        payload = _response_payload(response)
+        if payload is None:
+            return response
+        try:
+            adapted_payload = _adapt_mailbox_payload(
+                request,
+                payload,
+                letter_collection,
+            )
+        except (OriginalClientContractError, OSError, RuntimeError, TypeError, ValueError):
+            return _mailbox_failure(response)
+        return _replace_response_payload(response, adapted_payload)
+
+    app[_MAILBOX_MOUNTED_KEY] = True
+    app.router.add_get("/toy/letter/list", adapted)
+    app.router.add_get("/toy/letter/unread_count", adapted)
+    app.router.add_get("/toy/letter/detail", adapted)
+    app.router.add_post("/toy/letter/send", adapted)
+
+
 @dataclass(frozen=True)
 class OriginalClientServerRuntime:
     app: web.Application
@@ -133,9 +310,10 @@ def create_original_client_server_runtime(
     private_world: PrivateWorldPort | None = None,
     candidates: SQLitePrivateWorldCandidateStore | None = None,
     candidate_decisions: CandidateReviewBackend | None = None,
+    letter_collection: LetterCollection | None = None,
     trusted_origins: Sequence[str] = (),
 ) -> OriginalClientServerRuntime:
-    """Mount companion reads and explicit mutations before the toy catch-all."""
+    """Mount original-client adapters before the toy catch-all."""
 
     if not callable(fallback_handler):
         raise TypeError("a fallback request handler is required")
@@ -170,6 +348,12 @@ def create_original_client_server_runtime(
         mutation_backend,
         trusted_origins=origins,
     )
+    if letter_collection is not None:
+        mount_original_mailbox_wire_adapter(
+            app,
+            fallback_handler,
+            letter_collection,
+        )
     # Keep this last.  The original server intentionally owns a catch-all route.
     app.router.add_route("*", "/{tail:.*}", fallback_handler)
     runtime = OriginalClientServerRuntime(
@@ -295,12 +479,14 @@ def create_configured_original_client_server_runtime(
         server_module,
         values,
     )
+    collection = getattr(server_module, "_letter_collection", None)
     return create_original_client_server_runtime(
         fallback,
         memory_admin=memory_admin,
         private_world=private_world,
         candidates=candidates,
         candidate_decisions=candidate_decisions,
+        letter_collection=collection if callable(collection) else None,
         trusted_origins=origins,
     )
 
@@ -340,4 +526,5 @@ __all__ = [
     "create_configured_original_client_server_runtime",
     "create_original_client_server_runtime",
     "main",
+    "mount_original_mailbox_wire_adapter",
 ]

--- a/tests/http/test_original_client_mailbox_runtime.py
+++ b/tests/http/test_original_client_mailbox_runtime.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import asyncio
+import time
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from original_client_server import create_original_client_server_runtime
+
+
+async def _run(coroutine):
+    return await coroutine
+
+
+def _letters() -> list[dict[str, object]]:
+    return [
+        {
+            "letter_id": "letter.pending",
+            "content": "等待中的来信",
+            "letter_status": "COMPLETED",
+            "audit_status": 2,
+            "reply_text": "尚未公开的正文",
+            "reply_mode": "text_letter",
+            "reply_not_before": time.time() + 3600,
+            "media_status": "NOT_REQUESTED",
+            "is_read": 0,
+            "created_at": 1_700_000_001,
+        },
+        {
+            "letter_id": "letter.spoken",
+            "content": "说话视频来信",
+            "letter_status": "COMPLETED",
+            "audit_status": 2,
+            "reply_text": "已经完成的说话视频正文",
+            "reply_mode": "spoken_video",
+            "reply_not_before": 0.0,
+            "media_status": "COMPLETED",
+            "reply_video_url": (
+                "http://127.0.0.1:8899/toy/media/letter.spoken.mp4"
+            ),
+            "is_read": 0,
+            "created_at": 1_700_000_002,
+            "replied_at": 1_700_000_102,
+        },
+        {
+            "letter_id": "letter.musical",
+            "content": "音乐视频来信",
+            "letter_status": "COMPLETED",
+            "audit_status": 2,
+            "reply_text": "歌曲仍在生成，但正文已经完成。",
+            "reply_mode": "musical_video",
+            "reply_not_before": 0.0,
+            "media_status": "PENDING",
+            "reply_video_url": "",
+            "is_read": 1,
+            "created_at": 1_700_000_003,
+        },
+        {
+            "letter_id": "letter.failed",
+            "content": "失败来信",
+            "letter_status": "FAILED",
+            "audit_status": 2,
+            "reply_text": "",
+            "reply_mode": "text_letter",
+            "reply_not_before": 0.0,
+            "media_status": "NOT_REQUESTED",
+            "is_read": 1,
+            "created_at": 1_700_000_004,
+        },
+    ]
+
+
+def _fallback_factory(letters: list[dict[str, object]]):
+    async def fallback(request: web.Request) -> web.Response:
+        common_headers = {
+            "Cache-Control": "no-store",
+            "X-Original-Fallback": "preserved",
+        }
+        if request.path == "/toy/letter/list":
+            if request.query.get("scope") == "invalid":
+                return web.json_response(
+                    {
+                        "code": 400,
+                        "message": "INVALID_SCOPE",
+                        "data": {
+                            "status": "FAILED",
+                            "error_code": "INVALID_SCOPE",
+                        },
+                    },
+                    status=400,
+                    headers=common_headers,
+                )
+            return web.json_response(
+                {
+                    "code": 0,
+                    "message": "ok",
+                    "data": {
+                        "list": [{"letter_id": value["letter_id"]} for value in letters],
+                        "total": len(letters),
+                        "has_more": False,
+                        "next_cursor": 0,
+                        "remaining_today": 17,
+                        "scope": "current",
+                    },
+                },
+                headers=common_headers,
+            )
+        if request.path == "/toy/letter/unread_count":
+            return web.json_response(
+                {
+                    "code": 0,
+                    "message": "ok",
+                    "data": {"unread_count": 99, "scope": "current"},
+                },
+                headers=common_headers,
+            )
+        if request.path == "/toy/letter/detail":
+            letter_id = request.query.get("letter_id") or request.query.get("letterId")
+            value = next(
+                (item for item in letters if item["letter_id"] == letter_id),
+                None,
+            )
+            if value is None:
+                return web.json_response(
+                    {
+                        "code": 404,
+                        "message": "LETTER_NOT_FOUND",
+                        "data": {
+                            "status": "FAILED",
+                            "error_code": "LETTER_NOT_FOUND",
+                        },
+                    },
+                    status=404,
+                    headers=common_headers,
+                )
+            value["is_read"] = 1
+            return web.json_response(
+                {
+                    "code": 0,
+                    "message": "ok",
+                    "data": {
+                        "letter_id": letter_id,
+                        "reply_text": value.get("reply_text", ""),
+                    },
+                },
+                headers=common_headers,
+            )
+        if request.path == "/toy/letter/send":
+            return web.json_response(
+                {
+                    "code": 0,
+                    "message": "ok",
+                    "data": {
+                        "letter_id": "letter.spoken",
+                        "status": "COMPLETED",
+                    },
+                },
+                headers=common_headers,
+            )
+        return web.json_response({"fallback": request.path})
+
+    return fallback
+
+
+def test_original_collection_list_and_unread_use_camel_case_numeric_contract() -> None:
+    async def scenario() -> None:
+        letters = _letters()
+        runtime = create_original_client_server_runtime(
+            _fallback_factory(letters),
+            letter_collection=lambda scope: letters if scope == "current" else (),
+        )
+        async with TestClient(TestServer(runtime.app)) as client:
+            response = await client.get("/toy/letter/list")
+            assert response.status == 200
+            assert response.headers["X-Original-Fallback"] == "preserved"
+            data = (await response.json())["data"]
+            assert data["hasMore"] is False
+            assert data["nextCursor"] == 0
+            assert data["remainingToday"] == 17
+            assert data["has_more"] is False
+            assert data["remaining_today"] == 17
+            rows = {value["letterId"]: value for value in data["list"]}
+            assert rows["letter.pending"]["letterStatus"] == 1
+            assert rows["letter.pending"]["replyType"] == 0
+            assert rows["letter.spoken"]["letterStatus"] == 4
+            assert rows["letter.spoken"]["replyType"] == 2
+            assert rows["letter.musical"]["letterStatus"] == 4
+            assert rows["letter.musical"]["replyType"] == 1
+            assert rows["letter.failed"]["letterStatus"] == 5
+            assert rows["letter.failed"]["replyType"] == 0
+
+            unread = await client.get("/toy/letter/unread_count")
+            assert unread.status == 200
+            unread_data = (await unread.json())["data"]
+            assert unread_data["unreadCount"] == 2
+            assert unread_data["unread_count"] == 2
+
+    asyncio.run(scenario())
+
+
+def test_original_collection_detail_keeps_text_and_only_exposes_completed_local_video() -> None:
+    async def scenario() -> None:
+        letters = _letters()
+        runtime = create_original_client_server_runtime(
+            _fallback_factory(letters),
+            letter_collection=lambda _scope: letters,
+        )
+        async with TestClient(TestServer(runtime.app)) as client:
+            spoken = await client.get(
+                "/toy/letter/detail?letterId=letter.spoken"
+            )
+            spoken_data = (await spoken.json())["data"]
+            assert spoken_data["letterId"] == "letter.spoken"
+            assert spoken_data["letterStatus"] == 4
+            assert spoken_data["replyType"] == 2
+            assert spoken_data["replyText"] == "已经完成的说话视频正文"
+            assert spoken_data["replyVideoUrl"].endswith(
+                "/toy/media/letter.spoken.mp4"
+            )
+            assert spoken_data["isRead"] == 1
+
+            musical = await client.get(
+                "/toy/letter/detail?letter_id=letter.musical"
+            )
+            musical_data = (await musical.json())["data"]
+            assert musical_data["letterStatus"] == 4
+            assert musical_data["replyType"] == 1
+            assert musical_data["replyText"] == "歌曲仍在生成，但正文已经完成。"
+            assert musical_data["replyVideoUrl"] == ""
+            assert musical_data["media_status"] == "PENDING"
+
+            pending = await client.get(
+                "/toy/letter/detail?letter_id=letter.pending"
+            )
+            pending_data = (await pending.json())["data"]
+            assert pending_data["letterStatus"] == 1
+            assert pending_data["replyType"] == 0
+            assert pending_data["replyText"] == ""
+            assert pending_data["replyVideoUrl"] == ""
+
+    asyncio.run(scenario())
+
+
+def test_send_adds_original_terminal_fields_without_losing_internal_status() -> None:
+    async def scenario() -> None:
+        letters = _letters()
+        runtime = create_original_client_server_runtime(
+            _fallback_factory(letters),
+            letter_collection=lambda _scope: letters,
+        )
+        async with TestClient(TestServer(runtime.app)) as client:
+            response = await client.post(
+                "/toy/letter/send",
+                json={"content": "synthetic"},
+            )
+            assert response.status == 200
+            data = (await response.json())["data"]
+            assert data["status"] == "COMPLETED"
+            assert data["letterId"] == "letter.spoken"
+            assert data["letterStatus"] == 4
+            assert data["replyType"] == 2
+            assert data["letter_id"] == "letter.spoken"
+            assert data["letter_status"] == 4
+
+    asyncio.run(scenario())
+
+
+def test_invalid_scope_and_unknown_letter_errors_pass_through_unchanged() -> None:
+    async def scenario() -> None:
+        letters = _letters()
+        runtime = create_original_client_server_runtime(
+            _fallback_factory(letters),
+            letter_collection=lambda _scope: letters,
+        )
+        async with TestClient(TestServer(runtime.app)) as client:
+            invalid = await client.get("/toy/letter/list?scope=invalid")
+            assert invalid.status == 400
+            assert await invalid.json() == {
+                "code": 400,
+                "message": "INVALID_SCOPE",
+                "data": {
+                    "status": "FAILED",
+                    "error_code": "INVALID_SCOPE",
+                },
+            }
+
+            missing = await client.get(
+                "/toy/letter/detail?letter_id=letter.missing"
+            )
+            assert missing.status == 404
+            assert (await missing.json())["data"]["error_code"] == "LETTER_NOT_FOUND"
+
+    asyncio.run(scenario())
+
+
+def test_invalid_raw_letter_fails_closed_without_path_or_content_leak() -> None:
+    async def scenario() -> None:
+        runtime = create_original_client_server_runtime(
+            _fallback_factory([]),
+            letter_collection=lambda _scope: ({"letter_id": ""},),
+        )
+        async with TestClient(TestServer(runtime.app)) as client:
+            response = await client.get("/toy/letter/list")
+            assert response.status == 503
+            assert await response.json() == {
+                "code": 503,
+                "message": "ORIGINAL_CLIENT_MAILBOX_UNAVAILABLE",
+                "data": {
+                    "status": "UNAVAILABLE",
+                    "error_code": "ORIGINAL_CLIENT_MAILBOX_UNAVAILABLE",
+                },
+            }
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Rebuilds CLIENT-CONTRACT-02 from the latest protected `main` after the stale #80 draft.

## Scope

- mounts explicit adapters for the original Olivia mailbox routes before the existing toy catch-all:
  - `GET /toy/letter/list`;
  - `GET /toy/letter/unread_count`;
  - `GET /toy/letter/detail`;
  - `POST /toy/letter/send`;
- keeps all validation, generation, idempotency, CORS, persistence, and read-side effects in the existing `local_server.handler`;
- transforms only the final response through the already merged audited `original_client_letter_contract`;
- reads the same current/legacy letter collection already owned by the local runtime;
- publishes original camelCase fields and numeric enums while retaining current snake_case aliases for internal callers;
- maps completed spoken video to reply type `2` and completed generated-singing video to `4`;
- keeps canonical text as reply type `1` while media is pending or unavailable;
- hides delayed text until `reply_not_before`;
- exposes only safe loopback `/toy/media/*.mp4` URLs;
- preserves existing HTTP status, CORS/security headers, send status strings, and error envelopes;
- fails closed with one stable path-free error if raw state cannot be serialized;
- adds no new product route, UI, server, player, or storage path.

## Validation

- pending, spoken-video, musical-media-pending, and failed list rows;
- camelCase aggregates and unread count;
- detail text/video publication boundaries;
- send terminal aliases;
- fallback header preservation;
- invalid scope and missing-letter pass-through;
- malformed raw state fail-closed behavior.

## Boundary

This PR does not modify `local_server.py`, original client assets, the media renderer, Memory, PrivateWorld, or the standalone Control Center. It only adapts responses inside the one original-client runtime.

Supersedes the unmerged #80. Part of #35, #36, #37, and #38.