### PR TITLE
fix(letter): acknowledge sends before reply generation

### DIFF
--- a/docs/B02_COVERAGE.md
+++ b/docs/B02_COVERAGE.md
@@ -10,10 +10,11 @@
 | normal send/list/detail | `test_normal_send_list_and_detail_preserve_legacy_fields` | 200、保留 `letter_id`/`reply_text` 兼容字段 |
 | missing field/type | `test_missing_fields_and_invalid_json_never_become_success` | 400、明确字段/类型错误 |
 | malformed HTTP JSON/method | `test_handler_rejects_malformed_json_and_wrong_methods` | 400 `INVALID_JSON`、405 `METHOD_NOT_ALLOWED` |
-| provider failure/retry | `test_llm_failure_is_retryable_but_resend_is_explicitly_unavailable` | 503 + `FAILED` + retryable；重试 route 稳定 501 |
+| provider failure/retry | `test_handler_acknowledges_before_background_llm_failure` | send 200/PENDING；detail `FAILED` + retryable |
+| pending restart recovery | `test_persisted_pending_reply_resumes_when_http_runtime_starts` | 重启后恢复任务并持久化终态 |
 | legacy isolation/read-only | `test_legacy_scope_is_read_only_and_isolated_from_new_chat` | current/legacy 分离；legacy detail 不改读状态；禁止写入 |
 | true unimplemented capability | `test_unimplemented_routes_and_native_capabilities_are_not_fake_successes` | 501 `NOT_IMPLEMENTED`；health 不伪装 native capability |
 | schema/fixture privacy | `test_contract_and_fixture_artifacts_are_versioned_and_sanitized` | 版本、read-only schema、无原文/私密标识 |
 | runtime log privacy | `test_request_and_reply_values_never_enter_runtime_logs` | body/query/reply/token 不进入日志 |
 
-既有 B00 回归文件 `tests/test_baseline_hardening.py` 继续覆盖 CORS、HTTP 503/501/404、MIDI 终态、日志和安全扫描。
+既有 B00 回归文件 `tests/test_baseline_hardening.py` 继续覆盖 CORS、后台 LLM 失败、HTTP 501/404、MIDI 终态、日志和安全扫描。

--- a/docs/B02_COVERAGE.md
+++ b/docs/B02_COVERAGE.md
@@ -11,7 +11,7 @@
 | missing field/type | `test_missing_fields_and_invalid_json_never_become_success` | 400、明确字段/类型错误 |
 | malformed HTTP JSON/method | `test_handler_rejects_malformed_json_and_wrong_methods` | 400 `INVALID_JSON`、405 `METHOD_NOT_ALLOWED` |
 | provider failure/retry | `test_handler_acknowledges_before_background_llm_failure` | send 200/PENDING；detail `FAILED` + retryable |
-| pending restart recovery | `test_persisted_pending_reply_resumes_when_http_runtime_starts` | 重启后恢复任务并持久化终态 |
+| pending restart recovery | `test_persisted_pending_reply_resumes_when_http_runtime_starts` | 未派发 PENDING 恢复；不确定 PROCESSING fail closed，不重复调用 provider |
 | legacy isolation/read-only | `test_legacy_scope_is_read_only_and_isolated_from_new_chat` | current/legacy 分离；legacy detail 不改读状态；禁止写入 |
 | true unimplemented capability | `test_unimplemented_routes_and_native_capabilities_are_not_fake_successes` | 501 `NOT_IMPLEMENTED`；health 不伪装 native capability |
 | schema/fixture privacy | `test_contract_and_fixture_artifacts_are_versioned_and_sanitized` | 版本、read-only schema、无原文/私密标识 |

--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -21,10 +21,10 @@
 | 501 | `MIDI_*_NOT_IMPLEMENTED` | NOT_IMPLEMENTED | 否 | MIDI 上传/生成/导入未实现 |
 | 501 | `WEBSOCKET_UNAVAILABLE` / `ASR_UNAVAILABLE` / `TTS_UNAVAILABLE` / `LIVE_UNAVAILABLE` | UNAVAILABLE | 否 | 原生实时能力不可用 |
 | 501 | `ROUTE_NOT_IMPLEMENTED` | NOT_IMPLEMENTED | 否 | 未登记 route |
-| 503 | `LLM_TIMEOUT` / `LLM_UNAVAILABLE` | FAILED | 是 | provider 超时/不可用；信件终态为 FAILED |
+| 200 detail | `LLM_TIMEOUT` / `LLM_UNAVAILABLE` | FAILED | 是 | 发信先确认 PENDING；provider 超时/不可用后 detail 显示 FAILED |
 | 503 | `MEMORY_UNAVAILABLE` | UNAVAILABLE | 是 | legacy import 的 SQLite 存储不可用；不回显正文、路径或密钥 |
 | 400 | `INVALID_IDEMPOTENCY_KEY` | FAILED | 否 | 幂等键为空、类型错误或超过长度边界 |
 | 409 | `IDEMPOTENCY_CONFLICT` | FAILED | 否 | 同一幂等键重复提交了不同正文 |
-| 503 | `LLM_PROVIDER_REJECTED` / `LLM_PROTOCOL_ERROR` | FAILED | 否 | 上游非重试 4xx、坏 JSON 或空响应；不回显 provider body |
+| 200 detail | `LLM_PROVIDER_REJECTED` / `LLM_PROTOCOL_ERROR` | FAILED | 否 | 上游非重试 4xx、坏 JSON 或空响应；不回显 provider body |
 
 源实现和机器可读映射在 `http_contract.py`；新增错误码必须同时更新映射、schema、测试和本表。

--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -22,6 +22,7 @@
 | 501 | `WEBSOCKET_UNAVAILABLE` / `ASR_UNAVAILABLE` / `TTS_UNAVAILABLE` / `LIVE_UNAVAILABLE` | UNAVAILABLE | 否 | 原生实时能力不可用 |
 | 501 | `ROUTE_NOT_IMPLEMENTED` | NOT_IMPLEMENTED | 否 | 未登记 route |
 | 200 detail | `LLM_TIMEOUT` / `LLM_UNAVAILABLE` | FAILED | 是 | 发信先确认 PENDING；provider 超时/不可用后 detail 显示 FAILED |
+| 200 detail | `LLM_INTERRUPTED` | FAILED | 是 | 进程在 provider 调用终态落盘前中断；不自动重复生成 |
 | 503 | `MEMORY_UNAVAILABLE` | UNAVAILABLE | 是 | legacy import 的 SQLite 存储不可用；不回显正文、路径或密钥 |
 | 400 | `INVALID_IDEMPOTENCY_KEY` | FAILED | 否 | 幂等键为空、类型错误或超过长度边界 |
 | 409 | `IDEMPOTENCY_CONFLICT` | FAILED | 否 | 同一幂等键重复提交了不同正文 |

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -16,7 +16,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 - 错误响应：`{"code":<HTTP 状态>,"message":"<error_code>","data":{"status":"FAILED","error_code":"<error_code>"}}`
 - 真正未实现能力：HTTP `501`，`data.status=NOT_IMPLEMENTED`。
 - 已知但不可用的可选能力：HTTP `501`，`data.status=UNAVAILABLE`，并带 `capability`；不会返回 200 假成功。
-- LLM 超时/不可用：HTTP `503`，信件保留 `FAILED` 终态并带 `retryable=true`。
+- HTTP 发信先返回 `200`/`PENDING`；LLM 超时或不可用随后写入信件 `FAILED` 终态，detail 返回稳定 `error_code` 与 `retryable`。进程重启会继续持久化的 `PENDING` 任务。
 
 机器可读定义：
 
@@ -31,7 +31,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 | core | `/health?profile=core` | available | 进程内 core 健康检查；不探测外部 provider |
 | session | `/toy/signIn`, `/toy/getUserInfo` | available | local-memory/session fixture |
 | 信件只读 | `/toy/letter/list`, `/toy/letter/detail`, `/toy/letter/unread_count` | available | `scope=current` 默认；`scope=legacy` 只读隔离视图 |
-| 发信 | `/toy/letter/send` | available/degraded | 调用配置的 LLM adapter；失败返回 503，不生成占位回信 |
+| 发信 | `/toy/letter/send` | available/degraded | 先确认 `PENDING`，后台调用 LLM adapter；失败写入 detail，不生成占位回信 |
 | 回信重发/分享 | `/toy/letter/resend`, `/toy/letter/share` | unavailable | 501 稳定错误；未实现不伪造写入 |
 | 音乐目录 | `/toy/getMusicTypeInfo`, `/toy/searchSongs`, `/toy/searchPlaylist`, `/toy/searchUserSongs`, `/toy/searchPerformances`, `/toy/getSongStats` | available | 只返回脱敏 fixture 或显式空数据 |
 | 音乐写操作 | `/toy/addPerformance` 等 | unavailable | 501 `MUSIC_WRITE_NOT_IMPLEMENTED` |
@@ -47,7 +47,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 - legacy import 的 body、`mode` 或 `letters` 不合法：400 `INVALID_BODY`；SQLite 存储不可用：503 `MEMORY_UNAVAILABLE`。两类错误都不回显旧信正文、路径或密钥。
 - 找不到信件或 MIDI job：404，不返回空的成功对象。
 - 空信箱、无匹配歌曲、空 playlist：200，但 `source=local-memory|empty`、列表和计数明确为空。
-- LLM timeout/error：503；新信件标记 `FAILED`，不得写入 `reply_text` 占位符。
+- LLM timeout/error：发信确认保持 200/PENDING，detail 随后标记 `FAILED` 并带错误码；不得写入 `reply_text` 占位符。
 - `/letter/resend` 当前未实现；重复请求返回相同 501，不改变信件内容或状态。
 - `scope=legacy` 的 list/detail 只读，detail 不改变 `is_read`；send 对 legacy scope 返回 403 `READ_ONLY_SCOPE`。
 

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -16,7 +16,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 - 错误响应：`{"code":<HTTP 状态>,"message":"<error_code>","data":{"status":"FAILED","error_code":"<error_code>"}}`
 - 真正未实现能力：HTTP `501`，`data.status=NOT_IMPLEMENTED`。
 - 已知但不可用的可选能力：HTTP `501`，`data.status=UNAVAILABLE`，并带 `capability`；不会返回 200 假成功。
-- HTTP 发信先返回 `200`/`PENDING`；LLM 超时或不可用随后写入信件 `FAILED` 终态，detail 返回稳定 `error_code` 与 `retryable`。进程重启会继续持久化的 `PENDING` 任务。
+- HTTP 发信先返回 `200`/`PENDING`；LLM 超时或不可用随后写入信件 `FAILED` 终态，detail 返回稳定 `error_code` 与 `retryable`。重启只恢复尚未派发的 `PENDING`；不确定是否已到达 provider 的 `PROCESSING` 会 fail closed 为 `LLM_INTERRUPTED`，不自动重复生成。
 
 机器可读定义：
 

--- a/docs/B03_LLM_GATEWAY.md
+++ b/docs/B03_LLM_GATEWAY.md
@@ -64,12 +64,12 @@ stream_delta (零个或多个，仅内部事件)
 completed | cancelled | retryable_error | terminal_error
 ```
 
-事件队列有上限，生产者在队列满时等待，形成可测试的背压；消费方不应无限制地缓存正文。编排超时会取消当前 provider task 并发出 `retryable_error/LLM_TIMEOUT`；用户取消只发出 `cancelled`，不会伪造 `completed`。HTTP B02 目前等待非流式终态，不把这个内部接口包装成原生 Live 或 SSE。
+事件队列有上限，生产者在队列满时等待，形成可测试的背压；消费方不应无限制地缓存正文。编排超时会取消当前 provider task 并发出 `retryable_error/LLM_TIMEOUT`；用户取消只发出 `cancelled`，不会伪造 `completed`。HTTP B02 先确认持久化的 `PENDING` 信件，再在后台等待非流式终态；它不是原生 Live 或 SSE。
 
 ## B02 响应、错误和降级
 
 - 正常回信仍为 HTTP `200`，并保留 `letter_id`、`letterId`、`status=COMPLETED` 等 B02 字段。
-- 未配置 provider、网络失败、429/5xx 重试耗尽或超时：HTTP `503`，`data.status=FAILED`，不写 `reply_text` 占位文本；默认 `LLM_UNAVAILABLE`/`LLM_TIMEOUT` 为可重试。
+- 未配置 provider、网络失败、429/5xx 重试耗尽或超时：后台将信件置为 `FAILED`，detail 暴露脱敏错误码和 `retryable`，不写 `reply_text` 占位文本；默认 `LLM_UNAVAILABLE`/`LLM_TIMEOUT` 为可重试。
 - provider 非重试 4xx：映射为 `LLM_PROVIDER_REJECTED`，不把上游 body 回显给客户端。
 - provider JSON 损坏或空响应：映射为 `LLM_PROTOCOL_ERROR`，明确失败，不返回 `200`。
 - 输入超长、空消息、非法角色（只允许 `system`、`user`、`assistant`）在 provider 调用前拒绝。

--- a/docs/B03_LLM_GATEWAY.md
+++ b/docs/B03_LLM_GATEWAY.md
@@ -64,7 +64,7 @@ stream_delta (零个或多个，仅内部事件)
 completed | cancelled | retryable_error | terminal_error
 ```
 
-事件队列有上限，生产者在队列满时等待，形成可测试的背压；消费方不应无限制地缓存正文。编排超时会取消当前 provider task 并发出 `retryable_error/LLM_TIMEOUT`；用户取消只发出 `cancelled`，不会伪造 `completed`。HTTP B02 先确认持久化的 `PENDING` 信件，再在后台等待非流式终态；它不是原生 Live 或 SSE。
+事件队列有上限，生产者在队列满时等待，形成可测试的背压；消费方不应无限制地缓存正文。编排超时会取消当前 provider task 并发出 `retryable_error/LLM_TIMEOUT`；用户取消只发出 `cancelled`，不会伪造 `completed`。HTTP B02 先确认持久化的 `PENDING` 信件，再在后台等待非流式终态；派发前写入 `PROCESSING`，携带稳定请求/幂等标识，崩溃后的不确定调用不会自动重发。它不是原生 Live 或 SSE。
 
 ## B02 响应、错误和降级
 

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -18,7 +18,7 @@ B11 的可执行验收 ledger 与冻结 reviewer 流程见 [`B11_ACCEPTANCE_STAN
 ## 1. 当前事实（以文件和命令为准）
 
 - 当前只有本地 HTTP 兼容原型，没有可运行的原版 WebSocket、Live、ASR、TTS 或完整降级链路。
-- `local_server.py` 中运行时代码的官方转发路径已移除；LLM 失败返回实际 HTTP 503，MIDI 生成和未实现写操作返回实际 HTTP 501；`NOT_IMPLEMENTED` 是终态。
+- `local_server.py` 中运行时代码的官方转发路径已移除；发信先确认 PENDING，LLM 失败随后写入可查询终态，MIDI 生成和未实现写操作返回实际 HTTP 501；`NOT_IMPLEMENTED` 是终态。
 - 当前 baseline hardening pytest 收集 25 项；这只是本批安全/状态回归，不代表整产品全绿。根目录 `test_cosyvoice3.py` 仍是历史一次性脚本，旧收集曾为 0。
 - 本机目录快照：`0.0.9.615` 为 3,711,516,860 bytes / 183 文件；`CosyVoice` 为 15,484,055,181 / 58,681；`LiveTalking` 为 9,928,926,801 / 67,626；`olivia_assets` 为 5,004,535,016 / 145；`assets_extracted` 为 15,159,776 / 24；`output_audio` 为 112,759,722 / 12。它们均不进入提交。
 - 本机有 5 对 `letter_pairs` 原文，仅作本地审计输入，不跟踪原文；真实配置、记忆、日志、模型、媒体和 `.evidence/` 均被忽略。

--- a/http_contract.py
+++ b/http_contract.py
@@ -38,6 +38,7 @@ ERROR_CODES: dict[str, dict[str, Any]] = {
     "INTERNAL_ERROR": {"http_status": 500, "retryable": False},
     "LLM_UNAVAILABLE": {"http_status": 503, "retryable": True},
     "LLM_TIMEOUT": {"http_status": 503, "retryable": True},
+    "LLM_INTERRUPTED": {"http_status": 503, "retryable": True},
     "LLM_PROVIDER_REJECTED": {"http_status": 503, "retryable": False},
     "LLM_PROTOCOL_ERROR": {"http_status": 503, "retryable": False},
     "LETTER_RESEND_NOT_IMPLEMENTED": {"http_status": 501, "retryable": False},

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -482,7 +482,8 @@ class OpenAICompatibleAdapter(Gateway):
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
         if key:
             headers["Authorization"] = "Bearer " + key
-        headers["Idempotency-Key"] = request_id
+        if request_id.startswith("letter-reply:"):
+            headers["Idempotency-Key"] = request_id
         headers["X-Request-ID"] = request_id
         return headers
 

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -478,10 +478,12 @@ class OpenAICompatibleAdapter(Gateway):
         suffix = "responses" if self.config.api_style == "responses" else "chat/completions"
         return self.config.base_url.rstrip("/") + "/" + suffix
 
-    def _headers(self, key: str | None) -> dict[str, str]:
+    def _headers(self, key: str | None, request_id: str) -> dict[str, str]:
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
         if key:
             headers["Authorization"] = "Bearer " + key
+        headers["Idempotency-Key"] = request_id
+        headers["X-Request-ID"] = request_id
         return headers
 
     def _body(self, messages: Sequence[Mapping[str, Any]], *, stream: bool) -> dict[str, Any]:
@@ -506,7 +508,11 @@ class OpenAICompatibleAdapter(Gateway):
             try:
                 async with aiohttp.ClientSession(timeout=timeout) as session:
                     self.mark_network_call()
-                    async with session.post(self._url(), json=body, headers=self._headers(key)) as response:
+                    async with session.post(
+                        self._url(),
+                        json=body,
+                        headers=self._headers(key, request_id),
+                    ) as response:
                         status = response.status
                         if status == 429 or status >= 500:
                             if attempt < self.config.max_retries:
@@ -556,7 +562,11 @@ class OpenAICompatibleAdapter(Gateway):
             try:
                 async with aiohttp.ClientSession(timeout=timeout) as session:
                     self.mark_network_call()
-                    async with session.post(self._url(), json=body, headers=self._headers(key)) as response:
+                    async with session.post(
+                        self._url(),
+                        json=body,
+                        headers=self._headers(key, request),
+                    ) as response:
                         status = response.status
                         if status == 429 or status >= 500:
                             if attempt < self.config.max_retries:

--- a/local_server.py
+++ b/local_server.py
@@ -424,6 +424,10 @@ def _load_store_state() -> None:
                     item["reply_mode"] = _exact_reply_mode(
                         item.get("reply_mode", ReplyMode.TEXT_LETTER.value)
                     )
+                    if item.get("letter_status") == "PROCESSING":
+                        item["letter_status"] = "FAILED"
+                        item["error_code"] = "LLM_INTERRUPTED"
+                        needs_persist = True
                     if item.get("media_status") == "PROCESSING":
                         item["media_status"] = "QUEUED"
                         needs_persist = True
@@ -1041,6 +1045,8 @@ def _public_llm_error(code: str | None) -> tuple[str, bool]:
         return "REPLY_QUALITY_BLOCKED", False
     if code in {"LLM_TIMEOUT", "PROVIDER_TIMEOUT"}:
         return "LLM_TIMEOUT", True
+    if code == "LLM_INTERRUPTED":
+        return "LLM_INTERRUPTED", True
     if code in {"LLM_PROVIDER_REJECTED", "PROVIDER_REJECTED"}:
         return "LLM_PROVIDER_REJECTED", False
     if code in {"LLM_PROTOCOL_ERROR", "PROVIDER_PROTOCOL"}:
@@ -1071,7 +1077,7 @@ def _schedule_text_reply_delay(letter: dict, reply_mode: str) -> None:
 
 
 def _send_result_for_letter(letter: dict) -> dict:
-    if letter.get("letter_status") == "PENDING":
+    if letter.get("letter_status") in {"PENDING", "PROCESSING"}:
         return ok(
             {
                 "letter_id": letter["letter_id"],
@@ -1722,6 +1728,8 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
     if letter is None:
         return False
 
+    letter["letter_status"] = "PROCESSING"
+    _persist_store_state()
     decision = await emotion_triage.classify(content)
     exact_mode = _exact_reply_mode(decision.reply_mode)
     letter["triage"] = decision.to_dict()
@@ -1751,8 +1759,8 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
             timeout=LLM_TIMEOUT_SECONDS,
         )
     except asyncio.CancelledError:
-        letter["letter_status"] = "PENDING"
-        letter.pop("error_code", None)
+        letter["letter_status"] = "FAILED"
+        letter["error_code"] = "LLM_INTERRUPTED"
         _persist_store_state()
         _safe_log("letter_cancelled")
         raise

--- a/local_server.py
+++ b/local_server.py
@@ -150,7 +150,12 @@ class _LetterGateway(Gateway):
             "",
         )
         try:
-            text = await asyncio.to_thread(self.adapter.reply, content, "")
+            text = await asyncio.to_thread(
+                self.adapter.reply,
+                content,
+                "",
+                request_id=request_id,
+            )
         except LLMError as exc:
             if exc.code == "LLM_TIMEOUT":
                 raise ProviderTimeout() from None
@@ -355,10 +360,18 @@ class LetterAdapter:
         except Exception:
             _safe_log("memory_write_skipped", reason="optional_backend_unavailable")
 
-    def reply(self, content: str, context: str = "") -> str:
+    def reply(
+        self,
+        content: str,
+        context: str = "",
+        *,
+        request_id: str | None = None,
+    ) -> str:
         try:
             messages = self._messages(content, context)
-            return asyncio.run(self.gateway.complete(messages)).text
+            return asyncio.run(
+                self.gateway.complete(messages, request_id=request_id)
+            ).text
         except GatewayError as exc:
             code = "LLM_TIMEOUT" if isinstance(exc, ProviderTimeout) else "LLM_UNAVAILABLE"
             if exc.code == "PROVIDER_REJECTED":

--- a/local_server.py
+++ b/local_server.py
@@ -472,6 +472,7 @@ emotion_triage = LetterEmotionTriage(letters_adapter.gateway)
 media_semaphore = asyncio.Semaphore(1)
 media_tasks: set[asyncio.Task] = set()
 reply_tasks: set[asyncio.Task] = set()
+reply_jobs: dict[str, asyncio.Task] = {}
 
 
 def _persist_media_state() -> None:
@@ -1329,12 +1330,16 @@ async def route(method, path, body, query, *, defer_reply: bool = False):
                 None,
             )
             if previous is not None:
-                if previous.get("content") != content:
+                if (
+                    previous.get("content") != content
+                    or previous.get("material", {}) != material
+                ):
                     return err(409, "IDEMPOTENCY_CONFLICT", {
                         "status": "FAILED",
                         "error_code": "IDEMPOTENCY_CONFLICT",
                     })
-                return _send_result_for_letter(previous)
+                if previous.get("letter_status") not in {"FAILED", "CANCELED"}:
+                    return _send_result_for_letter(previous)
         else:
             previous = _recent_active_duplicate(content, material)
             if previous is not None:
@@ -1354,9 +1359,9 @@ async def route(method, path, body, query, *, defer_reply: bool = False):
             "music_duration_seconds": duration,
         }
         store.letters.insert(0, letter)
-        _persist_store_state()
         if idempotency_key is not None:
             store.request_keys[idempotency_key] = lid
+        _persist_store_state()
         if defer_reply:
             _schedule_reply_job(lid, content, idempotency_key=idempotency_key)
             return _send_result_for_letter(letter)
@@ -1580,6 +1585,9 @@ def _schedule_reply_job(
     *,
     idempotency_key: str | None,
 ) -> None:
+    active = reply_jobs.get(letter_id)
+    if active is not None and not active.done():
+        return
     task = asyncio.create_task(
         _run_reply_job(
             letter_id,
@@ -1588,7 +1596,64 @@ def _schedule_reply_job(
         )
     )
     reply_tasks.add(task)
-    task.add_done_callback(reply_tasks.discard)
+    reply_jobs[letter_id] = task
+
+    def discard(completed: asyncio.Task) -> None:
+        reply_tasks.discard(completed)
+        if reply_jobs.get(letter_id) is completed:
+            reply_jobs.pop(letter_id, None)
+
+    task.add_done_callback(discard)
+
+
+def _idempotency_key_for_letter(letter_id: str) -> str | None:
+    return next(
+        (
+            key
+            for key, mapped_letter_id in store.request_keys.items()
+            if mapped_letter_id == letter_id
+        ),
+        None,
+    )
+
+
+def _schedule_pending_reply_jobs() -> int:
+    scheduled = 0
+    for letter in tuple(store.letters):
+        if letter.get("letter_status") != "PENDING":
+            continue
+        letter_id = str(letter.get("letter_id", ""))
+        content = letter.get("content")
+        if not letter_id or not isinstance(content, str) or not content.strip():
+            continue
+        if letter_id in reply_jobs and not reply_jobs[letter_id].done():
+            continue
+        _schedule_reply_job(
+            letter_id,
+            content,
+            idempotency_key=_idempotency_key_for_letter(letter_id),
+        )
+        scheduled += 1
+    return scheduled
+
+
+async def _start_reply_tasks(_app: web.Application) -> None:
+    _schedule_pending_reply_jobs()
+
+
+async def _stop_reply_tasks(_app: web.Application) -> None:
+    tasks = tuple(reply_tasks)
+    for task in tasks:
+        task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def install_reply_task_lifecycle(app: web.Application) -> None:
+    """Resume durable pending replies and stop owned tasks with the HTTP app."""
+
+    app.on_startup.append(_start_reply_tasks)
+    app.on_cleanup.append(_stop_reply_tasks)
 
 
 def _prepare_private_world_delivery(letter: dict, canonical_text: str) -> None:
@@ -1673,7 +1738,9 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
         request = ReplyRequest(
             content=content,
             request_id=letter_id,
-            idempotency_key=idempotency_key,
+            idempotency_key=(
+                f"{idempotency_key}:{letter_id}" if idempotency_key else None
+            ),
             max_input_chars=LLM_CONFIG.max_input_chars,
         )
         result = await asyncio.wait_for(
@@ -1684,18 +1751,21 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
             timeout=LLM_TIMEOUT_SECONDS,
         )
     except asyncio.CancelledError:
-        letter["letter_status"] = "CANCELED"
-        letter["error_code"] = "LLM_CANCELLED"
+        letter["letter_status"] = "PENDING"
+        letter.pop("error_code", None)
+        _persist_store_state()
         _safe_log("letter_cancelled")
-        return False
+        raise
     except asyncio.TimeoutError:
         letter["letter_status"] = "FAILED"
         letter["error_code"] = "LLM_TIMEOUT"
+        _persist_store_state()
         _safe_log("letter_failed", error_code="LLM_TIMEOUT")
         return False
     except (ValueError, RuntimeError):
         letter["letter_status"] = "FAILED"
         letter["error_code"] = "LLM_UNAVAILABLE"
+        _persist_store_state()
         _safe_log("letter_failed", error_code="LLM_UNAVAILABLE")
         return False
 
@@ -1706,6 +1776,7 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
         public_code, _retryable = _public_llm_error(result.error_code)
         letter["letter_status"] = "FAILED"
         letter["error_code"] = public_code
+        _persist_store_state()
         _safe_log("letter_failed", error_code=public_code)
         return False
 
@@ -1731,5 +1802,6 @@ if __name__ == "__main__":
     recover_pending_private_world()
     app = web.Application()
     app.router.add_route("*", "/{tail:.*}", handler)
+    install_reply_task_lifecycle(app)
     _safe_log('server_start', host='127.0.0.1', port=PORT)
     web.run_app(app, host="127.0.0.1", port=PORT, access_log=None)

--- a/local_server.py
+++ b/local_server.py
@@ -74,6 +74,7 @@ from reply_reviewer import NullReviewer
 
 PORT = int(_os.environ.get("OLIVIA_PORT", "8899"))
 LLM_TIMEOUT_SECONDS = 30
+LETTER_RETRY_DEDUP_SECONDS = 60
 
 
 def _exact_reply_mode(value: object) -> str:
@@ -470,6 +471,7 @@ letters_adapter = LetterAdapter(
 emotion_triage = LetterEmotionTriage(letters_adapter.gateway)
 media_semaphore = asyncio.Semaphore(1)
 media_tasks: set[asyncio.Task] = set()
+reply_tasks: set[asyncio.Task] = set()
 
 
 def _persist_media_state() -> None:
@@ -655,7 +657,13 @@ async def handler(request: web.Request):
         result = body_error
     else:
         try:
-            result = await route(method, path, body, query)
+            result = await route(
+                method,
+                path,
+                body,
+                query,
+                defer_reply=(method == "POST" and path.rstrip("/") == "/toy/letter/send"),
+            )
         except Exception as e:
             code = _diagnostic_code('ROUTE', e)
             _safe_log('route_failure', method=method, path=path, error_code=code)
@@ -1062,6 +1070,14 @@ def _schedule_text_reply_delay(letter: dict, reply_mode: str) -> None:
 
 
 def _send_result_for_letter(letter: dict) -> dict:
+    if letter.get("letter_status") == "PENDING":
+        return ok(
+            {
+                "letter_id": letter["letter_id"],
+                "letterId": letter["letter_id"],
+                "status": "PENDING",
+            }
+        )
     if letter.get("reply_not_before", 0.0) > time.time():
         return ok({"letter_id": letter["letter_id"], "letterId": letter["letter_id"], "status": "PENDING", "reply_not_before": letter["reply_not_before"]})
     if letter.get("letter_status") == "COMPLETED" and letter.get("reply_text"):
@@ -1085,7 +1101,28 @@ def _send_result_for_letter(letter: dict) -> dict:
     )
 
 
-async def route(method, path, body, query):
+def _recent_active_duplicate(
+    content: str,
+    material: dict,
+    *,
+    now: float | None = None,
+) -> dict | None:
+    current_time = time.time() if now is None else now
+    for letter in store.letters:
+        created_at = letter.get("created_at")
+        if isinstance(created_at, bool) or not isinstance(created_at, (int, float)):
+            continue
+        age = current_time - float(created_at)
+        if age < 0 or age > LETTER_RETRY_DEDUP_SECONDS:
+            continue
+        if letter.get("letter_status") not in {"PENDING", "PROCESSING", "COMPLETED"}:
+            continue
+        if letter.get("content") == content and letter.get("material", {}) == material:
+            return letter
+    return None
+
+
+async def route(method, path, body, query, *, defer_reply: bool = False):
     p = path.rstrip("/")
 
     spec = contract.route_spec(p)
@@ -1295,6 +1332,10 @@ async def route(method, path, body, query):
                         "error_code": "IDEMPOTENCY_CONFLICT",
                     })
                 return _send_result_for_letter(previous)
+        else:
+            previous = _recent_active_duplicate(content, material)
+            if previous is not None:
+                return _send_result_for_letter(previous)
         lid = str(uuid.uuid4())
         letter = {
             "letter_id": lid,
@@ -1313,6 +1354,9 @@ async def route(method, path, body, query):
         _persist_store_state()
         if idempotency_key is not None:
             store.request_keys[idempotency_key] = lid
+        if defer_reply:
+            _schedule_reply_job(lid, content, idempotency_key=idempotency_key)
+            return _send_result_for_letter(letter)
         completed = await generate_reply(lid, content, idempotency_key=idempotency_key)
         if not completed:
             return _send_result_for_letter(letter)
@@ -1500,6 +1544,48 @@ def _schedule_media_job(letter_id: str, content: str, reply_text: str, reply_mod
     task = asyncio.create_task(_render_media_job(letter_id, content, reply_text, reply_mode))
     media_tasks.add(task)
     task.add_done_callback(media_tasks.discard)
+
+
+async def _run_reply_job(
+    letter_id: str,
+    content: str,
+    *,
+    idempotency_key: str | None,
+) -> bool:
+    try:
+        return await generate_reply(
+            letter_id,
+            content,
+            idempotency_key=idempotency_key,
+        )
+    except Exception:
+        letter = next(
+            (item for item in store.letters if item["letter_id"] == letter_id),
+            None,
+        )
+        if letter is not None and letter.get("letter_status") == "PENDING":
+            letter["letter_status"] = "FAILED"
+            letter["error_code"] = "LLM_UNAVAILABLE"
+            _persist_store_state()
+        _safe_log("letter_failed", error_code="LLM_UNAVAILABLE")
+        return False
+
+
+def _schedule_reply_job(
+    letter_id: str,
+    content: str,
+    *,
+    idempotency_key: str | None,
+) -> None:
+    task = asyncio.create_task(
+        _run_reply_job(
+            letter_id,
+            content,
+            idempotency_key=idempotency_key,
+        )
+    )
+    reply_tasks.add(task)
+    task.add_done_callback(reply_tasks.discard)
 
 
 def _prepare_private_world_delivery(letter: dict, canonical_text: str) -> None:

--- a/local_server.py
+++ b/local_server.py
@@ -1222,9 +1222,12 @@ async def route(method, path, body, query, *, defer_reply: bool = False):
             l["is_read"] = 1
         reply_published = l.get("reply_not_before", 0.0) <= time.time()
         reply_text = l.get("reply_text", "") if reply_published else ""
+        error_code, retryable = _public_llm_error(l.get("error_code"))
         return ok({
             "letter_id": l["letter_id"],
             "letter_status": l.get("letter_status", 4),
+            "error_code": error_code if l.get("letter_status") == "FAILED" else None,
+            "retryable": retryable if l.get("letter_status") == "FAILED" else False,
             "audit_status": l.get("audit_status", 2),
             "content": l.get("content", ""),
             "material": l.get("material", {}),

--- a/local_server.py
+++ b/local_server.py
@@ -1577,7 +1577,10 @@ async def _run_reply_job(
             (item for item in store.letters if item["letter_id"] == letter_id),
             None,
         )
-        if letter is not None and letter.get("letter_status") == "PENDING":
+        if letter is not None and letter.get("letter_status") in {
+            "PENDING",
+            "PROCESSING",
+        }:
             letter["letter_status"] = "FAILED"
             letter["error_code"] = "LLM_UNAVAILABLE"
             _persist_store_state()
@@ -1745,7 +1748,7 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
     try:
         request = ReplyRequest(
             content=content,
-            request_id=letter_id,
+            request_id=f"letter-reply:{letter_id}",
             idempotency_key=(
                 f"{idempotency_key}:{letter_id}" if idempotency_key else None
             ),

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -480,7 +480,7 @@ def create_configured_original_client_server_runtime(
         values,
     )
     collection = getattr(server_module, "_letter_collection", None)
-    return create_original_client_server_runtime(
+    runtime = create_original_client_server_runtime(
         fallback,
         memory_admin=memory_admin,
         private_world=private_world,
@@ -489,6 +489,14 @@ def create_configured_original_client_server_runtime(
         letter_collection=collection if callable(collection) else None,
         trusted_origins=origins,
     )
+    install_reply_task_lifecycle = getattr(
+        server_module,
+        "install_reply_task_lifecycle",
+        None,
+    )
+    if callable(install_reply_task_lifecycle):
+        install_reply_task_lifecycle(runtime.app)
+    return runtime
 
 
 def main() -> int:

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -23,10 +23,12 @@ def reset_local_store():
     local_server.store.letters.clear()
     local_server.store.legacy_letters.clear()
     local_server.store.midi_jobs.clear()
+    local_server.store.request_keys.clear()
     yield
     local_server.store.letters.clear()
     local_server.store.legacy_letters.clear()
     local_server.store.midi_jobs.clear()
+    local_server.store.request_keys.clear()
 
 
 def test_core_health_is_versioned_and_reports_unavailable_optional_capabilities() -> None:
@@ -159,6 +161,93 @@ def test_http_send_acknowledges_before_slow_reply_finishes(
     assert len(local_server.store.letters) == 1
     assert detail["data"]["letter_status"] == "COMPLETED"
     assert detail["data"]["reply_text"] == "synthetic delayed reply"
+
+
+def test_persisted_pending_reply_resumes_when_http_runtime_starts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    import local_server
+
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "reply",
+        lambda *_args: "synthetic recovered reply",
+    )
+    pending = {
+        "letter_id": "letter-restart-pending",
+        "content": "synthetic persisted input",
+        "material": {},
+        "letter_status": "PENDING",
+        "audit_status": 2,
+        "is_read": 1,
+        "created_at": 100,
+        "reply_text": "",
+        "reply_mode": "text_letter",
+        "triage": {"status": "pending"},
+        "music_duration_seconds": 118,
+    }
+    local_server.store.letters.append(pending)
+    local_server.store.request_keys["restart-key"] = pending["letter_id"]
+    local_server._persist_store_state()
+    local_server.store.letters.clear()
+    local_server.store.request_keys.clear()
+    local_server._load_store_state()
+
+    async def exercise() -> dict:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        local_server.install_reply_task_lifecycle(app)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            await asyncio.gather(*tuple(local_server.reply_tasks))
+            response = await client.get(
+                "/toy/letter/detail",
+                params={"letter_id": pending["letter_id"]},
+            )
+            return await response.json()
+
+    detail = asyncio.run(exercise())
+    persisted = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+
+    assert detail["data"]["letter_status"] == "COMPLETED"
+    assert detail["data"]["reply_text"] == "synthetic recovered reply"
+    assert persisted["letters"][0]["letter_status"] == "COMPLETED"
+    assert persisted["request_keys"]["restart-key"] == pending["letter_id"]
+
+
+def test_failed_idempotent_request_can_retry_with_same_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    allow_success = False
+
+    def reply(*_args):
+        if not allow_success:
+            raise local_server.LLMError("LLM_TIMEOUT")
+        return "synthetic recovered reply"
+
+    monkeypatch.setattr(local_server.letters_adapter, "reply", reply)
+    body = {
+        "content": "synthetic idempotent retry",
+        "material": {"stamp_id": "stamp-a"},
+        "idempotency_key": "retry-key",
+    }
+
+    first = asyncio.run(local_server.route("POST", "/toy/letter/send", body, {}))
+    assert local_server.store.letters[0]["letter_status"] == "FAILED"
+    allow_success = True
+    second = asyncio.run(local_server.route("POST", "/toy/letter/send", body, {}))
+
+    assert first["code"] == 503
+    assert second["code"] == 0
+    assert second["data"]["status"] == "COMPLETED"
+    assert second["data"]["letter_id"] != first["data"]["letter_id"]
+    assert local_server.store.request_keys["retry-key"] == second["data"]["letter_id"]
 
 
 def test_retry_dedup_does_not_block_distinct_expired_or_failed_letters() -> None:

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -99,6 +100,112 @@ def test_normal_send_list_and_detail_preserve_legacy_fields(monkeypatch: pytest.
     assert detail["data"]["reply_text"] == "synthetic reply"
     assert detail["data"]["reply_content"] == "synthetic reply"
     assert detail["data"]["read_only"] is False
+
+
+def test_http_send_acknowledges_before_slow_reply_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    import local_server
+
+    reply_started = threading.Event()
+    allow_reply = threading.Event()
+
+    def slow_reply(*_args) -> str:
+        reply_started.set()
+        allow_reply.wait(timeout=2.0)
+        return "synthetic delayed reply"
+
+    monkeypatch.setattr(local_server.letters_adapter, "reply", slow_reply)
+
+    async def exercise() -> tuple[dict, dict, dict]:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            pending_response = asyncio.create_task(
+                client.post(
+                    "/toy/letter/send",
+                    json={"content": "synthetic slow input"},
+                )
+            )
+            try:
+                response = await asyncio.wait_for(
+                    asyncio.shield(pending_response),
+                    timeout=0.2,
+                )
+                sent = await response.json()
+                duplicate_response = await client.post(
+                    "/toy/letter/send",
+                    json={"content": "synthetic slow input"},
+                )
+                duplicate = await duplicate_response.json()
+            finally:
+                allow_reply.set()
+            await asyncio.gather(*tuple(local_server.reply_tasks))
+            detail_response = await client.get(
+                "/toy/letter/detail",
+                params={"letter_id": sent["data"]["letter_id"]},
+            )
+            return sent, duplicate, await detail_response.json()
+
+    sent, duplicate, detail = asyncio.run(exercise())
+
+    assert reply_started.wait(timeout=0.2)
+    assert sent["code"] == 0
+    assert sent["data"]["status"] == "PENDING"
+    assert duplicate["data"]["letter_id"] == sent["data"]["letter_id"]
+    assert len(local_server.store.letters) == 1
+    assert detail["data"]["letter_status"] == "COMPLETED"
+    assert detail["data"]["reply_text"] == "synthetic delayed reply"
+
+
+def test_retry_dedup_does_not_block_distinct_expired_or_failed_letters() -> None:
+    import local_server
+
+    original = {
+        "letter_id": "letter-original",
+        "content": "synthetic input",
+        "material": {"stamp_id": "stamp-a"},
+        "letter_status": "COMPLETED",
+        "created_at": 100,
+    }
+    local_server.store.letters.append(original)
+
+    assert (
+        local_server._recent_active_duplicate(
+            "synthetic input",
+            {"stamp_id": "stamp-a"},
+            now=159,
+        )
+        is original
+    )
+    assert (
+        local_server._recent_active_duplicate(
+            "synthetic input",
+            {"stamp_id": "stamp-b"},
+            now=159,
+        )
+        is None
+    )
+    assert (
+        local_server._recent_active_duplicate(
+            "synthetic input",
+            {"stamp_id": "stamp-a"},
+            now=161,
+        )
+        is None
+    )
+    original["letter_status"] = "FAILED"
+    assert (
+        local_server._recent_active_duplicate(
+            "synthetic input",
+            {"stamp_id": "stamp-a"},
+            now=159,
+        )
+        is None
+    )
 
 
 def test_missing_fields_and_invalid_json_never_become_success() -> None:

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -267,6 +267,42 @@ def test_failed_idempotent_request_can_retry_with_same_key(
     assert local_server.store.request_keys["retry-key"] == second["data"]["letter_id"]
 
 
+def test_unexpected_background_failure_cannot_leave_processing_letter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    import local_server
+
+    async def crash(*_args, **_kwargs):
+        raise KeyError("synthetic private provider failure")
+
+    monkeypatch.setattr(local_server.reply_pipeline, "run", crash)
+
+    async def exercise() -> tuple[dict, dict]:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            sent_response = await client.post(
+                "/toy/letter/send",
+                json={"content": "synthetic unexpected failure"},
+            )
+            sent = await sent_response.json()
+            await asyncio.gather(*tuple(local_server.reply_tasks))
+            detail_response = await client.get(
+                "/toy/letter/detail",
+                params={"letter_id": sent["data"]["letter_id"]},
+            )
+            return sent, await detail_response.json()
+
+    sent, detail = asyncio.run(exercise())
+
+    assert sent["data"]["status"] == "PENDING"
+    assert detail["data"]["letter_status"] == "FAILED"
+    assert detail["data"]["error_code"] == "LLM_UNAVAILABLE"
+
+
 def test_retry_dedup_does_not_block_distinct_expired_or_failed_letters() -> None:
     import local_server
 

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -173,11 +173,13 @@ def test_persisted_pending_reply_resumes_when_http_runtime_starts(
     import local_server
 
     monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
-    monkeypatch.setattr(
-        local_server.letters_adapter,
-        "reply",
-        lambda *_args: "synthetic recovered reply",
-    )
+    generated_contents: list[str] = []
+
+    def recovered_reply(content: str, *_args) -> str:
+        generated_contents.append(content)
+        return "synthetic recovered reply"
+
+    monkeypatch.setattr(local_server.letters_adapter, "reply", recovered_reply)
     pending = {
         "letter_id": "letter-restart-pending",
         "content": "synthetic persisted input",
@@ -192,6 +194,12 @@ def test_persisted_pending_reply_resumes_when_http_runtime_starts(
         "music_duration_seconds": 118,
     }
     local_server.store.letters.append(pending)
+    local_server.store.letters.append({
+        **pending,
+        "letter_id": "letter-restart-uncertain",
+        "content": "synthetic uncertain provider input",
+        "letter_status": "PROCESSING",
+    })
     local_server.store.request_keys["restart-key"] = pending["letter_id"]
     local_server._persist_store_state()
     local_server.store.letters.clear()
@@ -208,14 +216,23 @@ def test_persisted_pending_reply_resumes_when_http_runtime_starts(
                 "/toy/letter/detail",
                 params={"letter_id": pending["letter_id"]},
             )
-            return await response.json()
+            interrupted_response = await client.get(
+                "/toy/letter/detail",
+                params={"letter_id": "letter-restart-uncertain"},
+            )
+            return await response.json(), await interrupted_response.json()
 
-    detail = asyncio.run(exercise())
+    detail, interrupted = asyncio.run(exercise())
     persisted = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
 
     assert detail["data"]["letter_status"] == "COMPLETED"
     assert detail["data"]["reply_text"] == "synthetic recovered reply"
-    assert persisted["letters"][0]["letter_status"] == "COMPLETED"
+    assert interrupted["data"]["letter_status"] == "FAILED"
+    assert interrupted["data"]["error_code"] == "LLM_INTERRUPTED"
+    assert generated_contents == ["synthetic persisted input"]
+    persisted_by_id = {item["letter_id"]: item for item in persisted["letters"]}
+    assert persisted_by_id[pending["letter_id"]]["letter_status"] == "COMPLETED"
+    assert persisted_by_id["letter-restart-uncertain"]["letter_status"] == "FAILED"
     assert persisted["request_keys"]["restart-key"] == pending["letter_id"]
 
 

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -77,10 +77,45 @@ def test_empty_letter_and_music_paths_are_explicitly_empty() -> None:
     assert songs["data"]["source"] == "empty"
 
 
+def test_letter_gateway_preserves_durable_request_id_to_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    seen_request_ids: list[str | None] = []
+
+    class CapturingGateway:
+        async def complete(self, _messages, *, request_id=None):
+            seen_request_ids.append(request_id)
+            return local_server.GatewayResponse(
+                text="synthetic reply",
+                request_id=request_id or "provider-generated-id",
+                provider="mock",
+                model="mock-model",
+            )
+
+    monkeypatch.setattr(local_server.letters_adapter, "gateway", CapturingGateway())
+    durable_request_id = "letter-reply:synthetic-letter-id"
+
+    response = asyncio.run(
+        local_server._LetterGateway(local_server.letters_adapter).complete(
+            [{"role": "user", "content": "synthetic input"}],
+            request_id=durable_request_id,
+        )
+    )
+
+    assert response.request_id == durable_request_id
+    assert seen_request_ids == [durable_request_id]
+
+
 def test_normal_send_list_and_detail_preserve_legacy_fields(monkeypatch: pytest.MonkeyPatch) -> None:
     import local_server
 
-    monkeypatch.setattr(local_server.letters_adapter, "reply", lambda *_args: "synthetic reply")
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "reply",
+        lambda *_args, **_kwargs: "synthetic reply",
+    )
     sent = asyncio.run(
         local_server.route(
             "POST",
@@ -115,7 +150,7 @@ def test_http_send_acknowledges_before_slow_reply_finishes(
     reply_started = threading.Event()
     allow_reply = threading.Event()
 
-    def slow_reply(*_args) -> str:
+    def slow_reply(*_args, **_kwargs) -> str:
         reply_started.set()
         allow_reply.wait(timeout=2.0)
         return "synthetic delayed reply"
@@ -175,7 +210,7 @@ def test_persisted_pending_reply_resumes_when_http_runtime_starts(
     monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
     generated_contents: list[str] = []
 
-    def recovered_reply(content: str, *_args) -> str:
+    def recovered_reply(content: str, *_args, **_kwargs) -> str:
         generated_contents.append(content)
         return "synthetic recovered reply"
 
@@ -243,7 +278,7 @@ def test_failed_idempotent_request_can_retry_with_same_key(
 
     allow_success = False
 
-    def reply(*_args):
+    def reply(*_args, **_kwargs):
         if not allow_success:
             raise local_server.LLMError("LLM_TIMEOUT")
         return "synthetic recovered reply"
@@ -401,7 +436,7 @@ def test_llm_failure_is_retryable_but_resend_is_explicitly_unavailable(
 ) -> None:
     import local_server
 
-    def fail(_content, _context=""):
+    def fail(_content, _context="", **_kwargs):
         raise local_server.LLMError("LLM_TIMEOUT")
 
     monkeypatch.setattr(local_server.letters_adapter, "reply", fail)
@@ -736,7 +771,11 @@ def test_request_and_reply_values_never_enter_runtime_logs(
 
     import local_server
 
-    monkeypatch.setattr(local_server.letters_adapter, "reply", lambda *_args: "synthetic reply secret")
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "reply",
+        lambda *_args, **_kwargs: "synthetic reply secret",
+    )
     capsys.readouterr()
 
     async def exercise():

--- a/tests/http/test_original_client_server.py
+++ b/tests/http/test_original_client_server.py
@@ -212,12 +212,14 @@ def test_configured_runtime_reuses_existing_memory_and_private_world_storage(
             conversation_memory=NullConversationMemoryPort(),
             conversation_memory_user_id="local-user",
         )
+        lifecycle_apps = []
         server = SimpleNamespace(
             handler=_fallback,
             letters_adapter=SimpleNamespace(memory_prompt_builder=builder),
             private_world_port=ledger,
             private_world_committer=object(),
             TRUSTED_FRONTEND_ORIGINS=frozenset({TRUSTED_ORIGIN}),
+            install_reply_task_lifecycle=lifecycle_apps.append,
         )
         runtime = create_configured_original_client_server_runtime(
             server_module=server,
@@ -229,6 +231,7 @@ def test_configured_runtime_reuses_existing_memory_and_private_world_storage(
         )
 
         assert runtime.memory_admin is not None
+        assert lifecycle_apps == [runtime.app]
         assert runtime.private_world_read is not None
         assert runtime.candidate_store is not None
         assert (root / "memory" / "memory_admin_audit.sqlite3").is_file()

--- a/tests/llm/test_gateway.py
+++ b/tests/llm/test_gateway.py
@@ -129,10 +129,37 @@ def test_chat_completion_adapter_uses_local_mock_server_and_env_key(monkeypatch:
     assert response.text == "mock reply"
     assert response.request_id == "request-1"
     assert seen["auth"] == "Bearer TEST"
-    assert seen["idempotency_key"] == "request-1"
+    assert seen["idempotency_key"] is None
     assert seen["request_id"] == "request-1"
     assert seen["body"]["model"] == "synthetic-model"
     assert seen["body"]["messages"] == list(ROOT_MESSAGES)
+
+
+def test_provider_idempotency_header_is_reserved_for_durable_letter_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def exercise() -> list[str | None]:
+        seen: list[str | None] = []
+
+        async def handler(request: web.Request) -> web.Response:
+            seen.append(request.headers.get("Idempotency-Key"))
+            return web.json_response(
+                {"choices": [{"message": {"content": "mock reply"}}]}
+            )
+
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", handler)
+        async with TestClient(TestServer(app)) as client:
+            adapter = OpenAICompatibleAdapter(make_config(str(client.make_url("/v1"))))
+            await adapter.complete(ROOT_MESSAGES, request_id="letter-reply-mode-router")
+            await adapter.complete(
+                ROOT_MESSAGES,
+                request_id="letter-reply:synthetic-letter-id",
+            )
+        return seen
+
+    monkeypatch.setenv("B03_TEST_KEY", "TEST")
+    assert run(exercise()) == [None, "letter-reply:synthetic-letter-id"]
 
 
 def test_responses_style_and_sse_stream_are_supported(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/llm/test_gateway.py
+++ b/tests/llm/test_gateway.py
@@ -109,6 +109,8 @@ def test_chat_completion_adapter_uses_local_mock_server_and_env_key(monkeypatch:
 
         async def handler(request: web.Request) -> web.Response:
             seen["auth"] = request.headers.get("Authorization")
+            seen["idempotency_key"] = request.headers.get("Idempotency-Key")
+            seen["request_id"] = request.headers.get("X-Request-ID")
             seen["body"] = await request.json()
             return web.json_response(
                 {"choices": [{"message": {"role": "assistant", "content": "mock reply"}}]}
@@ -127,6 +129,8 @@ def test_chat_completion_adapter_uses_local_mock_server_and_env_key(monkeypatch:
     assert response.text == "mock reply"
     assert response.request_id == "request-1"
     assert seen["auth"] == "Bearer TEST"
+    assert seen["idempotency_key"] == "request-1"
+    assert seen["request_id"] == "request-1"
     assert seen["body"]["model"] == "synthetic-model"
     assert seen["body"]["messages"] == list(ROOT_MESSAGES)
 

--- a/tests/test_baseline_hardening.py
+++ b/tests/test_baseline_hardening.py
@@ -518,7 +518,7 @@ def test_handler_cors_allows_pinned_official_frontend_preflight() -> None:
     )
 
 
-def test_handler_returns_http_503_for_llm_failure(monkeypatch) -> None:
+def test_handler_acknowledges_before_background_llm_failure(monkeypatch) -> None:
     import asyncio
 
     from aiohttp import web
@@ -535,17 +535,33 @@ def test_handler_returns_http_503_for_llm_failure(monkeypatch) -> None:
         app = web.Application()
         app.router.add_route("*", "/{tail:.*}", local_server.handler)
         async with TestClient(TestServer(app, access_log=None)) as client:
-            response = await client.post(
+            send_response = await client.post(
                 "/toy/letter/send",
                 json={"content": "synthetic HTTP status input", "material": {}},
             )
-            return response.status, await response.json()
+            send_payload = await send_response.json()
+            await asyncio.gather(*tuple(local_server.reply_tasks))
+            detail_response = await client.get(
+                "/toy/letter/detail",
+                params={"letter_id": send_payload["data"]["letter_id"]},
+            )
+            return (
+                send_response.status,
+                send_payload,
+                detail_response.status,
+                await detail_response.json(),
+            )
 
-    status, payload = asyncio.run(exercise())
+    send_status, send_payload, detail_status, detail_payload = asyncio.run(exercise())
 
-    assert status == 503
-    assert payload["code"] == 503
-    assert payload["data"]["status"] == "FAILED"
+    assert send_status == 200
+    assert send_payload["code"] == 0
+    assert send_payload["data"]["status"] == "PENDING"
+    assert detail_status == 200
+    assert detail_payload["code"] == 0
+    assert detail_payload["data"]["letter_status"] == "FAILED"
+    assert detail_payload["data"]["error_code"] == "LLM_TIMEOUT"
+    assert detail_payload["data"]["retryable"] is True
 
 
 def test_handler_returns_http_501_404_and_200_for_terminal_route_results() -> None:

--- a/tests/test_baseline_hardening.py
+++ b/tests/test_baseline_hardening.py
@@ -526,7 +526,7 @@ def test_handler_acknowledges_before_background_llm_failure(monkeypatch) -> None
 
     import local_server
 
-    def fail(_content, _context=""):
+    def fail(_content, _context="", **_kwargs):
         raise local_server.LLMError("LLM_TIMEOUT")
 
     monkeypatch.setattr(local_server.letters_adapter, "reply", fail)
@@ -642,7 +642,7 @@ def test_llm_failure_is_explicit_failed_without_placeholder_text(monkeypatch) ->
 
     local_server.store.letters.clear()
 
-    def fail(_content, _context=""):
+    def fail(_content, _context="", **_kwargs):
         raise local_server.LLMError("LLM_TIMEOUT")
 
     monkeypatch.setattr(local_server.letters_adapter, "reply", fail)
@@ -777,7 +777,7 @@ def test_slow_llm_does_not_block_loop_and_times_out_as_failed(monkeypatch) -> No
     started = threading.Event()
     finished = threading.Event()
 
-    def slow_reply(_content, _context=""):
+    def slow_reply(_content, _context="", **_kwargs):
         started.set()
         time.sleep(0.25)
         finished.set()
@@ -863,7 +863,11 @@ def test_request_logging_does_not_emit_letter_content(monkeypatch, capsys) -> No
     import local_server
 
     local_server.store.letters.clear()
-    monkeypatch.setattr(local_server.letters_adapter, "reply", lambda *_args: "synthetic reply")
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "reply",
+        lambda *_args, **_kwargs: "synthetic reply",
+    )
     result = asyncio.run(
         local_server.route(
             "POST",
@@ -889,7 +893,11 @@ def test_handler_logs_exclude_body_reply_token_and_full_query(monkeypatch, capsy
     import local_server
 
     local_server.store.letters.clear()
-    monkeypatch.setattr(local_server.letters_adapter, "reply", lambda *_args: "synthetic reply secret")
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "reply",
+        lambda *_args, **_kwargs: "synthetic reply secret",
+    )
     capsys.readouterr()
 
     async def exercise():
@@ -933,7 +941,11 @@ def test_aiohttp_app_access_logging_never_leaks_sensitive_query(monkeypatch, cap
     import local_server
 
     local_server.store.letters.clear()
-    monkeypatch.setattr(local_server.letters_adapter, "reply", lambda *_args: "synthetic access reply")
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "reply",
+        lambda *_args, **_kwargs: "synthetic access reply",
+    )
     capsys.readouterr()
 
     async def exercise():


### PR DESCRIPTION
## Summary
- acknowledge the real HTTP send endpoint immediately with `200` / `PENDING`
- generate replies in tracked background tasks and recover persisted work without replaying uncertain provider calls
- reuse recent identical submissions and allow failed idempotent requests to retry safely
- carry the durable letter request ID through the default provider path
- expose terminal background failures through the detail contract

## Validation
- full pytest: 682 passed, 1 deselected
- focused HTTP/gateway/hardening tests: 69 passed, 1 deselected
- baseline hardening scan PASS
- py_compile and diff-check PASS
- GitHub checks: 2/2 PASS

## Boundary
- no frontend asset changes
- no failed-copy cleanup; that remains the separate stacked PR #100