### PR TITLE
feat(reply): isolate canonical copy and TTS delivery

### DIFF
--- a/reply_delivery.py
+++ b/reply_delivery.py
@@ -150,7 +150,7 @@ def _semantic_blocks(sentences: tuple[str, ...]) -> tuple[tuple[int, str], ...]:
 _ORDINARY_VIDEO_CONSTRAINT = (
     "请生成一封可直接朗读的普通视频回信。只输出完整回信正文，不要标题、列表、括号说明、"
     "情绪标签、舞台提示或任何生成说明。按自然偏利落的普通话语速控制在40到50秒，"
-    "正文严格为160到180个汉字。内容应先回应对方当下的感受，再给出清晰判断，最后自然收束；"
+    "正文严格为180到200个汉字，目标为190字。内容应先回应对方当下的感受，再给出清晰判断，最后自然收束；"
     "让语义本身有共情、坚定和希望的缓慢变化，不要复述整封来信。"
     "写成面对熟人说话的口语，使用六到七个完整句子，每句只表达一个意思；"
     "保留来信中的人物、地点和事实关系，不要把具体场景改写成不存在的画面。"
@@ -173,7 +173,7 @@ def build_ordinary_video_llm_content(letter_content: str) -> str:
 
 def ordinary_video_reply_length_ok(reply_text: str) -> bool:
     compact_length = len("".join(str(reply_text).split()))
-    return 160 <= compact_length <= 180
+    return 180 <= compact_length <= 200
 
 
 def build_ordinary_video_repair_content(reply_text: str) -> str:
@@ -181,7 +181,7 @@ def build_ordinary_video_repair_content(reply_text: str) -> str:
 
     return (
         "请将下面这封由你生成的回信改写为可直接朗读的完整正文。"
-        "保留原意与林离口吻，严格控制在160到180个汉字，只输出正文；"
+        "保留原意与林离口吻，严格控制在180到200个汉字，目标为190字，只输出正文；"
         "使用自然口语和六到七个完整句子，不要改变来信事实，不要生造比喻、金句或画面；"
         "不要标题、解释、括号说明、情绪标签或舞台提示。\n\n"
         + str(reply_text).strip()

--- a/reply_model_quality.py
+++ b/reply_model_quality.py
@@ -203,6 +203,14 @@ class GatewayPersonaRewriter:
         *,
         user_text: str,
     ) -> str:
+        delivery_length_contract = None
+        if "VIDEO_REPLY_LENGTH_OUT_OF_RANGE" in violation_codes:
+            delivery_length_contract = {
+                "compact_characters_min": 180,
+                "compact_characters_max": 200,
+                "target_compact_characters": 190,
+                "priority": "required_over_concise_style",
+            }
         payload = {
             "persona": _persona_review_profile(
                 self.persona_path,
@@ -231,6 +239,8 @@ class GatewayPersonaRewriter:
                 violation_codes
             ),
         }
+        if delivery_length_contract is not None:
+            payload["delivery_length_contract"] = delivery_length_contract
         messages = (
             {
                 "role": "system",
@@ -242,6 +252,10 @@ class GatewayPersonaRewriter:
                     "style. Do not invent history or facts. Return only the replacement "
                     "plain-text reply: no analysis, JSON, Markdown heading, stage direction, "
                     "speaker prefix, or control markup."
+                    " When delivery_length_contract is present, it overrides the usual "
+                    "concise style: rewrite to its target length and verify the compact "
+                    "character count is within the inclusive range before returning. "
+                    "视频回信字数契约优先于简短风格；目标为190字，去除空白后必须在180到200字之间。"
                 ),
             },
             {
@@ -326,7 +340,7 @@ def create_model_quality_ports(
     )
     timeout = _env_timeout(
         "OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS",
-        min(configured_timeout, 12.0),
+        min(configured_timeout, 60.0),
     )
     reviewer = GatewayPersonaReviewer(
         gateway,
@@ -473,12 +487,26 @@ def _complete_text(
     timeout_seconds: float,
 ) -> str:
     async def invoke() -> str:
+        request_id = f"quality-{uuid.uuid4().hex}"
+        if bool(getattr(gateway, "stream_enabled", False)):
+            async def collect_stream() -> str:
+                chunks: list[str] = []
+                async for delta in gateway.stream(
+                    messages,
+                    request_id=request_id,
+                ):
+                    if delta.text:
+                        chunks.append(delta.text)
+                return "".join(chunks)
+
+            return await asyncio.wait_for(
+                collect_stream(),
+                timeout_seconds,
+            )
         response = await asyncio.wait_for(
             gateway.complete(
                 messages,
-                request_id=(
-                    f"quality-{uuid.uuid4().hex}"
-                ),
+                request_id=request_id,
             ),
             timeout_seconds,
         )

--- a/reply_policy.py
+++ b/reply_policy.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 import re
 
-from reply_context import ReplyContext
+from reply_context import ReplyContext, ReplyMode
 
 
 class ViolationSeverity(StrEnum):
@@ -16,6 +16,7 @@ class ViolationSeverity(StrEnum):
 
 class ViolationCode(StrEnum):
     OUTPUT_LIMIT_EXCEEDED = "OUTPUT_LIMIT_EXCEEDED"
+    VIDEO_REPLY_LENGTH_OUT_OF_RANGE = "VIDEO_REPLY_LENGTH_OUT_OF_RANGE"
     STAGE_DIRECTION_IN_SPOKEN_TEXT = "STAGE_DIRECTION_IN_SPOKEN_TEXT"
     INTERNAL_CONTROL_MARKUP = "INTERNAL_CONTROL_MARKUP"
     PRIVATE_STATE_EXPOSED = "PRIVATE_STATE_EXPOSED"
@@ -116,6 +117,19 @@ def scan_reply(
                 ViolationCode.OUTPUT_LIMIT_EXCEEDED,
                 ViolationSeverity.HARD,
                 limit,
+                len(candidate),
+            )
+        )
+    compact_length = len("".join(candidate.split()))
+    if (
+        context.mode in {ReplyMode.SPOKEN_VIDEO, ReplyMode.MUSICAL_VIDEO}
+        and not 180 <= compact_length <= 200
+    ):
+        violations.append(
+            Violation(
+                ViolationCode.VIDEO_REPLY_LENGTH_OUT_OF_RANGE,
+                ViolationSeverity.HARD,
+                0,
                 len(candidate),
             )
         )

--- a/tests/persona/test_persona_v2_release_e2e.py
+++ b/tests/persona/test_persona_v2_release_e2e.py
@@ -119,7 +119,7 @@ def test_chinese_letter_uses_release_persona_then_commits_canonical_once(
 
 @pytest.mark.parametrize("mode", [ReplyMode.SPOKEN_VIDEO, ReplyMode.MUSICAL_VIDEO])
 def test_media_spoken_text_rewrites_stage_directions_once(mode: ReplyMode) -> None:
-    rewriter = FixedRewriter("我听见了。先不用急着给自己一个结论。")
+    rewriter = FixedRewriter("我听见了。" + "林" * 185)
     result = asyncio.run(
         ReplyPipeline(
             CompletedOrchestrator("(smiles)\n我听见了。"),

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -9,12 +9,13 @@ from typing import Any, Mapping, Sequence
 
 import pytest
 
-from llm_gateway import Gateway, GatewayResponse
+from llm_gateway import Gateway, GatewayDelta, GatewayResponse
 from memory_port import NullMemoryPort
 from memory_prompt import MemoryPromptBuilder
 from reply_context import ReplyContext, ReplyMode, TrustedTime
 from reply_orchestrator import ReplyOrchestrator, ReplyRequest, ReplyState
 from reply_pipeline import ReplyPipeline, UnavailableRewriter
+from reply_model_quality import GatewayPersonaRewriter, create_model_quality_ports
 from reply_reviewer import NullReviewer
 
 
@@ -99,6 +100,18 @@ class CompatibilityBridge(Gateway):
         )
 
 
+class StreamingOnlyGateway(Gateway):
+    stream_enabled = True
+
+    async def complete(self, messages, *, request_id=None):
+        raise AssertionError("stream-enabled quality calls must not use complete")
+
+    async def stream(self, messages, *, request_id=None):
+        yield GatewayDelta("林" * 95, request_id or "stream", index=0)
+        yield GatewayDelta("林" * 95, request_id or "stream", index=1)
+        yield GatewayDelta("", request_id or "stream", index=2, finish_reason="stop")
+
+
 def _pipeline(
     gateway: Gateway,
     monkeypatch: pytest.MonkeyPatch,
@@ -130,9 +143,9 @@ def _pipeline(
     )
 
 
-def _context() -> ReplyContext:
+def _context(mode: ReplyMode = ReplyMode.TEXT_LETTER) -> ReplyContext:
     return ReplyContext.create(
-        ReplyMode.TEXT_LETTER,
+        mode,
         trusted_time=TrustedTime(
             datetime(2026, 8, 22, tzinfo=timezone.utc)
         ),
@@ -210,6 +223,49 @@ def test_deterministic_violation_uses_original_model_for_one_rewrite(
     assert rewrite["persona"]["display_name"] == "林离 Olivia"
 
 
+def test_video_length_rewrite_receives_the_exact_delivery_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = SequencedQualityGateway(
+        candidate="太短。",
+        reviews=[_review_payload(), _review_payload()],
+        rewritten="林" * 190,
+    )
+    pipeline = _pipeline(gateway, monkeypatch)
+
+    result = asyncio.run(
+        pipeline.run(
+            ReplyRequest(content="请认真回我。", request_id="video-length"),
+            _context(ReplyMode.MUSICAL_VIDEO),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.rewrite_calls == 1
+    rewrite = gateway.rewrite_requests[0]
+    assert rewrite["violation_codes"] == ["VIDEO_REPLY_LENGTH_OUT_OF_RANGE"]
+    assert rewrite["delivery_length_contract"] == {
+        "compact_characters_min": 180,
+        "compact_characters_max": 200,
+        "target_compact_characters": 190,
+        "priority": "required_over_concise_style",
+    }
+
+
+def test_quality_rewriter_uses_configured_streaming_transport() -> None:
+    rewritten = GatewayPersonaRewriter(
+        StreamingOnlyGateway(),
+        ROOT / "linli_character" / "persona_release_v2.json",
+        2.0,
+    ).rewrite(
+        "太短。",
+        _context(ReplyMode.MUSICAL_VIDEO),
+        ("VIDEO_REPLY_LENGTH_OUT_OF_RANGE",),
+    )
+
+    assert rewritten == "林" * 190
+
+
 def test_invalid_reviewer_json_degrades_only_clean_candidate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -278,3 +334,31 @@ def test_quality_model_can_be_disabled_without_disabling_generation(
     assert result.state is ReplyState.COMPLETED
     assert result.quality_status == "accepted_degraded"
     assert gateway.call_kinds == ["generation"]
+
+
+def test_quality_model_default_timeout_allows_slow_configured_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", raising=False)
+    gateway = SequencedQualityGateway(candidate="候选。", reviews=[])
+    orchestrator = SimpleNamespace(
+        gateway=SimpleNamespace(
+            adapter=SimpleNamespace(
+                config=SimpleNamespace(
+                    provider="openai_compatible",
+                    timeout_seconds=90.0,
+                ),
+                persona_v2_path=(
+                    ROOT / "linli_character" / "persona_release_v2.json"
+                ),
+                gateway=gateway,
+            )
+        )
+    )
+
+    reviewer, rewriter = create_model_quality_ports(orchestrator)
+
+    assert reviewer is not None
+    assert rewriter is not None
+    assert reviewer.adapter.config.timeout_seconds == 60.0
+    assert rewriter.timeout_seconds == 60.0

--- a/tests/persona/test_reply_pipeline.py
+++ b/tests/persona/test_reply_pipeline.py
@@ -133,7 +133,7 @@ class RecordingProvider:
     ) -> GatewayResponse:
         self.messages = tuple(dict(message) for message in messages)  # type: ignore[arg-type]
         return GatewayResponse(
-            text="我听见了。先不用急着给自己一个结论。",
+            text="我听见了。" + "林" * 185,
             request_id=request_id or "generated",
             provider="synthetic",
             model="synthetic",

--- a/tests/persona/test_reply_policy.py
+++ b/tests/persona/test_reply_policy.py
@@ -42,8 +42,41 @@ def test_spoken_output_enforces_length_and_standalone_stage_direction_rules() ->
 
     assert tuple(violation.code for violation in result.violations) == (
         ViolationCode.OUTPUT_LIMIT_EXCEEDED,
+        ViolationCode.VIDEO_REPLY_LENGTH_OUT_OF_RANGE,
         ViolationCode.STAGE_DIRECTION_IN_SPOKEN_TEXT,
     )
+
+
+def test_video_reply_requires_delivery_length_without_affecting_text_letters() -> None:
+    trusted_time = TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc))
+    short_reply = "短回复。"
+    valid_reply = "林" * 180
+
+    for mode in (ReplyMode.SPOKEN_VIDEO, ReplyMode.MUSICAL_VIDEO):
+        short_result = scan_reply(
+            short_reply,
+            ReplyContext.create(mode, trusted_time=trusted_time),
+        )
+        assert tuple(item.code for item in short_result.violations) == (
+            ViolationCode.VIDEO_REPLY_LENGTH_OUT_OF_RANGE,
+        )
+        assert scan_reply(
+            valid_reply,
+            ReplyContext.create(mode, trusted_time=trusted_time),
+        ).passed is True
+        assert scan_reply(
+            "林" * 179,
+            ReplyContext.create(mode, trusted_time=trusted_time),
+        ).passed is False
+        assert scan_reply(
+            "林" * 201,
+            ReplyContext.create(mode, trusted_time=trusted_time),
+        ).passed is False
+
+    assert scan_reply(
+        short_reply,
+        ReplyContext.create(ReplyMode.TEXT_LETTER, trusted_time=trusted_time),
+    ).passed is True
 
 
 def test_only_explicit_permanent_or_exclusive_commitments_are_blocked() -> None:

--- a/tests/persona/test_reply_quality_gate.py
+++ b/tests/persona/test_reply_quality_gate.py
@@ -54,6 +54,13 @@ def _context() -> ReplyContext:
     )
 
 
+def _video_context() -> ReplyContext:
+    return ReplyContext.create(
+        ReplyMode.MUSICAL_VIDEO,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    )
+
+
 def test_clean_candidate_passes_degraded_when_reviewer_is_disabled() -> None:
     result = run_reply_quality_gate(
         "A clean synthetic candidate.",
@@ -104,6 +111,40 @@ def test_second_hard_result_is_blocked_without_a_hidden_rewrite_loop() -> None:
     assert result.accepted is False
     assert result.rewrite_calls == 1
     assert result.reviewer_calls == 2
+    assert rewriter.calls == 1
+
+
+def test_short_video_reply_uses_the_single_global_rewrite_budget() -> None:
+    reviewer = _Reviewer(_pass_review(), _pass_review())
+    rewriter = _Rewriter("林" * 190)
+
+    result = run_reply_quality_gate(
+        "太短。",
+        _video_context(),
+        reviewer=reviewer,
+        rewriter=rewriter,
+    )
+
+    assert result.status is QualityGateStatus.ACCEPTED
+    assert result.rewrite_calls == 1
+    assert reviewer.calls == 2
+    assert rewriter.calls == 1
+
+
+def test_short_video_rewrite_is_blocked_without_a_second_rewrite() -> None:
+    reviewer = _Reviewer(_pass_review(), _pass_review())
+    rewriter = _Rewriter("还是太短。")
+
+    result = run_reply_quality_gate(
+        "太短。",
+        _video_context(),
+        reviewer=reviewer,
+        rewriter=rewriter,
+    )
+
+    assert result.status is QualityGateStatus.BLOCKED
+    assert result.violation_codes == ("VIDEO_REPLY_LENGTH_OUT_OF_RANGE",)
+    assert result.rewrite_calls == 1
     assert rewriter.calls == 1
 
 

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import sys
+import wave
+from array import array
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from reply_delivery import (
+    build_ordinary_video_llm_content,
+    build_ordinary_video_repair_content,
+    ordinary_video_reply_length_ok,
+    plan_reply_delivery,
+)
+from tts import external_cosyvoice_worker
+from tts.delivery import (
+    DeliveryAudioError,
+    _fit_overlong_wav,
+    build_external_delivery_request,
+    delivery_tempo_factor,
+)
+
+
+def test_ordinary_video_copy_contract_targets_cross_lingual_delivery_length() -> None:
+    initial = build_ordinary_video_llm_content("原始来信")
+    repair = build_ordinary_video_repair_content("旧候选")
+
+    assert "180到200个汉字" in initial
+    assert "目标为190字" in initial
+    assert "180到200个汉字" in repair
+    assert ordinary_video_reply_length_ok("林" * 179) is False
+    assert ordinary_video_reply_length_ok("林" * 180) is True
+    assert ordinary_video_reply_length_ok("林" * 200) is True
+    assert ordinary_video_reply_length_ok("林" * 201) is False
+
+
+def test_delivery_request_uses_audio_only_cross_lingual_conditioning() -> None:
+    config = SimpleNamespace(
+        runtime_root="runtime",
+        model_dir="model",
+        reference_audio="reference.wav",
+        reference_text="accepted reference transcript",
+        fp16=True,
+    )
+
+    request = build_external_delivery_request(
+        config,
+        plan_reply_delivery("第一句。第二句。"),
+    )
+
+    assert request["voice_condition_mode"] == "cross_lingual_audio_only"
+    assert "reference_text" not in request
+    assert "instruct_text" not in request
+    assert request["blocks"] == ["第一句。第二句。"]
+    assert request["seed"] == 200717
+
+
+def test_delivery_tempo_allows_only_modest_whole_utterance_fit() -> None:
+    assert delivery_tempo_factor(50.0) is None
+    assert delivery_tempo_factor(51.0) == 1.02
+    assert delivery_tempo_factor(52.0) == 1.04
+    assert delivery_tempo_factor(52.01) is None
+
+
+def test_delivery_fit_rejects_audio_over_52_seconds(tmp_path) -> None:
+    sample_rate = 8_000
+    path = tmp_path / "overlong.wav"
+    samples = array("h", [3_000] * (53 * sample_rate))
+    with wave.open(str(path), "wb") as target:
+        target.setnchannels(1)
+        target.setsampwidth(2)
+        target.setframerate(sample_rate)
+        target.writeframes(samples.tobytes())
+
+    with pytest.raises(DeliveryAudioError, match="TTS_DELIVERY_DURATION_OUT_OF_RANGE"):
+        _fit_overlong_wav(path, 53.0)
+
+
+def test_external_worker_renders_blocks_with_one_cross_lingual_model_load(
+    tmp_path, monkeypatch
+) -> None:
+    calls = {"loads": 0, "texts": []}
+
+    class Tensor:
+        def __init__(self, values):
+            self.values = values
+
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def float(self):
+            return self
+
+        def reshape(self, *_shape):
+            return self
+
+        def tolist(self):
+            return self.values
+
+    class AutoModel:
+        sample_rate = 100
+
+        def __init__(self, **_kwargs):
+            calls["loads"] += 1
+
+        def inference_cross_lingual(self, text, *_args, **kwargs):
+            calls["texts"].append(text)
+            calls.setdefault("kwargs", []).append(kwargs)
+            value = 0.1 if len(calls["texts"]) == 1 else 0.2
+            yield {"tts_speech": Tensor([value] * 100)}
+
+    cosyvoice = ModuleType("cosyvoice")
+    cli = ModuleType("cosyvoice.cli")
+    module = ModuleType("cosyvoice.cli.cosyvoice")
+    module.AutoModel = AutoModel
+    torch = ModuleType("torch")
+    torch.manual_seed = lambda value: calls.setdefault("seeds", []).append(value)
+    monkeypatch.setitem(sys.modules, "cosyvoice", cosyvoice)
+    monkeypatch.setitem(sys.modules, "cosyvoice.cli", cli)
+    monkeypatch.setitem(sys.modules, "cosyvoice.cli.cosyvoice", module)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    output = tmp_path / "delivery.wav"
+
+    external_cosyvoice_worker._synthesize(
+        {
+            "runtime_root": str(tmp_path),
+            "model_dir": str(tmp_path),
+            "reference_audio": str(tmp_path / "reference.wav"),
+            "blocks": ["第一句", "第二句"],
+            "cross_fade_seconds": 0.1,
+            "seed": 200717,
+        },
+        output,
+    )
+
+    assert calls == {
+        "loads": 1,
+        "texts": [
+            "You are a helpful assistant.<|endofprompt|>第一句",
+            "You are a helpful assistant.<|endofprompt|>第二句",
+        ],
+        "kwargs": [
+            {"zero_shot_spk_id": "", "stream": False, "speed": 1.0},
+            {"zero_shot_spk_id": "", "stream": False, "speed": 1.0},
+        ],
+        "seeds": [200717],
+    }
+    with wave.open(str(output), "rb") as rendered:
+        assert rendered.getnframes() == 190

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -56,10 +56,11 @@ def build_external_delivery_request(
         "model_dir": config.model_dir,
         "reference_audio": config.reference_audio,
         "fp16": bool(config.fp16),
-        "voice_condition_mode": "contextual_long_form",
+        "voice_condition_mode": "cross_lingual_audio_only",
         "blocks": [unit.text for unit in plan.speech_units()],
         "speed": 1.0,
         "cross_fade_seconds": 0.08,
+        "seed": 200717,
     }
 
 
@@ -86,7 +87,11 @@ def _ffmpeg() -> str:
 
 
 def _fit_overlong_wav(path: Path, duration_seconds: float) -> tuple[int, int]:
-    factor = delivery_tempo_factor(duration_seconds)
+    duration = float(duration_seconds)
+    if duration > 52.0:
+        raise DeliveryAudioError("TTS_DELIVERY_DURATION_OUT_OF_RANGE")
+
+    factor = delivery_tempo_factor(duration)
     if factor is None:
         return _validate_wav(path)
     fitted = path.with_name("speech-fitted.wav")

--- a/tts/external_cosyvoice_worker.py
+++ b/tts/external_cosyvoice_worker.py
@@ -27,26 +27,64 @@ def _write_wav(path: Path, sample_rate: int, samples: list[float]) -> None:
         target.writeframes(pcm.tobytes())
 
 
+def _append_with_cross_fade(
+    target: list[float],
+    block: list[float],
+    overlap: int,
+) -> None:
+    if not target or overlap <= 0:
+        target.extend(block)
+        return
+    count = min(overlap, len(target), len(block))
+    start = len(target) - count
+    for index in range(count):
+        weight = (index + 1) / (count + 1)
+        target[start + index] = (
+            target[start + index] * (1.0 - weight) + block[index] * weight
+        )
+    target.extend(block[count:])
+
+
 def _synthesize(request: dict[str, object], output: Path) -> None:
     runtime_root = Path(str(request["runtime_root"]))
     sys.path.insert(0, str(runtime_root))
     for key in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "MODELSCOPE_OFFLINE"):
         os.environ[key] = "1"
+    import torch
     from cosyvoice.cli.cosyvoice import AutoModel
 
+    torch.manual_seed(int(request.get("seed", 200717)))
     model = AutoModel(model_dir=str(request["model_dir"]), fp16=bool(request.get("fp16", True)))
-    prompt = "You are a helpful assistant.<|endofprompt|>" + str(request["reference_text"])
+    prompt_prefix = "You are a helpful assistant.<|endofprompt|>"
+    raw_blocks = request.get("blocks")
+    if isinstance(raw_blocks, list) and raw_blocks:
+        blocks = [str(value).strip() for value in raw_blocks if str(value).strip()]
+    else:
+        text = str(request.get("text", "")).strip()
+        blocks = [text] if text else []
+    if not blocks:
+        raise RuntimeError("empty CosyVoice input")
     samples: list[float] = []
-    for item in model.inference_zero_shot(
-        str(request["text"]),
-        prompt,
-        str(request["reference_audio"]),
-        stream=bool(request.get("stream", True)),
-        speed=float(request.get("speed", 1.0)),
-    ):
-        speech = item.get("tts_speech") if isinstance(item, dict) else None
-        if speech is not None:
-            samples.extend(float(value) for value in speech.detach().cpu().float().reshape(-1).tolist())
+    cross_fade = max(0.0, min(0.5, float(request.get("cross_fade_seconds", 0.0))))
+    overlap = round(cross_fade * int(model.sample_rate))
+    for block in blocks:
+        block_samples: list[float] = []
+        for item in model.inference_cross_lingual(
+            prompt_prefix + block,
+            str(request["reference_audio"]),
+            zero_shot_spk_id="",
+            stream=False,
+            speed=1.0,
+        ):
+            speech = item.get("tts_speech") if isinstance(item, dict) else None
+            if speech is not None:
+                block_samples.extend(
+                    float(value)
+                    for value in speech.detach().cpu().float().reshape(-1).tolist()
+                )
+        if not block_samples:
+            raise RuntimeError("empty CosyVoice block output")
+        _append_with_cross_fade(samples, block_samples, overlap)
     if not samples:
         raise RuntimeError("empty CosyVoice output")
     _write_wav(output, int(model.sample_rate), samples)


### PR DESCRIPTION
## Scope

Second slice replacing closed #106. Defines the 180-200 character ordinary-video copy contract, keeps the one-rewrite quality budget, and makes CrossLingual TTS use only canonical reply blocks with bounded whole-utterance fitting.

## Validation

- isolated slice: 46 passed
- stacked focused rerun: 37 passed
- py_compile: PASS
- diff-check: PASS

## Boundary

No reply-media rendering, LatentSync, music-video assembly, HTTP routing, provider run, or human listening claim. Stacked on #107 and should be reviewed as its own base/head pair.