### PR TITLE
fix(media): harden portable reply rendering

### DIFF
--- a/latentsync_reply.py
+++ b/latentsync_reply.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -9,6 +11,90 @@ from pathlib import Path
 
 class LatentSyncReplyError(RuntimeError):
     """Stable product error for the external LatentSync process."""
+
+
+def _environment_with_ffmpeg(shim_root: Path, cache_root: Path) -> dict[str, str]:
+    configured = os.environ.get("OLIVIA_FFMPEG_EXE", "").strip()
+    executable = configured if configured and Path(configured).is_file() else None
+    executable = executable or shutil.which("ffmpeg")
+    if executable is None:
+        try:
+            import imageio_ffmpeg
+
+            executable = imageio_ffmpeg.get_ffmpeg_exe()
+        except (ImportError, RuntimeError, OSError) as exc:
+            raise LatentSyncReplyError("LATENTSYNC_FFMPEG_UNAVAILABLE") from exc
+    resolved = Path(executable).resolve()
+    directory = resolved.parent
+    if resolved.stem.casefold() != "ffmpeg":
+        shim = Path(shim_root) / "ffmpeg.exe"
+        shutil.copy2(resolved, shim)
+        directory = shim.parent
+    environment = dict(os.environ)
+    environment["PATH"] = str(directory) + os.pathsep + environment.get("PATH", "")
+    cache_root.mkdir(parents=True, exist_ok=True)
+    environment["HF_HOME"] = str(cache_root / "huggingface")
+    environment["HF_HUB_CACHE"] = str(cache_root / "huggingface" / "hub")
+    environment["TORCH_HOME"] = str(cache_root / "torch")
+    environment["XDG_CACHE_HOME"] = str(cache_root)
+    environment["TEMP"] = str(shim_root)
+    environment["TMP"] = str(shim_root)
+    return environment
+
+
+def _prepare_source_clip(
+    source_video: Path,
+    audio_path: Path,
+    prepared_video: Path,
+    *,
+    environment: dict[str, str],
+) -> None:
+    """Decode only the needed span into a stable LatentSync input."""
+
+    ffmpeg = shutil.which("ffmpeg", path=environment["PATH"])
+    if ffmpeg is None:
+        raise LatentSyncReplyError("LATENTSYNC_FFMPEG_UNAVAILABLE")
+    command = [
+        ffmpeg,
+        "-y",
+        "-fflags",
+        "+discardcorrupt",
+        "-err_detect",
+        "ignore_err",
+        "-stream_loop",
+        "-1",
+        "-i",
+        str(source_video),
+        "-i",
+        str(audio_path),
+        "-map",
+        "0:v:0",
+        "-map",
+        "1:a:0",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "fast",
+        "-crf",
+        "18",
+        "-pix_fmt",
+        "yuv420p",
+        "-r",
+        "25",
+        "-c:a",
+        "aac",
+        "-shortest",
+        str(prepared_video),
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        check=False,
+        timeout=1800,
+        env=environment,
+    )
+    if result.returncode != 0 or not prepared_video.is_file():
+        raise LatentSyncReplyError("LATENTSYNC_SOURCE_PREPARE_FAILED")
 
 
 def render_latentsync_video(
@@ -27,7 +113,9 @@ def render_latentsync_video(
     output_path = Path(output_path)
     python_path = Path(python_path)
     latentsync_root = Path(latentsync_root)
-    config_path = latentsync_root / "configs" / "unet" / "stage2.yaml"
+    config_path = (
+        latentsync_root / "configs" / "unet" / "stage2_efficient.yaml"
+    )
     checkpoint_path = latentsync_root / "checkpoints" / "latentsync_unet.pt"
     required = (
         python_path,
@@ -41,7 +129,26 @@ def render_latentsync_video(
         raise LatentSyncReplyError("LATENTSYNC_INPUT_UNAVAILABLE")
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(prefix="olivia-latentsync-", dir=output_path.parent) as temporary:
+    cache_value = os.environ.get("OLIVIA_PROVIDER_CACHE_ROOT", "").strip()
+    cache_root = (
+        Path(cache_value).expanduser()
+        if cache_value
+        else output_path.parent.parent / "provider-cache"
+    )
+    work_root = cache_root / "latentsync-work"
+    work_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="job-", dir=work_root) as temporary:
+        temporary_root = Path(temporary)
+        environment = _environment_with_ffmpeg(temporary_root, cache_root)
+        prepared_video = temporary_root / "source-h264.mp4"
+        working_output = temporary_root / "reply.mp4"
+        pipeline_temp = temporary_root / "pipeline-temp"
+        _prepare_source_clip(
+            source_video,
+            audio_path,
+            prepared_video,
+            environment=environment,
+        )
         command = [
             str(python_path),
             "-m",
@@ -51,17 +158,17 @@ def render_latentsync_video(
             "--inference_ckpt_path",
             str(checkpoint_path),
             "--video_path",
-            str(source_video),
+            str(prepared_video),
             "--audio_path",
             str(audio_path),
             "--video_out_path",
-            str(output_path),
+            str(working_output),
             "--inference_steps",
             "20",
             "--guidance_scale",
             "1.5",
             "--temp_dir",
-            temporary,
+            str(pipeline_temp),
             "--seed",
             "1247",
             "--enable_deepcache",
@@ -73,18 +180,26 @@ def render_latentsync_video(
                 capture_output=True,
                 check=False,
                 timeout=timeout_seconds,
+                env=environment,
             )
         except (OSError, subprocess.TimeoutExpired) as exc:
             raise LatentSyncReplyError("LATENTSYNC_FAILED") from exc
-    if result.returncode != 0:
-        raise LatentSyncReplyError("LATENTSYNC_FAILED")
-    if not output_path.is_file() or output_path.stat().st_size == 0:
-        raise LatentSyncReplyError("LATENTSYNC_OUTPUT_MISSING")
+        if result.returncode != 0:
+            raise LatentSyncReplyError("LATENTSYNC_FAILED")
+        if not working_output.is_file() or working_output.stat().st_size == 0:
+            raise LatentSyncReplyError("LATENTSYNC_OUTPUT_MISSING")
+        partial_output = output_path.with_suffix(output_path.suffix + ".partial")
+        try:
+            shutil.copy2(working_output, partial_output)
+            partial_output.replace(output_path)
+        finally:
+            partial_output.unlink(missing_ok=True)
     return {
         "visual_provider": "LatentSync-1.5",
         "inference_steps": 20,
         "guidance_scale": 1.5,
         "deepcache": True,
+        "inference_profile": "stage2_efficient",
         "scene_source": "official_motion_video",
     }
 

--- a/latentsync_reply.py
+++ b/latentsync_reply.py
@@ -15,8 +15,13 @@ class LatentSyncReplyError(RuntimeError):
 
 def _environment_with_ffmpeg(shim_root: Path, cache_root: Path) -> dict[str, str]:
     configured = os.environ.get("OLIVIA_FFMPEG_EXE", "").strip()
-    executable = configured if configured and Path(configured).is_file() else None
-    executable = executable or shutil.which("ffmpeg")
+    if configured:
+        configured_path = Path(configured)
+        if not configured_path.is_file():
+            raise LatentSyncReplyError("LATENTSYNC_FFMPEG_UNAVAILABLE")
+        executable = str(configured_path)
+    else:
+        executable = shutil.which("ffmpeg")
     if executable is None:
         try:
             import imageio_ffmpeg

--- a/reply_media.py
+++ b/reply_media.py
@@ -92,13 +92,11 @@ def _tts_config(
     else:
         provider_options = dict(provider_options)
     if ordinary_video:
-        official_reference = Path(
-            os.environ.get(
-                "OLIVIA_REPLY_VOICE_REFERENCE",
-                "",
-            )
-        )
-        if official_reference.is_file():
+        configured_reference = os.environ.get("OLIVIA_REPLY_VOICE_REFERENCE")
+        if configured_reference is not None:
+            official_reference = Path(configured_reference)
+            if not official_reference.is_file():
+                raise ReplyMediaError("VOICE_REFERENCE_UNAVAILABLE")
             settings["reference_audio"] = str(
                 _bounded_voice_reference(official_reference, temporary_root)
             )

--- a/reply_media.py
+++ b/reply_media.py
@@ -27,6 +27,33 @@ class ReplyMediaError(RuntimeError):
     pass
 
 
+def _bounded_voice_reference(source: Path, temporary_root: Path) -> Path:
+    """Use only the reviewed clean 4.85-second voice prompt."""
+
+    try:
+        with wave.open(str(source), "rb") as reference:
+            frame_rate = reference.getframerate()
+            if frame_rate <= 0:
+                raise wave.Error("invalid frame rate")
+            maximum_frames = int(frame_rate * 4.85)
+            if reference.getnframes() <= maximum_frames:
+                return source
+            parameters = reference.getparams()
+            frames = reference.readframes(maximum_frames)
+    except (OSError, EOFError, wave.Error) as exc:
+        raise ReplyMediaError("VOICE_REFERENCE_INVALID") from exc
+
+    temporary_root.mkdir(parents=True, exist_ok=True)
+    bounded = temporary_root / "voice-reference.wav"
+    try:
+        with wave.open(str(bounded), "wb") as target:
+            target.setparams(parameters)
+            target.writeframes(frames)
+    except (OSError, wave.Error) as exc:
+        raise ReplyMediaError("VOICE_REFERENCE_INVALID") from exc
+    return bounded
+
+
 def _settings(path: Path) -> dict:
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
@@ -72,7 +99,10 @@ def _tts_config(
             )
         )
         if official_reference.is_file():
-            settings["reference_audio"] = str(official_reference)
+            settings["reference_audio"] = str(
+                _bounded_voice_reference(official_reference, temporary_root)
+            )
+            settings["leading_trim_seconds"] = 0.0
         provider_options["voice_condition_mode"] = "cross_lingual_audio_only"
     reference_audio = Path(str(settings.get("reference_audio", "")))
     leading_trim = settings.get("leading_trim_seconds")
@@ -211,7 +241,8 @@ def render_reply_video(
         delivery_metadata = (
             {
                 "delivery_plan": delivery_plan.to_dict(),
-                "delivery_plan_applied_to_audio": True,
+                "delivery_block_grouping_applied_to_audio": True,
+                "delivery_cue_controls_applied_to_audio": False,
                 # LatentSync derives the face performance from the paced audio
                 # while the accepted original-motion video keeps body/scene motion.
                 "visual_cues_backend_control": False,

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -1,11 +1,36 @@
 from __future__ import annotations
 
+from array import array
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+from types import SimpleNamespace
+from types import ModuleType
+import wave
+
 import pytest
 
+import latentsync_reply
+import music_reply
+from latentsync_reply import render_latentsync_video
 from music_duration import MUSIC_DURATION_OPTIONS, normalize_music_duration
 from music_reply import MusicReplyError, render_musical_reply
-from reply_delivery import plan_reply_delivery
-from reply_media import ReplyMediaError, render_reply_video
+from reply_delivery import (
+    build_ordinary_video_llm_content,
+    build_ordinary_video_repair_content,
+    ordinary_video_reply_length_ok,
+    plan_reply_delivery,
+)
+from reply_media import ReplyMediaError, _tts_config, render_reply_video
+from tts.delivery import (
+    DeliveryAudioError,
+    _fit_overlong_wav,
+    build_external_delivery_request,
+    delivery_tempo_factor,
+)
+from tts import external_cosyvoice_worker
 
 
 def test_delivery_plan_preserves_spoken_text_and_duration_options():
@@ -14,6 +39,19 @@ def test_delivery_plan_preserves_spoken_text_and_duration_options():
     assert plan.duration_target_seconds == (40.0, 50.0)
     assert MUSIC_DURATION_OPTIONS == (40, 60)
     assert normalize_music_duration(40) == 40
+
+
+def test_ordinary_video_copy_contract_matches_cross_lingual_calibration():
+    initial = build_ordinary_video_llm_content("原始来信")
+    repair = build_ordinary_video_repair_content("旧候选")
+
+    assert "180到200个汉字" in initial
+    assert "目标为190字" in initial
+    assert "180到200个汉字" in repair
+    assert ordinary_video_reply_length_ok("林" * 179) is False
+    assert ordinary_video_reply_length_ok("林" * 180) is True
+    assert ordinary_video_reply_length_ok("林" * 200) is True
+    assert ordinary_video_reply_length_ok("林" * 201) is False
     assert normalize_music_duration(60) == 60
 
 
@@ -26,6 +64,7 @@ def test_media_workers_fail_closed_without_external_provider(tmp_path):
             "测试回信",
             tmp_path / "music.mp4",
             normal_video_path=tmp_path / "normal.mp4",
+            official_reply_reference_path=tmp_path / "missing-official.mp4",
             song_video_path=tmp_path / "song.mp4",
             tts_config_path=tmp_path / "missing.json",
             visual_config_path=tmp_path / "missing.json",
@@ -33,3 +72,264 @@ def test_media_workers_fail_closed_without_external_provider(tmp_path):
             performance_video_path=tmp_path / "performance.mp4",
             duration_seconds=40,
         )
+
+
+def test_roformer_uses_explicit_f_drive_assets_and_utf8(tmp_path, monkeypatch):
+    executable = tmp_path / "roformer.exe"
+    model = tmp_path / "models" / "MelBandRoformer.ckpt"
+    config = tmp_path / "models" / "config.yaml"
+    song = tmp_path / "song.flac"
+    vocals = tmp_path / "vocals.wav"
+    for path in (executable, model, config, song):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"synthetic")
+    monkeypatch.setenv("OLIVIA_ROFORMER_EXE", str(executable))
+    monkeypatch.setenv("OLIVIA_ROFORMER_MODEL_PATH", str(model))
+    monkeypatch.setenv("OLIVIA_ROFORMER_CONFIG_PATH", str(config))
+    monkeypatch.setattr(music_reply, "_ffmpeg", lambda: "ffmpeg")
+    observed = []
+
+    def fake_run(command, error_code, *, timeout=900.0, env=None):
+        observed.append((command, error_code, env))
+        if "--store_dir" in command:
+            output_root = Path(command[command.index("--store_dir") + 1])
+            (output_root / "synthetic_vocals.wav").write_bytes(b"vocals")
+
+    monkeypatch.setattr(music_reply, "_run", fake_run)
+
+    music_reply.separate_vocals(song, vocals)
+
+    assert observed[0][0][:4] == ["ffmpeg", "-y", "-i", str(song)]
+    assert observed[0][1] == "ROFORMER_INPUT_CONVERSION_FAILED"
+    assert observed[1][0][-4:] == [
+        "--model_path",
+        str(model),
+        "--config_path",
+        str(config),
+    ]
+    assert observed[1][2]["PYTHONUTF8"] == "1"
+    assert observed[1][2]["PYTHONIOENCODING"] == "utf-8"
+    assert vocals.read_bytes() == b"vocals"
+
+
+def test_official_voice_reference_is_bounded_for_cosyvoice(tmp_path, monkeypatch):
+    reference = tmp_path / "official-reference.wav"
+    with wave.open(str(reference), "wb") as target:
+        target.setnchannels(1)
+        target.setsampwidth(2)
+        target.setframerate(16000)
+        target.writeframes(b"\0\0" * (16000 * 41))
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "settings": {
+                    "runtime_root": str(tmp_path / "runtime"),
+                    "model_dir": str(tmp_path / "model"),
+                    "reference_audio": str(reference),
+                    "reference_text": "synthetic reference",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OLIVIA_REPLY_VOICE_REFERENCE", str(reference))
+
+    configured = _tts_config(config_path, tmp_path / "work", ordinary_video=True)
+
+    with wave.open(configured.reference_audio, "rb") as bounded:
+        assert bounded.getnframes() / bounded.getframerate() == pytest.approx(4.85)
+    assert configured.leading_trim_seconds == 0
+    with wave.open(str(reference), "rb") as original:
+        assert original.getnframes() / original.getframerate() == 41
+
+
+def test_delivery_request_excludes_reference_text_and_instruct_controls():
+    config = SimpleNamespace(
+        runtime_root="runtime",
+        model_dir="model",
+        reference_audio="reference.wav",
+        reference_text="accepted reference transcript",
+        fp16=True,
+    )
+
+    request = build_external_delivery_request(
+        config,
+        plan_reply_delivery("第一句。第二句。"),
+    )
+
+    assert "reference_text" not in request
+    assert "instruct_text" not in request
+    assert request["blocks"] == ["第一句。第二句。"]
+    assert request["seed"] == 200717
+
+
+def test_delivery_tempo_allows_only_modest_whole_utterance_fit():
+    assert delivery_tempo_factor(50.0) is None
+    assert delivery_tempo_factor(51.0) == 1.02
+    assert delivery_tempo_factor(52.0) == 1.04
+    assert delivery_tempo_factor(52.01) is None
+
+
+def test_delivery_fit_rejects_audio_over_52_seconds(tmp_path):
+    sample_rate = 8_000
+    path = tmp_path / "overlong.wav"
+    samples = array(
+        "h",
+        (
+            3_000 if index < 53 * sample_rate else 0
+            for index in range(61 * sample_rate)
+        ),
+    )
+    with wave.open(str(path), "wb") as target:
+        target.setnchannels(1)
+        target.setsampwidth(2)
+        target.setframerate(sample_rate)
+        target.writeframes(samples.tobytes())
+
+    with pytest.raises(DeliveryAudioError, match="TTS_DELIVERY_DURATION_OUT_OF_RANGE"):
+        _fit_overlong_wav(path, 61.0)
+
+
+def test_external_worker_renders_delivery_blocks_with_one_model_load(
+    tmp_path, monkeypatch
+):
+    calls = {"loads": 0, "texts": []}
+
+    class Tensor:
+        def __init__(self, values):
+            self.values = values
+
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def float(self):
+            return self
+
+        def reshape(self, *_shape):
+            return self
+
+        def tolist(self):
+            return self.values
+
+    class AutoModel:
+        sample_rate = 100
+
+        def __init__(self, **_kwargs):
+            calls["loads"] += 1
+
+        def inference_cross_lingual(self, text, *_args, **kwargs):
+            calls["texts"].append(text)
+            calls.setdefault("kwargs", []).append(kwargs)
+            value = 0.1 if len(calls["texts"]) == 1 else 0.2
+            yield {"tts_speech": Tensor([value] * 100)}
+
+    cosyvoice = ModuleType("cosyvoice")
+    cli = ModuleType("cosyvoice.cli")
+    module = ModuleType("cosyvoice.cli.cosyvoice")
+    module.AutoModel = AutoModel
+    torch = ModuleType("torch")
+    torch.manual_seed = lambda value: calls.setdefault("seeds", []).append(value)
+    monkeypatch.setitem(sys.modules, "cosyvoice", cosyvoice)
+    monkeypatch.setitem(sys.modules, "cosyvoice.cli", cli)
+    monkeypatch.setitem(sys.modules, "cosyvoice.cli.cosyvoice", module)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    output = tmp_path / "delivery.wav"
+
+    external_cosyvoice_worker._synthesize(
+        {
+            "runtime_root": str(tmp_path),
+            "model_dir": str(tmp_path),
+            "reference_audio": str(tmp_path / "reference.wav"),
+            "blocks": ["第一句", "第二句"],
+            "cross_fade_seconds": 0.1,
+            "stream": False,
+            "seed": 200717,
+        },
+        output,
+    )
+
+    assert calls == {
+        "loads": 1,
+        "texts": [
+            "You are a helpful assistant.<|endofprompt|>第一句",
+            "You are a helpful assistant.<|endofprompt|>第二句",
+        ],
+        "kwargs": [
+            {"zero_shot_spk_id": "", "stream": False, "speed": 1.0},
+            {"zero_shot_spk_id": "", "stream": False, "speed": 1.0},
+        ],
+        "seeds": [200717],
+    }
+    with wave.open(str(output), "rb") as rendered:
+        assert rendered.getnframes() == 190
+
+
+def test_latentsync_process_receives_bundled_ffmpeg(tmp_path, monkeypatch):
+    root = tmp_path / "latentsync"
+    python = tmp_path / "python.exe"
+    source = tmp_path / "source.mp4"
+    audio = tmp_path / "speech.wav"
+    output = tmp_path / "reply.mp4"
+    ffmpeg = tmp_path / "ffmpeg" / "ffmpeg-win-x86_64.exe"
+    required = (
+        python,
+        source,
+        audio,
+        root / "scripts" / "inference.py",
+        root / "configs" / "unet" / "stage2_efficient.yaml",
+        root / "checkpoints" / "latentsync_unet.pt",
+        ffmpeg,
+    )
+    for path in required:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"synthetic")
+    monkeypatch.setitem(
+        sys.modules,
+        "imageio_ffmpeg",
+        SimpleNamespace(get_ffmpeg_exe=lambda: str(ffmpeg)),
+    )
+    monkeypatch.setenv("PATH", "synthetic-original-path")
+    monkeypatch.setenv("OLIVIA_PROVIDER_CACHE_ROOT", str(tmp_path / "provider-cache"))
+    observed = {}
+
+    def run(command, **kwargs):
+        if Path(command[0]).name.casefold() == "ffmpeg.exe":
+            Path(command[-1]).write_bytes(b"prepared-video")
+            observed["prepare_command"] = command
+            return SimpleNamespace(returncode=0)
+        observed["environment"] = kwargs.get("env")
+        observed["config_path"] = command[
+            command.index("--unet_config_path") + 1
+        ]
+        observed["ffmpeg"] = shutil.which(
+            "ffmpeg", path=observed["environment"]["PATH"]
+        )
+        Path(command[command.index("--video_out_path") + 1]).write_bytes(
+            b"synthetic-video"
+        )
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(latentsync_reply.subprocess, "run", run)
+
+    render_latentsync_video(
+        source,
+        audio,
+        output,
+        python_path=python,
+        latentsync_root=root,
+    )
+
+    environment = observed["environment"]
+    assert environment is not None
+    assert observed["ffmpeg"] is not None
+    assert Path(environment["HF_HOME"]).is_relative_to(tmp_path.parent)
+    assert Path(environment["TORCH_HOME"]).is_relative_to(tmp_path.parent)
+    assert Path(environment["TEMP"]).is_relative_to(tmp_path)
+    assert output.read_bytes() == b"synthetic-video"
+    assert Path(observed["prepare_command"][0]).name.casefold() == "ffmpeg.exe"
+    assert "libx264" in observed["prepare_command"]
+    assert Path(observed["config_path"]).name == "stage2_efficient.yaml"

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -307,6 +307,7 @@ def test_latentsync_process_receives_bundled_ffmpeg(tmp_path, monkeypatch):
         "imageio_ffmpeg",
         SimpleNamespace(get_ffmpeg_exe=lambda: str(ffmpeg)),
     )
+    monkeypatch.delenv("OLIVIA_FFMPEG_EXE", raising=False)
     monkeypatch.setenv("PATH", "synthetic-original-path")
     monkeypatch.setenv("OLIVIA_PROVIDER_CACHE_ROOT", str(tmp_path / "provider-cache"))
     observed = {}
@@ -348,3 +349,50 @@ def test_latentsync_process_receives_bundled_ffmpeg(tmp_path, monkeypatch):
     assert Path(observed["prepare_command"][0]).name.casefold() == "ffmpeg.exe"
     assert "libx264" in observed["prepare_command"]
     assert Path(observed["config_path"]).name == "stage2_efficient.yaml"
+
+
+def test_latentsync_rejects_missing_explicit_ffmpeg_without_fallback(
+    tmp_path, monkeypatch
+):
+    root = tmp_path / "latentsync"
+    python = tmp_path / "python.exe"
+    source = tmp_path / "source.mp4"
+    audio = tmp_path / "speech.wav"
+    for path in (
+        python,
+        source,
+        audio,
+        root / "scripts" / "inference.py",
+        root / "configs" / "unet" / "stage2_efficient.yaml",
+        root / "checkpoints" / "latentsync_unet.pt",
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"synthetic")
+    monkeypatch.setenv("OLIVIA_FFMPEG_EXE", str(tmp_path / "missing-ffmpeg.exe"))
+
+    def unexpected_discovery(*_args, **_kwargs):
+        raise AssertionError("configured FFmpeg failure must not fall back")
+
+    monkeypatch.setattr(latentsync_reply.shutil, "which", unexpected_discovery)
+    monkeypatch.setitem(
+        sys.modules,
+        "imageio_ffmpeg",
+        SimpleNamespace(get_ffmpeg_exe=unexpected_discovery),
+    )
+
+    def unexpected_subprocess(*_args, **_kwargs):
+        raise AssertionError("configured FFmpeg failure must not fall back")
+
+    monkeypatch.setattr(latentsync_reply.subprocess, "run", unexpected_subprocess)
+
+    with pytest.raises(
+        latentsync_reply.LatentSyncReplyError,
+        match="^LATENTSYNC_FFMPEG_UNAVAILABLE$",
+    ):
+        render_latentsync_video(
+            source,
+            audio,
+            tmp_path / "reply.mp4",
+            python_path=python,
+            latentsync_root=root,
+        )

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -103,6 +103,62 @@ def test_official_voice_reference_is_bounded_for_cosyvoice(tmp_path, monkeypatch
         assert original.getnframes() / original.getframerate() == 41
 
 
+def test_explicit_missing_voice_reference_fails_closed(tmp_path, monkeypatch):
+    generic_reference = tmp_path / "generic-reference.wav"
+    with wave.open(str(generic_reference), "wb") as target:
+        target.setnchannels(1)
+        target.setsampwidth(2)
+        target.setframerate(16000)
+        target.writeframes(b"\0\0" * 16000)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "settings": {
+                    "runtime_root": str(tmp_path / "runtime"),
+                    "model_dir": str(tmp_path / "model"),
+                    "reference_audio": str(generic_reference),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(
+        "OLIVIA_REPLY_VOICE_REFERENCE",
+        str(tmp_path / "missing-official-reference.wav"),
+    )
+
+    with pytest.raises(ReplyMediaError, match="VOICE_REFERENCE_UNAVAILABLE"):
+        _tts_config(config_path, tmp_path / "work", ordinary_video=True)
+
+
+def test_unconfigured_voice_reference_keeps_controlled_default(tmp_path, monkeypatch):
+    generic_reference = tmp_path / "generic-reference.wav"
+    with wave.open(str(generic_reference), "wb") as target:
+        target.setnchannels(1)
+        target.setsampwidth(2)
+        target.setframerate(16000)
+        target.writeframes(b"\0\0" * 16000)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "settings": {
+                    "runtime_root": str(tmp_path / "runtime"),
+                    "model_dir": str(tmp_path / "model"),
+                    "reference_audio": str(generic_reference),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("OLIVIA_REPLY_VOICE_REFERENCE", raising=False)
+
+    configured = _tts_config(config_path, tmp_path / "work", ordinary_video=True)
+
+    assert Path(configured.reference_audio) == generic_reference
+
+
 def test_delivery_request_excludes_reference_text_and_instruct_controls():
     config = SimpleNamespace(
         runtime_root="runtime",

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from array import array
 import json
-import os
 from pathlib import Path
 import shutil
 import sys
@@ -13,7 +12,6 @@ import wave
 import pytest
 
 import latentsync_reply
-import music_reply
 from latentsync_reply import render_latentsync_video
 from music_duration import MUSIC_DURATION_OPTIONS, normalize_music_duration
 from music_reply import MusicReplyError, render_musical_reply
@@ -64,7 +62,6 @@ def test_media_workers_fail_closed_without_external_provider(tmp_path):
             "测试回信",
             tmp_path / "music.mp4",
             normal_video_path=tmp_path / "normal.mp4",
-            official_reply_reference_path=tmp_path / "missing-official.mp4",
             song_video_path=tmp_path / "song.mp4",
             tts_config_path=tmp_path / "missing.json",
             visual_config_path=tmp_path / "missing.json",
@@ -72,44 +69,6 @@ def test_media_workers_fail_closed_without_external_provider(tmp_path):
             performance_video_path=tmp_path / "performance.mp4",
             duration_seconds=40,
         )
-
-
-def test_roformer_uses_explicit_f_drive_assets_and_utf8(tmp_path, monkeypatch):
-    executable = tmp_path / "roformer.exe"
-    model = tmp_path / "models" / "MelBandRoformer.ckpt"
-    config = tmp_path / "models" / "config.yaml"
-    song = tmp_path / "song.flac"
-    vocals = tmp_path / "vocals.wav"
-    for path in (executable, model, config, song):
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(b"synthetic")
-    monkeypatch.setenv("OLIVIA_ROFORMER_EXE", str(executable))
-    monkeypatch.setenv("OLIVIA_ROFORMER_MODEL_PATH", str(model))
-    monkeypatch.setenv("OLIVIA_ROFORMER_CONFIG_PATH", str(config))
-    monkeypatch.setattr(music_reply, "_ffmpeg", lambda: "ffmpeg")
-    observed = []
-
-    def fake_run(command, error_code, *, timeout=900.0, env=None):
-        observed.append((command, error_code, env))
-        if "--store_dir" in command:
-            output_root = Path(command[command.index("--store_dir") + 1])
-            (output_root / "synthetic_vocals.wav").write_bytes(b"vocals")
-
-    monkeypatch.setattr(music_reply, "_run", fake_run)
-
-    music_reply.separate_vocals(song, vocals)
-
-    assert observed[0][0][:4] == ["ffmpeg", "-y", "-i", str(song)]
-    assert observed[0][1] == "ROFORMER_INPUT_CONVERSION_FAILED"
-    assert observed[1][0][-4:] == [
-        "--model_path",
-        str(model),
-        "--config_path",
-        str(config),
-    ]
-    assert observed[1][2]["PYTHONUTF8"] == "1"
-    assert observed[1][2]["PYTHONIOENCODING"] == "utf-8"
-    assert vocals.read_bytes() == b"vocals"
 
 
 def test_official_voice_reference_is_bounded_for_cosyvoice(tmp_path, monkeypatch):


### PR DESCRIPTION
## Scope

Third slice replacing closed #106. Makes ordinary reply rendering portable: bounded official voice-reference preparation, provider-local temp/cache paths, and bundled FFmpeg propagation into LatentSync.

## Validation

- portable media focused: 9 passed
- py_compile: PASS
- diff-check: PASS

## Boundary

No MiniMax song generation, RoFormer vocal separation, musical concat, HTTP routing, provider execution, or human visual acceptance. Music-specific tests remain with the next slice. Stacked on #108.