### PR TITLE
feat(media): assemble spoken and musical reply video

### DIFF
--- a/docs/P03_06_END_TO_END_ACCEPTANCE.md
+++ b/docs/P03_06_END_TO_END_ACCEPTANCE.md
@@ -290,11 +290,12 @@ musical_video ReplyContext
 
 - SongSemanticPlan 合法；
 - Caption 只来自程序模板；
-- 音频时长符合 90/118 秒配置；
+- 音频时长符合 40/60 秒配置；
 - 歌曲和 vocals 非空；
 - normal video 与 song video 均生成；
 - 拼接顺序为 spoken -> optional transition -> performance；
 - transition 音轨已替换为静音；
+- 最后 2 秒视频与音频同步渐暗；
 - 各分段帧数与最终帧数一致；
 - 最终视频可解码；
 - 最终时长与分段总和一致；

--- a/music_reply.py
+++ b/music_reply.py
@@ -21,7 +21,7 @@ from song_content import plan_song_content
 
 
 _MINIMAX_WORKER_TIMEOUT_SECONDS = 7500.0
-_MUSIC_STAGE_MANIFEST_VERSION = 1
+_MUSIC_STAGE_MANIFEST_VERSION = 2
 
 
 class MusicReplyError(RuntimeError):
@@ -642,8 +642,34 @@ def _build_music_stage_manifest(
         "providers": {
             "music": {
                 "name": "MiniMax-Music-3",
+                "python": _file_fingerprint(
+                    _optional_path(os.environ.get("OLIVIA_MINIMAX_COMFY_PYTHON", ""))
+                ),
                 "worker": _file_fingerprint(minimax_worker_path),
-                "comfy_main": _file_fingerprint(minimax_root / "main.py"),
+                "entry": _file_fingerprint(minimax_root / "main.py"),
+                "node_code": _file_fingerprint(
+                    minimax_root / "comfy_extras" / "nodes_minimax_music.py"
+                ),
+                "models": {
+                    "unet": _file_fingerprint(
+                        minimax_root
+                        / "models"
+                        / "unet"
+                        / "minimax_music3_dit_int8_convrot.safetensors"
+                    ),
+                    "text_encoder": _file_fingerprint(
+                        minimax_root
+                        / "models"
+                        / "clip"
+                        / "minimax_music3_text_encoder_pruned_int8_convrot.safetensors"
+                    ),
+                    "vae": _file_fingerprint(
+                        minimax_root
+                        / "models"
+                        / "vae"
+                        / "minimax_music3_dav.safetensors"
+                    ),
+                },
             },
             "vocal_separator": {
                 "name": "MelBand-RoFormer",
@@ -663,6 +689,11 @@ def _build_music_stage_manifest(
                 ),
                 "config": _file_fingerprint(
                     latentsync_root / "configs" / "unet" / "stage2_efficient.yaml"
+                    if latentsync_root is not None
+                    else None
+                ),
+                "checkpoint": _file_fingerprint(
+                    latentsync_root / "checkpoints" / "latentsync_unet.pt"
                     if latentsync_root is not None
                     else None
                 ),
@@ -703,14 +734,25 @@ def _stage_reusable(
     manifest: dict[str, object],
     artifact_name: str,
     path: Path,
+    *,
+    upstream: dict[str, Path] | None = None,
 ) -> bool:
     artifacts = manifest.get("artifacts")
     expected = artifacts.get(artifact_name) if isinstance(artifacts, dict) else None
-    return (
-        _completed_stage(path)
-        and isinstance(expected, dict)
-        and expected == _file_fingerprint(path)
-    )
+    return _completed_stage(path) and expected == _stage_record(path, upstream)
+
+
+def _stage_record(
+    path: Path,
+    upstream: dict[str, Path] | None = None,
+) -> dict[str, object]:
+    return {
+        "fingerprint": _file_fingerprint(path),
+        "upstream": {
+            name: _file_fingerprint(source)
+            for name, source in sorted((upstream or {}).items())
+        },
+    }
 
 
 def _record_stage(
@@ -718,12 +760,14 @@ def _record_stage(
     manifest_path: Path,
     artifact_name: str,
     path: Path,
+    *,
+    upstream: dict[str, Path] | None = None,
 ) -> None:
     artifacts = manifest.setdefault("artifacts", {})
     if not isinstance(artifacts, dict):
         artifacts = {}
         manifest["artifacts"] = artifacts
-    artifacts[artifact_name] = _file_fingerprint(path)
+    artifacts[artifact_name] = _stage_record(path, upstream)
     _write_stage_manifest(manifest_path, manifest)
 
 
@@ -787,7 +831,12 @@ def render_musical_reply(
         _write_stage_manifest(manifest_path, manifest)
 
     spoken_base = stage_root / "official-spoken-000-035s.mp4"
-    if _stage_reusable(manifest, "normal_video", normal_video_path):
+    if _stage_reusable(
+        manifest,
+        "normal_video",
+        normal_video_path,
+        upstream={"spoken_base": spoken_base},
+    ):
         normal_metadata = {"spoken_stage": "reused"}
     else:
         if not _stage_reusable(manifest, "spoken_base", spoken_base):
@@ -805,7 +854,13 @@ def render_musical_reply(
             latentsync_root=Path(os.environ.get("OLIVIA_LATENTSYNC_ROOT", "")),
             adaptive_delivery=True,
         )
-        _record_stage(manifest, manifest_path, "normal_video", normal_video_path)
+        _record_stage(
+            manifest,
+            manifest_path,
+            "normal_video",
+            normal_video_path,
+            upstream={"spoken_base": spoken_base},
+        )
 
     song_audio = stage_root / "song.flac"
     vocals = stage_root / "vocals.wav"
@@ -834,14 +889,30 @@ def render_musical_reply(
         partial_song.replace(song_audio)
         _record_stage(manifest, manifest_path, "song_audio", song_audio)
 
-    if not _stage_reusable(manifest, "vocals", vocals):
+    if not _stage_reusable(
+        manifest,
+        "vocals",
+        vocals,
+        upstream={"song_audio": song_audio},
+    ):
         partial_vocals = stage_root / "vocals.partial.wav"
         partial_vocals.unlink(missing_ok=True)
         separate_vocals(song_audio, partial_vocals)
         partial_vocals.replace(vocals)
-        _record_stage(manifest, manifest_path, "vocals", vocals)
+        _record_stage(
+            manifest,
+            manifest_path,
+            "vocals",
+            vocals,
+            upstream={"song_audio": song_audio},
+        )
 
-    if _stage_reusable(manifest, "song_video", song_video_path):
+    if _stage_reusable(
+        manifest,
+        "song_video",
+        song_video_path,
+        upstream={"song_audio": song_audio, "vocals": vocals},
+    ):
         face_metadata = {"performance_stage": "reused"}
     else:
         partial_video = song_video_path.with_name(
@@ -855,7 +926,13 @@ def render_musical_reply(
             partial_video,
         )
         partial_video.replace(song_video_path)
-        _record_stage(manifest, manifest_path, "song_video", song_video_path)
+        _record_stage(
+            manifest,
+            manifest_path,
+            "song_video",
+            song_video_path,
+            upstream={"song_audio": song_audio, "vocals": vocals},
+        )
 
     concat_videos(
         normal_video_path,
@@ -863,7 +940,13 @@ def render_musical_reply(
         output_path,
         transition_video_path=transition_reference,
     )
-    _record_stage(manifest, manifest_path, "final_output", output_path)
+    _record_stage(
+        manifest,
+        manifest_path,
+        "final_output",
+        output_path,
+        upstream={"normal_video": normal_video_path, "song_video": song_video_path},
+    )
     return {
         **normal_metadata,
         **song_metadata,

--- a/music_reply.py
+++ b/music_reply.py
@@ -21,6 +21,7 @@ from song_content import plan_song_content
 
 
 _MINIMAX_WORKER_TIMEOUT_SECONDS = 7500.0
+_MUSIC_STAGE_MANIFEST_VERSION = 1
 
 
 class MusicReplyError(RuntimeError):
@@ -550,10 +551,10 @@ def concat_videos(
         result.replace(output_path)
 
 
-def _official_transition_reference() -> Path | None:
+def _official_transition_reference() -> Path:
     configured = os.environ.get("OLIVIA_OFFICIAL_REPLY_REFERENCE", "").strip()
     if not configured:
-        return None
+        raise MusicReplyError("MUSIC_REPLY_TRANSITION_UNAVAILABLE")
     reference = Path(configured)
     if not reference.is_file():
         raise MusicReplyError("MUSIC_REPLY_TRANSITION_UNAVAILABLE")
@@ -565,6 +566,165 @@ def _completed_stage(path: Path) -> bool:
         return path.is_file() and path.stat().st_size > 0
     except OSError:
         return False
+
+
+def _file_fingerprint(path: Path | None) -> dict[str, object]:
+    """Return a content-bound fingerprint without retaining local path names."""
+
+    if path is None:
+        return {"status": "not_configured"}
+    path = Path(path)
+    try:
+        if not path.is_file():
+            return {"status": "missing"}
+        digest = hashlib.sha256()
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return {
+            "status": "present",
+            "size": path.stat().st_size,
+            "sha256": digest.hexdigest(),
+        }
+    except OSError:
+        return {"status": "unavailable"}
+
+
+def _optional_path(value: str) -> Path | None:
+    value = str(value).strip()
+    return Path(value) if value else None
+
+
+def _build_music_stage_manifest(
+    content: str,
+    reply_text: str,
+    song_plan: object,
+    duration_seconds: int,
+    *,
+    official_reply_reference_path: Path,
+    transition_reference: Path,
+    performance_video_path: Path,
+    tts_config_path: Path,
+    visual_config_path: Path,
+    worker_path: Path,
+    minimax_worker_path: Path,
+    minimax_root: Path,
+) -> dict[str, object]:
+    """Bind resumable stages to canonical text, inputs, and provider revisions."""
+
+    latentsync_root = _optional_path(os.environ.get("OLIVIA_LATENTSYNC_ROOT", ""))
+    roformer_executable = _optional_path(os.environ.get("OLIVIA_ROFORMER_EXE", ""))
+    roformer_model = _optional_path(os.environ.get("OLIVIA_ROFORMER_MODEL_PATH", ""))
+    roformer_config = _optional_path(os.environ.get("OLIVIA_ROFORMER_CONFIG_PATH", ""))
+    return {
+        "schema_version": _MUSIC_STAGE_MANIFEST_VERSION,
+        "inputs": {
+            "letter_sha256": hashlib.sha256(str(content).encode("utf-8")).hexdigest(),
+            "canonical_reply_sha256": hashlib.sha256(
+                str(reply_text).encode("utf-8")
+            ).hexdigest(),
+            "lyrics_sha256": hashlib.sha256(
+                str(song_plan.lyrics).encode("utf-8")
+            ).hexdigest(),
+            "caption_sha256": hashlib.sha256(
+                str(song_plan.caption).encode("utf-8")
+            ).hexdigest(),
+            "duration_seconds": duration_seconds,
+        },
+        "assets": {
+            "official_reply_reference": _file_fingerprint(official_reply_reference_path),
+            "official_transition_reference": _file_fingerprint(transition_reference),
+            "performance_video": _file_fingerprint(performance_video_path),
+            "tts_config": _file_fingerprint(tts_config_path),
+            "visual_config": _file_fingerprint(visual_config_path),
+            "visual_worker": _file_fingerprint(worker_path),
+        },
+        "providers": {
+            "music": {
+                "name": "MiniMax-Music-3",
+                "worker": _file_fingerprint(minimax_worker_path),
+                "comfy_main": _file_fingerprint(minimax_root / "main.py"),
+            },
+            "vocal_separator": {
+                "name": "MelBand-RoFormer",
+                "executable": _file_fingerprint(roformer_executable),
+                "model": _file_fingerprint(roformer_model),
+                "config": _file_fingerprint(roformer_config),
+            },
+            "face_sync": {
+                "name": "LatentSync-1.5",
+                "python": _file_fingerprint(
+                    _optional_path(os.environ.get("OLIVIA_LATENTSYNC_PYTHON", ""))
+                ),
+                "inference": _file_fingerprint(
+                    latentsync_root / "scripts" / "inference.py"
+                    if latentsync_root is not None
+                    else None
+                ),
+                "config": _file_fingerprint(
+                    latentsync_root / "configs" / "unet" / "stage2_efficient.yaml"
+                    if latentsync_root is not None
+                    else None
+                ),
+            },
+        },
+        "artifacts": {},
+    }
+
+
+def _read_compatible_manifest(
+    manifest_path: Path,
+    expected: dict[str, object],
+) -> dict[str, object]:
+    try:
+        loaded = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {**expected, "artifacts": {}}
+    if not isinstance(loaded, dict) or any(
+        loaded.get(key) != expected.get(key)
+        for key in ("schema_version", "inputs", "assets", "providers")
+    ):
+        return {**expected, "artifacts": {}}
+    artifacts = loaded.get("artifacts")
+    return {**expected, "artifacts": artifacts if isinstance(artifacts, dict) else {}}
+
+
+def _write_stage_manifest(manifest_path: Path, manifest: dict[str, object]) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    partial = manifest_path.with_name(f"{manifest_path.stem}.partial{manifest_path.suffix}")
+    partial.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    partial.replace(manifest_path)
+
+
+def _stage_reusable(
+    manifest: dict[str, object],
+    artifact_name: str,
+    path: Path,
+) -> bool:
+    artifacts = manifest.get("artifacts")
+    expected = artifacts.get(artifact_name) if isinstance(artifacts, dict) else None
+    return (
+        _completed_stage(path)
+        and isinstance(expected, dict)
+        and expected == _file_fingerprint(path)
+    )
+
+
+def _record_stage(
+    manifest: dict[str, object],
+    manifest_path: Path,
+    artifact_name: str,
+    path: Path,
+) -> None:
+    artifacts = manifest.setdefault("artifacts", {})
+    if not isinstance(artifacts, dict):
+        artifacts = {}
+        manifest["artifacts"] = artifacts
+    artifacts[artifact_name] = _file_fingerprint(path)
+    _write_stage_manifest(manifest_path, manifest)
 
 
 def render_musical_reply(
@@ -584,6 +744,7 @@ def render_musical_reply(
     """Render the ordinary reply, append an original-view song performance."""
 
     duration_seconds = normalize_music_duration(duration_seconds)
+    transition_reference = _official_transition_reference()
     minimax_python = os.environ.get("OLIVIA_MINIMAX_COMFY_PYTHON", "").strip()
     minimax_root = os.environ.get("OLIVIA_MINIMAX_COMFY_ROOT", "").strip()
     minimax_worker = os.environ.get("OLIVIA_MINIMAX_WORKER", "").strip()
@@ -598,13 +759,41 @@ def render_musical_reply(
         f"{output_path.stem}-music-v2-{duration_seconds}s-stages"
     )
     stage_root.mkdir(parents=True, exist_ok=True)
-    if _completed_stage(normal_video_path):
+    manifest_path = stage_root / "manifest.json"
+    expected_manifest = _build_music_stage_manifest(
+        content,
+        reply_text,
+        song_plan,
+        duration_seconds,
+        official_reply_reference_path=official_reply_reference_path,
+        transition_reference=transition_reference,
+        performance_video_path=performance_video_path,
+        tts_config_path=tts_config_path,
+        visual_config_path=visual_config_path,
+        worker_path=worker_path,
+        minimax_worker_path=Path(minimax_worker),
+        minimax_root=Path(minimax_root),
+    )
+    try:
+        existing_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        existing_manifest = None
+    manifest_compatible = isinstance(existing_manifest, dict) and all(
+        existing_manifest.get(key) == expected_manifest.get(key)
+        for key in ("schema_version", "inputs", "assets", "providers")
+    )
+    manifest = _read_compatible_manifest(manifest_path, expected_manifest)
+    if not manifest_compatible:
+        _write_stage_manifest(manifest_path, manifest)
+
+    spoken_base = stage_root / "official-spoken-000-035s.mp4"
+    if _stage_reusable(manifest, "normal_video", normal_video_path):
         normal_metadata = {"spoken_stage": "reused"}
     else:
-        spoken_base = prepare_official_spoken_base(
-            official_reply_reference_path,
-            stage_root / "official-spoken-000-035s.mp4",
-        )
+        if not _stage_reusable(manifest, "spoken_base", spoken_base):
+            spoken_base.unlink(missing_ok=True)
+            prepare_official_spoken_base(official_reply_reference_path, spoken_base)
+            _record_stage(manifest, manifest_path, "spoken_base", spoken_base)
         normal_metadata = render_reply_video(
             reply_text,
             normal_video_path,
@@ -616,10 +805,11 @@ def render_musical_reply(
             latentsync_root=Path(os.environ.get("OLIVIA_LATENTSYNC_ROOT", "")),
             adaptive_delivery=True,
         )
+        _record_stage(manifest, manifest_path, "normal_video", normal_video_path)
 
     song_audio = stage_root / "song.flac"
     vocals = stage_root / "vocals.wav"
-    if _completed_stage(song_audio):
+    if _stage_reusable(manifest, "song_audio", song_audio):
         song_metadata = {
             "audio_model": "MiniMax-Music-3",
             "requested_duration_seconds": duration_seconds,
@@ -642,14 +832,16 @@ def render_musical_reply(
             caption=song_plan.caption,
         )
         partial_song.replace(song_audio)
+        _record_stage(manifest, manifest_path, "song_audio", song_audio)
 
-    if not _completed_stage(vocals):
+    if not _stage_reusable(manifest, "vocals", vocals):
         partial_vocals = stage_root / "vocals.partial.wav"
         partial_vocals.unlink(missing_ok=True)
         separate_vocals(song_audio, partial_vocals)
         partial_vocals.replace(vocals)
+        _record_stage(manifest, manifest_path, "vocals", vocals)
 
-    if _completed_stage(song_video_path):
+    if _stage_reusable(manifest, "song_video", song_video_path):
         face_metadata = {"performance_stage": "reused"}
     else:
         partial_video = song_video_path.with_name(
@@ -663,17 +855,15 @@ def render_musical_reply(
             partial_video,
         )
         partial_video.replace(song_video_path)
+        _record_stage(manifest, manifest_path, "song_video", song_video_path)
 
-    transition_reference = _official_transition_reference()
-    if transition_reference is None:
-        concat_videos(normal_video_path, song_video_path, output_path)
-    else:
-        concat_videos(
-            normal_video_path,
-            song_video_path,
-            output_path,
-            transition_video_path=transition_reference,
-        )
+    concat_videos(
+        normal_video_path,
+        song_video_path,
+        output_path,
+        transition_video_path=transition_reference,
+    )
+    _record_stage(manifest, manifest_path, "final_output", output_path)
     return {
         **normal_metadata,
         **song_metadata,
@@ -684,8 +874,6 @@ def render_musical_reply(
         "song_title": "回信里的歌",
         "reply_structure": (
             "normal_video_then_official_transition_then_song_video"
-            if transition_reference is not None
-            else "normal_video_then_song_video"
         ),
-        "transition_duration_seconds": 8.0 if transition_reference is not None else 0.0,
+        "transition_duration_seconds": 8.0,
     }

--- a/music_reply.py
+++ b/music_reply.py
@@ -240,6 +240,9 @@ class AceStepClient:
 
 
 def _ffmpeg() -> str:
+    configured = os.environ.get("OLIVIA_FFMPEG_EXE", "").strip()
+    if configured and Path(configured).is_file():
+        return configured
     executable = shutil.which("ffmpeg")
     if executable:
         return executable
@@ -251,18 +254,84 @@ def _ffmpeg() -> str:
         raise MusicReplyError("FFMPEG_UNAVAILABLE") from exc
 
 
-def _run(command: list[str], error_code: str, *, timeout: float = 900.0) -> None:
+def _run(
+    command: list[str],
+    error_code: str,
+    *,
+    timeout: float = 900.0,
+    env: dict[str, str] | None = None,
+) -> None:
     try:
-        result = subprocess.run(command, capture_output=True, check=False, timeout=timeout)
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+            env=env,
+        )
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise MusicReplyError(error_code) from exc
     if result.returncode != 0:
         raise MusicReplyError(error_code)
 
 
+def prepare_official_spoken_base(reference_path: Path, destination: Path) -> Path:
+    """Create the verified 0-35s speaking-performance base for musical replies."""
+
+    reference_path = Path(reference_path)
+    destination = Path(destination)
+    if not reference_path.is_file():
+        raise MusicReplyError("MUSIC_REPLY_SPOKEN_REFERENCE_UNAVAILABLE")
+    if _completed_stage(destination):
+        return destination
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    partial = destination.with_name(f"{destination.stem}.partial{destination.suffix}")
+    partial.unlink(missing_ok=True)
+    _run(
+        [
+            _ffmpeg(),
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-ss",
+            "0",
+            "-i",
+            str(reference_path),
+            "-t",
+            "35",
+            "-map",
+            "0:v:0",
+            "-an",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "18",
+            "-pix_fmt",
+            "yuv420p",
+            "-movflags",
+            "+faststart",
+            str(partial),
+        ],
+        "MUSIC_REPLY_SPOKEN_REFERENCE_FAILED",
+        timeout=900.0,
+    )
+    if not _completed_stage(partial):
+        raise MusicReplyError("MUSIC_REPLY_SPOKEN_REFERENCE_FAILED")
+    partial.replace(destination)
+    return destination
+
+
 def separate_vocals(song_path: Path, vocals_path: Path) -> None:
     executable = os.environ.get("OLIVIA_ROFORMER_EXE", "").strip()
-    if not executable or not Path(executable).is_file():
+    model_path = os.environ.get("OLIVIA_ROFORMER_MODEL_PATH", "").strip()
+    config_path = os.environ.get("OLIVIA_ROFORMER_CONFIG_PATH", "").strip()
+    if any(
+        not value or not Path(value).is_file()
+        for value in (executable, model_path, config_path)
+    ):
         raise MusicReplyError("ROFORMER_UNAVAILABLE")
     with tempfile.TemporaryDirectory(prefix="olivia-roformer-", dir=vocals_path.parent) as temporary:
         root = Path(temporary)
@@ -270,11 +339,39 @@ def separate_vocals(song_path: Path, vocals_path: Path) -> None:
         outputs = root / "outputs"
         inputs.mkdir()
         outputs.mkdir()
-        source = inputs / song_path.name
-        shutil.copyfile(song_path, source)
+        source = inputs / "song.wav"
         _run(
-            [executable, "--input_folder", str(inputs), "--store_dir", str(outputs)],
+            [
+                _ffmpeg(),
+                "-y",
+                "-i",
+                str(song_path),
+                "-ar",
+                "44100",
+                "-ac",
+                "2",
+                str(source),
+            ],
+            "ROFORMER_INPUT_CONVERSION_FAILED",
+        )
+        _run(
+            [
+                executable,
+                "--input_folder",
+                str(inputs),
+                "--store_dir",
+                str(outputs),
+                "--model_path",
+                model_path,
+                "--config_path",
+                config_path,
+            ],
             "ROFORMER_FAILED",
+            env={
+                **os.environ,
+                "PYTHONUTF8": "1",
+                "PYTHONIOENCODING": "utf-8",
+            },
         )
         candidates = sorted(outputs.rglob("*vocals*.wav"))
         if not candidates:
@@ -335,8 +432,9 @@ def concat_videos(
     output_path: Path,
     *,
     transition_video_path: Path | None = None,
-    transition_start_seconds: float = 41.0,
+    transition_start_seconds: float = 35.0,
     transition_end_seconds: float = 43.0,
+    end_fade_seconds: float = 2.0,
 ) -> None:
     """Join speech and performance, optionally preserving the reference turn/transition.
 
@@ -351,6 +449,8 @@ def concat_videos(
             raise MusicReplyError("MUSIC_REPLY_TRANSITION_UNAVAILABLE")
         if transition_start_seconds < 0 or transition_end_seconds <= transition_start_seconds:
             raise MusicReplyError("MUSIC_REPLY_TRANSITION_RANGE_INVALID")
+    if end_fade_seconds <= 0:
+        raise MusicReplyError("MUSIC_REPLY_FADE_DURATION_INVALID")
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="olivia-concat-", dir=output_path.parent) as temporary:
@@ -400,13 +500,27 @@ def concat_videos(
                 ),
             ])
         target_duration = target_frames / 25
+        fade_duration = min(float(end_fade_seconds), target_duration)
+        fade_start = target_duration - fade_duration
+        filters.extend(
+            [
+                (
+                    f"[joined_v]fade=t=out:st={fade_start:.6f}:"
+                    f"d={fade_duration:.6f}[final_v]"
+                ),
+                (
+                    f"[joined_a]afade=t=out:st={fade_start:.6f}:"
+                    f"d={fade_duration:.6f}[final_a]"
+                ),
+            ]
+        )
         assembled = root / "assembled-lossless.mkv"
         _run(
             [
                 _ffmpeg(), "-hide_banner", "-loglevel", "error", "-y",
                 *inputs,
                 "-filter_complex", ";".join(filters),
-                "-map", "[joined_v]", "-map", "[joined_a]",
+                "-map", "[final_v]", "-map", "[final_a]",
                 "-c:v", "libx264", "-preset", "ultrafast", "-qp", "0",
                 "-pix_fmt", "yuv420p", "-c:a", "pcm_s16le", str(assembled),
             ],
@@ -446,13 +560,20 @@ def _official_transition_reference() -> Path | None:
     return reference
 
 
+def _completed_stage(path: Path) -> bool:
+    try:
+        return path.is_file() and path.stat().st_size > 0
+    except OSError:
+        return False
+
+
 def render_musical_reply(
     content: str,
     reply_text: str,
     output_path: Path,
     *,
     normal_video_path: Path,
-    normal_scene_path: Path | None = None,
+    official_reply_reference_path: Path,
     song_video_path: Path,
     tts_config_path: Path,
     visual_config_path: Path,
@@ -473,20 +594,41 @@ def render_musical_reply(
         song_plan = plan_song_content(content, reply_text, duration_seconds)
     except Exception as exc:
         raise MusicReplyError("SONG_CONTENT_UNAVAILABLE") from exc
-    normal_metadata = render_reply_video(
-        reply_text,
-        normal_video_path,
-        tts_config_path=tts_config_path,
-        visual_config_path=visual_config_path,
-        worker_path=worker_path,
-        scene_path=normal_scene_path,
-        latentsync_python_path=Path(os.environ.get("OLIVIA_LATENTSYNC_PYTHON", "")),
-        latentsync_root=Path(os.environ.get("OLIVIA_LATENTSYNC_ROOT", "")),
+    stage_root = output_path.parent / (
+        f"{output_path.stem}-music-v2-{duration_seconds}s-stages"
     )
-    with tempfile.TemporaryDirectory(prefix="olivia-song-", dir=output_path.parent) as temporary:
-        root = Path(temporary)
-        song_audio = root / "song.flac"
-        vocals = root / "vocals.wav"
+    stage_root.mkdir(parents=True, exist_ok=True)
+    if _completed_stage(normal_video_path):
+        normal_metadata = {"spoken_stage": "reused"}
+    else:
+        spoken_base = prepare_official_spoken_base(
+            official_reply_reference_path,
+            stage_root / "official-spoken-000-035s.mp4",
+        )
+        normal_metadata = render_reply_video(
+            reply_text,
+            normal_video_path,
+            tts_config_path=tts_config_path,
+            visual_config_path=visual_config_path,
+            worker_path=worker_path,
+            scene_path=spoken_base,
+            latentsync_python_path=Path(os.environ.get("OLIVIA_LATENTSYNC_PYTHON", "")),
+            latentsync_root=Path(os.environ.get("OLIVIA_LATENTSYNC_ROOT", "")),
+            adaptive_delivery=True,
+        )
+
+    song_audio = stage_root / "song.flac"
+    vocals = stage_root / "vocals.wav"
+    if _completed_stage(song_audio):
+        song_metadata = {
+            "audio_model": "MiniMax-Music-3",
+            "requested_duration_seconds": duration_seconds,
+            "lyrics_source": "letter_and_reply",
+            "music_stage": "reused",
+        }
+    else:
+        partial_song = stage_root / "song.partial.flac"
+        partial_song.unlink(missing_ok=True)
         song_metadata = MiniMaxMusic3Worker(
             python_path=Path(minimax_python),
             worker_path=Path(minimax_worker),
@@ -494,28 +636,44 @@ def render_musical_reply(
         ).generate(
             content,
             reply_text,
-            song_audio,
+            partial_song,
             duration_seconds=duration_seconds,
             lyrics=song_plan.lyrics,
             caption=song_plan.caption,
         )
-        separate_vocals(song_audio, vocals)
+        partial_song.replace(song_audio)
+
+    if not _completed_stage(vocals):
+        partial_vocals = stage_root / "vocals.partial.wav"
+        partial_vocals.unlink(missing_ok=True)
+        separate_vocals(song_audio, partial_vocals)
+        partial_vocals.replace(vocals)
+
+    if _completed_stage(song_video_path):
+        face_metadata = {"performance_stage": "reused"}
+    else:
+        partial_video = song_video_path.with_name(
+            f"{song_video_path.stem}.partial{song_video_path.suffix}"
+        )
+        partial_video.unlink(missing_ok=True)
         face_metadata = render_full_face_performance(
             performance_video_path,
             vocals,
             song_audio,
-            song_video_path,
+            partial_video,
         )
-        transition_reference = _official_transition_reference()
-        if transition_reference is None:
-            concat_videos(normal_video_path, song_video_path, output_path)
-        else:
-            concat_videos(
-                normal_video_path,
-                song_video_path,
-                output_path,
-                transition_video_path=transition_reference,
-            )
+        partial_video.replace(song_video_path)
+
+    transition_reference = _official_transition_reference()
+    if transition_reference is None:
+        concat_videos(normal_video_path, song_video_path, output_path)
+    else:
+        concat_videos(
+            normal_video_path,
+            song_video_path,
+            output_path,
+            transition_video_path=transition_reference,
+        )
     return {
         **normal_metadata,
         **song_metadata,
@@ -529,5 +687,5 @@ def render_musical_reply(
             if transition_reference is not None
             else "normal_video_then_song_video"
         ),
-        "transition_duration_seconds": 2.0 if transition_reference is not None else 0.0,
+        "transition_duration_seconds": 8.0 if transition_reference is not None else 0.0,
     }

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -467,3 +467,204 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
 
     assert calls == {"spoken": 3, "minimax": 3, "separate": 4}
+
+
+def test_render_musical_reply_rebuilds_downstream_stages_when_song_audio_is_rebuilt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "letter.mp4"
+    normal = tmp_path / "letter-spoken.mp4"
+    song_video = tmp_path / "letter-song.mp4"
+    stage_root = tmp_path / "letter-music-v2-40s-stages"
+    minimax_worker = _write(tmp_path / "minimax-worker.py", b"provider-v1")
+    calls = {"minimax": 0, "separate": 0, "performance": 0}
+
+    monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", "synthetic-python")
+    monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", "synthetic-root")
+    monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", str(minimax_worker))
+    monkeypatch.setattr(
+        music_reply,
+        "plan_song_content",
+        lambda *_args: SongContentPlan(
+            emotion="gentle_reassurance",
+            lyrics="[Verse]\\nStay here",
+            caption="gentle piano ballad",
+            duration_seconds=40,
+        ),
+    )
+    monkeypatch.setattr(
+        music_reply,
+        "prepare_official_spoken_base",
+        lambda _reference, destination: _write(Path(destination), b"official-spoken"),
+    )
+    monkeypatch.setattr(
+        music_reply,
+        "render_reply_video",
+        lambda _text, destination, **_kwargs: (
+            _write(Path(destination), b"spoken") and {"spoken_stage": "completed"}
+        ),
+    )
+
+    def fake_generate(self, _content, _reply_text, destination, **_kwargs):
+        del self
+        calls["minimax"] += 1
+        _write(Path(destination), f"song-{calls['minimax']}".encode())
+        return {"music_stage": "completed"}
+
+    def fake_separate(_source, destination):
+        calls["separate"] += 1
+        _write(Path(destination), f"vocals-{calls['separate']}".encode())
+
+    def fake_face(_base, _vocals, _song, destination):
+        calls["performance"] += 1
+        _write(Path(destination), f"performance-{calls['performance']}".encode())
+        return {"performance_stage": "completed"}
+
+    monkeypatch.setattr(music_reply.MiniMaxMusic3Worker, "generate", fake_generate)
+    monkeypatch.setattr(music_reply, "separate_vocals", fake_separate)
+    monkeypatch.setattr(music_reply, "render_full_face_performance", fake_face)
+    transition = _write(tmp_path / "official-transition.mp4")
+    monkeypatch.setattr(
+        music_reply, "_official_transition_reference", lambda: transition
+    )
+    monkeypatch.setattr(
+        music_reply,
+        "concat_videos",
+        lambda _normal, _song, destination, **_kwargs: _write(
+            Path(destination), b"final"
+        ),
+    )
+    kwargs = {
+        "normal_video_path": normal,
+        "official_reply_reference_path": _write(tmp_path / "official.mp4"),
+        "song_video_path": song_video,
+        "tts_config_path": tmp_path / "tts.json",
+        "visual_config_path": tmp_path / "visual.json",
+        "worker_path": tmp_path / "visual-worker.py",
+        "performance_video_path": tmp_path / "base-performance.mp4",
+        "duration_seconds": 40,
+    }
+
+    music_reply.render_musical_reply("letter", "reply", output, **kwargs)
+    (stage_root / "song.flac").unlink()
+    music_reply.render_musical_reply("letter", "reply", output, **kwargs)
+
+    assert calls == {"minimax": 2, "separate": 2, "performance": 2}
+
+
+def test_render_musical_reply_invalidates_cache_when_configured_provider_assets_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "letter.mp4"
+    normal = tmp_path / "letter-spoken.mp4"
+    song_video = tmp_path / "letter-song.mp4"
+    minimax_python = _write(tmp_path / "minimax-python.exe", b"python-v1")
+    minimax_worker = _write(tmp_path / "minimax-worker.py", b"worker-v1")
+    minimax_root = tmp_path / "minimax-root"
+    minimax_entry = _write(minimax_root / "main.py", b"entry-v1")
+    minimax_node = _write(
+        minimax_root / "comfy_extras" / "nodes_minimax_music.py", b"node-v1"
+    )
+    minimax_models = [
+        _write(
+            minimax_root / "models" / "unet" / "minimax_music3_dit_int8_convrot.safetensors",
+            b"unet-v1",
+        ),
+        _write(
+            minimax_root / "models" / "clip" / "minimax_music3_text_encoder_pruned_int8_convrot.safetensors",
+            b"text-v1",
+        ),
+        _write(
+            minimax_root / "models" / "vae" / "minimax_music3_dav.safetensors",
+            b"vae-v1",
+        ),
+    ]
+    latentsync_root = tmp_path / "latentsync-root"
+    latentsync_checkpoint = _write(
+        latentsync_root / "checkpoints" / "latentsync_unet.pt", b"checkpoint-v1"
+    )
+    calls = {"minimax": 0, "separate": 0, "performance": 0}
+
+    monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", str(minimax_python))
+    monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", str(minimax_root))
+    monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", str(minimax_worker))
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_ROOT", str(latentsync_root))
+    monkeypatch.setattr(
+        music_reply,
+        "plan_song_content",
+        lambda *_args: SongContentPlan(
+            emotion="gentle_reassurance",
+            lyrics="[Verse]\\nStay here",
+            caption="gentle piano ballad",
+            duration_seconds=40,
+        ),
+    )
+    monkeypatch.setattr(
+        music_reply,
+        "prepare_official_spoken_base",
+        lambda _reference, destination: _write(Path(destination), b"official-spoken"),
+    )
+    monkeypatch.setattr(
+        music_reply,
+        "render_reply_video",
+        lambda _text, destination, **_kwargs: (
+            _write(Path(destination), b"spoken") and {"spoken_stage": "completed"}
+        ),
+    )
+
+    def fake_generate(self, _content, _reply_text, destination, **_kwargs):
+        del self
+        calls["minimax"] += 1
+        _write(Path(destination), f"song-{calls['minimax']}".encode())
+        return {"music_stage": "completed"}
+
+    def fake_separate(_source, destination):
+        calls["separate"] += 1
+        _write(Path(destination), f"vocals-{calls['separate']}".encode())
+
+    def fake_face(_base, _vocals, _song, destination):
+        calls["performance"] += 1
+        _write(Path(destination), f"performance-{calls['performance']}".encode())
+        return {"performance_stage": "completed"}
+
+    monkeypatch.setattr(music_reply.MiniMaxMusic3Worker, "generate", fake_generate)
+    monkeypatch.setattr(music_reply, "separate_vocals", fake_separate)
+    monkeypatch.setattr(music_reply, "render_full_face_performance", fake_face)
+    transition = _write(tmp_path / "official-transition.mp4")
+    monkeypatch.setattr(
+        music_reply, "_official_transition_reference", lambda: transition
+    )
+    monkeypatch.setattr(
+        music_reply,
+        "concat_videos",
+        lambda _normal, _song, destination, **_kwargs: _write(
+            Path(destination), b"final"
+        ),
+    )
+    kwargs = {
+        "normal_video_path": normal,
+        "official_reply_reference_path": _write(tmp_path / "official.mp4"),
+        "song_video_path": song_video,
+        "tts_config_path": tmp_path / "tts.json",
+        "visual_config_path": tmp_path / "visual.json",
+        "worker_path": tmp_path / "visual-worker.py",
+        "performance_video_path": tmp_path / "base-performance.mp4",
+        "duration_seconds": 40,
+    }
+
+    music_reply.render_musical_reply("letter", "reply", output, **kwargs)
+
+    for index, asset in enumerate(
+        [minimax_python, minimax_entry, minimax_node, *minimax_models, latentsync_checkpoint],
+        start=2,
+    ):
+        asset.write_bytes(f"provider-v{index}".encode())
+        music_reply.render_musical_reply("letter", "reply", output, **kwargs)
+        assert calls == {"minimax": index, "separate": index, "performance": index}
+
+    minimax_node.unlink()
+    music_reply.render_musical_reply("letter", "reply", output, **kwargs)
+
+    assert calls == {"minimax": 9, "separate": 9, "performance": 9}

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -325,6 +325,42 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
     assert result["performance_stage"] == "completed"
 
 
+def test_render_musical_reply_fails_closed_without_official_transition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", "synthetic-python")
+    monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", "synthetic-root")
+    monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", "synthetic-worker")
+    monkeypatch.setattr(
+        music_reply,
+        "plan_song_content",
+        lambda *_args: SongContentPlan(
+            emotion="gentle_reassurance",
+            lyrics="[Verse]\nStay here",
+            caption="gentle piano ballad",
+            duration_seconds=40,
+        ),
+    )
+    monkeypatch.delenv("OLIVIA_OFFICIAL_REPLY_REFERENCE", raising=False)
+    official_reference = _write(tmp_path / "official.mp4")
+
+    with pytest.raises(music_reply.MusicReplyError, match="MUSIC_REPLY_TRANSITION_UNAVAILABLE"):
+        music_reply.render_musical_reply(
+            "letter",
+            "reply",
+            tmp_path / "final.mp4",
+            normal_video_path=tmp_path / "spoken.mp4",
+            official_reply_reference_path=official_reference,
+            song_video_path=tmp_path / "performance.mp4",
+            tts_config_path=tmp_path / "tts.json",
+            visual_config_path=tmp_path / "visual.json",
+            worker_path=tmp_path / "worker.py",
+            performance_video_path=tmp_path / "base-performance.mp4",
+            duration_seconds=40,
+        )
+
+
 def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -335,11 +371,12 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     old_stage_root = tmp_path / "letter-stages"
     stage_root = tmp_path / "letter-music-v2-40s-stages"
     _write(old_stage_root / "song.flac", b"stale-118-second-song")
+    minimax_worker = _write(tmp_path / "minimax-worker.py", b"provider-v1")
     calls = {"spoken": 0, "minimax": 0, "separate": 0}
 
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", "synthetic-python")
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", "synthetic-root")
-    monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", "synthetic-worker")
+    monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", str(minimax_worker))
     monkeypatch.setattr(
         music_reply,
         "plan_song_content",
@@ -379,7 +416,10 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
             and {"performance_stage": "completed"}
         ),
     )
-    monkeypatch.setattr(music_reply, "_official_transition_reference", lambda: None)
+    transition = _write(tmp_path / "official-transition.mp4")
+    monkeypatch.setattr(
+        music_reply, "_official_transition_reference", lambda: transition
+    )
     monkeypatch.setattr(
         music_reply,
         "concat_videos",
@@ -417,3 +457,13 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     assert calls == {"spoken": 1, "minimax": 1, "separate": 2}
     assert result["spoken_stage"] == "reused"
     assert result["music_stage"] == "reused"
+    assert (stage_root / "manifest.json").is_file()
+
+    music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
+
+    assert calls == {"spoken": 2, "minimax": 2, "separate": 3}
+
+    minimax_worker.write_bytes(b"provider-v2")
+    music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
+
+    assert calls == {"spoken": 3, "minimax": 3, "separate": 4}

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -60,6 +60,35 @@ def _value_after(command: list[str], flag: str) -> str:
     return command[command.index(flag) + 1]
 
 
+def test_prepare_official_spoken_base_uses_only_first_35_seconds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reference = _write(tmp_path / "official-complete-reply.mp4")
+    destination = tmp_path / "stages" / "official-spoken-000-035s.mp4"
+    observed: list[tuple[list[str], str]] = []
+
+    monkeypatch.setattr(music_reply, "_ffmpeg", lambda: "ffmpeg")
+
+    def fake_run(command, error_code, *, timeout=900.0):
+        del timeout
+        observed.append((list(command), error_code))
+        _write(Path(command[-1]), b"official-spoken")
+
+    monkeypatch.setattr(music_reply, "_run", fake_run)
+
+    result = music_reply.prepare_official_spoken_base(reference, destination)
+
+    assert result == destination
+    assert destination.read_bytes() == b"official-spoken"
+    command, error_code = observed[0]
+    assert error_code == "MUSIC_REPLY_SPOKEN_REFERENCE_FAILED"
+    assert _value_after(command, "-ss") == "0"
+    assert _value_after(command, "-t") == "35"
+    assert _value_after(command, "-i") == str(reference)
+    assert "-an" in command
+
+
 def test_concat_videos_inserts_silent_transition_between_spoken_and_performance(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -102,7 +131,7 @@ def test_concat_videos_inserts_silent_transition_between_spoken_and_performance(
     assert "[normal_v][normal_a][transition_v][transition_a][song_v][song_a]" in filters
     assert "concat=n=3:v=1:a=1[joined_v][joined_a]" in filters
     assert "anullsrc=r=44100:cl=stereo" in filters
-    assert "trim=start=41.000000:end=43.000000" in filters
+    assert "trim=start=35.000000:end=43.000000" in filters
     assert assembly[:8] == [
         "ffmpeg",
         "-hide_banner",
@@ -117,8 +146,8 @@ def test_concat_videos_inserts_silent_transition_between_spoken_and_performance(
     assert str(transition) in assembly
 
     final = commands[1][0]
-    assert _value_after(final, "-frames:v") == "350"
-    assert _value_after(final, "-t") == "14.000000"
+    assert _value_after(final, "-frames:v") == "500"
+    assert _value_after(final, "-t") == "20.000000"
 
 
 def test_concat_videos_without_transition_preserves_two_segment_order(
@@ -149,6 +178,8 @@ def test_concat_videos_without_transition_preserves_two_segment_order(
     filters = _value_after(commands[0], "-filter_complex")
     assert "[normal_v][normal_a][song_v][song_a]" in filters
     assert "concat=n=2:v=1:a=1[joined_v][joined_a]" in filters
+    assert "fade=t=out:st=13.000000:d=2.000000" in filters
+    assert "afade=t=out:st=13.000000:d=2.000000" in filters
     assert "transition_v" not in filters
     assert _value_after(commands[1], "-frames:v") == "375"
     assert _value_after(commands[1], "-t") == "15.000000"
@@ -169,6 +200,12 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
     output = tmp_path / "final.mp4"
     normal = tmp_path / "spoken.mp4"
     song_video = tmp_path / "performance.mp4"
+    official_reference = _write(tmp_path / "official-complete-reply.mp4")
+    official_spoken = (
+        tmp_path
+        / "final-music-v2-40s-stages"
+        / "official-spoken-000-035s.mp4"
+    )
     transition = _write(tmp_path / "official-transition.mp4")
     order: list[str] = []
     observed: dict[str, object] = {}
@@ -222,6 +259,16 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
         _write(Path(destination), b"final")
 
     monkeypatch.setattr(music_reply, "plan_song_content", fake_plan)
+    monkeypatch.setattr(
+        music_reply,
+        "prepare_official_spoken_base",
+        lambda reference, destination: (
+            observed.setdefault(
+                "spoken_reference", (Path(reference), Path(destination))
+            )
+            and _write(Path(destination), b"official-spoken")
+        ),
+    )
     monkeypatch.setattr(music_reply, "render_reply_video", fake_normal)
     monkeypatch.setattr(music_reply.MiniMaxMusic3Worker, "generate", fake_generate)
     monkeypatch.setattr(music_reply, "separate_vocals", fake_separate)
@@ -234,7 +281,7 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
         "synthetic canonical reply",
         output,
         normal_video_path=normal,
-        normal_scene_path=tmp_path / "scene.mp4",
+        official_reply_reference_path=official_reference,
         song_video_path=song_video,
         tts_config_path=tmp_path / "tts.json",
         visual_config_path=tmp_path / "visual.json",
@@ -253,6 +300,9 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
     ]
     assert observed["minimax"][3]["lyrics"] == semantic.lyrics
     assert observed["minimax"][3]["caption"] == caption
+    assert observed["spoken"][2]["adaptive_delivery"] is True
+    assert observed["spoken"][2]["scene_path"] == official_spoken
+    assert observed["spoken_reference"] == (official_reference, official_spoken)
     assert observed["concat"] == (
         normal,
         song_video,
@@ -263,7 +313,7 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
     assert result["reply_structure"] == (
         "normal_video_then_official_transition_then_song_video"
     )
-    assert result["transition_duration_seconds"] == 2.0
+    assert result["transition_duration_seconds"] == 8.0
     assert result["lyrics_sha256"] == hashlib.sha256(
         semantic.lyrics.encode("utf-8")
     ).hexdigest()
@@ -273,3 +323,97 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
     assert result["spoken_stage"] == "completed"
     assert result["music_stage"] == "completed"
     assert result["performance_stage"] == "completed"
+
+
+def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "letter.mp4"
+    normal = tmp_path / "letter-spoken.mp4"
+    song_video = tmp_path / "letter-song.mp4"
+    old_stage_root = tmp_path / "letter-stages"
+    stage_root = tmp_path / "letter-music-v2-40s-stages"
+    _write(old_stage_root / "song.flac", b"stale-118-second-song")
+    calls = {"spoken": 0, "minimax": 0, "separate": 0}
+
+    monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", "synthetic-python")
+    monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", "synthetic-root")
+    monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", "synthetic-worker")
+    monkeypatch.setattr(
+        music_reply,
+        "plan_song_content",
+        lambda *_args: SongContentPlan(
+            emotion="gentle_reassurance",
+            lyrics="[Verse]\nStay here",
+            caption="gentle piano ballad",
+            duration_seconds=40,
+        ),
+    )
+
+    def fake_normal(_text, destination, **_kwargs):
+        calls["spoken"] += 1
+        _write(Path(destination), b"spoken")
+        return {"spoken_stage": "completed"}
+
+    def fake_generate(self, _content, _reply_text, destination, **_kwargs):
+        del self
+        calls["minimax"] += 1
+        _write(Path(destination), b"expensive-song")
+        return {"music_stage": "completed"}
+
+    def flaky_separate(_source, destination):
+        calls["separate"] += 1
+        if calls["separate"] == 1:
+            raise music_reply.MusicReplyError("ROFORMER_FAILED")
+        _write(Path(destination), b"vocals")
+
+    monkeypatch.setattr(music_reply, "render_reply_video", fake_normal)
+    monkeypatch.setattr(music_reply.MiniMaxMusic3Worker, "generate", fake_generate)
+    monkeypatch.setattr(music_reply, "separate_vocals", flaky_separate)
+    monkeypatch.setattr(
+        music_reply,
+        "render_full_face_performance",
+        lambda _base, _vocals, _song, destination: (
+            _write(Path(destination), b"performance")
+            and {"performance_stage": "completed"}
+        ),
+    )
+    monkeypatch.setattr(music_reply, "_official_transition_reference", lambda: None)
+    monkeypatch.setattr(
+        music_reply,
+        "concat_videos",
+        lambda _normal, _song, destination, **_kwargs: _write(
+            Path(destination), b"final"
+        ),
+    )
+
+    official_reference = _write(tmp_path / "official-complete-reply.mp4")
+    monkeypatch.setattr(
+        music_reply,
+        "prepare_official_spoken_base",
+        lambda _reference, destination: _write(Path(destination), b"official-spoken"),
+    )
+    kwargs = {
+        "normal_video_path": normal,
+        "official_reply_reference_path": official_reference,
+        "song_video_path": song_video,
+        "tts_config_path": tmp_path / "tts.json",
+        "visual_config_path": tmp_path / "visual.json",
+        "worker_path": tmp_path / "visual-worker.py",
+        "performance_video_path": tmp_path / "base-performance.mp4",
+        "duration_seconds": 40,
+    }
+    with pytest.raises(music_reply.MusicReplyError, match="ROFORMER_FAILED"):
+        music_reply.render_musical_reply("letter", "reply", output, **kwargs)
+
+    assert normal.read_bytes() == b"spoken"
+    assert (stage_root / "song.flac").read_bytes() == b"expensive-song"
+    assert (old_stage_root / "song.flac").read_bytes() == b"stale-118-second-song"
+
+    result = music_reply.render_musical_reply("letter", "reply", output, **kwargs)
+
+    assert output.read_bytes() == b"final"
+    assert calls == {"spoken": 1, "minimax": 1, "separate": 2}
+    assert result["spoken_stage"] == "reused"
+    assert result["music_stage"] == "reused"

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from array import array
 import json
+import os
 from pathlib import Path
 import shutil
 import sys
@@ -12,6 +13,7 @@ import wave
 import pytest
 
 import latentsync_reply
+import music_reply
 from latentsync_reply import render_latentsync_video
 from music_duration import MUSIC_DURATION_OPTIONS, normalize_music_duration
 from music_reply import MusicReplyError, render_musical_reply
@@ -62,6 +64,7 @@ def test_media_workers_fail_closed_without_external_provider(tmp_path):
             "测试回信",
             tmp_path / "music.mp4",
             normal_video_path=tmp_path / "normal.mp4",
+            official_reply_reference_path=tmp_path / "missing-official.mp4",
             song_video_path=tmp_path / "song.mp4",
             tts_config_path=tmp_path / "missing.json",
             visual_config_path=tmp_path / "missing.json",
@@ -69,6 +72,44 @@ def test_media_workers_fail_closed_without_external_provider(tmp_path):
             performance_video_path=tmp_path / "performance.mp4",
             duration_seconds=40,
         )
+
+
+def test_roformer_uses_explicit_f_drive_assets_and_utf8(tmp_path, monkeypatch):
+    executable = tmp_path / "roformer.exe"
+    model = tmp_path / "models" / "MelBandRoformer.ckpt"
+    config = tmp_path / "models" / "config.yaml"
+    song = tmp_path / "song.flac"
+    vocals = tmp_path / "vocals.wav"
+    for path in (executable, model, config, song):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"synthetic")
+    monkeypatch.setenv("OLIVIA_ROFORMER_EXE", str(executable))
+    monkeypatch.setenv("OLIVIA_ROFORMER_MODEL_PATH", str(model))
+    monkeypatch.setenv("OLIVIA_ROFORMER_CONFIG_PATH", str(config))
+    monkeypatch.setattr(music_reply, "_ffmpeg", lambda: "ffmpeg")
+    observed = []
+
+    def fake_run(command, error_code, *, timeout=900.0, env=None):
+        observed.append((command, error_code, env))
+        if "--store_dir" in command:
+            output_root = Path(command[command.index("--store_dir") + 1])
+            (output_root / "synthetic_vocals.wav").write_bytes(b"vocals")
+
+    monkeypatch.setattr(music_reply, "_run", fake_run)
+
+    music_reply.separate_vocals(song, vocals)
+
+    assert observed[0][0][:4] == ["ffmpeg", "-y", "-i", str(song)]
+    assert observed[0][1] == "ROFORMER_INPUT_CONVERSION_FAILED"
+    assert observed[1][0][-4:] == [
+        "--model_path",
+        str(model),
+        "--config_path",
+        str(config),
+    ]
+    assert observed[1][2]["PYTHONUTF8"] == "1"
+    assert observed[1][2]["PYTHONIOENCODING"] == "utf-8"
+    assert vocals.read_bytes() == b"vocals"
 
 
 def test_official_voice_reference_is_bounded_for_cosyvoice(tmp_path, monkeypatch):


### PR DESCRIPTION
## Scope

Fourth slice replacing closed #106. Generates one 40/60-second song plan, separates vocals through explicit local provider assets, lip-syncs the proven piano scene, then assembles ordinary spoken video + official silent transition + equal-length music performance with a fade-out.

## Validation

- musical assembly + portable boundary: 15 passed
- py_compile: PASS
- diff-check: PASS

## Boundary

No live provider/model run and no claim of human visual or singing-voice acceptance. No HTTP routing or automatic trigger wiring; that is the final slice. Stacked on #109.