### PR TITLE
feat(reply): route automatic spoken and musical video letters

### DIFF
--- a/docs/P03_06_END_TO_END_ACCEPTANCE.md
+++ b/docs/P03_06_END_TO_END_ACCEPTANCE.md
@@ -286,7 +286,7 @@ spoken_video / musical_video ReplyContext
      生成 song_video_path（演唱视频）
   -> concat_videos(...)
      normal_video_path
-     + 可选 official transition（旧音频静音）
+     + mandatory official silent turn/black transition（旧音频静音）
      + song_video_path
   -> 最终 MP4
 ```
@@ -298,7 +298,7 @@ spoken_video / musical_video ReplyContext
 - 音频时长符合 40/60 秒配置；
 - 歌曲和 vocals 非空；
 - normal video 与 song video 均生成；
-- 拼接顺序为 spoken -> optional transition -> performance；
+- 拼接顺序为 spoken -> mandatory official silent turn/black transition -> performance；
 - transition 音轨已替换为静音；
 - 最后 2 秒视频与音频同步渐暗；
 - 各分段帧数与最终帧数一致；

--- a/docs/P03_06_END_TO_END_ACCEPTANCE.md
+++ b/docs/P03_06_END_TO_END_ACCEPTANCE.md
@@ -15,7 +15,7 @@ P03 关闭前必须验证：
   -> 必要时一次修复
   -> canonical reply
   -> 持久化
-  -> 文字 / 说话视频 / 音乐视频
+  -> 文字回信 / 完整视频回信
   -> Mem0 写入
   -> PrivateWorld 交付或受控事件
   -> Companion Control Center 管理
@@ -180,7 +180,11 @@ GitHub Actions：
 - 输出可辨认为林离，而非通用助手；
 - 不凭空补史、不泄露内部字段。
 
-## 6. 说话视频真实验收
+## 6. 完整视频回信的说话阶段验收
+
+`spoken_video` 与 `musical_video` 是两种路由理由，不是两种用户成品。只要选择
+视频回信，最终交付都必须继续完成第 8 节的官方无声转场和音乐演唱阶段；完整音乐
+链不可用时不得只交付 spoken-only 视频。
 
 固定三条输入：
 
@@ -191,8 +195,8 @@ GitHub Actions：
 流程：
 
 ```text
-spoken_video ReplyContext
-  -> 160–180 字可朗读正文
+spoken_video / musical_video ReplyContext
+  -> 180–200 字可朗读正文
   -> DeliveryPlan
   -> CosyVoice
   -> 官方动作场景
@@ -255,7 +259,8 @@ spoken_video ReplyContext
 
 ## 8. 音乐视频真实验收
 
-音乐视频是“说话视频＋可选转场＋演唱视频”的顺序拼接，不是单独的演唱视频。
+完整视频回信是“说话视频＋官方无声转场＋演唱视频”的顺序拼接，不存在独立的
+spoken-only 成品，也不是单独的演唱视频。
 
 固定至少三条：
 
@@ -266,7 +271,7 @@ spoken_video ReplyContext
 仓库现有流程必须原样贯通：
 
 ```text
-musical_video ReplyContext
+spoken_video / musical_video ReplyContext
   -> canonical reply
   -> render_reply_video(...)
      生成 normal_video_path（说话视频）
@@ -522,7 +527,7 @@ CI 使用 mock，本机使用真实 provider。
 - 原版客户端终态正确；
 - 已配置媒体时说话视频通过；
 - MiniMax 音频风格达标；
-- 音乐视频按说话＋可选转场＋演唱顺序拼接并通过；
+- 视频回信按说话＋官方无声转场＋演唱顺序拼接并通过；
 - 故障注入不丢 canonical text；
 - 重启恢复通过；
 - 日志、报告和导出无秘密或私人内容泄漏；
@@ -533,7 +538,7 @@ CI 使用 mock，本机使用真实 provider。
 
 P03 完成后，系统应准确描述为：
 
-> 一个可在 Windows 本地长期运行、具备稳定林离人格、三种书信表达方式、成熟长期记忆、受控私人世界状态、图形化本地管理、可恢复持久化和诚实媒体降级的书信陪伴系统。
+> 一个可在 Windows 本地长期运行、具备稳定林离人格、文字与完整视频两种书信表达方式、成熟长期记忆、受控私人世界状态、图形化本地管理、可恢复持久化和诚实媒体降级的书信陪伴系统。
 
 不得提前描述为：
 

--- a/latentsync_reply.py
+++ b/latentsync_reply.py
@@ -13,13 +13,15 @@ class LatentSyncReplyError(RuntimeError):
     """Stable product error for the external LatentSync process."""
 
 
-def _environment_with_ffmpeg(shim_root: Path, cache_root: Path) -> dict[str, str]:
+def resolve_ffmpeg_executable() -> Path:
+    """Resolve the same FFmpeg executable used by the LatentSync renderer."""
+
     configured = os.environ.get("OLIVIA_FFMPEG_EXE", "").strip()
     if configured:
         configured_path = Path(configured)
         if not configured_path.is_file():
             raise LatentSyncReplyError("LATENTSYNC_FFMPEG_UNAVAILABLE")
-        executable = str(configured_path)
+        executable = configured_path
     else:
         executable = shutil.which("ffmpeg")
     if executable is None:
@@ -30,6 +32,25 @@ def _environment_with_ffmpeg(shim_root: Path, cache_root: Path) -> dict[str, str
         except (ImportError, RuntimeError, OSError) as exc:
             raise LatentSyncReplyError("LATENTSYNC_FFMPEG_UNAVAILABLE") from exc
     resolved = Path(executable).resolve()
+    if not resolved.is_file():
+        raise LatentSyncReplyError("LATENTSYNC_FFMPEG_UNAVAILABLE")
+    return resolved
+
+
+def media_runtime_available() -> bool:
+    """Check the FFmpeg resolver and frame probe used by complete delivery."""
+
+    try:
+        resolve_ffmpeg_executable()
+        import imageio_ffmpeg
+
+        return callable(getattr(imageio_ffmpeg, "count_frames_and_secs", None))
+    except (ImportError, RuntimeError, OSError, LatentSyncReplyError):
+        return False
+
+
+def _environment_with_ffmpeg(shim_root: Path, cache_root: Path) -> dict[str, str]:
+    resolved = resolve_ffmpeg_executable()
     directory = resolved.parent
     if resolved.stem.casefold() != "ffmpeg":
         shim = Path(shim_root) / "ffmpeg.exe"
@@ -209,4 +230,9 @@ def render_latentsync_video(
     }
 
 
-__all__ = ["LatentSyncReplyError", "render_latentsync_video"]
+__all__ = [
+    "LatentSyncReplyError",
+    "media_runtime_available",
+    "render_latentsync_video",
+    "resolve_ffmpeg_executable",
+]

--- a/latentsync_reply.py
+++ b/latentsync_reply.py
@@ -7,16 +7,18 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import Mapping
 
 
 class LatentSyncReplyError(RuntimeError):
     """Stable product error for the external LatentSync process."""
 
 
-def resolve_ffmpeg_executable() -> Path:
+def resolve_ffmpeg_executable(env: Mapping[str, str] | None = None) -> Path:
     """Resolve the same FFmpeg executable used by the LatentSync renderer."""
 
-    configured = os.environ.get("OLIVIA_FFMPEG_EXE", "").strip()
+    environment = os.environ if env is None else env
+    configured = str(environment.get("OLIVIA_FFMPEG_EXE", "")).strip()
     if configured:
         configured_path = Path(configured)
         if not configured_path.is_file():
@@ -37,11 +39,11 @@ def resolve_ffmpeg_executable() -> Path:
     return resolved
 
 
-def media_runtime_available() -> bool:
+def media_runtime_available(env: Mapping[str, str] | None = None) -> bool:
     """Check the FFmpeg resolver and frame probe used by complete delivery."""
 
     try:
-        resolve_ffmpeg_executable()
+        resolve_ffmpeg_executable(env)
         import imageio_ffmpeg
 
         return callable(getattr(imageio_ffmpeg, "count_frames_and_secs", None))

--- a/letter_triage.py
+++ b/letter_triage.py
@@ -339,12 +339,22 @@ class LetterReplyRouter:
         self,
         gateway: RouterGateway,
         *,
-        timeout_seconds: float = 10.0,
+        timeout_seconds: float | None = None,
         routing_context: RoutingContext | None = None,
         environ: Mapping[str, str] | None = None,
     ) -> None:
         self.gateway = gateway
-        self.timeout_seconds = max(0.05, float(timeout_seconds))
+        if timeout_seconds is None:
+            raw_timeout = (environ or os.environ).get(
+                "OLIVIA_REPLY_ROUTER_TIMEOUT_SECONDS", "60"
+            )
+            try:
+                configured_timeout = float(raw_timeout)
+            except (TypeError, ValueError):
+                configured_timeout = 60.0
+            self.timeout_seconds = min(300.0, max(5.0, configured_timeout))
+        else:
+            self.timeout_seconds = max(0.05, float(timeout_seconds))
         self.routing_context = routing_context
         self.environ = environ
 

--- a/letter_triage.py
+++ b/letter_triage.py
@@ -462,14 +462,13 @@ def _musical_video_configured(env: Mapping[str, str]) -> bool:
         str(env.get("OLIVIA_MINIMAX_WORKER", ""))
     ).expanduser()
     roformer = Path(str(env.get("OLIVIA_ROFORMER_EXE", ""))).expanduser()
-    performance = Path(
-        str(env.get("OLIVIA_MUSIC_PERFORMANCE_BASE", ""))
-    ).expanduser()
+    performance = _current_music_performance(env)
     return bool(
         minimax_python.is_file()
         and (minimax_root / "main.py").is_file()
         and minimax_worker.is_file()
         and roformer.is_file()
+        and performance is not None
         and performance.is_file()
     )
 
@@ -486,6 +485,30 @@ def _current_scene(env: Mapping[str, str]) -> Path | None:
         else "NIGHT"
     )
     value = str(env.get(f"OLIVIA_SCENE_{key}", "")).strip()
+    return Path(value).expanduser() if value else None
+
+
+def _current_music_performance(
+    env: Mapping[str, str],
+    *,
+    hour: int | None = None,
+) -> Path | None:
+    """Choose the evidenced piano scene from host local time.
+
+    No separate morning asset has been verified, so 05:00-09:00 explicitly
+    falls back to the day scene.  A single generic performance path is not
+    accepted because it would silently bypass the time-of-day contract.
+    """
+
+    local_hour = datetime.now().hour if hour is None else int(hour)
+    key = (
+        "DAY"
+        if 5 <= local_hour < 16
+        else "DUSK"
+        if 16 <= local_hour < 19
+        else "NIGHT"
+    )
+    value = str(env.get(f"OLIVIA_MUSIC_SCENE_{key}", "")).strip()
     return Path(value).expanduser() if value else None
 
 

--- a/letter_triage.py
+++ b/letter_triage.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Mapping, Protocol
 
 from llm_gateway import GatewayError
+from music_reply import musical_reply_configured
 
 
 ROUTER_SYSTEM_PROMPT = """你负责决定林离这一封回信采用哪一种表达方式。
@@ -413,20 +414,9 @@ def routing_context_from_environment(
     environ: Mapping[str, str] | None = None,
 ) -> RoutingContext:
     env = environ if environ is not None else os.environ
-    spoken_override = _optional_bool(env.get("OLIVIA_SPOKEN_VIDEO_AVAILABLE"))
-    musical_override = _optional_bool(env.get("OLIVIA_MUSICAL_VIDEO_AVAILABLE"))
-    spoken = (
-        spoken_override
-        if spoken_override is not None
-        else _spoken_video_configured(env)
-    )
+    spoken = _spoken_video_configured(env)
     musical_detected = spoken and _musical_video_configured(env)
-    musical = (
-        musical_override
-        if musical_override is not None
-        else musical_detected
-    )
-    complete_video = spoken and musical
+    complete_video = spoken and musical_detected
     return RoutingContext(
         spoken_video_available=complete_video,
         musical_video_available=complete_video,
@@ -455,24 +445,9 @@ def _spoken_video_configured(env: Mapping[str, str]) -> bool:
 
 
 def _musical_video_configured(env: Mapping[str, str]) -> bool:
-    minimax_python = Path(
-        str(env.get("OLIVIA_MINIMAX_COMFY_PYTHON", ""))
-    ).expanduser()
-    minimax_root = Path(
-        str(env.get("OLIVIA_MINIMAX_COMFY_ROOT", ""))
-    ).expanduser()
-    minimax_worker = Path(
-        str(env.get("OLIVIA_MINIMAX_WORKER", ""))
-    ).expanduser()
-    roformer = Path(str(env.get("OLIVIA_ROFORMER_EXE", ""))).expanduser()
-    performance = _current_music_performance(env)
-    return bool(
-        minimax_python.is_file()
-        and (minimax_root / "main.py").is_file()
-        and minimax_worker.is_file()
-        and roformer.is_file()
-        and performance is not None
-        and performance.is_file()
+    return musical_reply_configured(
+        env,
+        performance_video_path=_current_music_performance(env),
     )
 
 
@@ -513,17 +488,6 @@ def _current_music_performance(
     )
     value = str(env.get(f"OLIVIA_MUSIC_SCENE_{key}", "")).strip()
     return Path(value).expanduser() if value else None
-
-
-def _optional_bool(value: object) -> bool | None:
-    if value is None:
-        return None
-    normalized = str(value).strip().casefold()
-    if normalized in {"1", "true", "yes", "on"}:
-        return True
-    if normalized in {"0", "false", "no", "off"}:
-        return False
-    return None
 
 
 def _context_items(value: object) -> tuple[str, ...]:

--- a/letter_triage.py
+++ b/letter_triage.py
@@ -27,8 +27,11 @@ ROUTER_SYSTEM_PROMPT = """你负责决定林离这一封回信采用哪一种表
 
 可选模式只有：
 - text_letter：文字信；
-- spoken_video：直接说话的视频；
-- musical_video：音乐本身构成这次回应的一部分。
+- spoken_video：因为声音陪伴更合适而选择完整视频回信；
+- musical_video：因为音乐本身构成回应而选择完整视频回信。
+
+spoken_video 和 musical_video 只区分路由理由，不是两种成品。两者的交付物都必须是
+“说话视频 + 官方无声转场 + 音乐演唱视频”；任一视频阶段不可用时只能 text_letter。
 
 总原则：能直接说的话，优先直接说。高情绪、提到音乐、讨论音乐、请求演奏、
 唱歌或改编，都不能单独触发 musical_video。林离可以拒绝、推迟、只讨论，
@@ -66,8 +69,9 @@ current_work_relevance 只能引用 routing_context.current_music_work 中存在
 melody_idea 只能与 spontaneous_motif + compose 同时出现，不能因为用户写了“音乐”
 就声称林离突然想到旋律。
 
-spoken_video 只有在 routing_context.spoken_video_available=true、直接表达仍足够，
-但听见她的声音明显比文字更合适时选择。媒体不可用时必须选择 text_letter。
+spoken_video 只有在完整视频链可用、routing_context.spoken_video_available=true、
+直接表达仍足够，但听见她的声音明显比文字更合适时选择。媒体不可用时必须选择
+text_letter。
 普通日常默认 text_letter。不要为了证明人格而音乐化。
 
 只输出一个 JSON 对象，不要 Markdown 或解释：
@@ -422,11 +426,10 @@ def routing_context_from_environment(
         if musical_override is not None
         else musical_detected
     )
-    if musical and not spoken:
-        musical = False
+    complete_video = spoken and musical
     return RoutingContext(
-        spoken_video_available=spoken,
-        musical_video_available=musical,
+        spoken_video_available=complete_video,
+        musical_video_available=complete_video,
         current_music_work=_context_items(env.get("OLIVIA_CURRENT_MUSIC_WORK", "")),
     )
 

--- a/local_server.py
+++ b/local_server.py
@@ -45,7 +45,7 @@ from persona_provider import (
     persona_status,
 )
 from reply_orchestrator import ReplyOrchestrator, ReplyRequest, ReplyState
-from letter_triage import LetterEmotionTriage
+from letter_triage import LetterEmotionTriage, _current_music_performance
 from music_reply import MusicReplyError, render_musical_reply
 from music_duration import MUSIC_DURATION_OPTIONS
 from reply_media import ReplyMediaError, render_reply_video
@@ -1598,6 +1598,9 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
             worker = Path(_os.environ.get("OLIVIA_LIVETALKING_WORKER", ""))
             if reply_mode == "musical_video":
                 music_duration_seconds = int(letter.get("music_duration_seconds", 60))
+                performance_scene = _current_music_performance(_os.environ)
+                if performance_scene is None or not performance_scene.is_file():
+                    raise MusicReplyError("MUSIC_PERFORMANCE_SCENE_NOT_CONFIGURED")
                 await asyncio.to_thread(render_musical_reply,
                     content,
                     reply_text,
@@ -1612,7 +1615,7 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
                     tts_config_path=tts_config,
                     visual_config_path=visual_config,
                     worker_path=worker,
-                    performance_video_path=Path(_os.environ.get("OLIVIA_MUSIC_PERFORMANCE_BASE", "")),
+                    performance_video_path=performance_scene,
                     duration_seconds=music_duration_seconds,
                 )
             else:

--- a/local_server.py
+++ b/local_server.py
@@ -46,7 +46,7 @@ from persona_provider import (
 )
 from reply_orchestrator import ReplyOrchestrator, ReplyRequest, ReplyState
 from letter_triage import LetterEmotionTriage, _current_music_performance
-from music_reply import MusicReplyError, render_musical_reply
+from music_reply import MusicReplyError, render_musical_reply, select_speaking_scene, speaking_scene_candidates
 from music_duration import MUSIC_DURATION_OPTIONS
 from reply_media import ReplyMediaError, render_reply_video
 from reply_delivery import build_ordinary_video_llm_content
@@ -1609,9 +1609,9 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
                     song_video_path=output_dir / (
                         f"{letter_id}-song-v2-{music_duration_seconds}s.mp4"
                     ),
-                    official_reply_reference_path=Path(
-                        _os.environ.get("OLIVIA_OFFICIAL_REPLY_REFERENCE", "")
-                    ),
+                    official_reply_reference_path=select_speaking_scene(
+                        speaking_scene_candidates(_os.environ)
+                    ) or Path(),
                     tts_config_path=tts_config,
                     visual_config_path=visual_config,
                     worker_path=worker,

--- a/local_server.py
+++ b/local_server.py
@@ -47,7 +47,9 @@ from persona_provider import (
 from reply_orchestrator import ReplyOrchestrator, ReplyRequest, ReplyState
 from letter_triage import LetterEmotionTriage
 from music_reply import MusicReplyError, render_musical_reply
+from music_duration import MUSIC_DURATION_OPTIONS
 from reply_media import ReplyMediaError, render_reply_video
+from reply_delivery import build_ordinary_video_llm_content
 from local_memory import create_memory_adapter
 from memory_port import LegacyLetter, MemoryPort, NullMemoryPort
 from memory_prompt import MemoryPromptBuilder
@@ -1126,6 +1128,23 @@ def _schedule_text_reply_delay(letter: dict, reply_mode: str) -> None:
     letter["reply_not_before"] = time.time() + delay * 60.0
 
 
+def _reply_pipeline_timeout_seconds() -> float:
+    """Cover generation plus review, one rewrite, and the final recheck."""
+
+    default_quality_timeout = min(float(LLM_TIMEOUT_SECONDS), 60.0)
+    try:
+        quality_timeout = float(
+            _os.environ.get(
+                "OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS",
+                str(default_quality_timeout),
+            )
+        )
+    except (TypeError, ValueError):
+        quality_timeout = default_quality_timeout
+    quality_timeout = max(1.0, min(quality_timeout, 300.0))
+    return float(LLM_TIMEOUT_SECONDS) + 3.0 * quality_timeout + 5.0
+
+
 def _send_result_for_letter(letter: dict) -> dict:
     if letter.get("letter_status") in {"PENDING", "PROCESSING"}:
         return ok(
@@ -1373,9 +1392,9 @@ async def route(method, path, body, query, *, defer_reply: bool = False):
             return _invalid_field_type("material", "object")
         if not isinstance(content, str) or not content.strip():
             return err(400, 'INVALID_CONTENT', {'status': 'FAILED', 'error_code': 'INVALID_CONTENT'})
-        duration = material.get("music_duration_seconds", 118)
-        if isinstance(duration, bool) or duration not in {90, 118}:
-            return err(400, "MUSIC_DURATION_INVALID", {"status": "FAILED", "error_code": "MUSIC_DURATION_INVALID", "allowed": [90, 118]})
+        duration = material.get("music_duration_seconds", 60)
+        if isinstance(duration, bool) or duration not in MUSIC_DURATION_OPTIONS:
+            return err(400, "MUSIC_DURATION_INVALID", {"status": "FAILED", "error_code": "MUSIC_DURATION_INVALID", "allowed": list(MUSIC_DURATION_OPTIONS)})
         if len(content) > 10000:
             return err(400, 'CONTENT_TOO_LONG', {
                 'status': 'FAILED',
@@ -1574,32 +1593,37 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
         output_dir.mkdir(parents=True, exist_ok=True)
         output_path = output_dir / f"{letter_id}.mp4"
         try:
-            from datetime import datetime
-
-            hour = datetime.now().hour
-            scene_key = "morning" if 5 <= hour < 10 else "day" if 10 <= hour < 17 else "dusk" if 17 <= hour < 20 else "night"
-            normal_scene_value = _os.environ.get(f"OLIVIA_SCENE_{scene_key.upper()}", "")
-            normal_scene = Path(normal_scene_value).expanduser() if normal_scene_value else None
-            if normal_scene is None or not normal_scene.is_file():
-                raise ReplyMediaError("ORDINARY_SCENE_NOT_CONFIGURED")
             tts_config = Path(_os.environ.get("OLIVIA_TTS_CONFIG", ""))
             visual_config = Path(_os.environ.get("OLIVIA_VISUAL_CONFIG", ""))
             worker = Path(_os.environ.get("OLIVIA_LIVETALKING_WORKER", ""))
             if reply_mode == "musical_video":
+                music_duration_seconds = int(letter.get("music_duration_seconds", 60))
                 await asyncio.to_thread(render_musical_reply,
                     content,
                     reply_text,
                     output_path,
-                    normal_video_path=output_dir / f"{letter_id}-spoken.mp4",
-                    song_video_path=output_dir / f"{letter_id}-song.mp4",
-                    normal_scene_path=normal_scene,
+                    normal_video_path=output_dir / f"{letter_id}-official-spoken-v1.mp4",
+                    song_video_path=output_dir / (
+                        f"{letter_id}-song-v2-{music_duration_seconds}s.mp4"
+                    ),
+                    official_reply_reference_path=Path(
+                        _os.environ.get("OLIVIA_OFFICIAL_REPLY_REFERENCE", "")
+                    ),
                     tts_config_path=tts_config,
                     visual_config_path=visual_config,
                     worker_path=worker,
                     performance_video_path=Path(_os.environ.get("OLIVIA_MUSIC_PERFORMANCE_BASE", "")),
-                    duration_seconds=int(letter.get("music_duration_seconds", 118)),
+                    duration_seconds=music_duration_seconds,
                 )
             else:
+                from datetime import datetime
+
+                hour = datetime.now().hour
+                scene_key = "morning" if 5 <= hour < 10 else "day" if 10 <= hour < 17 else "dusk" if 17 <= hour < 20 else "night"
+                normal_scene_value = _os.environ.get(f"OLIVIA_SCENE_{scene_key.upper()}", "")
+                normal_scene = Path(normal_scene_value).expanduser() if normal_scene_value else None
+                if normal_scene is None or not normal_scene.is_file():
+                    raise ReplyMediaError("ORDINARY_SCENE_NOT_CONFIGURED")
                 await asyncio.to_thread(render_reply_video,
                     reply_text,
                     output_path,
@@ -1613,6 +1637,7 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
                 )
             letter["reply_video_url"] = f"http://127.0.0.1:{PORT}/toy/media/{output_path.name}"
             letter["media_status"] = "COMPLETED"
+            letter["media_error_code"] = None
             _persist_media_state()
         except (ReplyMediaError, MusicReplyError, ValueError, OSError) as exc:
             letter["media_status"] = "UNAVAILABLE"
@@ -1801,6 +1826,12 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
     _persist_store_state()
     decision = await emotion_triage.classify(content)
     exact_mode = _exact_reply_mode(decision.reply_mode)
+    if exact_mode == ReplyMode.SPOKEN_VIDEO.value:
+        # A product video reply is one complete letter: spoken response,
+        # original transition, then the generated performance.  The router may
+        # still express that voice is the reason video is warranted, but there
+        # is no standalone spoken-only delivery surface.
+        exact_mode = ReplyMode.MUSICAL_VIDEO.value
     letter["triage"] = decision.to_dict()
     letter["reply_mode"] = exact_mode
     if exact_mode in {
@@ -1812,8 +1843,14 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
     _persist_store_state()
 
     try:
+        reply_input = (
+            build_ordinary_video_llm_content(content)
+            if exact_mode
+            in {ReplyMode.SPOKEN_VIDEO.value, ReplyMode.MUSICAL_VIDEO.value}
+            else content
+        )
         request = ReplyRequest(
-            content=content,
+            content=reply_input,
             request_id=f"letter-reply:{letter_id}",
             idempotency_key=(
                 f"{idempotency_key}:{letter_id}" if idempotency_key else None
@@ -1825,7 +1862,7 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
                 request,
                 letters_adapter.build_reply_context(ReplyMode(exact_mode)),
             ),
-            timeout=LLM_TIMEOUT_SECONDS,
+            timeout=_reply_pipeline_timeout_seconds(),
         )
     except asyncio.CancelledError:
         letter["letter_status"] = "FAILED"
@@ -1875,6 +1912,8 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
     letters_adapter.remember_conversation(content, result.text)
     _safe_log("letter_completed", reply_mode=exact_mode)
     return True
+
+
 
 if __name__ == "__main__":
     recover_pending_private_world()

--- a/music_reply.py
+++ b/music_reply.py
@@ -10,6 +10,7 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
+from typing import Mapping
 from urllib.error import HTTPError, URLError
 from urllib.parse import urljoin, urlsplit
 from urllib.request import Request, urlopen
@@ -35,6 +36,47 @@ def normalize_music_duration(value: object) -> int:
         return _normalize_music_duration(value)
     except ValueError:
         raise MusicReplyError("MUSIC_DURATION_INVALID") from None
+
+
+def musical_reply_configured(
+    env: Mapping[str, str],
+    *,
+    performance_video_path: Path | None,
+) -> bool:
+    """Return whether the renderer's complete musical delivery closure exists."""
+
+    def configured_path(name: str) -> Path:
+        return Path(str(env.get(name, ""))).expanduser()
+
+    minimax_root = configured_path("OLIVIA_MINIMAX_COMFY_ROOT")
+    latentsync_root = configured_path("OLIVIA_LATENTSYNC_ROOT")
+    required = (
+        configured_path("OLIVIA_OFFICIAL_REPLY_REFERENCE"),
+        configured_path("OLIVIA_TTS_CONFIG"),
+        configured_path("OLIVIA_VISUAL_CONFIG"),
+        configured_path("OLIVIA_LIVETALKING_WORKER"),
+        configured_path("OLIVIA_ROFORMER_EXE"),
+        configured_path("OLIVIA_ROFORMER_MODEL_PATH"),
+        configured_path("OLIVIA_ROFORMER_CONFIG_PATH"),
+        configured_path("OLIVIA_MINIMAX_COMFY_PYTHON"),
+        configured_path("OLIVIA_MINIMAX_WORKER"),
+        minimax_root / "main.py",
+        minimax_root / "comfy_extras" / "nodes_minimax_music.py",
+        minimax_root / "models" / "unet" / "minimax_music3_dit_int8_convrot.safetensors",
+        minimax_root / "models" / "clip" / "minimax_music3_text_encoder_pruned_int8_convrot.safetensors",
+        minimax_root / "models" / "vae" / "minimax_music3_dav.safetensors",
+        configured_path("OLIVIA_LATENTSYNC_PYTHON"),
+        latentsync_root / "scripts" / "inference.py",
+        latentsync_root / "configs" / "unet" / "stage2_efficient.yaml",
+        latentsync_root / "checkpoints" / "latentsync_unet.pt",
+    )
+    return bool(
+        performance_video_path is not None
+        and performance_video_path.is_file()
+        and minimax_root.is_dir()
+        and latentsync_root.is_dir()
+        and all(path.is_file() for path in required)
+    )
 
 
 class MiniMaxMusic3Worker:

--- a/music_reply.py
+++ b/music_reply.py
@@ -18,6 +18,7 @@ from urllib.request import Request, urlopen
 from latentsync_reply import (
     LatentSyncReplyError,
     render_latentsync_video,
+    resolve_ffmpeg_executable,
 )
 from music_duration import MUSIC_DURATION_OPTIONS, normalize_music_duration as _normalize_music_duration
 from reply_media import (
@@ -296,17 +297,9 @@ class AceStepClient:
 
 
 def _ffmpeg() -> str:
-    configured = os.environ.get("OLIVIA_FFMPEG_EXE", "").strip()
-    if configured and Path(configured).is_file():
-        return configured
-    executable = shutil.which("ffmpeg")
-    if executable:
-        return executable
     try:
-        import imageio_ffmpeg
-
-        return imageio_ffmpeg.get_ffmpeg_exe()
-    except (ImportError, RuntimeError, OSError) as exc:
+        return str(resolve_ffmpeg_executable())
+    except LatentSyncReplyError as exc:
         raise MusicReplyError("FFMPEG_UNAVAILABLE") from exc
 
 

--- a/music_reply.py
+++ b/music_reply.py
@@ -17,11 +17,14 @@ from urllib.request import Request, urlopen
 
 from latentsync_reply import (
     LatentSyncReplyError,
-    media_runtime_available,
     render_latentsync_video,
 )
 from music_duration import MUSIC_DURATION_OPTIONS, normalize_music_duration as _normalize_music_duration
-from reply_media import render_reply_video
+from reply_media import (
+    ReplyMediaError,
+    assemble_complete_video_delivery,
+    render_reply_video,
+)
 from song_content import plan_song_content
 
 
@@ -54,11 +57,17 @@ def musical_reply_configured(
 
     minimax_root = configured_path("OLIVIA_MINIMAX_COMFY_ROOT")
     latentsync_root = configured_path("OLIVIA_LATENTSYNC_ROOT")
+    try:
+        assemble_complete_video_delivery(
+            configured_path("OLIVIA_TTS_CONFIG"),
+            configured_path("OLIVIA_VISUAL_CONFIG"),
+            configured_path("OLIVIA_LIVETALKING_WORKER"),
+            configured_path("OLIVIA_LOCAL_DATA_ROOT"),
+        )
+    except ReplyMediaError:
+        return False
     required = (
         configured_path("OLIVIA_OFFICIAL_REPLY_REFERENCE"),
-        configured_path("OLIVIA_TTS_CONFIG"),
-        configured_path("OLIVIA_VISUAL_CONFIG"),
-        configured_path("OLIVIA_LIVETALKING_WORKER"),
         configured_path("OLIVIA_ROFORMER_EXE"),
         configured_path("OLIVIA_ROFORMER_MODEL_PATH"),
         configured_path("OLIVIA_ROFORMER_CONFIG_PATH"),
@@ -79,7 +88,6 @@ def musical_reply_configured(
         and performance_video_path.is_file()
         and minimax_root.is_dir()
         and latentsync_root.is_dir()
-        and media_runtime_available()
         and all(path.is_file() for path in required)
     )
 

--- a/music_reply.py
+++ b/music_reply.py
@@ -87,6 +87,7 @@ def musical_reply_configured(
             configured_path("OLIVIA_VISUAL_CONFIG"),
             configured_path("OLIVIA_LIVETALKING_WORKER"),
             configured_path("OLIVIA_LOCAL_DATA_ROOT"),
+            env,
         )
     except ReplyMediaError:
         return False

--- a/music_reply.py
+++ b/music_reply.py
@@ -46,6 +46,28 @@ def normalize_music_duration(value: object) -> int:
         raise MusicReplyError("MUSIC_DURATION_INVALID") from None
 
 
+def speaking_scene_candidates(env: Mapping[str, str]) -> tuple[Path, ...]:
+    """Return configured speaking-scene candidates; legacy singleton is a fallback."""
+
+    raw = str(env.get("OLIVIA_SPOKEN_SCENE_CANDIDATES", ""))
+    values = raw.split(os.pathsep) if raw else [str(env.get("OLIVIA_OFFICIAL_REPLY_REFERENCE", ""))]
+    result: list[Path] = []
+    for value in values:
+        candidate = Path(value.strip()).expanduser() if value.strip() else None
+        if candidate is not None and candidate not in result:
+            result.append(candidate)
+    return tuple(result)
+
+
+def select_speaking_scene(
+    candidates: tuple[Path, ...], *, expression: str | None = None
+) -> Path | None:
+    """Stable default seam; future expression/lip-sync selection can replace this."""
+
+    del expression
+    return candidates[0] if candidates else None
+
+
 def musical_reply_configured(
     env: Mapping[str, str],
     *,
@@ -58,6 +80,7 @@ def musical_reply_configured(
 
     minimax_root = configured_path("OLIVIA_MINIMAX_COMFY_ROOT")
     latentsync_root = configured_path("OLIVIA_LATENTSYNC_ROOT")
+    speaking_scene = select_speaking_scene(speaking_scene_candidates(env))
     try:
         assemble_complete_video_delivery(
             configured_path("OLIVIA_TTS_CONFIG"),
@@ -68,7 +91,7 @@ def musical_reply_configured(
     except ReplyMediaError:
         return False
     required = (
-        configured_path("OLIVIA_OFFICIAL_REPLY_REFERENCE"),
+        speaking_scene or Path(""),
         configured_path("OLIVIA_ROFORMER_EXE"),
         configured_path("OLIVIA_ROFORMER_MODEL_PATH"),
         configured_path("OLIVIA_ROFORMER_CONFIG_PATH"),
@@ -600,10 +623,9 @@ def concat_videos(
 
 
 def _official_transition_reference() -> Path:
-    configured = os.environ.get("OLIVIA_OFFICIAL_REPLY_REFERENCE", "").strip()
-    if not configured:
+    reference = select_speaking_scene(speaking_scene_candidates(os.environ))
+    if reference is None:
         raise MusicReplyError("MUSIC_REPLY_TRANSITION_UNAVAILABLE")
-    reference = Path(configured)
     if not reference.is_file():
         raise MusicReplyError("MUSIC_REPLY_TRANSITION_UNAVAILABLE")
     return reference

--- a/music_reply.py
+++ b/music_reply.py
@@ -15,7 +15,11 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urljoin, urlsplit
 from urllib.request import Request, urlopen
 
-from latentsync_reply import LatentSyncReplyError, render_latentsync_video
+from latentsync_reply import (
+    LatentSyncReplyError,
+    media_runtime_available,
+    render_latentsync_video,
+)
 from music_duration import MUSIC_DURATION_OPTIONS, normalize_music_duration as _normalize_music_duration
 from reply_media import render_reply_video
 from song_content import plan_song_content
@@ -75,6 +79,7 @@ def musical_reply_configured(
         and performance_video_path.is_file()
         and minimax_root.is_dir()
         and latentsync_root.is_dir()
+        and media_runtime_available()
         and all(path.is_file() for path in required)
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.9,<4",
+    "imageio-ffmpeg>=0.6,<1",
     "jsonschema>=4.26,<5",
 ]
 

--- a/reply_media.py
+++ b/reply_media.py
@@ -12,6 +12,7 @@ import tempfile
 import wave
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Mapping
 
 from latentsync_reply import LatentSyncReplyError, media_runtime_available, render_latentsync_video, resolve_ffmpeg_executable
 from reply_delivery import ReplyDeliveryPlan, plan_reply_delivery
@@ -85,6 +86,7 @@ def _tts_config(
     temporary_root: Path,
     *,
     ordinary_video: bool = False,
+    env: Mapping[str, str] | None = None,
 ) -> TTSConfig:
     settings = _settings(path)
     runtime_root = Path(str(settings.get("runtime_root", "")))
@@ -95,7 +97,8 @@ def _tts_config(
     else:
         provider_options = dict(provider_options)
     if ordinary_video:
-        configured_reference = os.environ.get("OLIVIA_REPLY_VOICE_REFERENCE")
+        environment = os.environ if env is None else env
+        configured_reference = environment.get("OLIVIA_REPLY_VOICE_REFERENCE")
         if configured_reference is not None:
             official_reference = Path(configured_reference)
             if not official_reference.is_file():
@@ -157,17 +160,18 @@ def assemble_complete_video_delivery(
     visual_config_path: Path,
     worker_path: Path,
     temporary_root: Path,
+    env: Mapping[str, str] | None = None,
 ) -> CompleteVideoDelivery:
     """Pure configuration seam shared by availability and the real renderer."""
 
     try:
-        tts = _tts_config(tts_config_path, temporary_root, ordinary_video=True)
+        tts = _tts_config(tts_config_path, temporary_root, ordinary_video=True, env=env)
         visual = _visual_config(visual_config_path)
         visual.validate()
     except (ReplyMediaError, ValueError, TypeError) as exc:
         raise ReplyMediaError("COMPLETE_VIDEO_CONFIG_UNAVAILABLE") from exc
     worker = Path(worker_path)
-    if not delivery_configured(tts) or not worker.is_file() or not media_runtime_available():
+    if not delivery_configured(tts) or not worker.is_file() or not media_runtime_available(env):
         raise ReplyMediaError("COMPLETE_VIDEO_CONFIG_UNAVAILABLE")
     return CompleteVideoDelivery(tts, visual, worker)
 

--- a/reply_media.py
+++ b/reply_media.py
@@ -13,7 +13,7 @@ import wave
 from dataclasses import dataclass
 from pathlib import Path
 
-from latentsync_reply import LatentSyncReplyError, media_runtime_available, render_latentsync_video
+from latentsync_reply import LatentSyncReplyError, media_runtime_available, render_latentsync_video, resolve_ffmpeg_executable
 from reply_delivery import ReplyDeliveryPlan, plan_reply_delivery
 try:
     from runtime.visual.livetalking import LiveTalkingConfig, capture_candidate_frames
@@ -74,14 +74,9 @@ def _settings(path: Path) -> dict:
 
 
 def _ffmpeg() -> str:
-    executable = shutil.which("ffmpeg")
-    if executable:
-        return executable
     try:
-        import imageio_ffmpeg
-
-        return imageio_ffmpeg.get_ffmpeg_exe()
-    except (ImportError, RuntimeError, OSError) as exc:
+        return str(resolve_ffmpeg_executable())
+    except LatentSyncReplyError as exc:
         raise ReplyMediaError("FFMPEG_UNAVAILABLE") from exc
 
 

--- a/reply_media.py
+++ b/reply_media.py
@@ -10,9 +10,10 @@ import shutil
 import subprocess
 import tempfile
 import wave
+from dataclasses import dataclass
 from pathlib import Path
 
-from latentsync_reply import LatentSyncReplyError, render_latentsync_video
+from latentsync_reply import LatentSyncReplyError, media_runtime_available, render_latentsync_video
 from reply_delivery import ReplyDeliveryPlan, plan_reply_delivery
 try:
     from runtime.visual.livetalking import LiveTalkingConfig, capture_candidate_frames
@@ -20,11 +21,18 @@ except ImportError:  # Optional visual provider is not part of the portable patc
     LiveTalkingConfig = object  # type: ignore[misc,assignment]
     capture_candidate_frames = None
 from tts import TTSConfig, TTSRequest, TTSService
-from tts.delivery import DeliveryAudioError, render_delivery_wav
+from tts.delivery import DeliveryAudioError, delivery_configured, render_delivery_wav
 
 
 class ReplyMediaError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class CompleteVideoDelivery:
+    tts: TTSConfig
+    visual: LiveTalkingConfig
+    worker: Path
 
 
 def _bounded_voice_reference(source: Path, temporary_root: Path) -> Path:
@@ -149,6 +157,26 @@ def _visual_config(path: Path) -> LiveTalkingConfig:
     return LiveTalkingConfig(**{key: value for key, value in settings.items() if key in fields})
 
 
+def assemble_complete_video_delivery(
+    tts_config_path: Path,
+    visual_config_path: Path,
+    worker_path: Path,
+    temporary_root: Path,
+) -> CompleteVideoDelivery:
+    """Pure configuration seam shared by availability and the real renderer."""
+
+    try:
+        tts = _tts_config(tts_config_path, temporary_root, ordinary_video=True)
+        visual = _visual_config(visual_config_path)
+        visual.validate()
+    except (ReplyMediaError, ValueError, TypeError) as exc:
+        raise ReplyMediaError("COMPLETE_VIDEO_CONFIG_UNAVAILABLE") from exc
+    worker = Path(worker_path)
+    if not delivery_configured(tts) or not worker.is_file() or not media_runtime_available():
+        raise ReplyMediaError("COMPLETE_VIDEO_CONFIG_UNAVAILABLE")
+    return CompleteVideoDelivery(tts, visual, worker)
+
+
 def _encode_frames(frames: Path, audio: Path, output: Path, duration: float) -> None:
     temporary = output.with_suffix(".rendering.mp4")
     command = [
@@ -205,6 +233,9 @@ def render_reply_video(
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="olivia-reply-", dir=output_path.parent) as temporary:
         root = Path(temporary)
+        delivery = assemble_complete_video_delivery(
+            tts_config_path, visual_config_path, worker_path, root
+        )
         audio_path = root / "reply.wav"
         frames = root / "frames"
         delivery_plan: ReplyDeliveryPlan | None = None
@@ -212,7 +243,7 @@ def render_reply_video(
             delivery_plan = plan_reply_delivery(text)
             try:
                 delivery_result = render_delivery_wav(
-                    _tts_config(tts_config_path, root, ordinary_video=True),
+                    delivery.tts,
                     delivery_plan,
                     audio_path,
                 )
@@ -220,7 +251,7 @@ def render_reply_video(
                 raise ReplyMediaError(str(exc)) from exc
             duration = float(delivery_result.duration_seconds)
         else:
-            service = TTSService(_tts_config(tts_config_path, root))
+            service = TTSService(delivery.tts)
             try:
                 result = asyncio.run(
                     service.synthesize(
@@ -271,11 +302,11 @@ def render_reply_video(
         if capture_candidate_frames is None:
             raise ReplyMediaError("THIRD_PARTY_VISUAL_NOT_INSTALLED")
         capture_candidate_frames(
-            _visual_config(visual_config_path),
+            delivery.visual,
             audio_path=audio_path,
             output_dir=frames,
             frame_indices=tuple(range(frame_count)),
-            worker_path=worker_path,
+            worker_path=delivery.worker,
         )
         _encode_frames(frames, audio_path, output_path, duration)
     return {

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -139,6 +139,46 @@ def test_normal_send_list_and_detail_preserve_legacy_fields(monkeypatch: pytest.
     assert detail["data"]["read_only"] is False
 
 
+def test_send_accepts_only_the_short_music_duration_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "reply",
+        lambda *_args, **_kwargs: "synthetic reply",
+    )
+
+    rejected = asyncio.run(
+        local_server.route(
+            "POST",
+            "/toy/letter/send",
+            {"content": "synthetic input", "material": {"music_duration_seconds": 118}},
+            {},
+        )
+    )
+    accepted = asyncio.run(
+        local_server.route(
+            "POST",
+            "/toy/letter/send",
+            {"content": "synthetic input", "material": {"music_duration_seconds": 60}},
+            {},
+        )
+    )
+
+    assert rejected == {
+        "code": 400,
+        "message": "MUSIC_DURATION_INVALID",
+        "data": {
+            "status": "FAILED",
+            "error_code": "MUSIC_DURATION_INVALID",
+            "allowed": [40, 60],
+        },
+    }
+    assert accepted["code"] == 0
+
+
 def test_http_send_acknowledges_before_slow_reply_finishes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -226,7 +266,7 @@ def test_persisted_pending_reply_resumes_when_http_runtime_starts(
         "reply_text": "",
         "reply_mode": "text_letter",
         "triage": {"status": "pending"},
-        "music_duration_seconds": 118,
+        "music_duration_seconds": 60,
     }
     local_server.store.letters.append(pending)
     local_server.store.letters.append({

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -342,6 +342,34 @@ def test_complete_video_readiness_fails_closed_for_every_missing_renderer_depend
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(b"synthetic")
 
+    tts_runtime = tmp_path / "tts-runtime"
+    (tts_runtime / "venv/Scripts").mkdir(parents=True)
+    (tts_runtime / "venv/Scripts/python.exe").write_bytes(b"synthetic")
+    tts_model = tmp_path / "tts-model"
+    tts_model.mkdir()
+    tts_reference = write("tts/reference.wav")
+    Path(env["OLIVIA_TTS_CONFIG"]).write_text(json.dumps({"settings": {
+        "runtime_root": str(tts_runtime), "model_dir": str(tts_model),
+        "reference_audio": tts_reference,
+    }}), encoding="utf-8")
+    visual_runtime = tmp_path / "visual-runtime"
+    visual_runtime.mkdir()
+    visual_checkpoint = write("visual/checkpoint.pt")
+    visual_avatar = visual_runtime / "data/avatars/b11_olivia"
+    visual_avatar.mkdir(parents=True)
+    visual_work = tmp_path / "visual-work"
+    visual_work.mkdir()
+    Path(env["OLIVIA_VISUAL_CONFIG"]).write_text(json.dumps({"settings": {
+        "runtime_root": str(visual_runtime), "checkpoint_path": visual_checkpoint,
+        "checkpoint_sha256": "0" * 64, "avatar_payload": str(visual_avatar),
+        "original_reference": env["OLIVIA_OFFICIAL_REPLY_REFERENCE"], "work_root": str(visual_work),
+        "avatar_id": "b11_olivia", "checkpoint_url": "https://example.test/checkpoint",
+        "checkpoint_revision": "v1", "checkpoint_license": "Apache-2.0",
+        "upstream_source": "https://github.com/lipku/LiveTalking",
+        "upstream_revision": "a97f01ba366e55eeed94e88d6bae38ed77b3a1b9",
+        "upstream_license": "Apache-2.0",
+    }}), encoding="utf-8")
+
     assert routing_context_from_environment(env) == RoutingContext(True, True)
 
     for missing in required:

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -25,6 +25,15 @@ class _Gateway:
         return _Response(self.response)
 
 
+def test_router_timeout_uses_portable_environment_configuration():
+    router = LetterReplyRouter(
+        _Gateway("{}"),
+        environ={"OLIVIA_REPLY_ROUTER_TIMEOUT_SECONDS": "90"},
+    )
+
+    assert router.timeout_seconds == 90.0
+
+
 def _route(*, context=None, **overrides):
     payload = {
         "mode": "text_letter",

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -6,6 +6,7 @@ import json
 from letter_triage import (
     LetterReplyRouter,
     RoutingContext,
+    _current_music_performance,
     routing_context_from_environment,
 )
 
@@ -32,6 +33,28 @@ def test_router_timeout_uses_portable_environment_configuration():
     )
 
     assert router.timeout_seconds == 90.0
+
+
+def test_music_performance_uses_system_tod_with_day_morning_fallback(tmp_path):
+    day = tmp_path / "TOD1200.mp4"
+    dusk = tmp_path / "TOD1730.mp4"
+    night = tmp_path / "TOD2000.mp4"
+    for path in (day, dusk, night):
+        path.write_bytes(b"scene")
+    environ = {
+        "OLIVIA_MUSIC_SCENE_DAY": str(day),
+        "OLIVIA_MUSIC_SCENE_DUSK": str(dusk),
+        "OLIVIA_MUSIC_SCENE_NIGHT": str(night),
+    }
+
+    assert _current_music_performance(environ, hour=5) == day
+    assert _current_music_performance(environ, hour=8) == day
+    assert _current_music_performance(environ, hour=9) == day
+    assert _current_music_performance(environ, hour=15) == day
+    assert _current_music_performance(environ, hour=16) == dusk
+    assert _current_music_performance(environ, hour=18) == dusk
+    assert _current_music_performance(environ, hour=19) == night
+    assert _current_music_performance(environ, hour=4) == night
 
 
 def _route(*, context=None, **overrides):

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -249,7 +249,7 @@ def test_router_receives_trusted_context_separately_from_letter():
     assert payload["routing_context"]["musical_video_available"] is True
 
 
-def test_environment_overrides_and_current_work_are_bounded():
+def test_environment_overrides_do_not_claim_video_availability_and_current_work_is_bounded():
     context = routing_context_from_environment(
         {
             "OLIVIA_SPOKEN_VIDEO_AVAILABLE": "1",
@@ -257,8 +257,8 @@ def test_environment_overrides_and_current_work_are_bounded():
             "OLIVIA_CURRENT_MUSIC_WORK": '["作品甲", "作品乙", "作品甲"]',
         }
     )
-    assert context.spoken_video_available is True
-    assert context.musical_video_available is True
+    assert context.spoken_video_available is False
+    assert context.musical_video_available is False
     assert context.current_music_work == ("作品甲", "作品乙")
 
 
@@ -272,6 +272,78 @@ def test_spoken_reason_is_unavailable_without_complete_video_pipeline():
 
     assert context.spoken_video_available is False
     assert context.musical_video_available is False
+
+
+def test_complete_video_readiness_fails_closed_for_every_missing_renderer_dependency(
+    tmp_path,
+):
+    def write(relative: str) -> str:
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"synthetic")
+        return str(path)
+
+    data_root = tmp_path / "data"
+    data_root.mkdir()
+    scene = write("scenes/spoken.mp4")
+    performance = write("scenes/performance.mp4")
+    minimax_root = tmp_path / "minimax"
+    latentsync_root = tmp_path / "latentsync"
+    env = {
+        "OLIVIA_LOCAL_DATA_ROOT": str(data_root),
+        "OLIVIA_TTS_CONFIG": write("config/tts.json"),
+        "OLIVIA_VISUAL_CONFIG": write("config/visual.json"),
+        "OLIVIA_LIVETALKING_WORKER": write("workers/visual.py"),
+        "OLIVIA_OFFICIAL_REPLY_REFERENCE": write("official/reply.mp4"),
+        "OLIVIA_ROFORMER_EXE": write("roformer/roformer.exe"),
+        "OLIVIA_ROFORMER_MODEL_PATH": write("roformer/model.ckpt"),
+        "OLIVIA_ROFORMER_CONFIG_PATH": write("roformer/config.yaml"),
+        "OLIVIA_MINIMAX_COMFY_PYTHON": write("minimax/python.exe"),
+        "OLIVIA_MINIMAX_COMFY_ROOT": str(minimax_root),
+        "OLIVIA_MINIMAX_WORKER": write("workers/minimax.py"),
+        "OLIVIA_LATENTSYNC_PYTHON": write("latentsync/python.exe"),
+        "OLIVIA_LATENTSYNC_ROOT": str(latentsync_root),
+        "OLIVIA_SPOKEN_VIDEO_AVAILABLE": "1",
+        "OLIVIA_MUSICAL_VIDEO_AVAILABLE": "1",
+        **{
+            f"OLIVIA_SCENE_{tod}": scene
+            for tod in ("MORNING", "DAY", "DUSK", "NIGHT")
+        },
+        **{
+            f"OLIVIA_MUSIC_SCENE_{tod}": performance
+            for tod in ("DAY", "DUSK", "NIGHT")
+        },
+    }
+    required = [
+        tmp_path / "config/tts.json",
+        tmp_path / "config/visual.json",
+        tmp_path / "workers/visual.py",
+        tmp_path / "official/reply.mp4",
+        tmp_path / "roformer/roformer.exe",
+        tmp_path / "roformer/model.ckpt",
+        tmp_path / "roformer/config.yaml",
+        tmp_path / "minimax/python.exe",
+        tmp_path / "workers/minimax.py",
+        minimax_root / "main.py",
+        minimax_root / "comfy_extras/nodes_minimax_music.py",
+        minimax_root / "models/unet/minimax_music3_dit_int8_convrot.safetensors",
+        minimax_root / "models/clip/minimax_music3_text_encoder_pruned_int8_convrot.safetensors",
+        minimax_root / "models/vae/minimax_music3_dav.safetensors",
+        tmp_path / "latentsync/python.exe",
+        latentsync_root / "scripts/inference.py",
+        latentsync_root / "configs/unet/stage2_efficient.yaml",
+        latentsync_root / "checkpoints/latentsync_unet.pt",
+    ]
+    for path in required:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"synthetic")
+
+    assert routing_context_from_environment(env) == RoutingContext(True, True)
+
+    for missing in required:
+        missing.unlink()
+        assert routing_context_from_environment(env) == RoutingContext(False, False)
+        missing.write_bytes(b"synthetic")
 
 
 def test_invalid_router_output_fails_closed_to_text_letter():

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
+from pathlib import Path
 
+import latentsync_reply
 from letter_triage import (
     LetterReplyRouter,
     RoutingContext,
@@ -276,6 +279,7 @@ def test_spoken_reason_is_unavailable_without_complete_video_pipeline():
 
 def test_complete_video_readiness_fails_closed_for_every_missing_renderer_dependency(
     tmp_path,
+    monkeypatch,
 ):
     def write(relative: str) -> str:
         path = tmp_path / relative
@@ -344,6 +348,21 @@ def test_complete_video_readiness_fails_closed_for_every_missing_renderer_depend
         missing.unlink()
         assert routing_context_from_environment(env) == RoutingContext(False, False)
         missing.write_bytes(b"synthetic")
+
+    monkeypatch.setitem(sys.modules, "imageio_ffmpeg", None)
+    for resolved_ffmpeg in (None, write("runtime/ffmpeg.exe")):
+        monkeypatch.setattr(
+            latentsync_reply.shutil,
+            "which",
+            lambda _name: resolved_ffmpeg,
+        )
+        assert routing_context_from_environment(env) == RoutingContext(False, False)
+
+    acceptance_document = Path("docs/P03_06_END_TO_END_ACCEPTANCE.md").read_text(
+        encoding="utf-8"
+    )
+    assert "optional transition" not in acceptance_document
+    assert "mandatory official silent turn/black transition" in acceptance_document
 
 
 def test_invalid_router_output_fails_closed_to_text_letter():

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -318,6 +318,10 @@ def test_complete_video_readiness_fails_closed_for_every_missing_renderer_depend
             for tod in ("DAY", "DUSK", "NIGHT")
         },
     }
+    ffmpeg = tmp_path / "runtime" / "ffmpeg.exe"
+    ffmpeg.parent.mkdir(parents=True, exist_ok=True)
+    ffmpeg.write_bytes(b"synthetic")
+    env["OLIVIA_FFMPEG_EXE"] = str(ffmpeg)
     required = [
         tmp_path / "config/tts.json",
         tmp_path / "config/visual.json",

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -262,6 +262,18 @@ def test_environment_overrides_and_current_work_are_bounded():
     assert context.current_music_work == ("作品甲", "作品乙")
 
 
+def test_spoken_reason_is_unavailable_without_complete_video_pipeline():
+    context = routing_context_from_environment(
+        {
+            "OLIVIA_SPOKEN_VIDEO_AVAILABLE": "1",
+            "OLIVIA_MUSICAL_VIDEO_AVAILABLE": "0",
+        }
+    )
+
+    assert context.spoken_video_available is False
+    assert context.musical_video_available is False
+
+
 def test_invalid_router_output_fails_closed_to_text_letter():
     result = asyncio.run(
         LetterReplyRouter(

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 import pytest
 
@@ -43,8 +44,63 @@ def test_exact_modes_keep_legacy_wire_compatibility():
     assert local_server._exact_reply_mode("video") == "musical_video"
 
 
+def test_successful_media_retry_clears_the_previous_failure_code(
+    tmp_path: Path,
+    monkeypatch,
+):
+    scene = tmp_path / "scene.mp4"
+    scene.write_bytes(b"scene")
+    official_reference = tmp_path / "official-complete-reply.mp4"
+    official_reference.write_bytes(b"official")
+    letter = {
+        "letter_id": "retry-media",
+        "content": "letter",
+        "reply_text": "reply",
+        "reply_mode": "musical_video",
+        "media_status": "UNAVAILABLE",
+        "media_error_code": "MINIMAX_MUSIC3_FAILED",
+        "music_duration_seconds": 60,
+    }
+    local_server.store.letters[:] = [letter]
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
+    monkeypatch.setenv("OLIVIA_SCENE_DAY", str(scene))
+    monkeypatch.setenv("OLIVIA_OFFICIAL_REPLY_REFERENCE", str(official_reference))
+    monkeypatch.setattr(local_server, "_persist_media_state", lambda: None)
+    observed = {}
+
+    def render(_content, _reply, output, **kwargs):
+        observed.update(kwargs)
+        Path(output).write_bytes(b"final-video")
+        return {}
+
+    monkeypatch.setattr(local_server, "render_musical_reply", render)
+
+    asyncio.run(
+        local_server._render_media_job(
+            "retry-media", "letter", "reply", "musical_video"
+        )
+    )
+
+    assert letter["media_status"] == "COMPLETED"
+    assert letter["media_error_code"] is None
+    assert observed["official_reply_reference_path"] == official_reference
+    assert "normal_scene_path" not in observed
+    assert observed["normal_video_path"].name.endswith("-official-spoken-v1.mp4")
+    assert observed["song_video_path"].name.endswith("-song-v2-60s.mp4")
+
+
+def test_reply_pipeline_total_timeout_covers_all_quality_stages(monkeypatch):
+    monkeypatch.setattr(local_server, "LLM_TIMEOUT_SECONDS", 90.0)
+    monkeypatch.delenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", raising=False)
+
+    assert local_server._reply_pipeline_timeout_seconds() == 275.0
+
+    monkeypatch.setenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", "20")
+    assert local_server._reply_pipeline_timeout_seconds() == 155.0
+
+
 @pytest.mark.parametrize(
-    ("exact_mode", "decision", "expected_media"),
+    ("routed_mode", "decision", "delivery_mode", "expected_media"),
     (
         (
             ReplyMode.TEXT_LETTER.value,
@@ -55,6 +111,7 @@ def test_exact_modes_keep_legacy_wire_compatibility():
                 "completed",
                 True,
             ),
+            ReplyMode.TEXT_LETTER.value,
             (),
         ),
         (
@@ -68,7 +125,8 @@ def test_exact_modes_keep_legacy_wire_compatibility():
                 direct_response_sufficient=True,
                 voice_materially_better=True,
             ),
-            (ReplyMode.SPOKEN_VIDEO.value,),
+            ReplyMode.MUSICAL_VIDEO.value,
+            (ReplyMode.MUSICAL_VIDEO.value,),
         ),
         (
             ReplyMode.MUSICAL_VIDEO.value,
@@ -84,17 +142,19 @@ def test_exact_modes_keep_legacy_wire_compatibility():
                 music_materially_better=True,
                 character_willing=True,
             ),
+            ReplyMode.MUSICAL_VIDEO.value,
             (ReplyMode.MUSICAL_VIDEO.value,),
         ),
     ),
 )
-def test_generate_reply_carries_one_exact_mode_through_context_and_media(
+def test_generate_reply_delivers_every_video_route_as_spoken_transition_and_music(
     monkeypatch,
-    exact_mode,
+    routed_mode,
     decision,
+    delivery_mode,
     expected_media,
 ):
-    letter_id = f"synthetic-{exact_mode}"
+    letter_id = f"synthetic-{routed_mode}"
     letter = {
         "letter_id": letter_id,
         "content": "synthetic current letter",
@@ -109,7 +169,8 @@ def test_generate_reply_carries_one_exact_mode_through_context_and_media(
     async def classify(_content):
         return decision
 
-    async def run_pipeline(_request, context):
+    async def run_pipeline(request, context):
+        observed["request_content"] = request.content
         observed["context_mode"] = context.mode.value
         return PipelineResult(
             letter_id,
@@ -136,12 +197,15 @@ def test_generate_reply_carries_one_exact_mode_through_context_and_media(
     assert asyncio.run(
         local_server.generate_reply(letter_id, "synthetic current letter")
     )
-    assert observed["context_mode"] == exact_mode
-    assert letter["reply_mode"] == exact_mode
+    assert observed["context_mode"] == delivery_mode
+    assert ("<ordinary_video_reply_constraints>" in observed["request_content"]) is (
+        delivery_mode != ReplyMode.TEXT_LETTER.value
+    )
+    assert letter["reply_mode"] == delivery_mode
     assert tuple(scheduled) == expected_media
 
     public = local_server.letter_to_out(letter)
-    assert public["reply_mode_exact"] == exact_mode
+    assert public["reply_mode_exact"] == delivery_mode
     assert public["reply_mode"] == (
-        "text" if exact_mode == ReplyMode.TEXT_LETTER.value else "video"
+        "text" if delivery_mode == ReplyMode.TEXT_LETTER.value else "video"
     )

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -64,6 +64,9 @@ def test_successful_media_retry_clears_the_previous_failure_code(
     local_server.store.letters[:] = [letter]
     monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
     monkeypatch.setenv("OLIVIA_SCENE_DAY", str(scene))
+    monkeypatch.setenv("OLIVIA_MUSIC_SCENE_DAY", str(scene))
+    monkeypatch.setenv("OLIVIA_MUSIC_SCENE_DUSK", str(scene))
+    monkeypatch.setenv("OLIVIA_MUSIC_SCENE_NIGHT", str(scene))
     monkeypatch.setenv("OLIVIA_OFFICIAL_REPLY_REFERENCE", str(official_reference))
     monkeypatch.setattr(local_server, "_persist_media_state", lambda: None)
     observed = {}
@@ -84,6 +87,7 @@ def test_successful_media_retry_clears_the_previous_failure_code(
     assert letter["media_status"] == "COMPLETED"
     assert letter["media_error_code"] is None
     assert observed["official_reply_reference_path"] == official_reference
+    assert observed["performance_video_path"] == scene
     assert "normal_scene_path" not in observed
     assert observed["normal_video_path"].name.endswith("-official-spoken-v1.mp4")
     assert observed["song_video_path"].name.endswith("-song-v2-60s.mp4")

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -140,6 +140,7 @@ def test_install_entrypoint_prioritizes_selected_payload() -> None:
 
 def test_managed_runtime_installs_all_server_dependencies() -> None:
     repo_root = Path(__file__).parents[2]
+    project = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
     script = (repo_root / "installer" / "Install.ps1").read_text(
         encoding="utf-8-sig"
     )
@@ -148,6 +149,7 @@ def test_managed_runtime_installs_all_server_dependencies() -> None:
     ).read_text(encoding="utf-8")
 
     assert "import aiohttp,jsonschema" in script
+    assert '"imageio-ffmpeg>=0.6,<1"' in project
     assert "jsonschema==4.26.0" in requirements
     assert "jsonschema-specifications==2025.9.1" in requirements
     assert "referencing==0.37.0" in requirements

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -14,6 +14,7 @@ import pytest
 
 import latentsync_reply
 import music_reply
+import reply_media
 from latentsync_reply import render_latentsync_video
 from music_duration import MUSIC_DURATION_OPTIONS, normalize_music_duration
 from music_reply import MusicReplyError, render_musical_reply
@@ -437,3 +438,14 @@ def test_latentsync_rejects_missing_explicit_ffmpeg_without_fallback(
             python_path=python,
             latentsync_root=root,
         )
+
+def test_all_video_paths_share_explicit_ffmpeg_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    executable = tmp_path / "ffmpeg.exe"
+    executable.write_bytes(b"synthetic")
+    monkeypatch.setenv("OLIVIA_FFMPEG_EXE", str(executable))
+
+    assert latentsync_reply.resolve_ffmpeg_executable() == executable.resolve()
+    assert music_reply._ffmpeg() == str(executable.resolve())
+    assert reply_media._ffmpeg() == str(executable.resolve())

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -449,3 +449,13 @@ def test_all_video_paths_share_explicit_ffmpeg_override(
     assert latentsync_reply.resolve_ffmpeg_executable() == executable.resolve()
     assert music_reply._ffmpeg() == str(executable.resolve())
     assert reply_media._ffmpeg() == str(executable.resolve())
+
+
+def test_speaking_scene_candidates_are_stable_and_legacy_compatible(tmp_path: Path) -> None:
+    first = tmp_path / "first.mp4"
+    second = tmp_path / "second.mp4"
+    env = {"OLIVIA_SPOKEN_SCENE_CANDIDATES": os.pathsep.join((str(first), str(second), str(first)))}
+    candidates = music_reply.speaking_scene_candidates(env)
+    assert candidates == (first, second)
+    assert music_reply.select_speaking_scene(candidates) == first
+    assert music_reply.speaking_scene_candidates({"OLIVIA_OFFICIAL_REPLY_REFERENCE": str(second)}) == (second,)

--- a/tests/test_baseline_hardening.py
+++ b/tests/test_baseline_hardening.py
@@ -785,6 +785,7 @@ def test_slow_llm_does_not_block_loop_and_times_out_as_failed(monkeypatch) -> No
 
     monkeypatch.setattr(local_server.letters_adapter, "reply", slow_reply)
     monkeypatch.setattr(local_server, "LLM_TIMEOUT_SECONDS", 0.03)
+    monkeypatch.setattr(local_server.reply_engine, "timeout_seconds", 0.03)
 
     async def exercise():
         heartbeat_ticks = 0

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -6,6 +6,7 @@ from array import array
 from types import ModuleType, SimpleNamespace
 
 import pytest
+import tts.delivery as delivery
 
 from reply_delivery import (
     build_ordinary_video_llm_content,
@@ -75,6 +76,27 @@ def test_delivery_fit_rejects_audio_over_52_seconds(tmp_path) -> None:
 
     with pytest.raises(DeliveryAudioError, match="TTS_DELIVERY_DURATION_OUT_OF_RANGE"):
         _fit_overlong_wav(path, 53.0)
+
+
+def test_delivery_fit_uses_canonical_explicit_ffmpeg_override(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "overlong.wav"
+    source.write_bytes(b"synthetic")
+    executable = tmp_path / "ffmpeg.exe"
+    executable.write_bytes(b"synthetic")
+    monkeypatch.setenv("OLIVIA_FFMPEG_EXE", str(executable))
+    observed = []
+
+    def fake_run(command, **_kwargs):
+        observed.append(command[0])
+        fitted = tmp_path / "speech-fitted.wav"
+        with wave.open(str(fitted), "wb") as target:
+            target.setnchannels(1); target.setsampwidth(2); target.setframerate(8000)
+            target.writeframes(array("h", [0] * 8000 * 50).tobytes())
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setattr(delivery.subprocess, "run", fake_run)
+    _fit_overlong_wav(source, 51.0)
+    assert observed == [str(executable.resolve())]
 
 
 def test_external_worker_renders_blocks_with_one_cross_lingual_model_load(

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -11,6 +11,7 @@ import wave
 from dataclasses import dataclass
 from pathlib import Path
 
+from latentsync_reply import LatentSyncReplyError, resolve_ffmpeg_executable
 from reply_delivery import ReplyDeliveryPlan
 
 from .contracts import TTSConfig
@@ -75,14 +76,9 @@ def _validate_wav(path: Path) -> tuple[int, int]:
 
 
 def _ffmpeg() -> str:
-    executable = shutil.which("ffmpeg")
-    if executable:
-        return executable
     try:
-        import imageio_ffmpeg
-
-        return imageio_ffmpeg.get_ffmpeg_exe()
-    except (ImportError, RuntimeError, OSError) as exc:
+        return str(resolve_ffmpeg_executable())
+    except LatentSyncReplyError as exc:
         raise DeliveryAudioError("FFMPEG_UNAVAILABLE") from exc
 
 

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -130,6 +130,18 @@ def _fit_overlong_wav(path: Path, duration_seconds: float) -> tuple[int, int]:
     return sample_rate, frame_count
 
 
+def delivery_configured(config: TTSConfig) -> bool:
+    """Read-only closure check shared by delivery preflight and rendering."""
+
+    return all((
+        Path(str(config.provider_options.get("external_python", "") or "")).is_file(),
+        Path(__file__).with_name("external_cosyvoice_worker.py").is_file(),
+        Path(config.runtime_root).is_dir(),
+        Path(config.model_dir).is_dir(),
+        Path(config.reference_audio).is_file(),
+    ))
+
+
 def render_delivery_wav(
     config: TTSConfig,
     plan: ReplyDeliveryPlan,
@@ -139,18 +151,10 @@ def render_delivery_wav(
 ) -> DeliveryAudioResult:
     """Render all delivery segments while loading the maintained model once."""
 
+    if not delivery_configured(config) or not plan.cues:
+        raise DeliveryAudioError("TTS_DELIVERY_UNAVAILABLE")
     executable = Path(str(config.provider_options.get("external_python", "") or ""))
     worker = Path(__file__).with_name("external_cosyvoice_worker.py")
-    required = (
-        executable.is_file(),
-        worker.is_file(),
-        Path(config.runtime_root).is_dir(),
-        Path(config.model_dir).is_dir(),
-        Path(config.reference_audio).is_file(),
-        bool(plan.cues),
-    )
-    if not all(required):
-        raise DeliveryAudioError("TTS_DELIVERY_UNAVAILABLE")
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     temp_parent = str(config.provider_options.get("temp_root", "") or "").strip()


### PR DESCRIPTION
## Scope

Final slice replacing closed #106. Wires the real triage result into durable letter metadata and background rendering: ordinary video uses the canonical spoken path; musical video uses spoken video + official transition + generated song performance. Music failure remains media-only and does not replace canonical text.

## Validation

- HTTP/routing focused: 82 passed, 1 deselected
- full stacked source (before split): 706 passed, 1 deselected
- baseline scanner: PASS, 0 findings
- py_compile: PASS
- diff-check: PASS

## Boundary

No forced trigger, no synchronous model generation at send time, no live provider run, and no human media acceptance claim. Stacked on #110.