### PR TITLE
feat(llm): support required voice-direction tool calls

### DIFF
--- a/docs/B03_LLM_GATEWAY.md
+++ b/docs/B03_LLM_GATEWAY.md
@@ -50,6 +50,43 @@ rtk python tools/healthcheck.py --profile llm
 
 代码可通过 `llm_gateway.register_provider("name", factory)` 注册 provider。factory 接收 `GatewayConfig`，返回实现 `Gateway.complete()` 与可选 `Gateway.stream()` 的对象；异常只能使用 `GatewayError` 的稳定 code/retryable 分类，不能把响应 body、header、key 或 prompt 放入异常文本。
 
+### 必需 function call 契约
+
+`GatewayToolCall` 是公开的不可变返回值，只有 `name: str` 与
+`arguments: Mapping[str, Any]` 两个字段。需要结构化、非自由文本结果的
+调用方使用：
+
+```python
+calls = await gateway.complete_with_tools(
+    messages=messages,
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "apply_voice_performance",
+            "parameters": {"type": "object"},
+        },
+    }],
+    tool_choice="required",
+    request_id="opaque-request-id",
+)
+```
+
+- 该窄接口只接受 `tool_choice="required"`，并始终以
+  `stream=false` 发起一次请求；它不会回退到自由文本。
+- `api_style="chat_completions"` 发送 OpenAI Chat Completions 的
+  `tools`/`tool_choice` 形状，并读取
+  `choices[0].message.tool_calls[*].function`。
+- `api_style="responses"` 将同一输入函数 schema 转为 Responses 的
+  `type/name/description/parameters` 形状，并读取
+  `output[*]` 中 `type="function_call"` 的 `name` 和 `arguments`。
+- 缺少调用、无效 name、非对象 arguments 或不能解析的 arguments JSON 都是
+  非重试的 `PROVIDER_PROTOCOL`；不支持该能力或 provider 不可用仍为可重试的
+  `PROVIDER_UNAVAILABLE`。调用方不得把这些错误转换成占位成功。
+- 自定义 provider 若声明支持此公开能力，必须覆写
+  `Gateway.complete_with_tools()` 并返回 `Sequence[GatewayToolCall]`；若不支持，
+  保持基类的 `PROVIDER_UNAVAILABLE` 失败边界。自定义实现也必须保留 request ID、
+  不记录提示词/响应正文，并使用稳定的 `GatewayError` 分类。
+
 ## 回信事件与并发语义
 
 `reply_orchestrator.py` 提供 `ReplyRequest`、`ReplyOrchestrator.start()`、`ReplyRun.events()` 和 `ReplyRun.cancel()`。每个 request 具有 request ID；给出相同 `idempotency_key` 且输入一致时复用同一个结果，输入不一致返回 `IDEMPOTENCY_CONFLICT`。

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -196,6 +196,12 @@ class GatewayResponse:
 
 
 @dataclass(frozen=True)
+class GatewayToolCall:
+    name: str
+    arguments: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
 class GatewayDelta:
     text: str
     request_id: str
@@ -349,6 +355,16 @@ class Gateway:
     ) -> GatewayResponse:
         raise NotImplementedError
 
+    async def complete_with_tools(
+        self,
+        *,
+        messages: Sequence[Mapping[str, Any]],
+        tools: Sequence[Mapping[str, object]],
+        tool_choice: str,
+        request_id: str | None = None,
+    ) -> Sequence[GatewayToolCall]:
+        raise ProviderUnavailable()
+
     async def stream(
         self,
         messages: Sequence[Mapping[str, Any]],
@@ -385,6 +401,31 @@ class FallbackAdapter(Gateway):
             if not exc.retryable:
                 raise
             return await self.fallback.complete(messages, request_id=request_id)
+
+    async def complete_with_tools(
+        self,
+        *,
+        messages: Sequence[Mapping[str, Any]],
+        tools: Sequence[Mapping[str, object]],
+        tool_choice: str,
+        request_id: str | None = None,
+    ) -> Sequence[GatewayToolCall]:
+        try:
+            return await self.primary.complete_with_tools(
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                request_id=request_id,
+            )
+        except GatewayError as exc:
+            if not exc.retryable:
+                raise
+            return await self.fallback.complete_with_tools(
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                request_id=request_id,
+            )
 
     async def stream(self, messages: Sequence[Mapping[str, Any]], *, request_id: str | None = None) -> AsyncIterator[GatewayDelta]:
         emitted = False
@@ -553,6 +594,40 @@ class OpenAICompatibleAdapter(Gateway):
             raise InvalidGatewayInput("OUTPUT_TOO_LONG")
         return GatewayResponse(text, request, self.config.provider, self.config.model)
 
+    async def complete_with_tools(
+        self,
+        *,
+        messages: Sequence[Mapping[str, Any]],
+        tools: Sequence[Mapping[str, object]],
+        tool_choice: str,
+        request_id: str | None = None,
+    ) -> Sequence[GatewayToolCall]:
+        request = request_id or uuid.uuid4().hex
+        body = self._body(messages, stream=False)
+        if self.config.api_style == "responses":
+            converted: list[dict[str, object]] = []
+            for tool in tools:
+                function = tool.get("function") if isinstance(tool, Mapping) else None
+                if not isinstance(function, Mapping):
+                    raise InvalidGatewayInput("INVALID_TOOL")
+                converted.append(
+                    {
+                        "type": "function",
+                        "name": function.get("name"),
+                        "description": function.get("description", ""),
+                        "parameters": function.get("parameters", {}),
+                    }
+                )
+            body["tools"] = converted
+        else:
+            body["tools"] = list(tools)
+        body["tool_choice"] = tool_choice
+        data = await self._post_json(body, request)
+        calls = _extract_tool_calls(data)
+        if not calls:
+            raise ProviderProtocolError()
+        return calls
+
     async def stream(self, messages: Sequence[Mapping[str, Any]], *, request_id: str | None = None) -> AsyncIterator[GatewayDelta]:
         request = request_id or uuid.uuid4().hex
         body = self._body(messages, stream=True)
@@ -645,6 +720,44 @@ def _extract_response_text(data: Mapping[str, Any]) -> str:
                 parts.append(content)
         return "".join(parts).strip()
     return ""
+
+
+def _extract_tool_calls(data: Mapping[str, Any]) -> tuple[GatewayToolCall, ...]:
+    raw_calls: list[Mapping[str, Any]] = []
+    choices = data.get("choices")
+    if isinstance(choices, list) and choices:
+        choice = choices[0]
+        if isinstance(choice, Mapping):
+            message = choice.get("message", choice)
+            if isinstance(message, Mapping) and isinstance(message.get("tool_calls"), list):
+                raw_calls.extend(
+                    item for item in message["tool_calls"] if isinstance(item, Mapping)
+                )
+    output = data.get("output")
+    if isinstance(output, list):
+        raw_calls.extend(
+            item
+            for item in output
+            if isinstance(item, Mapping) and item.get("type") == "function_call"
+        )
+
+    calls: list[GatewayToolCall] = []
+    for raw in raw_calls:
+        function = raw.get("function")
+        source = function if isinstance(function, Mapping) else raw
+        name = source.get("name")
+        arguments = source.get("arguments")
+        if not isinstance(name, str) or not name:
+            raise ProviderProtocolError()
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                raise ProviderProtocolError() from None
+        if not isinstance(arguments, Mapping):
+            raise ProviderProtocolError()
+        calls.append(GatewayToolCall(name=name, arguments=dict(arguments)))
+    return tuple(calls)
 
 
 def _content_to_text(value: Any) -> str:
@@ -750,6 +863,7 @@ __all__ = [
     "GatewayConfig",
     "GatewayDelta",
     "GatewayError",
+    "GatewayToolCall",
     "FallbackAdapter",
     "GatewayResponse",
     "InvalidGatewayInput",

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -602,6 +602,8 @@ class OpenAICompatibleAdapter(Gateway):
         tool_choice: str,
         request_id: str | None = None,
     ) -> Sequence[GatewayToolCall]:
+        if tool_choice != "required":
+            raise InvalidGatewayInput("REQUIRED_TOOL_CHOICE")
         request = request_id or uuid.uuid4().hex
         body = self._body(messages, stream=False)
         if self.config.api_style == "responses":

--- a/tests/llm/test_gateway.py
+++ b/tests/llm/test_gateway.py
@@ -135,6 +135,65 @@ def test_chat_completion_adapter_uses_local_mock_server_and_env_key(monkeypatch:
     assert seen["body"]["messages"] == list(ROOT_MESSAGES)
 
 
+def test_openai_compatible_adapter_returns_required_tool_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def exercise():
+        seen = {}
+
+        async def handler(request: web.Request) -> web.Response:
+            seen["request_id"] = request.headers.get("X-Request-ID")
+            seen["body"] = await request.json()
+            return web.json_response(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "tool_calls": [
+                                    {
+                                        "function": {
+                                            "name": "apply_voice_performance",
+                                            "arguments": '{"overall_emotion":"steady reassurance"}',
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            )
+
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", handler)
+        async with TestClient(TestServer(app)) as client:
+            adapter = OpenAICompatibleAdapter(make_config(str(client.make_url("/v1"))))
+            calls = await adapter.complete_with_tools(
+                messages=ROOT_MESSAGES,
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "apply_voice_performance",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+                tool_choice="required",
+                request_id="voice-direction:fixture",
+            )
+        return calls, seen
+
+    monkeypatch.setenv("B03_TEST_KEY", "TEST")
+    calls, seen = run(exercise())
+
+    assert [(call.name, call.arguments) for call in calls] == [
+        ("apply_voice_performance", {"overall_emotion": "steady reassurance"})
+    ]
+    assert seen["request_id"] == "voice-direction:fixture"
+    assert seen["body"]["tool_choice"] == "required"
+    assert seen["body"]["tools"][0]["function"]["name"] == "apply_voice_performance"
+
+
 def test_provider_idempotency_header_is_reserved_for_durable_letter_calls(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/llm/test_gateway.py
+++ b/tests/llm/test_gateway.py
@@ -194,6 +194,22 @@ def test_openai_compatible_adapter_returns_required_tool_calls(
     assert seen["body"]["tools"][0]["function"]["name"] == "apply_voice_performance"
 
 
+def test_tool_completion_rejects_non_required_choice_before_provider_call() -> None:
+    async def exercise() -> InvalidGatewayInput:
+        adapter = OpenAICompatibleAdapter(
+            GatewayConfig(provider="openai_compatible", base_url="", model="")
+        )
+        with pytest.raises(InvalidGatewayInput) as error:
+            await adapter.complete_with_tools(
+                messages=ROOT_MESSAGES,
+                tools=[{"type": "function", "function": {"name": "apply_voice_performance"}}],
+                tool_choice="auto",
+            )
+        return error.value
+
+    assert run(exercise()).code == "REQUIRED_TOOL_CHOICE"
+
+
 def test_provider_idempotency_header_is_reserved_for_durable_letter_calls(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Scope
- add typed required tool-call completion to the shared LLM gateway
- preserve request IDs and durable letter idempotency behavior
- parse OpenAI-compatible function-call arguments fail-closed
- document the public required-tool-call and custom-provider contract

## Validation
- python -m pytest -q tests/llm/test_gateway.py (13 passed)
- python -m py_compile llm_gateway.py tests/llm/test_gateway.py
- python baseline_hardening_scan.py --mode all (PASS)
- git diff --check

## Tracking and governance
- Part of #27.
- This is a prerequisite stack above #111. The non-main base is not a governance waiver: this PR remains blocked from Ready/merge until #111 lands on `main` and #112 is retargeted to `main`.
- Earlier exact-pair Spec evidence is https://github.com/Ornn8/bside-olivia-community/pull/112#issuecomment-5397154760. That evidence applies only to `bee814ee273f1191335e77f54edf4bee66a2870d...e8a613d5a95117be79d5735b5de7f36d048c8237` and is superseded by the corrective head; a new independent frozen-diff verdict is required before this PR can become Ready.

## Boundary
- Synthetic local HTTP and static checks only; no real provider, TTS, LatentSync, MiniMax, or video run.