### PR TITLE
feat(tts): direct frozen replies as one performance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ py-modules = [
     "reply_pipeline",
     "reply_quality_gate",
     "reply_reviewer",
+    "voice_direction",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/tts/test_voice_direction.py
+++ b/tests/tts/test_voice_direction.py
@@ -1,0 +1,128 @@
+import asyncio
+
+import pytest
+
+from voice_direction import (
+    VoiceDirectionError,
+    VoiceToolCall,
+    direct_voice_performance,
+)
+
+
+class _FakeVoiceDirector:
+    def __init__(self, call: VoiceToolCall) -> None:
+        self.call = call
+        self.requests: list[dict[str, object]] = []
+
+    async def complete_with_tools(
+        self,
+        *,
+        messages: list[dict[str, str]],
+        tools: list[dict[str, object]],
+        tool_choice: str,
+    ) -> list[VoiceToolCall]:
+        self.requests.append(
+            {"messages": messages, "tools": tools, "tool_choice": tool_choice}
+        )
+        return [self.call]
+
+
+def test_director_uses_frozen_reply_as_context_and_preserves_it_exactly() -> None:
+    reply = "你不是不够好。你只是被一次突然的离开伤到了。先别急着逼自己相信谁。"
+    director = _FakeVoiceDirector(
+        VoiceToolCall(
+            name="apply_voice_performance",
+            arguments={
+                "segments": [
+                    {
+                        "sentence_start": 1,
+                        "sentence_end": 1,
+                        "emotion": "克制的心疼",
+                        "intensity": 0.46,
+                        "speed": 0.99,
+                        "pause_after_ms": 260,
+                        "gain_db": -0.2,
+                    },
+                    {
+                        "sentence_start": 2,
+                        "sentence_end": 3,
+                        "emotion": "温和但笃定",
+                        "intensity": 0.58,
+                        "speed": 1.01,
+                        "pause_after_ms": 0,
+                        "gain_db": 0.1,
+                    },
+                ]
+            },
+        )
+    )
+
+    plan = asyncio.run(direct_voice_performance(reply, director))
+
+    assert plan.spoken_text == reply
+    assert plan.source == "llm_tool_call"
+    assert plan.control_channel == "non_spoken"
+    assert [segment.text for segment in plan.segments] == [
+        "你不是不够好。",
+        "你只是被一次突然的离开伤到了。先别急着逼自己相信谁。",
+    ]
+    request = director.requests[0]
+    assert request["tool_choice"] == "required"
+    assert reply in request["messages"][1]["content"]
+    assert "emotion" in str(request["tools"])
+
+
+@pytest.mark.parametrize(
+    "segments",
+    [
+        [
+            {
+                "sentence_start": 2,
+                "sentence_end": 3,
+                "emotion": "温和",
+                "intensity": 0.5,
+                "speed": 1.0,
+                "pause_after_ms": 0,
+                "gain_db": 0.0,
+            }
+        ],
+        [
+            {
+                "sentence_start": 1,
+                "sentence_end": 2,
+                "emotion": "温和",
+                "intensity": 0.5,
+                "speed": 1.0,
+                "pause_after_ms": 0,
+                "gain_db": 0.0,
+            },
+            {
+                "sentence_start": 2,
+                "sentence_end": 3,
+                "emotion": "笃定",
+                "intensity": 0.5,
+                "speed": 1.0,
+                "pause_after_ms": 0,
+                "gain_db": 0.0,
+            },
+        ],
+    ],
+)
+def test_director_rejects_uncovered_or_overlapping_sentence_ranges(
+    segments: list[dict[str, object]],
+) -> None:
+    director = _FakeVoiceDirector(
+        VoiceToolCall(name="apply_voice_performance", arguments={"segments": segments})
+    )
+
+    with pytest.raises(VoiceDirectionError, match="cover every sentence exactly once"):
+        asyncio.run(direct_voice_performance("第一句。第二句。第三句。", director))
+
+
+def test_director_rejects_plain_text_instead_of_required_tool_call() -> None:
+    class _NoToolDirector:
+        async def complete_with_tools(self, **_: object) -> list[VoiceToolCall]:
+            return []
+
+    with pytest.raises(VoiceDirectionError, match="exactly one tool call"):
+        asyncio.run(direct_voice_performance("这是一句完整的话。", _NoToolDirector()))

--- a/tests/tts/test_voice_direction.py
+++ b/tests/tts/test_voice_direction.py
@@ -2,16 +2,12 @@ import asyncio
 
 import pytest
 
-from voice_direction import (
-    VoiceDirectionError,
-    VoiceToolCall,
-    direct_voice_performance,
-)
+from voice_direction import VoiceDirectionError, VoiceToolCall, direct_voice_performance
 
 
 class _FakeVoiceDirector:
-    def __init__(self, call: VoiceToolCall) -> None:
-        self.call = call
+    def __init__(self, arguments: dict[str, object]) -> None:
+        self.arguments = arguments
         self.requests: list[dict[str, object]] = []
 
     async def complete_with_tools(
@@ -24,105 +20,73 @@ class _FakeVoiceDirector:
         self.requests.append(
             {"messages": messages, "tools": tools, "tool_choice": tool_choice}
         )
-        return [self.call]
+        return [VoiceToolCall(name="apply_voice_performance", arguments=self.arguments)]
 
 
-def test_director_uses_frozen_reply_as_context_and_preserves_it_exactly() -> None:
+def _valid_direction() -> dict[str, object]:
+    return {
+        "overall_emotion": "克制而温暖的陪伴感",
+        "global_speed": 1.06,
+        "energy": 0.55,
+        "breath_before_sentences": [2],
+        "emphasize_sentences": [1],
+    }
+
+
+def test_director_preserves_frozen_reply_and_requests_only_global_controls() -> None:
     reply = "你不是不够好。你只是被一次突然的离开伤到了。先别急着逼自己相信谁。"
-    director = _FakeVoiceDirector(
-        VoiceToolCall(
-            name="apply_voice_performance",
-            arguments={
-                "segments": [
-                    {
-                        "sentence_start": 1,
-                        "sentence_end": 1,
-                        "emotion": "克制的心疼",
-                        "intensity": 0.46,
-                        "speed": 0.99,
-                        "pause_after_ms": 260,
-                        "gain_db": -0.2,
-                    },
-                    {
-                        "sentence_start": 2,
-                        "sentence_end": 3,
-                        "emotion": "温和但笃定",
-                        "intensity": 0.58,
-                        "speed": 1.01,
-                        "pause_after_ms": 0,
-                        "gain_db": 0.1,
-                    },
-                ]
-            },
-        )
-    )
+    director = _FakeVoiceDirector(_valid_direction())
 
     plan = asyncio.run(direct_voice_performance(reply, director))
 
     assert plan.spoken_text == reply
-    assert plan.source == "llm_tool_call"
-    assert plan.control_channel == "non_spoken"
-    assert [segment.text for segment in plan.segments] == [
-        "你不是不够好。",
-        "你只是被一次突然的离开伤到了。先别急着逼自己相信谁。",
-    ]
+    assert len(plan.speech_units()) == 1
+    assert plan.cues[0].text == reply
+    assert plan.cues[0].emotion == plan.overall_emotion
+    assert plan.cues[0].intensity == plan.energy
+    assert "segments" not in plan.to_dict()
     request = director.requests[0]
     assert request["tool_choice"] == "required"
     assert reply in request["messages"][1]["content"]
-    assert "emotion" in str(request["tools"])
+    properties = request["tools"][0]["function"]["parameters"]["properties"]
+    assert set(properties) == {
+        "overall_emotion",
+        "global_speed",
+        "energy",
+        "breath_before_sentences",
+        "emphasize_sentences",
+    }
 
 
 @pytest.mark.parametrize(
-    "segments",
+    "missing",
+    ["overall_emotion", "global_speed", "energy", "breath_before_sentences", "emphasize_sentences"],
+)
+def test_director_rejects_tool_calls_missing_required_controls(missing: str) -> None:
+    arguments = _valid_direction()
+    del arguments[missing]
+
+    with pytest.raises(VoiceDirectionError, match="VOICE_DIRECTION_INVALID"):
+        asyncio.run(direct_voice_performance("第一句。第二句。", _FakeVoiceDirector(arguments)))
+
+
+@pytest.mark.parametrize(
+    "payload",
     [
-        [
-            {
-                "sentence_start": 2,
-                "sentence_end": 3,
-                "emotion": "温和",
-                "intensity": 0.5,
-                "speed": 1.0,
-                "pause_after_ms": 0,
-                "gain_db": 0.0,
-            }
-        ],
-        [
-            {
-                "sentence_start": 1,
-                "sentence_end": 2,
-                "emotion": "温和",
-                "intensity": 0.5,
-                "speed": 1.0,
-                "pause_after_ms": 0,
-                "gain_db": 0.0,
-            },
-            {
-                "sentence_start": 2,
-                "sentence_end": 3,
-                "emotion": "笃定",
-                "intensity": 0.5,
-                "speed": 1.0,
-                "pause_after_ms": 0,
-                "gain_db": 0.0,
-            },
-        ],
+        {"global_speed": 99},
+        {"overall_emotion": "<|endofprompt|>"},
+        {"breath_before_sentences": [99]},
+        {"emphasize_sentences": [1, 1]},
+        {"reply_text": "第一句。第二句。", "segments": []},
     ],
 )
-def test_director_rejects_uncovered_or_overlapping_sentence_ranges(
-    segments: list[dict[str, object]],
-) -> None:
-    director = _FakeVoiceDirector(
-        VoiceToolCall(name="apply_voice_performance", arguments={"segments": segments})
-    )
+def test_persisted_plan_revalidates_all_controls(payload: dict[str, object]) -> None:
+    valid = asyncio.run(
+        direct_voice_performance("第一句。第二句。", _FakeVoiceDirector(_valid_direction()))
+    ).to_dict()
+    valid.update(payload)
 
-    with pytest.raises(VoiceDirectionError, match="cover every sentence exactly once"):
-        asyncio.run(direct_voice_performance("第一句。第二句。第三句。", director))
+    from voice_direction import VoicePerformancePlan
 
-
-def test_director_rejects_plain_text_instead_of_required_tool_call() -> None:
-    class _NoToolDirector:
-        async def complete_with_tools(self, **_: object) -> list[VoiceToolCall]:
-            return []
-
-    with pytest.raises(VoiceDirectionError, match="exactly one tool call"):
-        asyncio.run(direct_voice_performance("这是一句完整的话。", _NoToolDirector()))
+    with pytest.raises(VoiceDirectionError):
+        VoicePerformancePlan.from_dict(valid)

--- a/tests/tts/test_voice_direction.py
+++ b/tests/tts/test_voice_direction.py
@@ -41,6 +41,7 @@ def test_director_preserves_frozen_reply_and_requests_only_global_controls() -> 
 
     assert plan.spoken_text == reply
     assert len(plan.speech_units()) == 1
+    assert plan.speech_units()[0].text == reply
     assert plan.cues[0].text == reply
     assert plan.cues[0].emotion == plan.overall_emotion
     assert plan.cues[0].intensity == plan.energy

--- a/voice_direction.py
+++ b/voice_direction.py
@@ -94,13 +94,9 @@ class VoicePerformancePlan:
 
     @property
     def render_text(self) -> str:
-        rendered: list[str] = []
-        for sentence_id, sentence in enumerate(_sentences(self.reply_text), 1):
-            prefix = "[breath]" if sentence_id in self.breath_before_sentences else ""
-            rendered.append(
-                prefix + (f"<strong>{sentence}</strong>" if sentence_id in self.emphasize_sentences else sentence)
-            )
-        return "".join(rendered)
+        """Compatibility text channel; sparse marks remain structured controls."""
+
+        return self.reply_text
 
     @property
     def cues(self) -> tuple[VoicePerformanceSegment, ...]:

--- a/voice_direction.py
+++ b/voice_direction.py
@@ -1,13 +1,14 @@
-"""LLM-directed, non-spoken performance controls for a frozen reply."""
+"""Fail-closed LLM direction for one frozen reply performance."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import isfinite
 from typing import Any, Mapping, Protocol, Sequence
 
 
 class VoiceDirectionError(RuntimeError):
-    """The voice-director response cannot safely drive the frozen reply."""
+    """A director response cannot safely control the frozen reply."""
 
 
 @dataclass(frozen=True)
@@ -38,6 +39,8 @@ class VoiceSpeechUnit:
 
 @dataclass(frozen=True)
 class VoicePerformanceSegment:
+    """A local compatibility view, never a provider-authored control surface."""
+
     text: str
     sentence_start: int
     sentence_end: int
@@ -47,55 +50,75 @@ class VoicePerformanceSegment:
     pause_after_seconds: float
     gain_db: float
 
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "text": self.text,
-            "sentence_start": self.sentence_start,
-            "sentence_end": self.sentence_end,
-            "emotion": self.emotion,
-            "intensity": self.intensity,
-            "speed": self.speed,
-            "pause_after_seconds": self.pause_after_seconds,
-            "gain_db": self.gain_db,
-        }
+
+_SOURCE = "llm_tool_call"
+_CONTROL_CHANNEL = "non_spoken"
+_DURATION_TARGET = (40.0, 50.0)
+_TOOL_FIELDS = frozenset(
+    {
+        "overall_emotion",
+        "global_speed",
+        "energy",
+        "breath_before_sentences",
+        "emphasize_sentences",
+    }
+)
+_PERSISTED_FIELDS = _TOOL_FIELDS | {
+    "reply_text",
+    "source",
+    "control_channel",
+    "duration_target_seconds",
+}
 
 
 @dataclass(frozen=True)
 class VoicePerformancePlan:
+    """One whole-reply direction; text identity is always derived locally."""
+
     reply_text: str
-    segments: tuple[VoicePerformanceSegment, ...]
-    overall_emotion: str = "natural, warm conversation"
-    global_speed: float = 1.06
-    energy: float = 0.55
-    breath_before_sentences: tuple[int, ...] = ()
-    emphasize_sentences: tuple[int, ...] = ()
-    source: str = "llm_tool_call"
-    control_channel: str = "non_spoken"
-    duration_target_seconds: tuple[float, float] = (40.0, 50.0)
+    overall_emotion: str
+    global_speed: float
+    energy: float
+    breath_before_sentences: tuple[int, ...]
+    emphasize_sentences: tuple[int, ...]
+    source: str = _SOURCE
+    control_channel: str = _CONTROL_CHANNEL
+    duration_target_seconds: tuple[float, float] = _DURATION_TARGET
+
+    def __post_init__(self) -> None:
+        _validate_plan(self)
 
     @property
     def spoken_text(self) -> str:
-        return "".join(segment.text for segment in self.segments)
-
-    @property
-    def cues(self) -> tuple[VoicePerformanceSegment, ...]:
-        """Compatibility with the maintained delivery renderer."""
-
-        return self.segments
+        return self.reply_text
 
     @property
     def render_text(self) -> str:
-        """Return one marked-up utterance; removing supported tags yields the frozen text."""
-
-        sentences = _sentences(self.reply_text)
         rendered: list[str] = []
-        for sentence_id, sentence in enumerate(sentences, 1):
+        for sentence_id, sentence in enumerate(_sentences(self.reply_text), 1):
             prefix = "[breath]" if sentence_id in self.breath_before_sentences else ""
-            if sentence_id in self.emphasize_sentences:
-                rendered.append(prefix + "<strong>" + sentence + "</strong>")
-            else:
-                rendered.append(prefix + sentence)
+            rendered.append(
+                prefix + (f"<strong>{sentence}</strong>" if sentence_id in self.emphasize_sentences else sentence)
+            )
         return "".join(rendered)
+
+    @property
+    def cues(self) -> tuple[VoicePerformanceSegment, ...]:
+        """Expose exactly one locally-derived cue for maintained renderers."""
+
+        sentence_count = len(_sentences(self.reply_text))
+        return (
+            VoicePerformanceSegment(
+                text=self.reply_text,
+                sentence_start=1,
+                sentence_end=sentence_count,
+                emotion=self.overall_emotion,
+                intensity=self.energy,
+                speed=self.global_speed,
+                pause_after_seconds=0.0,
+                gain_db=_gain_db(self.energy),
+            ),
+        )
 
     def speech_units(self) -> tuple[VoiceSpeechUnit, ...]:
         return (
@@ -104,15 +127,13 @@ class VoicePerformancePlan:
                 cue_index=0,
                 speed=self.global_speed,
                 pause_after_seconds=0.0,
-                gain_db=max(-0.75, min(0.75, (self.energy - 0.5) * 1.5)),
+                gain_db=_gain_db(self.energy),
             ),
         )
 
     def to_dict(self) -> dict[str, object]:
         return {
             "reply_text": self.reply_text,
-            "render_text": self.render_text,
-            "segments": [segment.to_dict() for segment in self.segments],
             "overall_emotion": self.overall_emotion,
             "global_speed": self.global_speed,
             "energy": self.energy,
@@ -125,126 +146,52 @@ class VoicePerformancePlan:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, object]) -> "VoicePerformancePlan":
-        reply_text = value.get("reply_text")
-        raw_segments = value.get("segments")
-        if not isinstance(reply_text, str) or not isinstance(raw_segments, list):
+        if set(value) != _PERSISTED_FIELDS:
             raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
-        segments: list[VoicePerformanceSegment] = []
-        try:
-            for raw in raw_segments:
-                if not isinstance(raw, Mapping):
-                    raise ValueError
-                segments.append(
-                    VoicePerformanceSegment(
-                        text=str(raw["text"]),
-                        sentence_start=int(raw["sentence_start"]),
-                        sentence_end=int(raw["sentence_end"]),
-                        emotion=str(raw["emotion"]),
-                        intensity=float(raw["intensity"]),
-                        speed=float(raw["speed"]),
-                        pause_after_seconds=float(raw["pause_after_seconds"]),
-                        gain_db=float(raw["gain_db"]),
-                    )
-                )
-        except (KeyError, TypeError, ValueError):
-            raise VoiceDirectionError("VOICE_DIRECTION_INVALID") from None
-        try:
-            overall_emotion = str(value.get("overall_emotion", "natural, warm conversation"))
-            global_speed = float(value.get("global_speed", 1.06))
-            energy = float(value.get("energy", 0.55))
-            breath_before = tuple(int(item) for item in value.get("breath_before_sentences", []))
-            emphasize = tuple(int(item) for item in value.get("emphasize_sentences", []))
-        except (TypeError, ValueError):
-            raise VoiceDirectionError("VOICE_DIRECTION_INVALID") from None
-        plan = cls(
+        reply_text = value["reply_text"]
+        overall_emotion = value["overall_emotion"]
+        source = value["source"]
+        channel = value["control_channel"]
+        if not all(isinstance(item, str) for item in (reply_text, overall_emotion, source, channel)):
+            raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+        return cls(
             reply_text=reply_text,
-            segments=tuple(segments),
             overall_emotion=overall_emotion,
-            global_speed=global_speed,
-            energy=energy,
-            breath_before_sentences=breath_before,
-            emphasize_sentences=emphasize,
+            global_speed=_number(value["global_speed"], minimum=1.02, maximum=1.08),
+            energy=_number(value["energy"], minimum=0.35, maximum=0.8),
+            breath_before_sentences=_sentence_marks(
+                value["breath_before_sentences"], sentence_count=len(_sentences(reply_text)), minimum=2, maximum_items=2
+            ),
+            emphasize_sentences=_sentence_marks(
+                value["emphasize_sentences"], sentence_count=len(_sentences(reply_text)), minimum=1, maximum_items=1
+            ),
+            source=source,
+            control_channel=channel,
+            duration_target_seconds=_duration_target(value["duration_target_seconds"]),
         )
-        if not segments or plan.spoken_text != reply_text:
-            raise VoiceDirectionError("VOICE_DIRECTION_TEXT_MISMATCH")
-        return plan
 
 
 _TOOL = {
     "type": "function",
     "function": {
         "name": "apply_voice_performance",
-        "description": (
-            "Direct one continuous Chinese utterance without rewriting it. "
-            "Choose one global performance and only supported non-spoken sentence marks."
-        ),
+        "description": "Direct one frozen utterance with global, non-spoken controls only.",
         "parameters": {
             "type": "object",
             "additionalProperties": False,
-            "required": [
-                "overall_emotion",
-                "global_speed",
-                "energy",
-                "breath_before_sentences",
-                "emphasize_sentences",
-                "segments",
-            ],
+            "required": sorted(_TOOL_FIELDS),
             "properties": {
-                "overall_emotion": {
-                    "type": "string",
-                    "description": "One concise whole-utterance acting intention, not spoken text.",
-                },
-                "global_speed": {
-                    "type": "number",
-                    "minimum": 1.02,
-                    "maximum": 1.08,
-                    "description": "Natural conversational pace; default near 1.06, never lethargic.",
-                },
-                "energy": {
-                    "type": "number",
-                    "minimum": 0.35,
-                    "maximum": 0.8,
-                },
+                "overall_emotion": {"type": "string", "description": "One concise whole-utterance acting intention."},
+                "global_speed": {"type": "number", "minimum": 1.02, "maximum": 1.08},
+                "energy": {"type": "number", "minimum": 0.35, "maximum": 0.8},
                 "breath_before_sentences": {
-                    "type": "array",
-                    "maxItems": 2,
-                    "uniqueItems": True,
+                    "type": "array", "maxItems": 2, "uniqueItems": True,
                     "items": {"type": "integer", "minimum": 2},
                 },
                 "emphasize_sentences": {
-                    "type": "array",
-                    "maxItems": 1,
-                    "uniqueItems": True,
+                    "type": "array", "maxItems": 1, "uniqueItems": True,
                     "items": {"type": "integer", "minimum": 1},
                 },
-                "segments": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 5,
-                    "items": {
-                        "type": "object",
-                        "additionalProperties": False,
-                        "required": [
-                            "sentence_start",
-                            "sentence_end",
-                            "emotion",
-                            "intensity",
-                        ],
-                        "properties": {
-                            "sentence_start": {"type": "integer", "minimum": 1},
-                            "sentence_end": {"type": "integer", "minimum": 1},
-                            "emotion": {
-                                "type": "string",
-                                "description": "Short acting intention, not spoken text.",
-                            },
-                            "intensity": {
-                                "type": "number",
-                                "minimum": 0.0,
-                                "maximum": 1.0,
-                            },
-                        },
-                    },
-                }
             },
         },
     },
@@ -255,8 +202,7 @@ def _sentences(text: str) -> tuple[str, ...]:
     if not isinstance(text, str) or not text.strip():
         raise VoiceDirectionError("VOICE_DIRECTION_EMPTY_REPLY")
     parts: list[str] = []
-    start = 0
-    index = 0
+    start = index = 0
     while index < len(text):
         if text[index] not in "。！？!?；;":
             index += 1
@@ -267,23 +213,66 @@ def _sentences(text: str) -> tuple[str, ...]:
         while end < len(text) and text[end].isspace():
             end += 1
         parts.append(text[start:end])
-        start = end
-        index = end
+        start = index = end
     if start < len(text):
         parts.append(text[start:])
     return tuple(part for part in parts if part)
 
 
-def _number(value: object, *, name: str, minimum: float, maximum: float) -> float:
+def _number(value: object, *, minimum: float, maximum: float) -> float:
     if isinstance(value, bool):
-        raise VoiceDirectionError(f"VOICE_DIRECTION_{name.upper()}_INVALID")
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
     try:
         result = float(value)
     except (TypeError, ValueError):
-        raise VoiceDirectionError(f"VOICE_DIRECTION_{name.upper()}_INVALID") from None
-    if not minimum <= result <= maximum:
-        raise VoiceDirectionError(f"VOICE_DIRECTION_{name.upper()}_INVALID")
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID") from None
+    if not isfinite(result) or not minimum <= result <= maximum:
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
     return result
+
+
+def _sentence_marks(value: object, *, sentence_count: int, minimum: int, maximum_items: int) -> tuple[int, ...]:
+    if not isinstance(value, list) or len(value) > maximum_items:
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    if any(not isinstance(item, int) or isinstance(item, bool) for item in value):
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    if len(set(value)) != len(value) or any(item < minimum or item > sentence_count for item in value):
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    return tuple(sorted(value))
+
+
+def _duration_target(value: object) -> tuple[float, float]:
+    if not isinstance(value, list) or len(value) != 2:
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    parsed = tuple(_number(item, minimum=0.0, maximum=3600.0) for item in value)
+    if parsed != _DURATION_TARGET:
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    return parsed
+
+
+def _validate_plan(plan: VoicePerformancePlan) -> None:
+    _sentences(plan.reply_text)
+    if (
+        not plan.overall_emotion.strip()
+        or len(plan.overall_emotion) > 80
+        or any(token in plan.overall_emotion for token in ("<|", "|>", "[", "]", "<", ">"))
+        or plan.source != _SOURCE
+        or plan.control_channel != _CONTROL_CHANNEL
+    ):
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    _number(plan.global_speed, minimum=1.02, maximum=1.08)
+    _number(plan.energy, minimum=0.35, maximum=0.8)
+    sentence_count = len(_sentences(plan.reply_text))
+    if _sentence_marks(list(plan.breath_before_sentences), sentence_count=sentence_count, minimum=2, maximum_items=2) != plan.breath_before_sentences:
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    if _sentence_marks(list(plan.emphasize_sentences), sentence_count=sentence_count, minimum=1, maximum_items=1) != plan.emphasize_sentences:
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    if plan.duration_target_seconds != _DURATION_TARGET:
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+
+
+def _gain_db(energy: float) -> float:
+    return max(-0.75, min(0.75, (energy - 0.5) * 1.5))
 
 
 async def direct_voice_performance(
@@ -292,7 +281,7 @@ async def direct_voice_performance(
     *,
     request_id: str | None = None,
 ) -> VoicePerformancePlan:
-    """Ask a second LLM call to direct, never rewrite, the frozen reply."""
+    """Ask a second LLM call for global controls without changing frozen text."""
 
     sentences = _sentences(reply_text)
     indexed = "\n".join(f"S{index}: {text}" for index, text in enumerate(sentences, 1))
@@ -300,131 +289,35 @@ async def direct_voice_performance(
         {
             "role": "system",
             "content": (
-                "你是 Olivia 普通视频回信的声音导演。正文已定稿，禁止改字、补字或把控制提示当台词。"
-                "必须调用 apply_voice_performance。整篇语音只生成一次，不按段分别推理。"
-                "选择一个贯穿全文的自然表演方向和全局语速；正常对话默认约 1.06，避免拖沓或一字一顿。"
-                "局部变化只能使用少量句前呼吸和一句重音标记，二者都是模型官方支持的非发声控制。"
-                "segments 只描述渐进的情绪理解，不提供分段语速、分段停顿或分段响度。"
+                "你是 Olivia 普通视频回信的声音导演。正文已定稿，禁止改字、补字或复述台词。"
+                "必须调用 apply_voice_performance。只提供整篇 overall_emotion、global_speed、energy，"
+                "以及极少的句前呼吸和一句重音标记；不得输出逐段情绪、强度、速度、停顿或响度。"
             ),
         },
         {
             "role": "user",
-            "content": (
-                "以下冻结正文仅供表演理解。请覆盖每个句子一次且仅一次，分段必须连续；不要复述正文。"
-                "\n\n【完整冻结正文】\n"
-                + reply_text
-                + "\n\n【句子编号】\n"
-                + indexed
-            ),
+            "content": "以下冻结正文仅供表演理解。不要复述正文。\n\n【完整冻结正文】\n" + reply_text + "\n\n【句子编号】\n" + indexed,
         },
     ]
     try:
-        calls = await gateway.complete_with_tools(
-            messages=messages,
-            tools=[_TOOL],
-            tool_choice="required",
-            request_id=request_id,
-        )
+        calls = await gateway.complete_with_tools(messages=messages, tools=[_TOOL], tool_choice="required", request_id=request_id)
     except TypeError as exc:
-        # Small injected fakes may predate the optional request_id keyword.
         if request_id is not None:
             raise VoiceDirectionError("VOICE_DIRECTION_GATEWAY_INVALID") from exc
-        calls = await gateway.complete_with_tools(
-            messages=messages,
-            tools=[_TOOL],
-            tool_choice="required",
-        )
-    if len(calls) != 1:
-        raise VoiceDirectionError("voice director must return exactly one tool call")
-    call = calls[0]
-    if call.name != "apply_voice_performance":
+        calls = await gateway.complete_with_tools(messages=messages, tools=[_TOOL], tool_choice="required")
+    if len(calls) != 1 or calls[0].name != "apply_voice_performance":
         raise VoiceDirectionError("VOICE_DIRECTION_TOOL_INVALID")
-    raw_segments = call.arguments.get("segments")
-    if not isinstance(raw_segments, list) or not raw_segments or len(raw_segments) > 5:
-        raise VoiceDirectionError("VOICE_DIRECTION_SEGMENTS_INVALID")
-
-    overall_emotion = str(call.arguments.get("overall_emotion", "natural, warm conversation")).strip()
-    if (
-        not overall_emotion
-        or len(overall_emotion) > 80
-        or any(token in overall_emotion for token in ("<|", "|>", "[", "]", "<", ">"))
-    ):
-        raise VoiceDirectionError("VOICE_DIRECTION_EMOTION_INVALID")
-    global_speed = _number(
-        call.arguments.get("global_speed", 1.06),
-        name="global_speed",
-        minimum=1.02,
-        maximum=1.08,
-    )
-    energy = _number(
-        call.arguments.get("energy", 0.55),
-        name="energy",
-        minimum=0.35,
-        maximum=0.8,
-    )
-    def safe_sentence_ids(value: object, *, minimum: int, maximum_items: int) -> tuple[int, ...]:
-        if not isinstance(value, list):
-            return ()
-        accepted: list[int] = []
-        for item in value:
-            try:
-                sentence_id = int(item)
-            except (TypeError, ValueError):
-                continue
-            if minimum <= sentence_id <= len(sentences) and sentence_id not in accepted:
-                accepted.append(sentence_id)
-            if len(accepted) == maximum_items:
-                break
-        return tuple(sorted(accepted))
-
-    # Optional acoustic marks fail soft: invalid marks are omitted, never moved.
-    breath_before = safe_sentence_ids(
-        call.arguments.get("breath_before_sentences", []), minimum=2, maximum_items=2
-    )
-    emphasize = safe_sentence_ids(
-        call.arguments.get("emphasize_sentences", []), minimum=1, maximum_items=1
-    )
-
-    expected_start = 1
-    segments: list[VoicePerformanceSegment] = []
-    for raw in raw_segments:
-        if not isinstance(raw, Mapping):
-            raise VoiceDirectionError("VOICE_DIRECTION_SEGMENTS_INVALID")
-        try:
-            sentence_start = int(raw["sentence_start"])
-            sentence_end = int(raw["sentence_end"])
-            emotion = str(raw["emotion"]).strip()
-        except (KeyError, TypeError, ValueError):
-            raise VoiceDirectionError("VOICE_DIRECTION_SEGMENTS_INVALID") from None
-        if sentence_start != expected_start or sentence_end < sentence_start:
-            raise VoiceDirectionError("segments must cover every sentence exactly once")
-        if sentence_end > len(sentences) or not emotion or len(emotion) > 40:
-            raise VoiceDirectionError("VOICE_DIRECTION_SEGMENTS_INVALID")
-        segment_text = "".join(sentences[sentence_start - 1 : sentence_end])
-        segments.append(
-            VoicePerformanceSegment(
-                text=segment_text,
-                sentence_start=sentence_start,
-                sentence_end=sentence_end,
-                emotion=emotion,
-                intensity=_number(raw.get("intensity"), name="intensity", minimum=0, maximum=1),
-                speed=global_speed,
-                pause_after_seconds=0.0,
-                gain_db=max(-0.75, min(0.75, (energy - 0.5) * 1.5)),
-            )
-        )
-        expected_start = sentence_end + 1
-    if expected_start != len(sentences) + 1:
-        raise VoiceDirectionError("segments must cover every sentence exactly once")
-    plan = VoicePerformancePlan(
+    arguments = calls[0].arguments
+    if not isinstance(arguments, Mapping) or set(arguments) != _TOOL_FIELDS:
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    overall_emotion = arguments["overall_emotion"]
+    if not isinstance(overall_emotion, str):
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    return VoicePerformancePlan(
         reply_text=reply_text,
-        segments=tuple(segments),
         overall_emotion=overall_emotion,
-        global_speed=global_speed,
-        energy=energy,
-        breath_before_sentences=breath_before,
-        emphasize_sentences=emphasize,
+        global_speed=_number(arguments["global_speed"], minimum=1.02, maximum=1.08),
+        energy=_number(arguments["energy"], minimum=0.35, maximum=0.8),
+        breath_before_sentences=_sentence_marks(arguments["breath_before_sentences"], sentence_count=len(sentences), minimum=2, maximum_items=2),
+        emphasize_sentences=_sentence_marks(arguments["emphasize_sentences"], sentence_count=len(sentences), minimum=1, maximum_items=1),
     )
-    if plan.spoken_text != reply_text:
-        raise VoiceDirectionError("VOICE_DIRECTION_TEXT_MISMATCH")
-    return plan

--- a/voice_direction.py
+++ b/voice_direction.py
@@ -1,0 +1,430 @@
+"""LLM-directed, non-spoken performance controls for a frozen reply."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol, Sequence
+
+
+class VoiceDirectionError(RuntimeError):
+    """The voice-director response cannot safely drive the frozen reply."""
+
+
+@dataclass(frozen=True)
+class VoiceToolCall:
+    name: str
+    arguments: Mapping[str, Any]
+
+
+class VoiceToolGateway(Protocol):
+    async def complete_with_tools(
+        self,
+        *,
+        messages: Sequence[Mapping[str, str]],
+        tools: Sequence[Mapping[str, object]],
+        tool_choice: str,
+        request_id: str | None = None,
+    ) -> Sequence[VoiceToolCall]: ...
+
+
+@dataclass(frozen=True)
+class VoiceSpeechUnit:
+    text: str
+    cue_index: int
+    speed: float
+    pause_after_seconds: float
+    gain_db: float
+
+
+@dataclass(frozen=True)
+class VoicePerformanceSegment:
+    text: str
+    sentence_start: int
+    sentence_end: int
+    emotion: str
+    intensity: float
+    speed: float
+    pause_after_seconds: float
+    gain_db: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "text": self.text,
+            "sentence_start": self.sentence_start,
+            "sentence_end": self.sentence_end,
+            "emotion": self.emotion,
+            "intensity": self.intensity,
+            "speed": self.speed,
+            "pause_after_seconds": self.pause_after_seconds,
+            "gain_db": self.gain_db,
+        }
+
+
+@dataclass(frozen=True)
+class VoicePerformancePlan:
+    reply_text: str
+    segments: tuple[VoicePerformanceSegment, ...]
+    overall_emotion: str = "natural, warm conversation"
+    global_speed: float = 1.06
+    energy: float = 0.55
+    breath_before_sentences: tuple[int, ...] = ()
+    emphasize_sentences: tuple[int, ...] = ()
+    source: str = "llm_tool_call"
+    control_channel: str = "non_spoken"
+    duration_target_seconds: tuple[float, float] = (40.0, 50.0)
+
+    @property
+    def spoken_text(self) -> str:
+        return "".join(segment.text for segment in self.segments)
+
+    @property
+    def cues(self) -> tuple[VoicePerformanceSegment, ...]:
+        """Compatibility with the maintained delivery renderer."""
+
+        return self.segments
+
+    @property
+    def render_text(self) -> str:
+        """Return one marked-up utterance; removing supported tags yields the frozen text."""
+
+        sentences = _sentences(self.reply_text)
+        rendered: list[str] = []
+        for sentence_id, sentence in enumerate(sentences, 1):
+            prefix = "[breath]" if sentence_id in self.breath_before_sentences else ""
+            if sentence_id in self.emphasize_sentences:
+                rendered.append(prefix + "<strong>" + sentence + "</strong>")
+            else:
+                rendered.append(prefix + sentence)
+        return "".join(rendered)
+
+    def speech_units(self) -> tuple[VoiceSpeechUnit, ...]:
+        return (
+            VoiceSpeechUnit(
+                text=self.render_text,
+                cue_index=0,
+                speed=self.global_speed,
+                pause_after_seconds=0.0,
+                gain_db=max(-0.75, min(0.75, (self.energy - 0.5) * 1.5)),
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "reply_text": self.reply_text,
+            "render_text": self.render_text,
+            "segments": [segment.to_dict() for segment in self.segments],
+            "overall_emotion": self.overall_emotion,
+            "global_speed": self.global_speed,
+            "energy": self.energy,
+            "breath_before_sentences": list(self.breath_before_sentences),
+            "emphasize_sentences": list(self.emphasize_sentences),
+            "source": self.source,
+            "control_channel": self.control_channel,
+            "duration_target_seconds": list(self.duration_target_seconds),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> "VoicePerformancePlan":
+        reply_text = value.get("reply_text")
+        raw_segments = value.get("segments")
+        if not isinstance(reply_text, str) or not isinstance(raw_segments, list):
+            raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+        segments: list[VoicePerformanceSegment] = []
+        try:
+            for raw in raw_segments:
+                if not isinstance(raw, Mapping):
+                    raise ValueError
+                segments.append(
+                    VoicePerformanceSegment(
+                        text=str(raw["text"]),
+                        sentence_start=int(raw["sentence_start"]),
+                        sentence_end=int(raw["sentence_end"]),
+                        emotion=str(raw["emotion"]),
+                        intensity=float(raw["intensity"]),
+                        speed=float(raw["speed"]),
+                        pause_after_seconds=float(raw["pause_after_seconds"]),
+                        gain_db=float(raw["gain_db"]),
+                    )
+                )
+        except (KeyError, TypeError, ValueError):
+            raise VoiceDirectionError("VOICE_DIRECTION_INVALID") from None
+        try:
+            overall_emotion = str(value.get("overall_emotion", "natural, warm conversation"))
+            global_speed = float(value.get("global_speed", 1.06))
+            energy = float(value.get("energy", 0.55))
+            breath_before = tuple(int(item) for item in value.get("breath_before_sentences", []))
+            emphasize = tuple(int(item) for item in value.get("emphasize_sentences", []))
+        except (TypeError, ValueError):
+            raise VoiceDirectionError("VOICE_DIRECTION_INVALID") from None
+        plan = cls(
+            reply_text=reply_text,
+            segments=tuple(segments),
+            overall_emotion=overall_emotion,
+            global_speed=global_speed,
+            energy=energy,
+            breath_before_sentences=breath_before,
+            emphasize_sentences=emphasize,
+        )
+        if not segments or plan.spoken_text != reply_text:
+            raise VoiceDirectionError("VOICE_DIRECTION_TEXT_MISMATCH")
+        return plan
+
+
+_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "apply_voice_performance",
+        "description": (
+            "Direct one continuous Chinese utterance without rewriting it. "
+            "Choose one global performance and only supported non-spoken sentence marks."
+        ),
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": [
+                "overall_emotion",
+                "global_speed",
+                "energy",
+                "breath_before_sentences",
+                "emphasize_sentences",
+                "segments",
+            ],
+            "properties": {
+                "overall_emotion": {
+                    "type": "string",
+                    "description": "One concise whole-utterance acting intention, not spoken text.",
+                },
+                "global_speed": {
+                    "type": "number",
+                    "minimum": 1.02,
+                    "maximum": 1.08,
+                    "description": "Natural conversational pace; default near 1.06, never lethargic.",
+                },
+                "energy": {
+                    "type": "number",
+                    "minimum": 0.35,
+                    "maximum": 0.8,
+                },
+                "breath_before_sentences": {
+                    "type": "array",
+                    "maxItems": 2,
+                    "uniqueItems": True,
+                    "items": {"type": "integer", "minimum": 2},
+                },
+                "emphasize_sentences": {
+                    "type": "array",
+                    "maxItems": 1,
+                    "uniqueItems": True,
+                    "items": {"type": "integer", "minimum": 1},
+                },
+                "segments": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 5,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": [
+                            "sentence_start",
+                            "sentence_end",
+                            "emotion",
+                            "intensity",
+                        ],
+                        "properties": {
+                            "sentence_start": {"type": "integer", "minimum": 1},
+                            "sentence_end": {"type": "integer", "minimum": 1},
+                            "emotion": {
+                                "type": "string",
+                                "description": "Short acting intention, not spoken text.",
+                            },
+                            "intensity": {
+                                "type": "number",
+                                "minimum": 0.0,
+                                "maximum": 1.0,
+                            },
+                        },
+                    },
+                }
+            },
+        },
+    },
+}
+
+
+def _sentences(text: str) -> tuple[str, ...]:
+    if not isinstance(text, str) or not text.strip():
+        raise VoiceDirectionError("VOICE_DIRECTION_EMPTY_REPLY")
+    parts: list[str] = []
+    start = 0
+    index = 0
+    while index < len(text):
+        if text[index] not in "。！？!?；;":
+            index += 1
+            continue
+        end = index + 1
+        while end < len(text) and text[end] in "”’\"'」』】）)":
+            end += 1
+        while end < len(text) and text[end].isspace():
+            end += 1
+        parts.append(text[start:end])
+        start = end
+        index = end
+    if start < len(text):
+        parts.append(text[start:])
+    return tuple(part for part in parts if part)
+
+
+def _number(value: object, *, name: str, minimum: float, maximum: float) -> float:
+    if isinstance(value, bool):
+        raise VoiceDirectionError(f"VOICE_DIRECTION_{name.upper()}_INVALID")
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        raise VoiceDirectionError(f"VOICE_DIRECTION_{name.upper()}_INVALID") from None
+    if not minimum <= result <= maximum:
+        raise VoiceDirectionError(f"VOICE_DIRECTION_{name.upper()}_INVALID")
+    return result
+
+
+async def direct_voice_performance(
+    reply_text: str,
+    gateway: VoiceToolGateway,
+    *,
+    request_id: str | None = None,
+) -> VoicePerformancePlan:
+    """Ask a second LLM call to direct, never rewrite, the frozen reply."""
+
+    sentences = _sentences(reply_text)
+    indexed = "\n".join(f"S{index}: {text}" for index, text in enumerate(sentences, 1))
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "你是 Olivia 普通视频回信的声音导演。正文已定稿，禁止改字、补字或把控制提示当台词。"
+                "必须调用 apply_voice_performance。整篇语音只生成一次，不按段分别推理。"
+                "选择一个贯穿全文的自然表演方向和全局语速；正常对话默认约 1.06，避免拖沓或一字一顿。"
+                "局部变化只能使用少量句前呼吸和一句重音标记，二者都是模型官方支持的非发声控制。"
+                "segments 只描述渐进的情绪理解，不提供分段语速、分段停顿或分段响度。"
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                "以下冻结正文仅供表演理解。请覆盖每个句子一次且仅一次，分段必须连续；不要复述正文。"
+                "\n\n【完整冻结正文】\n"
+                + reply_text
+                + "\n\n【句子编号】\n"
+                + indexed
+            ),
+        },
+    ]
+    try:
+        calls = await gateway.complete_with_tools(
+            messages=messages,
+            tools=[_TOOL],
+            tool_choice="required",
+            request_id=request_id,
+        )
+    except TypeError as exc:
+        # Small injected fakes may predate the optional request_id keyword.
+        if request_id is not None:
+            raise VoiceDirectionError("VOICE_DIRECTION_GATEWAY_INVALID") from exc
+        calls = await gateway.complete_with_tools(
+            messages=messages,
+            tools=[_TOOL],
+            tool_choice="required",
+        )
+    if len(calls) != 1:
+        raise VoiceDirectionError("voice director must return exactly one tool call")
+    call = calls[0]
+    if call.name != "apply_voice_performance":
+        raise VoiceDirectionError("VOICE_DIRECTION_TOOL_INVALID")
+    raw_segments = call.arguments.get("segments")
+    if not isinstance(raw_segments, list) or not raw_segments or len(raw_segments) > 5:
+        raise VoiceDirectionError("VOICE_DIRECTION_SEGMENTS_INVALID")
+
+    overall_emotion = str(call.arguments.get("overall_emotion", "natural, warm conversation")).strip()
+    if (
+        not overall_emotion
+        or len(overall_emotion) > 80
+        or any(token in overall_emotion for token in ("<|", "|>", "[", "]", "<", ">"))
+    ):
+        raise VoiceDirectionError("VOICE_DIRECTION_EMOTION_INVALID")
+    global_speed = _number(
+        call.arguments.get("global_speed", 1.06),
+        name="global_speed",
+        minimum=1.02,
+        maximum=1.08,
+    )
+    energy = _number(
+        call.arguments.get("energy", 0.55),
+        name="energy",
+        minimum=0.35,
+        maximum=0.8,
+    )
+    def safe_sentence_ids(value: object, *, minimum: int, maximum_items: int) -> tuple[int, ...]:
+        if not isinstance(value, list):
+            return ()
+        accepted: list[int] = []
+        for item in value:
+            try:
+                sentence_id = int(item)
+            except (TypeError, ValueError):
+                continue
+            if minimum <= sentence_id <= len(sentences) and sentence_id not in accepted:
+                accepted.append(sentence_id)
+            if len(accepted) == maximum_items:
+                break
+        return tuple(sorted(accepted))
+
+    # Optional acoustic marks fail soft: invalid marks are omitted, never moved.
+    breath_before = safe_sentence_ids(
+        call.arguments.get("breath_before_sentences", []), minimum=2, maximum_items=2
+    )
+    emphasize = safe_sentence_ids(
+        call.arguments.get("emphasize_sentences", []), minimum=1, maximum_items=1
+    )
+
+    expected_start = 1
+    segments: list[VoicePerformanceSegment] = []
+    for raw in raw_segments:
+        if not isinstance(raw, Mapping):
+            raise VoiceDirectionError("VOICE_DIRECTION_SEGMENTS_INVALID")
+        try:
+            sentence_start = int(raw["sentence_start"])
+            sentence_end = int(raw["sentence_end"])
+            emotion = str(raw["emotion"]).strip()
+        except (KeyError, TypeError, ValueError):
+            raise VoiceDirectionError("VOICE_DIRECTION_SEGMENTS_INVALID") from None
+        if sentence_start != expected_start or sentence_end < sentence_start:
+            raise VoiceDirectionError("segments must cover every sentence exactly once")
+        if sentence_end > len(sentences) or not emotion or len(emotion) > 40:
+            raise VoiceDirectionError("VOICE_DIRECTION_SEGMENTS_INVALID")
+        segment_text = "".join(sentences[sentence_start - 1 : sentence_end])
+        segments.append(
+            VoicePerformanceSegment(
+                text=segment_text,
+                sentence_start=sentence_start,
+                sentence_end=sentence_end,
+                emotion=emotion,
+                intensity=_number(raw.get("intensity"), name="intensity", minimum=0, maximum=1),
+                speed=global_speed,
+                pause_after_seconds=0.0,
+                gain_db=max(-0.75, min(0.75, (energy - 0.5) * 1.5)),
+            )
+        )
+        expected_start = sentence_end + 1
+    if expected_start != len(sentences) + 1:
+        raise VoiceDirectionError("segments must cover every sentence exactly once")
+    plan = VoicePerformancePlan(
+        reply_text=reply_text,
+        segments=tuple(segments),
+        overall_emotion=overall_emotion,
+        global_speed=global_speed,
+        energy=energy,
+        breath_before_sentences=breath_before,
+        emphasize_sentences=emphasize,
+    )
+    if plan.spoken_text != reply_text:
+        raise VoiceDirectionError("VOICE_DIRECTION_TEXT_MISMATCH")
+    return plan


### PR DESCRIPTION
## Scope
- add a fail-closed VoicePerformancePlan for one continuous frozen reply
- use a required second LLM tool call for only whole-reply emotion, speed, energy, and sparse supported marks
- derive the sole renderer cue locally from the frozen text; no LLM-authored segments are persisted
- reject missing, extra, tampered, or out-of-range direction data

Tracks #27. Depends on PR #112.

## Validation
- python -m pytest -q tests/llm/test_gateway.py tests/tts/test_voice_direction.py (23 passed)
- python -m py_compile voice_direction.py tests/tts/test_voice_direction.py
- python baseline_hardening_scan.py --mode all
- python -m pip wheel --no-deps --no-build-isolation . (voice_direction.py present in wheel)
- git diff --check

## Boundary
Synthetic/static contract only. TTS execution and media entrypoint wiring remain separate follow-up PRs; no provider, TTS, or visual run.