### PR TITLE
feat(tts): render directed replies in one inference

### DIFF
--- a/docs/B06_LOCAL_TTS_ACCEPTANCE.md
+++ b/docs/B06_LOCAL_TTS_ACCEPTANCE.md
@@ -11,6 +11,34 @@ This note is a sanitized acceptance record. Private model directories, reference
 - B05 boundary: no B05 HTTP/event wiring or integrated claim was added.
 - Asset policy: profile install records external references only; `external_assets_copied=false` and lifecycle uninstall dry-run reported `external_assets_deleted=false`.
 
+## Directed ordinary-video compatibility and listening acceptance
+
+The single-pass emotion-directed path remains a thin adapter over the same
+verified external B06 assembly. It requires the pinned CosyVoice runtime
+revision `074ca6dc9e80a2f424f1f74b48bdd7d3fea531cc`, the pinned
+`Fun-CosyVoice3-0.5B-2512` model revision
+`29e01c4e8d000f4bcd70751be16fa94bf3d85a18`, and Apache-2.0 license evidence
+for both. The worker checks that the pinned runtime exposes callable
+`inference_instruct2`; an incompatible runtime fails closed as
+`COSYVOICE_INSTRUCT2_UNSUPPORTED` before synthesis.
+
+The manifest replacement boundary remains: B10B calls the existing
+tts.service.TTSService public health contract; it does not reimplement
+synthesis. Its uninstall boundary also remains unchanged: B10B uninstall
+removes only modules/tts_local metadata; CosyVoice runtime and weights remain
+external. No runtime, model, voice reference, or generated WAV is copied into
+the repository.
+
+Candidate 1 of the product continuous-delivery listening comparison was
+selected as the baseline by the project owner. The accepted local-only WAV was
+41.28 seconds, 24 kHz mono, with SHA-256
+`863ef5185c448f189c46524fd8e87010bf353bc2bf8e3df9f59bdc0948ec14ce`.
+The listening acceptance covers continuous whole-reply delivery, the intended
+global emotional direction, and absence of an audible control-instruction
+prefix. It does not claim song-voice cloning, visual quality, or general model
+quality beyond that reviewed candidate. The WAV and private voice reference
+remain ignored local evidence.
+
 ## Final real gate
 
 One ordinary PowerShell invocation performed profile install and then one-process real acceptance. The provider used `text_frontend=none`, offline flags, D:-drive TEMP/TMP/Numba cache, and local-only model/reference assets.

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 import sys
 import wave
 from array import array
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -297,3 +299,64 @@ def test_external_worker_runs_one_whole_reply_instruct2_inference(
     ]
     with wave.open(str(output), "rb") as rendered:
         assert rendered.getnframes() == 4200
+
+
+def test_external_worker_rejects_runtime_without_pinned_instruct2_api(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    class AutoModel:
+        sample_rate = 100
+
+        def __init__(self, **_kwargs):
+            pass
+
+    cosyvoice = ModuleType("cosyvoice")
+    cli = ModuleType("cosyvoice.cli")
+    module = ModuleType("cosyvoice.cli.cosyvoice")
+    module.AutoModel = AutoModel
+    monkeypatch.setitem(sys.modules, "cosyvoice", cosyvoice)
+    monkeypatch.setitem(sys.modules, "cosyvoice.cli", cli)
+    monkeypatch.setitem(sys.modules, "cosyvoice.cli.cosyvoice", module)
+
+    with pytest.raises(RuntimeError, match="COSYVOICE_INSTRUCT2_UNSUPPORTED"):
+        external_cosyvoice_worker._synthesize(
+            {
+                "runtime_root": str(tmp_path),
+                "model_dir": str(tmp_path),
+                "reference_audio": str(tmp_path / "reference.wav"),
+                "voice_condition_mode": "instruct2_single_pass",
+                "text": "one complete frozen reply",
+                "instruct_text": "steady reassurance<|endofprompt|>",
+            },
+            tmp_path / "directed.wav",
+        )
+
+
+def test_directed_tts_provenance_and_human_acceptance_are_publicly_recorded() -> None:
+    root = Path(__file__).resolve().parents[2]
+    manifest = json.loads(
+        (root / "runtime/packaging/manifests/b10b.modules.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    upstreams = {
+        item["id"]: item for item in manifest["provenance"]["upstreams"]
+    }
+    runtime = upstreams["b06-cosyvoice-runtime"]
+    model = upstreams["b06-cosyvoice-model"]
+    acceptance = (root / "docs/B06_LOCAL_TTS_ACCEPTANCE.md").read_text(
+        encoding="utf-8"
+    )
+    normalized_acceptance = " ".join(acceptance.split())
+
+    assert runtime["revision"] == "074ca6dc9e80a2f424f1f74b48bdd7d3fea531cc"
+    assert runtime["license"] == "Apache-2.0"
+    assert runtime["adapter_boundary"] in normalized_acceptance
+    assert runtime["uninstall_path"] in normalized_acceptance
+    assert model["revision"] == "29e01c4e8d000f4bcd70751be16fa94bf3d85a18"
+    assert "inference_instruct2" in acceptance
+    assert "41.28 seconds" in acceptance
+    assert "24 kHz mono" in acceptance
+    assert "863ef5185c448f189c46524fd8e87010bf353bc2bf8e3df9f59bdc0948ec14ce" in acceptance
+    assert "Candidate 1" in acceptance

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -23,7 +23,7 @@ from tts.delivery import (
     build_external_delivery_request,
     delivery_tempo_factor,
 )
-from voice_direction import VoicePerformancePlan, VoicePerformanceSegment
+from voice_direction import VoicePerformancePlan
 
 
 def test_ordinary_video_copy_contract_targets_cross_lingual_delivery_length() -> None:
@@ -65,22 +65,11 @@ def test_llm_voice_plan_builds_one_non_spoken_instruct2_request() -> None:
     reply_text = "I hear you. I will stay with you through this."
     plan = VoicePerformancePlan(
         reply_text=reply_text,
-        segments=(
-            VoicePerformanceSegment(
-                text=reply_text,
-                sentence_start=1,
-                sentence_end=2,
-                emotion="restrained empathy becoming steady reassurance",
-                intensity=0.62,
-                speed=1.06,
-                pause_after_seconds=0.0,
-                gain_db=0.1,
-            ),
-        ),
         overall_emotion="restrained empathy becoming steady reassurance",
         global_speed=1.06,
         energy=0.62,
-        emphasize_sentences=(2,),
+        breath_before_sentences=(),
+        emphasize_sentences=(1,),
     )
     config = SimpleNamespace(
         runtime_root="runtime",

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -81,7 +81,7 @@ def test_llm_voice_plan_builds_one_non_spoken_instruct2_request() -> None:
     request = build_external_delivery_request(config, plan)
 
     assert request["voice_condition_mode"] == "instruct2_single_pass"
-    assert plan.render_text != reply_text
+    assert plan.render_text == reply_text
     assert request["text"] == reply_text
     assert "[breath]" not in str(request["text"])
     assert "<strong>" not in str(request["text"])

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -62,13 +62,13 @@ def test_delivery_request_uses_one_contextual_long_form_payload() -> None:
 
 
 def test_llm_voice_plan_builds_one_non_spoken_instruct2_request() -> None:
-    reply_text = "I hear you. I will stay with you through this."
+    reply_text = "First sentence。Second sentence。"
     plan = VoicePerformancePlan(
         reply_text=reply_text,
         overall_emotion="restrained empathy becoming steady reassurance",
         global_speed=1.06,
         energy=0.62,
-        breath_before_sentences=(),
+        breath_before_sentences=(2,),
         emphasize_sentences=(1,),
     )
     config = SimpleNamespace(
@@ -81,8 +81,13 @@ def test_llm_voice_plan_builds_one_non_spoken_instruct2_request() -> None:
     request = build_external_delivery_request(config, plan)
 
     assert request["voice_condition_mode"] == "instruct2_single_pass"
-    assert request["text"] == plan.render_text
+    assert plan.render_text != reply_text
+    assert request["text"] == reply_text
+    assert "[breath]" not in str(request["text"])
+    assert "<strong>" not in str(request["text"])
     assert request["instruct_text"].count("<|endofprompt|>") == 1
+    assert "natural silent breath before sentence 2" in str(request["instruct_text"])
+    assert "Gently emphasize sentence 1" in str(request["instruct_text"])
     assert request["performance_control_mode"] == "single_pass_llm_instruct"
     assert request["duration_target_seconds"] == [40.0, 50.0]
     assert request["max_attempts"] == 3
@@ -263,7 +268,7 @@ def test_external_worker_runs_one_whole_reply_instruct2_inference(
             "reference_audio": str(tmp_path / "reference.wav"),
             "voice_condition_mode": "instruct2_single_pass",
             "text": "one complete frozen reply",
-            "instruct_text": "steady reassurance<|endofprompt|>",
+            "instruct_text": "steady<|endofprompt|> reassurance<|endofprompt|>",
             "speed": 1.06,
             "duration_target_seconds": [40.0, 50.0],
             "max_attempts": 3,
@@ -320,6 +325,50 @@ def test_external_worker_rejects_runtime_without_pinned_instruct2_api(
             },
             tmp_path / "directed.wav",
         )
+
+
+def test_external_worker_rejects_frozen_text_with_model_control_token(tmp_path) -> None:
+    calls: list[object] = []
+
+    class Model:
+        sample_rate = 100
+
+        def inference_instruct2(self, *_args, **_kwargs):
+            calls.append("called")
+            return ()
+
+    with pytest.raises(RuntimeError, match="TTS_DIRECTED_TEXT_CONTAINS_CONTROL_TOKEN"):
+        external_cosyvoice_worker._synthesize_instruct2_single_pass(
+            Model(),
+            {
+                "reference_audio": str(tmp_path / "reference.wav"),
+                "text": "frozen reply <|endofprompt|>",
+                "instruct_text": "steady reassurance<|endofprompt|>",
+            },
+            tmp_path / "directed.wav",
+        )
+
+    assert calls == []
+
+
+def test_directed_request_rejects_frozen_text_with_model_control_token() -> None:
+    plan = VoicePerformancePlan(
+        reply_text="frozen reply <|endofprompt|>",
+        overall_emotion="steady reassurance",
+        global_speed=1.06,
+        energy=0.62,
+        breath_before_sentences=(),
+        emphasize_sentences=(),
+    )
+    config = SimpleNamespace(
+        runtime_root="runtime",
+        model_dir="model",
+        reference_audio="reference.wav",
+        fp16=True,
+    )
+
+    with pytest.raises(DeliveryAudioError, match="TTS_DIRECTED_TEXT_CONTAINS_CONTROL_TOKEN"):
+        build_external_delivery_request(config, plan)
 
 
 def test_directed_tts_provenance_and_human_acceptance_are_publicly_recorded() -> None:

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -21,6 +21,7 @@ from tts.delivery import (
     build_external_delivery_request,
     delivery_tempo_factor,
 )
+from voice_direction import VoicePerformancePlan, VoicePerformanceSegment
 
 
 def test_ordinary_video_copy_contract_targets_cross_lingual_delivery_length() -> None:
@@ -36,7 +37,7 @@ def test_ordinary_video_copy_contract_targets_cross_lingual_delivery_length() ->
     assert ordinary_video_reply_length_ok("林" * 201) is False
 
 
-def test_delivery_request_uses_audio_only_cross_lingual_conditioning() -> None:
+def test_delivery_request_uses_one_contextual_long_form_payload() -> None:
     config = SimpleNamespace(
         runtime_root="runtime",
         model_dir="model",
@@ -50,11 +51,52 @@ def test_delivery_request_uses_audio_only_cross_lingual_conditioning() -> None:
         plan_reply_delivery("第一句。第二句。"),
     )
 
-    assert request["voice_condition_mode"] == "cross_lingual_audio_only"
+    assert request["voice_condition_mode"] == "contextual_long_form"
     assert "reference_text" not in request
     assert "instruct_text" not in request
     assert request["blocks"] == ["第一句。第二句。"]
     assert request["seed"] == 200717
+    assert request["performance_control_mode"] == "single_pass_global"
+
+
+def test_llm_voice_plan_builds_one_non_spoken_instruct2_request() -> None:
+    reply_text = "I hear you. I will stay with you through this."
+    plan = VoicePerformancePlan(
+        reply_text=reply_text,
+        segments=(
+            VoicePerformanceSegment(
+                text=reply_text,
+                sentence_start=1,
+                sentence_end=2,
+                emotion="restrained empathy becoming steady reassurance",
+                intensity=0.62,
+                speed=1.06,
+                pause_after_seconds=0.0,
+                gain_db=0.1,
+            ),
+        ),
+        overall_emotion="restrained empathy becoming steady reassurance",
+        global_speed=1.06,
+        energy=0.62,
+        emphasize_sentences=(2,),
+    )
+    config = SimpleNamespace(
+        runtime_root="runtime",
+        model_dir="model",
+        reference_audio="reference.wav",
+        fp16=True,
+    )
+
+    request = build_external_delivery_request(config, plan)
+
+    assert request["voice_condition_mode"] == "instruct2_single_pass"
+    assert request["text"] == plan.render_text
+    assert request["instruct_text"].count("<|endofprompt|>") == 1
+    assert request["performance_control_mode"] == "single_pass_llm_instruct"
+    assert request["duration_target_seconds"] == [40.0, 50.0]
+    assert request["max_attempts"] == 3
+    assert "blocks" not in request
+    assert "reference_text" not in request
 
 
 def test_delivery_tempo_allows_only_modest_whole_utterance_fit() -> None:
@@ -173,3 +215,85 @@ def test_external_worker_renders_blocks_with_one_cross_lingual_model_load(
     }
     with wave.open(str(output), "rb") as rendered:
         assert rendered.getnframes() == 190
+
+
+def test_external_worker_runs_one_whole_reply_instruct2_inference(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    calls = {"loads": 0, "inference": []}
+
+    class Tensor:
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def float(self):
+            return self
+
+        def reshape(self, *_shape):
+            return self
+
+        def tolist(self):
+            return [0.05] * 4200
+
+    class AutoModel:
+        sample_rate = 100
+
+        def __init__(self, **_kwargs):
+            calls["loads"] += 1
+
+        def inference_instruct2(self, text, instruction, reference_audio, **kwargs):
+            calls["inference"].append((text, instruction, reference_audio, kwargs))
+            yield {"tts_speech": Tensor()}
+
+    cosyvoice = ModuleType("cosyvoice")
+    cli = ModuleType("cosyvoice.cli")
+    module = ModuleType("cosyvoice.cli.cosyvoice")
+    module.AutoModel = AutoModel
+    torch = ModuleType("torch")
+    torch.manual_seed = lambda _value: None
+    torch.cuda = SimpleNamespace(is_available=lambda: False)
+    numpy = ModuleType("numpy")
+    numpy.random = SimpleNamespace(seed=lambda _value: None)
+    monkeypatch.setitem(sys.modules, "cosyvoice", cosyvoice)
+    monkeypatch.setitem(sys.modules, "cosyvoice.cli", cli)
+    monkeypatch.setitem(sys.modules, "cosyvoice.cli.cosyvoice", module)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "numpy", numpy)
+    output = tmp_path / "directed.wav"
+
+    external_cosyvoice_worker._synthesize(
+        {
+            "runtime_root": str(tmp_path),
+            "model_dir": str(tmp_path),
+            "reference_audio": str(tmp_path / "reference.wav"),
+            "voice_condition_mode": "instruct2_single_pass",
+            "text": "one complete frozen reply",
+            "instruct_text": "steady reassurance<|endofprompt|>",
+            "speed": 1.06,
+            "duration_target_seconds": [40.0, 50.0],
+            "max_attempts": 3,
+            "seed": 200717,
+        },
+        output,
+    )
+
+    assert calls["loads"] == 1
+    assert calls["inference"] == [
+        (
+            "one complete frozen reply",
+            "steady reassurance<|endofprompt|>",
+            str(tmp_path / "reference.wav"),
+            {
+                "zero_shot_spk_id": "",
+                "stream": False,
+                "speed": 1.06,
+                "text_frontend": False,
+            },
+        )
+    ]
+    with wave.open(str(output), "rb") as rendered:
+        assert rendered.getnframes() == 4200

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -21,6 +21,9 @@ class DeliveryAudioError(RuntimeError):
     """Stable ordinary-reply audio rendering failure."""
 
 
+_END_OF_PROMPT_TOKEN = "<|endofprompt|>"
+
+
 @dataclass(frozen=True)
 class DeliveryAudioResult:
     duration_seconds: float
@@ -46,6 +49,29 @@ def validate_delivery_duration(duration_seconds: float) -> None:
         raise DeliveryAudioError("TTS_DELIVERY_DURATION_OUT_OF_RANGE")
 
 
+def _normalized_instruct_text(value: str) -> str:
+    """Leave the model control token exclusively at the instruction tail."""
+
+    return value.replace(_END_OF_PROMPT_TOKEN, "").rstrip() + _END_OF_PROMPT_TOKEN
+
+
+def _directed_instruct_text(plan: object, *, emotion: str, speed: float, energy: float) -> str:
+    """Express optional sparse direction in CosyVoice's non-spoken channel."""
+
+    parts = [
+        "You are a helpful assistant.",
+        f"Deliver this complete reply with {emotion}.",
+        f"Keep one continuous performance at energy {energy:.2f} and pace {speed:.2f}.",
+    ]
+    breaths = tuple(getattr(plan, "breath_before_sentences", ()) or ())
+    emphasis = tuple(getattr(plan, "emphasize_sentences", ()) or ())
+    if breaths:
+        parts.append("Take a natural silent breath before sentence " + ", ".join(map(str, breaths)) + ".")
+    if emphasis:
+        parts.append("Gently emphasize sentence " + ", ".join(map(str, emphasis)) + ".")
+    return _normalized_instruct_text(" ".join(parts))
+
+
 def build_external_delivery_request(
     config: TTSConfig,
     plan: ReplyDeliveryPlan | object,
@@ -54,7 +80,8 @@ def build_external_delivery_request(
 
     units = tuple(plan.speech_units())
     spoken_text = str(getattr(plan, "spoken_text", "") or "".join(unit.text for unit in units))
-    render_text = str(getattr(plan, "render_text", "") or spoken_text)
+    if _END_OF_PROMPT_TOKEN in spoken_text:
+        raise DeliveryAudioError("TTS_DIRECTED_TEXT_CONTAINS_CONTROL_TOKEN")
     if len(units) == 1:
         speed = float(units[0].speed)
         gain_db = float(getattr(units[0], "gain_db", 0.0))
@@ -75,11 +102,12 @@ def build_external_delivery_request(
         return {
             **common,
             "voice_condition_mode": "instruct2_single_pass",
-            "text": render_text,
-            "instruct_text": (
-                "You are a helpful assistant. 请用"
-                + overall_emotion
-                + "表达这段回信。<|endofprompt|>"
+            "text": spoken_text,
+            "instruct_text": _directed_instruct_text(
+                plan,
+                emotion=overall_emotion,
+                speed=max(1.02, min(1.08, speed)),
+                energy=float(getattr(plan, "energy", 0.0)),
             ),
             "speed": max(1.02, min(1.08, speed)),
             "gain_db": max(-0.75, min(0.75, gain_db)),
@@ -92,7 +120,7 @@ def build_external_delivery_request(
     return {
         **common,
         "voice_condition_mode": "contextual_long_form",
-        "blocks": [render_text],
+        "blocks": [spoken_text],
         "block_controls": [
             {
                 "speed": max(0.96, min(1.15, speed)),

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -48,20 +48,63 @@ def validate_delivery_duration(duration_seconds: float) -> None:
 
 def build_external_delivery_request(
     config: TTSConfig,
-    plan: ReplyDeliveryPlan,
+    plan: ReplyDeliveryPlan | object,
 ) -> dict[str, object]:
-    """Keep delivery control separate from the one continuous spoken payload."""
+    """Render the frozen reply in one inference so the voice never resets."""
 
-    return {
+    units = tuple(plan.speech_units())
+    spoken_text = str(getattr(plan, "spoken_text", "") or "".join(unit.text for unit in units))
+    render_text = str(getattr(plan, "render_text", "") or spoken_text)
+    if len(units) == 1:
+        speed = float(units[0].speed)
+        gain_db = float(getattr(units[0], "gain_db", 0.0))
+    else:
+        total_chars = max(1, sum(len(unit.text) for unit in units))
+        speed = sum(len(unit.text) * float(unit.speed) for unit in units) / total_chars
+        gain_db = sum(
+            len(unit.text) * float(getattr(unit, "gain_db", 0.0)) for unit in units
+        ) / total_chars
+    common: dict[str, object] = {
         "runtime_root": config.runtime_root,
         "model_dir": config.model_dir,
         "reference_audio": config.reference_audio,
         "fp16": bool(config.fp16),
-        "voice_condition_mode": "cross_lingual_audio_only",
-        "blocks": [unit.text for unit in plan.speech_units()],
-        "speed": 1.0,
+    }
+    overall_emotion = str(getattr(plan, "overall_emotion", "") or "").strip()
+    if overall_emotion:
+        return {
+            **common,
+            "voice_condition_mode": "instruct2_single_pass",
+            "text": render_text,
+            "instruct_text": (
+                "You are a helpful assistant. 请用"
+                + overall_emotion
+                + "表达这段回信。<|endofprompt|>"
+            ),
+            "speed": max(1.02, min(1.08, speed)),
+            "gain_db": max(-0.75, min(0.75, gain_db)),
+            "duration_target_seconds": [40.0, 50.0],
+            "max_attempts": 3,
+            "seed": 200717,
+            "performance_control_mode": "single_pass_llm_instruct",
+            "director_segment_count": len(getattr(plan, "cues", units)),
+        }
+    return {
+        **common,
+        "voice_condition_mode": "contextual_long_form",
+        "blocks": [render_text],
+        "block_controls": [
+            {
+                "speed": max(0.96, min(1.15, speed)),
+                "pause_after_seconds": 0.0,
+                "gain_db": max(-1.5, min(1.5, gain_db)),
+            }
+        ],
+        "speed": max(0.96, min(1.15, speed)),
         "cross_fade_seconds": 0.08,
         "seed": 200717,
+        "performance_control_mode": "single_pass_global",
+        "director_segment_count": len(getattr(plan, "cues", units)),
     }
 
 
@@ -140,7 +183,7 @@ def delivery_configured(config: TTSConfig) -> bool:
 
 def render_delivery_wav(
     config: TTSConfig,
-    plan: ReplyDeliveryPlan,
+    plan: ReplyDeliveryPlan | object,
     output_path: Path,
     *,
     timeout_seconds: float = 3600.0,

--- a/tts/external_cosyvoice_worker.py
+++ b/tts/external_cosyvoice_worker.py
@@ -17,6 +17,9 @@ from array import array
 from pathlib import Path
 
 
+_END_OF_PROMPT_TOKEN = "<|endofprompt|>"
+
+
 def _write_wav(path: Path, sample_rate: int, samples: list[float]) -> None:
     pcm = array("h", (max(-32768, min(32767, round(value * 32767.0))) for value in samples))
     if sys.byteorder != "little":
@@ -68,8 +71,10 @@ def _synthesize_instruct2_single_pass(model, request: dict[str, object], output:
     instruction = str(request.get("instruct_text", "")).strip()
     if not text.strip() or not instruction:
         raise RuntimeError("single-pass text or instruction missing")
-    instruction = instruction.replace("<|endofprompt|>", "").rstrip()
-    instruction += "<|endofprompt|>"
+    if _END_OF_PROMPT_TOKEN in text:
+        raise RuntimeError("TTS_DIRECTED_TEXT_CONTAINS_CONTROL_TOKEN")
+    instruction = instruction.replace(_END_OF_PROMPT_TOKEN, "").rstrip()
+    instruction += _END_OF_PROMPT_TOKEN
     speed = max(0.96, min(1.15, float(request.get("speed", 1.0))))
     gain_db = max(-0.75, min(0.75, float(request.get("gain_db", 0.0))))
     gain = 10.0 ** (gain_db / 20.0)

--- a/tts/external_cosyvoice_worker.py
+++ b/tts/external_cosyvoice_worker.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import random
 import sys
 import wave
 from array import array
@@ -27,67 +28,195 @@ def _write_wav(path: Path, sample_rate: int, samples: list[float]) -> None:
         target.writeframes(pcm.tobytes())
 
 
-def _append_with_cross_fade(
-    target: list[float],
-    block: list[float],
-    overlap: int,
-) -> None:
-    if not target or overlap <= 0:
-        target.extend(block)
-        return
-    count = min(overlap, len(target), len(block))
-    start = len(target) - count
-    for index in range(count):
-        weight = (index + 1) / (count + 1)
-        target[start + index] = (
-            target[start + index] * (1.0 - weight) + block[index] * weight
-        )
-    target.extend(block[count:])
-
-
 def _synthesize(request: dict[str, object], output: Path) -> None:
     runtime_root = Path(str(request["runtime_root"]))
     sys.path.insert(0, str(runtime_root))
     for key in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "MODELSCOPE_OFFLINE"):
         os.environ[key] = "1"
-    import torch
     from cosyvoice.cli.cosyvoice import AutoModel
 
-    torch.manual_seed(int(request.get("seed", 200717)))
     model = AutoModel(model_dir=str(request["model_dir"]), fp16=bool(request.get("fp16", True)))
-    prompt_prefix = "You are a helpful assistant.<|endofprompt|>"
-    raw_blocks = request.get("blocks")
-    if isinstance(raw_blocks, list) and raw_blocks:
-        blocks = [str(value).strip() for value in raw_blocks if str(value).strip()]
-    else:
-        text = str(request.get("text", "")).strip()
-        blocks = [text] if text else []
-    if not blocks:
-        raise RuntimeError("empty CosyVoice input")
+    if request.get("voice_condition_mode") == "instruct2_single_pass":
+        _synthesize_instruct2_single_pass(model, request, output)
+        return
+    if request.get("voice_condition_mode") == "contextual_long_form" or request.get("blocks"):
+        _synthesize_delivery(model, request, output)
+        return
+    prompt = "You are a helpful assistant.<|endofprompt|>" + str(request["reference_text"])
     samples: list[float] = []
-    cross_fade = max(0.0, min(0.5, float(request.get("cross_fade_seconds", 0.0))))
-    overlap = round(cross_fade * int(model.sample_rate))
-    for block in blocks:
-        block_samples: list[float] = []
-        for item in model.inference_cross_lingual(
-            prompt_prefix + block,
+    for item in model.inference_zero_shot(
+        str(request["text"]),
+        prompt,
+        str(request["reference_audio"]),
+        stream=bool(request.get("stream", True)),
+        speed=float(request.get("speed", 1.0)),
+    ):
+        speech = item.get("tts_speech") if isinstance(item, dict) else None
+        if speech is not None:
+            samples.extend(float(value) for value in speech.detach().cpu().float().reshape(-1).tolist())
+    if not samples:
+        raise RuntimeError("empty CosyVoice output")
+    _write_wav(output, int(model.sample_rate), samples)
+
+
+def _synthesize_instruct2_single_pass(model, request: dict[str, object], output: Path) -> None:
+    """Apply one LLM-chosen global style without placing it in spoken text."""
+
+    text = str(request.get("text", ""))
+    instruction = str(request.get("instruct_text", "")).strip()
+    if not text.strip() or not instruction:
+        raise RuntimeError("single-pass text or instruction missing")
+    instruction = instruction.replace("<|endofprompt|>", "").rstrip()
+    instruction += "<|endofprompt|>"
+    speed = max(0.96, min(1.15, float(request.get("speed", 1.0))))
+    gain_db = max(-0.75, min(0.75, float(request.get("gain_db", 0.0))))
+    gain = 10.0 ** (gain_db / 20.0)
+    raw_target = request.get("duration_target_seconds", [40.0, 50.0])
+    if not isinstance(raw_target, list) or len(raw_target) != 2:
+        raw_target = [40.0, 50.0]
+    target_min = max(1.0, float(raw_target[0]))
+    target_max = max(target_min, float(raw_target[1]))
+    max_attempts = max(1, min(3, int(request.get("max_attempts", 1))))
+    base_seed = int(request.get("seed", 200717))
+    best_samples: list[float] = []
+    best_distance = float("inf")
+
+    for attempt in range(max_attempts):
+        seed = base_seed + attempt
+        random.seed(seed)
+        try:
+            import numpy as np
+
+            np.random.seed(seed % (2**32))
+        except ImportError:
+            pass
+        try:
+            import torch
+
+            torch.manual_seed(seed)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(seed)
+        except ImportError:
+            pass
+
+        samples: list[float] = []
+        for item in model.inference_instruct2(
+            text,
+            instruction,
             str(request["reference_audio"]),
             zero_shot_spk_id="",
             stream=False,
-            speed=1.0,
+            speed=speed,
+            text_frontend=False,
+        ):
+            speech = item.get("tts_speech") if isinstance(item, dict) else None
+            if speech is not None:
+                samples.extend(
+                    float(value) * gain
+                    for value in speech.detach().cpu().float().reshape(-1).tolist()
+                )
+        if not samples:
+            continue
+        duration = len(samples) / int(model.sample_rate)
+        distance = max(target_min - duration, 0.0, duration - target_max)
+        if distance < best_distance:
+            best_samples = samples
+            best_distance = distance
+        if target_min <= duration <= target_max:
+            _write_wav(output, int(model.sample_rate), samples)
+            return
+    if not best_samples:
+        raise RuntimeError("empty CosyVoice single-pass output")
+    _write_wav(output, int(model.sample_rate), best_samples)
+
+
+def _cross_fade(chunks: list[list[float]], sample_rate: int, seconds: float) -> list[float]:
+    if not chunks:
+        return []
+    output = list(chunks[0])
+    requested = max(0, round(sample_rate * seconds))
+    for chunk in chunks[1:]:
+        overlap = min(requested, len(output), len(chunk))
+        if overlap <= 0:
+            output.extend(chunk)
+            continue
+        start = len(output) - overlap
+        denominator = max(1, overlap - 1)
+        for index in range(overlap):
+            weight = index / denominator
+            output[start + index] = output[start + index] * (1.0 - weight) + chunk[index] * weight
+        output.extend(chunk[overlap:])
+    return output
+
+
+def _synthesize_delivery(model, request: dict[str, object], output: Path) -> None:
+    """Use the maintained frontend for coherent blocks, then hide its joins."""
+
+    try:
+        import torch
+
+        torch.manual_seed(int(request.get("seed", 200717)))
+    except ImportError:
+        pass
+
+    raw_blocks = request.get("blocks")
+    if not isinstance(raw_blocks, list) or not raw_blocks:
+        raise RuntimeError("delivery blocks missing")
+    blocks = [str(block) for block in raw_blocks]
+    if any(not block.strip() for block in blocks):
+        raise RuntimeError("delivery block missing")
+    reference_audio = str(request["reference_audio"])
+    default_speed = max(0.96, min(1.15, float(request.get("speed", 1.0))))
+    raw_controls = request.get("block_controls")
+    controls = raw_controls if isinstance(raw_controls, list) else []
+    if controls and len(controls) != len(blocks):
+        raise RuntimeError("delivery block controls mismatch")
+    chunks: list[list[float]] = []
+    pauses: list[float] = []
+    for index, block in enumerate(blocks):
+        control = controls[index] if controls and isinstance(controls[index], dict) else {}
+        speed = max(0.96, min(1.15, float(control.get("speed", default_speed))))
+        pause = max(0.0, min(0.65, float(control.get("pause_after_seconds", 0.0))))
+        gain_db = max(-1.5, min(1.5, float(control.get("gain_db", 0.0))))
+        gain = 10.0 ** (gain_db / 20.0)
+        model_text = "You are a helpful assistant.<|endofprompt|>" + block
+        block_samples: list[float] = []
+        for item in model.inference_cross_lingual(
+            model_text,
+            reference_audio,
+            zero_shot_spk_id="",
+            stream=False,
+            speed=speed,
         ):
             speech = item.get("tts_speech") if isinstance(item, dict) else None
             if speech is not None:
                 block_samples.extend(
-                    float(value)
+                    float(value) * gain
                     for value in speech.detach().cpu().float().reshape(-1).tolist()
                 )
         if not block_samples:
-            raise RuntimeError("empty CosyVoice block output")
-        _append_with_cross_fade(samples, block_samples, overlap)
+            raise RuntimeError("empty CosyVoice delivery block")
+        chunks.append(block_samples)
+        pauses.append(pause)
+
+    sample_rate = int(model.sample_rate)
+    cross_fade_seconds = max(
+        0.0, min(0.25, float(request.get("cross_fade_seconds", 0.15)))
+    )
+    samples: list[float] = []
+    for index, chunk in enumerate(chunks):
+        if not samples:
+            samples.extend(chunk)
+        elif pauses[index - 1] > 0:
+            samples.extend([0.0] * round(sample_rate * pauses[index - 1]))
+            samples.extend(chunk)
+        else:
+            samples = _cross_fade([samples, chunk], sample_rate, cross_fade_seconds)
+    if pauses and pauses[-1] > 0:
+        samples.extend([0.0] * round(sample_rate * pauses[-1]))
     if not samples:
-        raise RuntimeError("empty CosyVoice output")
-    _write_wav(output, int(model.sample_rate), samples)
+        raise RuntimeError("empty CosyVoice delivery output")
+    _write_wav(output, sample_rate, samples)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tts/external_cosyvoice_worker.py
+++ b/tts/external_cosyvoice_worker.py
@@ -62,6 +62,8 @@ def _synthesize(request: dict[str, object], output: Path) -> None:
 def _synthesize_instruct2_single_pass(model, request: dict[str, object], output: Path) -> None:
     """Apply one LLM-chosen global style without placing it in spoken text."""
 
+    if not callable(getattr(model, "inference_instruct2", None)):
+        raise RuntimeError("COSYVOICE_INSTRUCT2_UNSUPPORTED")
     text = str(request.get("text", ""))
     instruction = str(request.get("instruct_text", "")).strip()
     if not text.strip() or not instruction:


### PR DESCRIPTION
## Scope
- convert a VoicePerformancePlan into one CosyVoice inference_instruct2 request
- keep spoken text and non-spoken acting instruction separate
- enforce one whole-utterance context, 40–50 second target, at most three full candidates
- preserve the existing contextual long-form fallback contract

## Validation
- python -m pytest -q tests/tts/test_delivery_contract.py tests/tts/test_voice_direction.py (12 passed)
- focused py_compile
- git diff --check

## Stack
Depends on PR #113. Media and HTTP wiring follow separately; no real TTS/model run is performed in this PR.