### PR TITLE
feat(media): apply LLM voice direction to video replies

### DIFF
--- a/local_server.py
+++ b/local_server.py
@@ -50,6 +50,11 @@ from music_reply import MusicReplyError, render_musical_reply, select_speaking_s
 from music_duration import MUSIC_DURATION_OPTIONS
 from reply_media import ReplyMediaError, render_reply_video
 from reply_delivery import build_ordinary_video_llm_content
+from voice_direction import (
+    VoiceDirectionError,
+    VoicePerformancePlan,
+    direct_voice_performance,
+)
 from local_memory import create_memory_adapter
 from memory_port import LegacyLetter, MemoryPort, NullMemoryPort
 from memory_prompt import MemoryPromptBuilder
@@ -496,6 +501,36 @@ reply_jobs: dict[str, asyncio.Task] = {}
 
 def _persist_media_state() -> None:
     _persist_store_state()
+
+
+async def _voice_plan_for_letter(
+    letter: dict,
+    reply_text: str,
+) -> VoicePerformancePlan:
+    """Direct the frozen reply once, then reuse its persisted performance plan."""
+
+    stored = letter.get("voice_performance_plan")
+    if isinstance(stored, dict):
+        try:
+            plan = VoicePerformancePlan.from_dict(stored)
+        except VoiceDirectionError:
+            pass
+        else:
+            if plan.reply_text == reply_text:
+                return plan
+    plan = await asyncio.wait_for(
+        direct_voice_performance(
+            reply_text,
+            letters_adapter.gateway,
+            request_id=f"{letter.get('letter_id', 'reply')}-voice-direction",
+        ),
+        timeout=LLM_TIMEOUT_SECONDS,
+    )
+    if plan.reply_text != reply_text:
+        raise VoiceDirectionError("VOICE_DIRECTION_TEXT_MISMATCH")
+    letter["voice_performance_plan"] = plan.to_dict()
+    _persist_media_state()
+    return plan
 music_adapter = MusicAdapter()
 reply_engine = ReplyOrchestrator(
     _LetterGateway(letters_adapter),
@@ -1596,6 +1631,7 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
             tts_config = Path(_os.environ.get("OLIVIA_TTS_CONFIG", ""))
             visual_config = Path(_os.environ.get("OLIVIA_VISUAL_CONFIG", ""))
             worker = Path(_os.environ.get("OLIVIA_LIVETALKING_WORKER", ""))
+            voice_plan = await _voice_plan_for_letter(letter, reply_text)
             if reply_mode == "musical_video":
                 music_duration_seconds = int(letter.get("music_duration_seconds", 60))
                 performance_scene = _current_music_performance(_os.environ)
@@ -1617,6 +1653,7 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
                     worker_path=worker,
                     performance_video_path=performance_scene,
                     duration_seconds=music_duration_seconds,
+                    voice_performance_plan=voice_plan,
                 )
             else:
                 from datetime import datetime
@@ -1637,12 +1674,21 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
                     latentsync_python_path=Path(_os.environ.get("OLIVIA_LATENTSYNC_PYTHON", "")),
                     latentsync_root=Path(_os.environ.get("OLIVIA_LATENTSYNC_ROOT", "")),
                     adaptive_delivery=True,
+                    voice_performance_plan=voice_plan,
                 )
             letter["reply_video_url"] = f"http://127.0.0.1:{PORT}/toy/media/{output_path.name}"
             letter["media_status"] = "COMPLETED"
             letter["media_error_code"] = None
             _persist_media_state()
-        except (ReplyMediaError, MusicReplyError, ValueError, OSError) as exc:
+        except (
+            ReplyMediaError,
+            MusicReplyError,
+            VoiceDirectionError,
+            GatewayError,
+            asyncio.TimeoutError,
+            ValueError,
+            OSError,
+        ) as exc:
             letter["media_status"] = "UNAVAILABLE"
             letter["media_error_code"] = str(exc)[:80] or "MEDIA_PROVIDER_UNAVAILABLE"
             _persist_media_state()

--- a/local_server.py
+++ b/local_server.py
@@ -497,6 +497,7 @@ media_semaphore = asyncio.Semaphore(1)
 media_tasks: set[asyncio.Task] = set()
 reply_tasks: set[asyncio.Task] = set()
 reply_jobs: dict[str, asyncio.Task] = {}
+media_jobs: dict[str, asyncio.Task] = {}
 
 
 def _persist_media_state() -> None:
@@ -509,20 +510,35 @@ async def _voice_plan_for_letter(
 ) -> VoicePerformancePlan:
     """Direct the frozen reply once, then reuse its persisted performance plan."""
 
-    stored = letter.get("voice_performance_plan")
-    if isinstance(stored, dict):
+    if "voice_performance_plan" in letter:
+        stored = letter.get("voice_performance_plan")
+        if not isinstance(stored, dict):
+            raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_PLAN_INVALID")
         try:
             plan = VoicePerformancePlan.from_dict(stored)
         except VoiceDirectionError:
-            pass
-        else:
-            if plan.reply_text == reply_text:
-                return plan
+            raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_PLAN_INVALID") from None
+        if plan.reply_text != reply_text:
+            raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_PLAN_INVALID")
+        return plan
+
+    letter_id = str(letter.get("letter_id", "")).strip()
+    if not letter_id:
+        raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_REQUEST_INVALID")
+    request_id = f"letter-reply:{letter_id}:voice-direction"
+    persisted_request_id = letter.get("voice_direction_request_id")
+    if persisted_request_id is not None and persisted_request_id != request_id:
+        raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_REQUEST_INVALID")
+    if persisted_request_id is None:
+        # Commit the provider idempotency key before issuing the paid call, so a
+        # restart in the provider-success/persistence window uses the same key.
+        letter["voice_direction_request_id"] = request_id
+        _persist_media_state()
     plan = await asyncio.wait_for(
         direct_voice_performance(
             reply_text,
             letters_adapter.gateway,
-            request_id=f"{letter.get('letter_id', 'reply')}-voice-direction",
+            request_id=request_id,
         ),
         timeout=LLM_TIMEOUT_SECONDS,
     )
@@ -1695,9 +1711,19 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
 
 
 def _schedule_media_job(letter_id: str, content: str, reply_text: str, reply_mode: str) -> None:
+    active = media_jobs.get(letter_id)
+    if active is not None and not active.done():
+        return
     task = asyncio.create_task(_render_media_job(letter_id, content, reply_text, reply_mode))
     media_tasks.add(task)
-    task.add_done_callback(media_tasks.discard)
+    media_jobs[letter_id] = task
+
+    def discard(completed: asyncio.Task) -> None:
+        media_tasks.discard(completed)
+        if media_jobs.get(letter_id) is completed:
+            media_jobs.pop(letter_id, None)
+
+    task.add_done_callback(discard)
 
 
 async def _run_reply_job(
@@ -1786,16 +1812,51 @@ def _schedule_pending_reply_jobs() -> int:
     return scheduled
 
 
+def _schedule_pending_media_jobs() -> int:
+    """Resume only durable completed replies whose media render was interrupted."""
+
+    scheduled = 0
+    for letter in tuple(store.letters):
+        if letter.get("media_status") not in {"PENDING", "QUEUED"}:
+            continue
+        if letter.get("letter_status") != "COMPLETED":
+            continue
+        letter_id = str(letter.get("letter_id", "")).strip()
+        content = letter.get("content")
+        reply_text = letter.get("reply_text")
+        reply_mode = _exact_reply_mode(letter.get("reply_mode"))
+        if (
+            not letter_id
+            or not isinstance(content, str)
+            or not content.strip()
+            or not isinstance(reply_text, str)
+            or not reply_text.strip()
+            or reply_mode not in {ReplyMode.SPOKEN_VIDEO.value, ReplyMode.MUSICAL_VIDEO.value}
+        ):
+            continue
+        active = media_jobs.get(letter_id)
+        if active is not None and not active.done():
+            continue
+        _schedule_media_job(letter_id, content, reply_text, reply_mode)
+        scheduled += 1
+    return scheduled
+
+
 async def _start_reply_tasks(_app: web.Application) -> None:
     _schedule_pending_reply_jobs()
+    _schedule_pending_media_jobs()
 
 
 async def _stop_reply_tasks(_app: web.Application) -> None:
-    tasks = tuple(reply_tasks)
+    tasks = tuple(reply_tasks | media_tasks)
     for task in tasks:
         task.cancel()
     if tasks:
         await asyncio.gather(*tasks, return_exceptions=True)
+    reply_tasks.clear()
+    media_tasks.clear()
+    reply_jobs.clear()
+    media_jobs.clear()
 
 
 def install_reply_task_lifecycle(app: web.Application) -> None:
@@ -1875,12 +1936,6 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
     _persist_store_state()
     decision = await emotion_triage.classify(content)
     exact_mode = _exact_reply_mode(decision.reply_mode)
-    if exact_mode == ReplyMode.SPOKEN_VIDEO.value:
-        # A product video reply is one complete letter: spoken response,
-        # original transition, then the generated performance.  The router may
-        # still express that voice is the reason video is warranted, but there
-        # is no standalone spoken-only delivery surface.
-        exact_mode = ReplyMode.MUSICAL_VIDEO.value
     letter["triage"] = decision.to_dict()
     letter["reply_mode"] = exact_mode
     if exact_mode in {
@@ -1956,6 +2011,7 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
         ReplyMode.MUSICAL_VIDEO.value,
     }:
         letter["media_status"] = "PENDING"
+        _persist_media_state()
         _schedule_media_job(letter_id, content, result.text, exact_mode)
 
     letters_adapter.remember_conversation(content, result.text)

--- a/music_reply.py
+++ b/music_reply.py
@@ -27,6 +27,7 @@ from reply_media import (
     render_reply_video,
 )
 from song_content import plan_song_content
+from voice_direction import VoicePerformancePlan
 
 
 _MINIMAX_WORKER_TIMEOUT_SECONDS = 7500.0
@@ -680,6 +681,7 @@ def _build_music_stage_manifest(
     worker_path: Path,
     minimax_worker_path: Path,
     minimax_root: Path,
+    voice_performance_plan: VoicePerformancePlan | None,
 ) -> dict[str, object]:
     """Bind resumable stages to canonical text, inputs, and provider revisions."""
 
@@ -701,6 +703,13 @@ def _build_music_stage_manifest(
                 str(song_plan.caption).encode("utf-8")
             ).hexdigest(),
             "duration_seconds": duration_seconds,
+            "voice_performance_sha256": hashlib.sha256(
+                json.dumps(
+                    voice_performance_plan.to_dict() if voice_performance_plan else None,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                ).encode("utf-8")
+            ).hexdigest(),
         },
         "assets": {
             "official_reply_reference": _file_fingerprint(official_reply_reference_path),
@@ -855,6 +864,7 @@ def render_musical_reply(
     worker_path: Path,
     performance_video_path: Path,
     duration_seconds: int,
+    voice_performance_plan: VoicePerformancePlan | None = None,
 ) -> dict[str, object]:
     """Render the ordinary reply, append an original-view song performance."""
 
@@ -888,6 +898,7 @@ def render_musical_reply(
         worker_path=worker_path,
         minimax_worker_path=Path(minimax_worker),
         minimax_root=Path(minimax_root),
+        voice_performance_plan=voice_performance_plan,
     )
     try:
         existing_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -924,6 +935,7 @@ def render_musical_reply(
             latentsync_python_path=Path(os.environ.get("OLIVIA_LATENTSYNC_PYTHON", "")),
             latentsync_root=Path(os.environ.get("OLIVIA_LATENTSYNC_ROOT", "")),
             adaptive_delivery=True,
+            voice_performance_plan=voice_performance_plan,
         )
         _record_stage(
             manifest,

--- a/reply_media.py
+++ b/reply_media.py
@@ -16,6 +16,7 @@ from typing import Mapping
 
 from latentsync_reply import LatentSyncReplyError, media_runtime_available, render_latentsync_video, resolve_ffmpeg_executable
 from reply_delivery import ReplyDeliveryPlan, plan_reply_delivery
+from voice_direction import VoicePerformancePlan
 try:
     from runtime.visual.livetalking import LiveTalkingConfig, capture_candidate_frames
 except ImportError:  # Optional visual provider is not part of the portable patch.
@@ -228,6 +229,7 @@ def render_reply_video(
     latentsync_python_path: Path | None = None,
     latentsync_root: Path | None = None,
     adaptive_delivery: bool = False,
+    voice_performance_plan: VoicePerformancePlan | None = None,
 ) -> dict[str, object]:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="olivia-reply-", dir=output_path.parent) as temporary:
@@ -237,9 +239,11 @@ def render_reply_video(
         )
         audio_path = root / "reply.wav"
         frames = root / "frames"
-        delivery_plan: ReplyDeliveryPlan | None = None
+        delivery_plan: ReplyDeliveryPlan | VoicePerformancePlan | None = None
         if adaptive_delivery:
-            delivery_plan = plan_reply_delivery(text)
+            delivery_plan = voice_performance_plan or plan_reply_delivery(text)
+            if delivery_plan.spoken_text != text:
+                raise ReplyMediaError("VOICE_DIRECTION_TEXT_MISMATCH")
             try:
                 delivery_result = render_delivery_wav(
                     delivery.tts,
@@ -269,8 +273,14 @@ def render_reply_video(
         delivery_metadata = (
             {
                 "delivery_plan": delivery_plan.to_dict(),
-                "delivery_block_grouping_applied_to_audio": True,
-                "delivery_cue_controls_applied_to_audio": False,
+                "delivery_plan_applied_to_audio": True,
+                "delivery_audio_mode": "single_pass_continuous",
+                "per_segment_audio_controls_applied": False,
+                "voice_emotion_control": (
+                    "llm_global_instruct2"
+                    if isinstance(delivery_plan, VoicePerformancePlan)
+                    else "legacy_global_pace"
+                ),
                 # LatentSync derives the face performance from the paced audio
                 # while the accepted original-motion video keeps body/scene motion.
                 "visual_cues_backend_control": False,

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -4,13 +4,14 @@ import asyncio
 from pathlib import Path
 
 import pytest
+from aiohttp import web
 
 import local_server
 from letter_triage import TriageResult
 from reply_context import ReplyMode
 from reply_orchestrator import ReplyState
 from reply_pipeline import PipelineResult
-from voice_direction import VoicePerformancePlan, VoicePerformanceSegment
+from voice_direction import VoiceDirectionError, VoicePerformancePlan, VoicePerformanceSegment
 
 
 def test_text_delay_records_deadline_without_blocking(monkeypatch):
@@ -199,11 +200,148 @@ def test_both_product_video_renderers_receive_the_persisted_llm_voice_plan(
 
     assert received == {"spoken_video": plan, "musical_video": plan}
     assert directed_requests == [
-        "spoken-entry-voice-direction",
-        "musical-entry-voice-direction",
+        "letter-reply:spoken-entry:voice-direction",
+        "letter-reply:musical-entry:voice-direction",
     ]
     assert letters[0]["voice_performance_plan"] == plan.to_dict()
     assert letters[1]["voice_performance_plan"] == plan.to_dict()
+
+
+def test_corrupt_persisted_voice_plan_fails_closed_without_redirection(monkeypatch):
+    letter = {
+        "letter_id": "corrupt-plan",
+        "voice_performance_plan": {"reply_text": "frozen reply"},
+    }
+    provider_calls = []
+
+    async def direct(_text, _gateway, *, request_id=None):
+        provider_calls.append(request_id)
+        raise AssertionError("corrupt state must not call the voice provider")
+
+    monkeypatch.setattr(local_server, "direct_voice_performance", direct)
+
+    with pytest.raises(VoiceDirectionError, match="VOICE_DIRECTION_PERSISTED_PLAN_INVALID"):
+        asyncio.run(local_server._voice_plan_for_letter(letter, "frozen reply"))
+
+    assert provider_calls == []
+
+
+def test_voice_direction_retries_keep_a_persisted_provider_idempotency_key(monkeypatch):
+    reply_text = "This reply is frozen before voice direction."
+    request_id = "letter-reply:durable-direction:voice-direction"
+    letter = {"letter_id": "durable-direction"}
+    provider_calls = []
+    persisted_request_ids = []
+    plan = VoicePerformancePlan(
+        reply_text=reply_text,
+        segments=(
+            VoicePerformanceSegment(
+                text=reply_text,
+                sentence_start=1,
+                sentence_end=1,
+                emotion="steady reassurance",
+                intensity=0.5,
+                speed=1.06,
+                pause_after_seconds=0.0,
+                gain_db=0.0,
+            ),
+        ),
+    )
+
+    def persist():
+        persisted_request_ids.append(letter.get("voice_direction_request_id"))
+
+    async def direct(_text, _gateway, *, request_id=None):
+        provider_calls.append(request_id)
+        assert letter["voice_direction_request_id"] == request_id
+        if len(provider_calls) == 1:
+            raise asyncio.CancelledError()
+        return plan
+
+    monkeypatch.setattr(local_server, "_persist_media_state", persist)
+    monkeypatch.setattr(local_server, "direct_voice_performance", direct)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(local_server._voice_plan_for_letter(letter, reply_text))
+    assert persisted_request_ids == [request_id]
+    assert provider_calls == [request_id]
+
+    assert asyncio.run(local_server._voice_plan_for_letter(letter, reply_text)) == plan
+    assert asyncio.run(local_server._voice_plan_for_letter(letter, reply_text)) == plan
+    assert provider_calls == [request_id, request_id]
+    assert letter["voice_performance_plan"] == plan.to_dict()
+
+
+def test_startup_resumes_only_valid_pending_or_interrupted_media_jobs(monkeypatch):
+    local_server.store.letters[:] = [
+        {
+            "letter_id": "resume-spoken",
+            "content": "saved letter",
+            "reply_text": "saved reply",
+            "reply_mode": ReplyMode.SPOKEN_VIDEO.value,
+            "letter_status": "COMPLETED",
+            "media_status": "PENDING",
+        },
+        {
+            "letter_id": "resume-musical",
+            "content": "saved musical letter",
+            "reply_text": "saved musical reply",
+            "reply_mode": ReplyMode.MUSICAL_VIDEO.value,
+            "letter_status": "COMPLETED",
+            "media_status": "QUEUED",
+        },
+        {
+            "letter_id": "not-video",
+            "content": "saved text letter",
+            "reply_text": "saved text reply",
+            "reply_mode": ReplyMode.TEXT_LETTER.value,
+            "letter_status": "COMPLETED",
+            "media_status": "PENDING",
+        },
+        {
+            "letter_id": "not-complete",
+            "content": "incomplete letter",
+            "reply_text": "",
+            "reply_mode": ReplyMode.SPOKEN_VIDEO.value,
+            "letter_status": "PENDING",
+            "media_status": "QUEUED",
+        },
+    ]
+    scheduled = []
+    monkeypatch.setattr(local_server, "_schedule_pending_reply_jobs", lambda: 0)
+    monkeypatch.setattr(
+        local_server,
+        "_schedule_media_job",
+        lambda letter_id, content, reply_text, mode: scheduled.append(
+            (letter_id, content, reply_text, mode)
+        ),
+    )
+
+    asyncio.run(local_server._start_reply_tasks(web.Application()))
+
+    assert scheduled == [
+        ("resume-spoken", "saved letter", "saved reply", ReplyMode.SPOKEN_VIDEO.value),
+        ("resume-musical", "saved musical letter", "saved musical reply", ReplyMode.MUSICAL_VIDEO.value),
+    ]
+
+
+def test_shutdown_cancels_and_releases_owned_media_jobs():
+    async def exercise() -> bool:
+        waiting = asyncio.Event()
+
+        async def media_job():
+            await waiting.wait()
+
+        task = asyncio.create_task(media_job())
+        local_server.media_tasks.add(task)
+        local_server.media_jobs["cleanup-media"] = task
+        await asyncio.sleep(0)
+        await local_server._stop_reply_tasks(web.Application())
+        return task.cancelled()
+
+    assert asyncio.run(exercise())
+    assert local_server.media_tasks == set()
+    assert local_server.media_jobs == {}
 
 
 def test_reply_pipeline_total_timeout_covers_all_quality_stages(monkeypatch):
@@ -242,8 +380,8 @@ def test_reply_pipeline_total_timeout_covers_all_quality_stages(monkeypatch):
                 direct_response_sufficient=True,
                 voice_materially_better=True,
             ),
-            ReplyMode.MUSICAL_VIDEO.value,
-            (ReplyMode.MUSICAL_VIDEO.value,),
+            ReplyMode.SPOKEN_VIDEO.value,
+            (ReplyMode.SPOKEN_VIDEO.value,),
         ),
         (
             ReplyMode.MUSICAL_VIDEO.value,
@@ -264,7 +402,7 @@ def test_reply_pipeline_total_timeout_covers_all_quality_stages(monkeypatch):
         ),
     ),
 )
-def test_generate_reply_delivers_every_video_route_as_spoken_transition_and_music(
+def test_generate_reply_preserves_the_router_selected_video_route(
     monkeypatch,
     routed_mode,
     decision,

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -10,6 +10,7 @@ from letter_triage import TriageResult
 from reply_context import ReplyMode
 from reply_orchestrator import ReplyState
 from reply_pipeline import PipelineResult
+from voice_direction import VoicePerformancePlan, VoicePerformanceSegment
 
 
 def test_text_delay_records_deadline_without_blocking(monkeypatch):
@@ -71,12 +72,30 @@ def test_successful_media_retry_clears_the_previous_failure_code(
     monkeypatch.setattr(local_server, "_persist_media_state", lambda: None)
     observed = {}
 
+    async def voice_plan(_letter, text):
+        return VoicePerformancePlan(
+            reply_text=text,
+            segments=(
+                VoicePerformanceSegment(
+                    text=text,
+                    sentence_start=1,
+                    sentence_end=1,
+                    emotion="steady",
+                    intensity=0.5,
+                    speed=1.06,
+                    pause_after_seconds=0.0,
+                    gain_db=0.0,
+                ),
+            ),
+        )
+
     def render(_content, _reply, output, **kwargs):
         observed.update(kwargs)
         Path(output).write_bytes(b"final-video")
         return {}
 
     monkeypatch.setattr(local_server, "render_musical_reply", render)
+    monkeypatch.setattr(local_server, "_voice_plan_for_letter", voice_plan)
 
     asyncio.run(
         local_server._render_media_job(
@@ -91,6 +110,100 @@ def test_successful_media_retry_clears_the_previous_failure_code(
     assert "normal_scene_path" not in observed
     assert observed["normal_video_path"].name.endswith("-official-spoken-v1.mp4")
     assert observed["song_video_path"].name.endswith("-song-v2-60s.mp4")
+
+
+def test_both_product_video_renderers_receive_the_persisted_llm_voice_plan(
+    tmp_path: Path,
+    monkeypatch,
+):
+    reply_text = "I hear you, and I am staying with you through this."
+    plan = VoicePerformancePlan(
+        reply_text=reply_text,
+        segments=(
+            VoicePerformanceSegment(
+                text=reply_text,
+                sentence_start=1,
+                sentence_end=1,
+                emotion="restrained empathy becoming steady reassurance",
+                intensity=0.62,
+                speed=1.06,
+                pause_after_seconds=0.0,
+                gain_db=0.1,
+            ),
+        ),
+        overall_emotion="restrained empathy becoming steady reassurance",
+        global_speed=1.06,
+        energy=0.62,
+        emphasize_sentences=(1,),
+    )
+    scene = tmp_path / "scene.mp4"
+    scene.write_bytes(b"scene")
+    official = tmp_path / "official.mp4"
+    official.write_bytes(b"official")
+    letters = [
+        {
+            "letter_id": "spoken-entry",
+            "content": "ordinary video request",
+            "reply_text": reply_text,
+            "reply_mode": "spoken_video",
+        },
+        {
+            "letter_id": "musical-entry",
+            "content": "spoken plus music request",
+            "reply_text": reply_text,
+            "reply_mode": "musical_video",
+            "music_duration_seconds": 60,
+        },
+    ]
+    local_server.store.letters[:] = letters
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path / "data"))
+    monkeypatch.setenv("OLIVIA_OFFICIAL_REPLY_REFERENCE", str(official))
+    for key in ("MORNING", "DAY", "DUSK", "NIGHT"):
+        monkeypatch.setenv(f"OLIVIA_SCENE_{key}", str(scene))
+        monkeypatch.setenv(f"OLIVIA_MUSIC_SCENE_{key}", str(scene))
+    monkeypatch.setattr(local_server, "_persist_media_state", lambda: None)
+
+    directed_requests = []
+
+    async def direct_frozen_reply(text, gateway, *, request_id=None):
+        assert text == reply_text
+        assert gateway is local_server.letters_adapter.gateway
+        directed_requests.append(request_id)
+        return plan
+
+    received = {}
+
+    def render_spoken(_text, output, **kwargs):
+        received["spoken_video"] = kwargs["voice_performance_plan"]
+        Path(output).write_bytes(b"spoken")
+        return {}
+
+    def render_musical(_content, _text, output, **kwargs):
+        received["musical_video"] = kwargs["voice_performance_plan"]
+        Path(output).write_bytes(b"musical")
+        return {}
+
+    monkeypatch.setattr(local_server, "direct_voice_performance", direct_frozen_reply)
+    monkeypatch.setattr(local_server, "render_reply_video", render_spoken)
+    monkeypatch.setattr(local_server, "render_musical_reply", render_musical)
+
+    async def exercise():
+        await local_server._render_media_job(
+            "spoken-entry", "ordinary video request", reply_text, "spoken_video"
+        )
+        await local_server._render_media_job(
+            "musical-entry", "spoken plus music request", reply_text, "musical_video"
+        )
+
+    asyncio.run(exercise())
+
+    assert received == {"spoken_video": plan, "musical_video": plan}
+    assert directed_requests == [
+        "spoken-entry-voice-direction",
+        "musical-entry-voice-direction",
+    ]
+    assert letters[0]["voice_performance_plan"] == plan.to_dict()
+    assert letters[1]["voice_performance_plan"] == plan.to_dict()
 
 
 def test_reply_pipeline_total_timeout_covers_all_quality_stages(monkeypatch):

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -11,7 +11,7 @@ from letter_triage import TriageResult
 from reply_context import ReplyMode
 from reply_orchestrator import ReplyState
 from reply_pipeline import PipelineResult
-from voice_direction import VoiceDirectionError, VoicePerformancePlan, VoicePerformanceSegment
+from voice_direction import VoiceDirectionError, VoicePerformancePlan
 
 
 def test_text_delay_records_deadline_without_blocking(monkeypatch):
@@ -76,18 +76,11 @@ def test_successful_media_retry_clears_the_previous_failure_code(
     async def voice_plan(_letter, text):
         return VoicePerformancePlan(
             reply_text=text,
-            segments=(
-                VoicePerformanceSegment(
-                    text=text,
-                    sentence_start=1,
-                    sentence_end=1,
-                    emotion="steady",
-                    intensity=0.5,
-                    speed=1.06,
-                    pause_after_seconds=0.0,
-                    gain_db=0.0,
-                ),
-            ),
+            overall_emotion="steady",
+            global_speed=1.06,
+            energy=0.5,
+            breath_before_sentences=(),
+            emphasize_sentences=(),
         )
 
     def render(_content, _reply, output, **kwargs):
@@ -120,21 +113,10 @@ def test_both_product_video_renderers_receive_the_persisted_llm_voice_plan(
     reply_text = "I hear you, and I am staying with you through this."
     plan = VoicePerformancePlan(
         reply_text=reply_text,
-        segments=(
-            VoicePerformanceSegment(
-                text=reply_text,
-                sentence_start=1,
-                sentence_end=1,
-                emotion="restrained empathy becoming steady reassurance",
-                intensity=0.62,
-                speed=1.06,
-                pause_after_seconds=0.0,
-                gain_db=0.1,
-            ),
-        ),
         overall_emotion="restrained empathy becoming steady reassurance",
         global_speed=1.06,
         energy=0.62,
+        breath_before_sentences=(),
         emphasize_sentences=(1,),
     )
     scene = tmp_path / "scene.mp4"
@@ -234,18 +216,11 @@ def test_voice_direction_retries_keep_a_persisted_provider_idempotency_key(monke
     persisted_request_ids = []
     plan = VoicePerformancePlan(
         reply_text=reply_text,
-        segments=(
-            VoicePerformanceSegment(
-                text=reply_text,
-                sentence_start=1,
-                sentence_end=1,
-                emotion="steady reassurance",
-                intensity=0.5,
-                speed=1.06,
-                pause_after_seconds=0.0,
-                gain_db=0.0,
-            ),
-        ),
+        overall_emotion="steady reassurance",
+        global_speed=1.06,
+        energy=0.5,
+        breath_before_sentences=(),
+        emphasize_sentences=(),
     )
 
     def persist():

--- a/tests/llm/test_gateway.py
+++ b/tests/llm/test_gateway.py
@@ -215,10 +215,18 @@ def test_provider_idempotency_header_is_reserved_for_durable_letter_calls(
                 ROOT_MESSAGES,
                 request_id="letter-reply:synthetic-letter-id",
             )
+            await adapter.complete(
+                ROOT_MESSAGES,
+                request_id="letter-reply:synthetic-letter-id:voice-direction",
+            )
         return seen
 
     monkeypatch.setenv("B03_TEST_KEY", "TEST")
-    assert run(exercise()) == [None, "letter-reply:synthetic-letter-id"]
+    assert run(exercise()) == [
+        None,
+        "letter-reply:synthetic-letter-id",
+        "letter-reply:synthetic-letter-id:voice-direction",
+    ]
 
 
 def test_responses_style_and_sse_stream_are_supported(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Scope
- direct each frozen canonical video reply with one required LLM tool call
- persist and reuse the exact VoicePerformancePlan for retries
- pass the same plan through ordinary spoken video and spoken-plus-music rendering
- bind musical stage cache reuse to the persisted performance plan

## Validation
- python -m pytest -q tests/http/test_reply_delay_and_media.py tests/media/test_music_reply_concat_pipeline.py tests/media/test_portable_media_boundaries.py tests/tts/test_delivery_contract.py tests/tts/test_voice_direction.py -> 44 passed
- changed-module py_compile PASS
- git diff --check PASS

## Boundaries
- stacked on #114
- no real TTS, LatentSync, MiniMax, provider, or long-video execution
- no installer, Live, frontend, or release changes
