### PR TITLE
Wire PrivateWorld into the letter runtime

### DIFF
--- a/contracts/private_world_runtime_health.schema.json
+++ b/contracts/private_world_runtime_health.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "P02 PrivateWorld runtime health",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "status",
+    "provider",
+    "reason_code",
+    "enabled",
+    "schema_version",
+    "migration_status",
+    "event_count",
+    "snapshot_count",
+    "probe",
+    "network_called"
+  ],
+  "properties": {
+    "status": {"enum": ["available", "unavailable", "disabled"]},
+    "provider": {"enum": ["sqlite", "none"]},
+    "reason_code": {"type": ["string", "null"]},
+    "enabled": {"type": "boolean"},
+    "schema_version": {"type": ["integer", "null"]},
+    "migration_status": {"type": ["string", "null"]},
+    "event_count": {"type": "integer", "minimum": 0},
+    "snapshot_count": {"type": "integer", "minimum": 0},
+    "probe": {"enum": ["in-process", "not-run"]},
+    "network_called": {"const": false}
+  },
+  "$defs": {
+    "current_schema": {"const": 2},
+    "migration": {
+      "enum": ["created_v2", "current_v2", "migrated_v1_to_v2"]
+    },
+    "unavailable_reason": {
+      "enum": [
+        "PRIVATE_WORLD_DATA_ROOT_NOT_CONFIGURED",
+        "PRIVATE_WORLD_DB_MUST_BE_ABSOLUTE",
+        "PRIVATE_WORLD_STORAGE_UNAVAILABLE"
+      ]
+    }
+  },
+  "oneOf": [
+    {
+      "title": "available SQLite ledger",
+      "properties": {
+        "status": {"const": "available"},
+        "provider": {"const": "sqlite"},
+        "reason_code": {"const": null},
+        "enabled": {"const": true},
+        "schema_version": {"$ref": "#/$defs/current_schema"},
+        "migration_status": {"$ref": "#/$defs/migration"},
+        "probe": {"const": "in-process"}
+      }
+    },
+    {
+      "title": "unavailable local storage",
+      "allOf": [
+        {
+          "properties": {
+            "status": {"const": "unavailable"},
+            "provider": {"const": "none"},
+            "reason_code": {"$ref": "#/$defs/unavailable_reason"},
+            "enabled": {"const": true},
+            "probe": {"const": "not-run"}
+          }
+        },
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "schema_version": {"type": "null"},
+                "migration_status": {"type": "null"}
+              }
+            },
+            {
+              "properties": {
+                "schema_version": {"$ref": "#/$defs/current_schema"},
+                "migration_status": {"$ref": "#/$defs/migration"}
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "disabled or invalid local configuration",
+      "properties": {
+        "status": {"const": "disabled"},
+        "provider": {"const": "none"},
+        "reason_code": {
+          "enum": [
+            "PRIVATE_WORLD_DISABLED",
+            "PRIVATE_WORLD_ENABLED_INVALID"
+          ]
+        },
+        "enabled": {"const": false},
+        "schema_version": {"type": "null"},
+        "migration_status": {"type": "null"},
+        "event_count": {"const": 0},
+        "snapshot_count": {"const": 0},
+        "probe": {"const": "not-run"}
+      }
+    }
+  ]
+}

--- a/contracts/reply_context.schema.json
+++ b/contracts/reply_context.schema.json
@@ -162,7 +162,7 @@
         "tension",
         "relationship_stage",
         "nickname_permission",
-        "home_access",
+        "home_history_allowed",
         "known_continuations"
       ],
       "properties": {
@@ -220,14 +220,7 @@
             "allowed"
           ]
         },
-        "home_access": {
-          "enum": [
-            "no_access",
-            "visit_access",
-            "errand_access",
-            "domestic_access"
-          ]
-        },
+        "home_history_allowed": {"type": "boolean"},
         "known_continuations": {
           "type": "array",
           "maxItems": 32,

--- a/docs/P02_10_PRIVATE_WORLD.md
+++ b/docs/P02_10_PRIVATE_WORLD.md
@@ -26,3 +26,18 @@ home-history permission and character-known facts.
 This module does not persist and does not call a provider. It also does not
 infer events, render prompts, or update relationship values. P02-11 owns
 persistence and P02-13 owns the model-facing projection.
+
+## Runtime health projection
+
+`/health?profile=core` exposes the optional local runtime as
+`providers.private_world`. Its public payload is validated by
+`contracts/private_world_runtime_health.schema.json` and contains only
+availability, provider kind, a stable reason code, schema/migration markers,
+aggregate counts, probe state, and `network_called=false`. It never exposes a
+database path, snapshot text, nicknames, relationship scores, raw home-access
+levels, continuation data, or reply text.
+
+The runtime reports `available/sqlite` only after the current snapshot can be
+read and parsed. Storage, JSON, schema, or snapshot semantic failures report
+`unavailable/none` with `PRIVATE_WORLD_STORAGE_UNAVAILABLE`; normal reply
+delivery stays pending for later recovery.

--- a/docs/P02_13_PRIVATE_WORLD_PROJECTION.md
+++ b/docs/P02_13_PRIVATE_WORLD_PROJECTION.md
@@ -4,10 +4,10 @@
 numeric state into the finite `PrivateBehaviorView` enums accepted by
 `ReplyContext`; raw scores and the complete snapshot never enter the prompt.
 
-Current nickname permissions are returned as bounded labels. Home access is
-projected only as the finite permission enum used to decide whether already
-retrieved home history may be acknowledged; it does not create or describe a
-home scene.
+Current nickname permissions are returned as bounded labels. The model receives
+only the boolean `home_history_allowed`, which decides whether already retrieved
+home history may be acknowledged; raw home-access levels never enter the
+projection and it does not create or describe a home scene.
 
 Local Continuation is filtered per fact. `control_only` and `pending`
 statements, identifiers, and awareness labels never enter the model payload.

--- a/docs/P02_17_PRIVATE_WORLD_DELIVERY.md
+++ b/docs/P02_17_PRIVATE_WORLD_DELIVERY.md
@@ -9,3 +9,9 @@ Startup recovery retries pending records without changing or deleting canonical
 text. An unavailable backend leaves the reply intact and records only a stable
 error code. Generation failure, quality block, request retry, TTS/video/music
 failure, and media rerender never call the commit path.
+
+SQLite read/write errors and semantic snapshot failures (including malformed
+JSON, missing required fields, or invalid bounded values) are backend failures,
+not invalid delivery events. They leave the canonical reply as
+`private_world_status=PENDING` with `PRIVATE_WORLD_UNAVAILABLE`, so a later
+startup recovery may safely retry the same delivery id.

--- a/docs/P02_PERSONA_V2_RELEASE.md
+++ b/docs/P02_PERSONA_V2_RELEASE.md
@@ -88,6 +88,9 @@ truncated.
 PrivateWorld scores and control state never enter the model. Only the bounded
 behavior projection and currently authorized nicknames may enter character
 context. Pending and control-only continuation events remain hidden.
+The model-facing projection represents home-history permission only as a
+boolean; raw `no_access`/`visit_access`/`errand_access`/`domestic_access`
+levels remain PrivateWorld control state.
 
 ## Release checklist
 

--- a/docs/P02_REPLY_CONTEXT.md
+++ b/docs/P02_REPLY_CONTEXT.md
@@ -10,10 +10,11 @@ review a reply, or commit private state. The matching JSON Schema is
 - `ReplyContext.create(...)` accepts a `ReplyMode`, timezone-aware
   `TrustedTime`, identified `TrustedWorldFact` values, a bounded
   `PrivateBehaviorView`, and explicit `OutputConstraints`.
-- `PrivateBehaviorView` contains only finite relationship/home enums plus
-  typed `KnownContinuationFact` values already marked character-known. It
-  rejects raw scores, control awareness, arbitrary dictionaries, duplicates,
-  and unbounded statements.
+- `PrivateBehaviorView` contains only finite relationship projections, the
+  boolean `home_history_allowed`, and typed `KnownContinuationFact` values
+  already marked character-known. It rejects raw home-access levels, scores,
+  control awareness, arbitrary dictionaries, duplicates, and unbounded
+  statements.
 - `ReplyModeAdapter` preserves the legacy wire values: `text` maps to
   `text_letter`, while `video` maps to `spoken_video`. Both spoken and musical
   video serialize back to `video`.

--- a/local_server.py
+++ b/local_server.py
@@ -66,9 +66,9 @@ from private_world_delivery import (
     DeliveryStatus,
     PrivateWorldDeliveryCommitter,
 )
-from private_world_ledger import SQLitePrivateWorldLedger
 from private_world_reducer import ReducerEventKind
 from private_world_projection import project_private_world
+from private_world_runtime import PrivateWorldRuntime, create_private_world_runtime
 from reply_context import (
     ReplyContext,
     ReplyMode,
@@ -478,16 +478,11 @@ def _persist_store_state() -> None:
 
 _load_store_state()
 memory_adapter: MemoryPort = create_memory_adapter()
-private_world_committer: PrivateWorldDeliveryCommitter | None = None
-private_world_port: PrivateWorldPort = NullPrivateWorldPort()
-_private_world_path = Path(_os.environ.get("OLIVIA_PRIVATE_WORLD_DB", ""))
-if _private_world_path.is_absolute():
-    try:
-        _private_world_ledger = SQLitePrivateWorldLedger(_private_world_path)
-        private_world_port = _private_world_ledger
-        private_world_committer = PrivateWorldDeliveryCommitter(_private_world_ledger)
-    except (OSError, ValueError, RuntimeError):
-        pass
+private_world_runtime: PrivateWorldRuntime = create_private_world_runtime()
+private_world_port: PrivateWorldPort = private_world_runtime.port
+private_world_committer: PrivateWorldDeliveryCommitter | None = (
+    private_world_runtime.committer
+)
 letters_adapter = LetterAdapter(
     memory_port=memory_adapter,
     private_world_port=private_world_port,
@@ -969,6 +964,7 @@ def _health_result(profile: str = contract.HEALTH_PROFILE_CORE) -> dict:
                     "network_called": False,
                 },
                 "memory": memory_info,
+                "private_world": private_world_runtime.public_status(),
                 "music_catalog": {
                     "status": "available",
                     "provider": "sanitized-local-fixture",

--- a/private_world_delivery.py
+++ b/private_world_delivery.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from enum import StrEnum
 import hashlib
 import re
+import sqlite3
 
 from private_world_ledger import LedgerEvent, LedgerWriteError, SQLitePrivateWorldLedger
 from private_world_reducer import ReducerEvent, ReducerEventKind, reduce_private_world
@@ -62,7 +63,19 @@ class PrivateWorldDeliveryCommitter:
             delivery.basis_event_ids,
         )
         try:
-            reduced = reduce_private_world(self.ledger.snapshot(), event)
+            snapshot = self.ledger.snapshot()
+        except (
+            AttributeError,
+            KeyError,
+            LedgerWriteError,
+            OSError,
+            sqlite3.Error,
+            TypeError,
+            ValueError,
+        ):
+            return DeliveryStatus.UNAVAILABLE
+        try:
+            reduced = reduce_private_world(snapshot, event)
             digest = hashlib.sha256(delivery.delivery_id.encode("utf-8")).hexdigest()
             applied = self.ledger.apply_once(
                 LedgerEvent(
@@ -80,7 +93,6 @@ class PrivateWorldDeliveryCommitter:
                 ),
                 reduced.snapshot,
             )
-        except (LedgerWriteError, OSError):
+        except (LedgerWriteError, OSError, sqlite3.Error):
             return DeliveryStatus.UNAVAILABLE
         return DeliveryStatus.COMMITTED if applied else DeliveryStatus.DUPLICATE
-

--- a/private_world_ledger.py
+++ b/private_world_ledger.py
@@ -6,6 +6,7 @@ from contextlib import closing, contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
+import os
 from pathlib import Path
 import re
 import sqlite3
@@ -26,6 +27,22 @@ _METADATA_KEY = "schema_version"
 _LEGACY_TABLES = frozenset(
     {"private_world_events", "private_world_snapshots"}
 )
+_V1_PAYLOAD_FIELDS = frozenset(
+    {
+        "version",
+        "view",
+        "familiarity",
+        "trust",
+        "comfort",
+        "closeness",
+        "tension",
+        "relationship_stage",
+        "nickname_permissions",
+        "home_access",
+        "continuation_awareness",
+    }
+)
+_V2_PAYLOAD_FIELDS = _V1_PAYLOAD_FIELDS | {"continuation_facts"}
 
 
 class LedgerWriteError(RuntimeError):
@@ -129,127 +146,127 @@ class SQLitePrivateWorldLedger:
         finally:
             connection.close()
 
-    def _existing_schema_version(self) -> int:
-        if (
-            not self._database_path.is_file()
-            or self._database_path.stat().st_size == 0
-        ):
+    @staticmethod
+    def _existing_schema_version(connection: sqlite3.Connection) -> int:
+        rows = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ).fetchall()
+        tables = {str(row[0]) for row in rows}
+        if not tables:
             return 0
-        try:
-            with closing(
-                sqlite3.connect(
-                    self._database_path,
-                    timeout=5,
-                )
-            ) as connection:
-                rows = connection.execute(
-                    "SELECT name FROM sqlite_master WHERE type = 'table'"
-                ).fetchall()
-                tables = {str(row[0]) for row in rows}
-                if not tables:
-                    return 0
-                if "private_world_metadata" in tables:
-                    row = connection.execute(
-                        "SELECT value FROM private_world_metadata WHERE key = ?",
-                        (_METADATA_KEY,),
-                    ).fetchone()
-                    if row is None:
-                        raise LedgerWriteError(
-                            "private world schema metadata is incomplete"
-                        )
-                    try:
-                        return int(row[0])
-                    except (TypeError, ValueError) as exc:
-                        raise LedgerWriteError(
-                            "private world schema metadata is invalid"
-                        ) from exc
-                if _LEGACY_TABLES.issubset(tables):
-                    return 1
+        if "private_world_metadata" in tables:
+            row = connection.execute(
+                "SELECT value FROM private_world_metadata WHERE key = ?",
+                (_METADATA_KEY,),
+            ).fetchone()
+            if row is None:
                 raise LedgerWriteError(
-                    "private world schema is unrecognized"
+                    "private world schema metadata is incomplete"
                 )
-        except sqlite3.Error as exc:
-            raise LedgerWriteError(
-                "private world schema inspection failed"
-            ) from exc
+            try:
+                return int(row[0])
+            except (TypeError, ValueError) as exc:
+                raise LedgerWriteError(
+                    "private world schema metadata is invalid"
+                ) from exc
+        if _LEGACY_TABLES.issubset(tables):
+            return 1
+        raise LedgerWriteError("private world schema is unrecognized")
 
-    def _backup_legacy_database(self) -> None:
+    def _backup_legacy_database(self, source: sqlite3.Connection) -> None:
         stamp = datetime.now(timezone.utc).strftime(
             "%Y%m%dT%H%M%S%fZ"
         )
         backup = self._database_path.with_name(
             f"{self._database_path.name}.pre-v2-{stamp}.bak"
         )
+        created = False
         try:
-            with closing(
-                sqlite3.connect(
-                    self._database_path,
-                    timeout=5,
-                )
-            ) as source, closing(
-                sqlite3.connect(
-                    backup,
-                    timeout=5,
-                )
-            ) as destination:
-                source.backup(destination)
-                destination.commit()
-        except sqlite3.Error as exc:
-            backup.unlink(missing_ok=True)
+            image = source.serialize()
+            with backup.open("xb") as stream:
+                created = True
+                stream.write(image)
+                stream.flush()
+                os.fsync(stream.fileno())
+        except (OSError, sqlite3.Error) as exc:
+            if created:
+                backup.unlink(missing_ok=True)
             raise LedgerWriteError(
                 "private world migration backup failed"
             ) from exc
 
     def _initialize(self) -> None:
-        previous = self._existing_schema_version()
-        if previous > PRIVATE_WORLD_LEDGER_SCHEMA_VERSION:
-            raise LedgerWriteError(
-                "private world schema is newer than this runtime"
-            )
-        if previous == 1:
-            self._backup_legacy_database()
-            self._migration_status = "migrated_v1_to_v2"
-        elif previous == 0:
-            self._migration_status = "created_v2"
-        else:
-            self._migration_status = "current_v2"
-
         try:
-            with self._connection() as connection:
-                connection.executescript(
-                    """
-                    CREATE TABLE IF NOT EXISTS private_world_events (
+            with closing(
+                sqlite3.connect(self._database_path, timeout=5)
+            ) as connection:
+                connection.execute("PRAGMA foreign_keys = ON")
+                connection.execute("BEGIN IMMEDIATE")
+                try:
+                    previous = self._existing_schema_version(connection)
+                    if previous > PRIVATE_WORLD_LEDGER_SCHEMA_VERSION:
+                        raise LedgerWriteError(
+                            "private world schema is newer than this runtime"
+                        )
+                    migrated_rows: tuple[tuple[int, str], ...] = ()
+                    if previous == 1:
+                        migrated_rows = self._validated_v1_rows(connection)
+                        self._backup_legacy_database(connection)
+                    connection.execute(
+                        """CREATE TABLE IF NOT EXISTS private_world_events (
                         event_id TEXT PRIMARY KEY,
                         delivery_id TEXT NOT NULL UNIQUE,
                         event_type TEXT NOT NULL,
                         payload_json TEXT NOT NULL,
                         occurred_at TEXT NOT NULL
-                    );
-                    CREATE TABLE IF NOT EXISTS private_world_snapshots (
+                        )"""
+                    )
+                    connection.execute(
+                        """CREATE TABLE IF NOT EXISTS private_world_snapshots (
                         version INTEGER PRIMARY KEY,
                         payload_json TEXT NOT NULL,
                         event_id TEXT NOT NULL UNIQUE,
                         FOREIGN KEY(event_id) REFERENCES private_world_events(event_id)
-                    );
-                    CREATE TABLE IF NOT EXISTS private_world_metadata (
+                        )"""
+                    )
+                    connection.execute(
+                        """CREATE TABLE IF NOT EXISTS private_world_metadata (
                         key TEXT PRIMARY KEY,
                         value TEXT NOT NULL
-                    );
-                    """
-                )
-                connection.execute(
-                    """INSERT INTO private_world_metadata (key, value)
+                        )"""
+                    )
+                    if migrated_rows:
+                        connection.executemany(
+                            """UPDATE private_world_snapshots
+                           SET payload_json = ? WHERE version = ?""",
+                            (
+                                (payload_json, version)
+                                for version, payload_json in migrated_rows
+                            ),
+                        )
+                    connection.execute(
+                        """INSERT INTO private_world_metadata (key, value)
                        VALUES (?, ?)
                        ON CONFLICT(key) DO UPDATE SET value = excluded.value""",
-                    (
-                        _METADATA_KEY,
-                        str(PRIVATE_WORLD_LEDGER_SCHEMA_VERSION),
-                    ),
-                )
+                        (
+                            _METADATA_KEY,
+                            str(PRIVATE_WORLD_LEDGER_SCHEMA_VERSION),
+                        ),
+                    )
+                    connection.commit()
+                except BaseException:
+                    connection.rollback()
+                    raise
         except sqlite3.Error as exc:
             raise LedgerWriteError(
                 "private world schema initialization failed"
             ) from exc
+        if previous == 1:
+            self._migration_status = "migrated_v1_to_v2"
+        elif previous == 0:
+            self._migration_status = "created_v2"
+        else:
+            self._migration_status = "current_v2"
 
     def apply_once(
         self,
@@ -279,12 +296,9 @@ class SQLitePrivateWorldLedger:
                     """SELECT version, payload_json FROM private_world_snapshots
                        ORDER BY version DESC LIMIT 1"""
                 ).fetchone()
-                snapshot_json = json.dumps(
-                    snapshot.to_dict(),
-                    ensure_ascii=False,
-                    sort_keys=True,
-                    separators=(",", ":"),
-                )
+                if latest is not None:
+                    self._strict_stored_snapshot(latest[0], latest[1])
+                snapshot_json = self._snapshot_json(snapshot)
                 if latest is None:
                     write_snapshot = snapshot.version in {1, 2}
                 elif snapshot.version == latest[0]:
@@ -349,28 +363,43 @@ class SQLitePrivateWorldLedger:
             for row in rows
         )
 
-    def snapshot(self) -> PrivateWorldSnapshot:
-        with self._connection() as connection:
-            row = connection.execute(
-                """SELECT payload_json FROM private_world_snapshots
-                   ORDER BY version DESC LIMIT 1"""
-            ).fetchone()
-        if row is None:
-            return PrivateWorldSnapshot()
-        payload = json.loads(row[0])
-        continuation_facts = tuple(
-            LocalContinuationFact(
-                fact_id=item["fact_id"],
-                statement=item["statement"],
-                awareness=ContinuationAwareness(
-                    item["awareness"]
-                ),
-            )
-            for item in payload.get(
-                "continuation_facts",
-                (),
-            )
+    @staticmethod
+    def _snapshot_json(snapshot: PrivateWorldSnapshot) -> str:
+        return json.dumps(
+            snapshot.to_dict(),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
         )
+
+    @staticmethod
+    def _v1_snapshot_json(snapshot: PrivateWorldSnapshot) -> str:
+        payload = snapshot.to_dict()
+        payload.pop("continuation_facts")
+        return json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    @staticmethod
+    def _payload_object(payload_json: object) -> dict[str, object]:
+        if not isinstance(payload_json, str):
+            raise LedgerWriteError("stored state payload is invalid")
+        try:
+            payload = json.loads(payload_json)
+        except json.JSONDecodeError as exc:
+            raise LedgerWriteError("stored state payload is invalid") from exc
+        if not isinstance(payload, dict):
+            raise LedgerWriteError("stored state must be an object")
+        return payload
+
+    @staticmethod
+    def _snapshot_from_payload(
+        payload: dict[str, object],
+        facts: tuple[LocalContinuationFact, ...],
+    ) -> PrivateWorldSnapshot:
         return PrivateWorldSnapshot(
             version=payload["version"],
             familiarity=payload["familiarity"],
@@ -378,20 +407,116 @@ class SQLitePrivateWorldLedger:
             comfort=payload["comfort"],
             closeness=payload["closeness"],
             tension=payload["tension"],
-            relationship_stage=payload[
-                "relationship_stage"
-            ],
-            nickname_permissions=tuple(
-                payload["nickname_permissions"]
-            ),
-            home_access=HomeAccess(
-                payload["home_access"]
-            ),
+            relationship_stage=payload["relationship_stage"],
+            nickname_permissions=tuple(payload["nickname_permissions"]),
+            home_access=HomeAccess(payload["home_access"]),
             continuation_awareness=ContinuationAwareness(
                 payload["continuation_awareness"]
             ),
-            continuation_facts=continuation_facts,
+            continuation_facts=facts,
         )
+
+    def _strict_v1_stored_snapshot(
+        self,
+        stored_version: object,
+        payload_json: object,
+    ) -> PrivateWorldSnapshot:
+        if type(stored_version) is not int or stored_version < 1:
+            raise LedgerWriteError("stored v1 row version is invalid")
+        try:
+            payload = self._payload_object(payload_json)
+            fields = set(payload)
+            if fields not in {_V1_PAYLOAD_FIELDS, _V2_PAYLOAD_FIELDS}:
+                raise ValueError("stored v1 fields are invalid")
+            if payload["view"] != "snapshot":
+                raise ValueError("stored v1 view is invalid")
+            facts = payload.get("continuation_facts", [])
+            if fields == _V2_PAYLOAD_FIELDS and not isinstance(facts, list):
+                raise ValueError("stored v1 continuation facts must be a list")
+            snapshot = self._snapshot_from_payload(
+                payload,
+                tuple(
+                    LocalContinuationFact(
+                        fact_id=item["fact_id"],
+                        statement=item["statement"],
+                        awareness=ContinuationAwareness(item["awareness"]),
+                    )
+                    for item in facts
+                ),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise LedgerWriteError("stored v1 state is invalid") from exc
+        if snapshot.version != stored_version:
+            raise LedgerWriteError("stored v1 version does not match row")
+        expected_payload = (
+            self._snapshot_json(snapshot)
+            if fields == _V2_PAYLOAD_FIELDS
+            else self._v1_snapshot_json(snapshot)
+        )
+        if expected_payload != payload_json:
+            raise LedgerWriteError("stored v1 state is not canonical")
+        return snapshot
+
+    def _validated_v1_rows(
+        self,
+        connection: sqlite3.Connection,
+    ) -> tuple[tuple[int, str], ...]:
+        rows = connection.execute(
+            """SELECT version, payload_json FROM private_world_snapshots
+               ORDER BY version"""
+        ).fetchall()
+        migrated: list[tuple[int, str]] = []
+        for stored_version, payload_json in rows:
+            snapshot = self._strict_v1_stored_snapshot(stored_version, payload_json)
+            migrated.append((stored_version, self._snapshot_json(snapshot)))
+        return tuple(migrated)
+
+    def _strict_stored_snapshot(
+        self,
+        stored_version: object,
+        payload_json: object,
+    ) -> PrivateWorldSnapshot:
+        """Load only a canonical stored-state row that round-trips without loss."""
+
+        if type(stored_version) is not int or stored_version < 1:
+            raise LedgerWriteError("stored snapshot row version is invalid")
+        try:
+            payload = self._payload_object(payload_json)
+            if set(payload) != _V2_PAYLOAD_FIELDS:
+                raise ValueError("stored state fields are invalid")
+            if payload["view"] != "snapshot":
+                raise ValueError("stored state view is invalid")
+            facts = payload["continuation_facts"]
+            if not isinstance(facts, list):
+                raise ValueError("stored continuation facts must be a list")
+            snapshot = self._snapshot_from_payload(
+                payload,
+                tuple(
+                    LocalContinuationFact(
+                        fact_id=item["fact_id"],
+                        statement=item["statement"],
+                        awareness=ContinuationAwareness(item["awareness"]),
+                    )
+                    for item in facts
+                ),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise LedgerWriteError("stored snapshot is invalid") from exc
+        if snapshot.version != stored_version:
+            raise LedgerWriteError("stored snapshot version does not match row")
+        if self._snapshot_json(snapshot) != payload_json:
+            raise LedgerWriteError("stored snapshot is not canonical")
+        return snapshot
+
+    def snapshot(self) -> PrivateWorldSnapshot:
+        with self._connection() as connection:
+            row = connection.execute(
+                """SELECT version, payload_json FROM private_world_snapshots
+                   ORDER BY version DESC LIMIT 1"""
+            ).fetchone()
+        if row is None:
+            return PrivateWorldSnapshot()
+        return self._strict_stored_snapshot(row[0], row[1])
 
     def control_view(self) -> PrivateWorldControlView:
         return self.snapshot().control_view()
@@ -407,6 +532,12 @@ class SQLitePrivateWorldLedger:
             snapshot_count = connection.execute(
                 "SELECT COUNT(*) FROM private_world_snapshots"
             ).fetchone()[0]
+            latest = connection.execute(
+                """SELECT version, payload_json FROM private_world_snapshots
+                   ORDER BY version DESC LIMIT 1"""
+            ).fetchone()
+        if latest is not None:
+            self._strict_stored_snapshot(latest[0], latest[1])
         return {
             "status": "READY",
             "event_count": event_count,

--- a/private_world_projection.py
+++ b/private_world_projection.py
@@ -11,7 +11,6 @@ from private_world_port import (
 )
 from reply_context import (
     BehaviorLevel,
-    HomeAccess,
     KnownContinuationFact,
     NicknamePermission,
     PrivateBehaviorView,
@@ -92,7 +91,9 @@ def project_private_world(
             if nicknames
             else NicknamePermission.NOT_ALLOWED
         ),
-        home_access=HomeAccess(snapshot.home_access.value),
+        home_history_allowed=(
+            snapshot.home_access.value != "no_access"
+        ),
         known_continuations=known_facts,
     )
     return ProjectedPrivateWorld(

--- a/private_world_runtime.py
+++ b/private_world_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import os
 from pathlib import Path
+import sqlite3
 from typing import Mapping
 
 from private_world_delivery import PrivateWorldDeliveryCommitter
@@ -46,9 +47,18 @@ class PrivateWorldRuntime:
         ):
             try:
                 counts = self.port.health()
+                self.port.snapshot()
                 event_count = int(counts["event_count"])
                 snapshot_count = int(counts["snapshot_count"])
-            except (OSError, RuntimeError, ValueError):
+            except (
+                AttributeError,
+                KeyError,
+                OSError,
+                RuntimeError,
+                TypeError,
+                ValueError,
+                sqlite3.Error,
+            ):
                 status = "unavailable"
                 reason_code = "PRIVATE_WORLD_STORAGE_UNAVAILABLE"
         return {
@@ -110,7 +120,17 @@ def create_private_world_runtime(
 ) -> PrivateWorldRuntime:
     """Create the optional local ledger without blocking the reply runtime."""
 
-    path, reason, enabled = resolve_private_world_database(environ)
+    try:
+        path, reason, enabled = resolve_private_world_database(environ)
+    except (OSError, ValueError, RuntimeError, sqlite3.Error):
+        return PrivateWorldRuntime(
+            NullPrivateWorldPort(),
+            None,
+            "unavailable",
+            "none",
+            "PRIVATE_WORLD_STORAGE_UNAVAILABLE",
+            True,
+        )
     if not enabled:
         return PrivateWorldRuntime(
             NullPrivateWorldPort(),
@@ -145,7 +165,7 @@ def create_private_world_runtime(
             event_count=int(counts["event_count"]),
             snapshot_count=int(counts["snapshot_count"]),
         )
-    except (OSError, ValueError, RuntimeError, LedgerWriteError):
+    except (OSError, ValueError, RuntimeError, sqlite3.Error, LedgerWriteError):
         return PrivateWorldRuntime(
             NullPrivateWorldPort(),
             None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,19 @@ py-modules = [
     "conversation_memory_runtime",
     "extract_player",
     "http_contract",
+    "letter_triage",
+    "llm_gateway",
     "letter_status",
+    "local_memory",
     "local_server",
+    "latentsync_reply",
     "mem0_memory",
     "memory",
+    "memory_port",
+    "memory_prompt",
+    "music_caption",
+    "music_duration",
+    "music_reply",
     "original_client_companion_api",
     "original_client_companion_backend",
     "original_client_companion_mutation_api",
@@ -54,6 +63,7 @@ py-modules = [
     "persona_loader",
     "persona_assembly",
     "prompt_budget",
+    "persona_provider",
     "private_world_port",
     "private_world_candidates",
     "private_world_commands",
@@ -63,12 +73,17 @@ py-modules = [
     "private_world_admin",
     "private_world_delivery",
     "private_world_projection",
+    "private_world_runtime",
     "reply_context",
+    "reply_delivery",
+    "reply_media",
+    "reply_orchestrator",
     "reply_policy",
     "reply_model_quality",
     "reply_pipeline",
     "reply_quality_gate",
     "reply_reviewer",
+    "song_content",
     "voice_direction",
 ]
 
@@ -85,4 +100,14 @@ include = [
 ]
 
 [tool.setuptools.package-data]
+contracts = [
+    "music_fixture.json",
+    "reply_review.schema.json",
+    "persona_v2.schema.json",
+    "persona_v2_provenance.schema.json",
+]
 control_center = ["static/*.html", "static/*.css", "static/*.js"]
+linli_character = [
+    "persona_release_v2.json",
+    "persona_release_provenance_v2.json",
+]

--- a/reply_context.py
+++ b/reply_context.py
@@ -53,13 +53,6 @@ class NicknamePermission(str, Enum):
     ALLOWED = "allowed"
 
 
-class HomeAccess(str, Enum):
-    NO_ACCESS = "no_access"
-    VISIT_ACCESS = "visit_access"
-    ERRAND_ACCESS = "errand_access"
-    DOMESTIC_ACCESS = "domestic_access"
-
-
 _ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
 _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 
@@ -157,7 +150,7 @@ class PrivateBehaviorView:
     tension: BehaviorLevel = BehaviorLevel.UNKNOWN
     relationship_stage: RelationshipStage = RelationshipStage.UNKNOWN
     nickname_permission: NicknamePermission = NicknamePermission.NOT_ALLOWED
-    home_access: HomeAccess = HomeAccess.NO_ACCESS
+    home_history_allowed: bool = False
     known_continuations: tuple[KnownContinuationFact, ...] = ()
 
     def __post_init__(self) -> None:
@@ -169,7 +162,6 @@ class PrivateBehaviorView:
             (self.tension, BehaviorLevel),
             (self.relationship_stage, RelationshipStage),
             (self.nickname_permission, NicknamePermission),
-            (self.home_access, HomeAccess),
         )
         if any(
             not isinstance(value, expected)
@@ -177,6 +169,10 @@ class PrivateBehaviorView:
         ):
             raise ReplyContextError(
                 "private behavior is outside the bounded view"
+            )
+        if type(self.home_history_allowed) is not bool:
+            raise ReplyContextError(
+                "home history permission must be boolean"
             )
         if isinstance(self.known_continuations, (str, bytes)):
             raise ReplyContextError(
@@ -205,7 +201,7 @@ class PrivateBehaviorView:
             "tension": self.tension.value,
             "relationship_stage": self.relationship_stage.value,
             "nickname_permission": self.nickname_permission.value,
-            "home_access": self.home_access.value,
+            "home_history_allowed": self.home_history_allowed,
             "known_continuations": [
                 fact.to_dict() for fact in self.known_continuations
             ],

--- a/reply_policy.py
+++ b/reply_policy.py
@@ -67,7 +67,7 @@ _CONTROL_MARKUP_RE = re.compile(
     re.IGNORECASE,
 )
 _PRIVATE_STATE_RE = re.compile(
-    r"(?i)(?:[\"']?)(?:familiarity|trust|comfort|closeness|tension|relationship_stage|nickname_permission|home_access)(?:[\"']?)\s*[:=]"
+    r"(?i)(?:[\"']?)(?:familiarity|trust|comfort|closeness|tension|relationship_stage|nickname_permission|home_access|home_history_allowed)(?:[\"']?)\s*[:=]"
 )
 _STAGE_DIRECTION_RE = re.compile(
     r"(?m)^\s*(?:[\(（\[【][^\n]{1,120}[\)）\]】]|\*[^\n*]{1,120}\*)\s*$"

--- a/tests/persona/test_private_continuity_persona_integration.py
+++ b/tests/persona/test_private_continuity_persona_integration.py
@@ -67,7 +67,8 @@ def test_private_continuity_reaches_persona_without_control_only_state() -> None
 
     assert "小河豚" in system
     assert '"trust":"high"' in system
-    assert '"home_access":"visit_access"' in system
+    assert '"home_history_allowed":true' in system
+    assert "visit_access" not in system
     assert "林离已经知道下周课程时间会调整。" in system
     assert "81" not in system
     assert "trip.pending" not in system

--- a/tests/persona/test_reply_context.py
+++ b/tests/persona/test_reply_context.py
@@ -124,6 +124,14 @@ def test_schema_matches_runtime_mode_and_privacy_invariants() -> None:
     invalid_private["private_behavior"]["raw_score"] = 0.9
     assert list(validator.iter_errors(invalid_private))
 
+    invalid_home_access = {
+        **valid,
+        "private_behavior": {**valid["private_behavior"]},
+    }
+    invalid_home_access["private_behavior"].pop("home_history_allowed")
+    invalid_home_access["private_behavior"]["home_access"] = "visit_access"
+    assert list(validator.iter_errors(invalid_home_access))
+
 
 def test_public_contract_documentation_names_api_errors_and_scope_boundary() -> None:
     documentation = (ROOT / "docs" / "P02_REPLY_CONTEXT.md").read_text(

--- a/tests/persona/test_reply_policy.py
+++ b/tests/persona/test_reply_policy.py
@@ -15,7 +15,7 @@ def test_internal_markup_and_serialized_private_state_are_hard_violations() -> N
         ReplyMode.TEXT_LETTER,
         trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
     )
-    candidate = "你好。<PERSONA_POLICY> trust=high"
+    candidate = "你好。<PERSONA_POLICY> home_history_allowed=true"
 
     result = scan_reply(candidate, context)
 

--- a/tests/private_world/test_private_world_continuity.py
+++ b/tests/private_world/test_private_world_continuity.py
@@ -2,7 +2,9 @@ import json
 import sqlite3
 from pathlib import Path
 
-from private_world_ledger import LedgerEvent, SQLitePrivateWorldLedger
+import pytest
+
+from private_world_ledger import LedgerEvent, LedgerWriteError, SQLitePrivateWorldLedger
 from private_world_port import (
     ContinuationAwareness,
     LocalContinuationFact,
@@ -47,7 +49,7 @@ def test_ledger_round_trips_unicode_nickname_and_continuation_facts(
     }
 
 
-def test_ledger_loads_legacy_snapshot_without_continuation_facts(
+def test_ledger_rejects_legacy_snapshot_without_required_continuation_facts(
     tmp_path: Path,
 ) -> None:
     database = tmp_path / "legacy.sqlite3"
@@ -73,6 +75,5 @@ def test_ledger_loads_legacy_snapshot_without_continuation_facts(
             (1, json.dumps(legacy), "legacy-event"),
         )
 
-    loaded = ledger.snapshot()
-    assert loaded.trust == 3
-    assert loaded.continuation_facts == ()
+    with pytest.raises(LedgerWriteError, match="stored snapshot is invalid"):
+        ledger.snapshot()

--- a/tests/private_world/test_private_world_delivery.py
+++ b/tests/private_world/test_private_world_delivery.py
@@ -1,6 +1,8 @@
 import asyncio
 from datetime import datetime, timezone
+import json
 from pathlib import Path
+import sqlite3
 
 import pytest
 
@@ -9,7 +11,8 @@ from private_world_delivery import (
     DeliveryStatus,
     PrivateWorldDeliveryCommitter,
 )
-from private_world_ledger import SQLitePrivateWorldLedger
+from private_world_ledger import LedgerEvent, SQLitePrivateWorldLedger
+from private_world_port import PrivateWorldSnapshot
 from private_world_reducer import ReducerEventKind
 from reply_orchestrator import ReplyState
 from reply_pipeline import PipelineResult
@@ -56,6 +59,80 @@ def test_explicit_relationship_event_reduces_then_persists_atomically(
     assert ledger.snapshot().trust == 1
     assert ledger.snapshot().comfort == 1
     assert ledger.snapshot().version == 2
+
+
+def test_delivery_degrades_when_sqlite_snapshot_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ledger = SQLitePrivateWorldLedger(tmp_path / "private.sqlite3")
+    committer = PrivateWorldDeliveryCommitter(ledger)
+    delivery = DeliveryEvent(
+        delivery_id="letter-sqlite-failure:1",
+        kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
+        occurred_at=NOW,
+        semantic_key="canonical.sqlite-failure",
+    )
+
+    def unavailable_snapshot() -> object:
+        raise sqlite3.DatabaseError("synthetic sqlite failure")
+
+    monkeypatch.setattr(ledger, "snapshot", unavailable_snapshot)
+
+    assert committer.commit(delivery) is DeliveryStatus.UNAVAILABLE
+
+
+def test_delivery_degrades_when_snapshot_json_is_semantically_corrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ledger = SQLitePrivateWorldLedger(tmp_path / "private.sqlite3")
+    committer = PrivateWorldDeliveryCommitter(ledger)
+    delivery = DeliveryEvent(
+        delivery_id="letter-corrupt-snapshot:1",
+        kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
+        occurred_at=NOW,
+        semantic_key="canonical.corrupt-snapshot",
+    )
+
+    def corrupt_snapshot() -> object:
+        raise json.JSONDecodeError("synthetic corrupt snapshot", "{", 1)
+
+    monkeypatch.setattr(ledger, "snapshot", corrupt_snapshot)
+
+    assert committer.commit(delivery) is DeliveryStatus.UNAVAILABLE
+
+
+def test_delivery_degrades_when_snapshot_json_has_the_wrong_shape(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "private.sqlite3"
+    ledger = SQLitePrivateWorldLedger(database)
+    ledger.apply_once(
+        LedgerEvent(
+            event_id="wrong-shape-seed-event",
+            delivery_id="wrong-shape-seed-delivery",
+            event_type="canonical_reply_delivered",
+            payload={"applied": False},
+            occurred_at=NOW.isoformat(),
+        ),
+        PrivateWorldSnapshot(version=1),
+    )
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "UPDATE private_world_snapshots SET payload_json = ?",
+            ("[]",),
+        )
+    committer = PrivateWorldDeliveryCommitter(ledger)
+
+    assert committer.commit(
+        DeliveryEvent(
+            delivery_id="wrong-shape-delivery:1",
+            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
+            occurred_at=NOW,
+            semantic_key="canonical.wrong-shape",
+        )
+    ) is DeliveryStatus.UNAVAILABLE
 
 
 class AcceptedPipeline:

--- a/tests/private_world/test_private_world_projection.py
+++ b/tests/private_world/test_private_world_projection.py
@@ -44,7 +44,7 @@ def test_current_unicode_nicknames_and_home_permission_enter_finite_projection()
     assert projected.authorized_nicknames == ("小河豚", "旅行者")
     assert projected.to_dict()["authorized_nicknames"] == ["小河豚", "旅行者"]
     assert projected.behavior.nickname_permission.value == "allowed"
-    assert projected.behavior.home_access.value == "visit_access"
+    assert projected.behavior.home_history_allowed is True
     assert projected.may_acknowledge_home_history is True
 
 

--- a/tests/private_world/test_private_world_runtime.py
+++ b/tests/private_world/test_private_world_runtime.py
@@ -1,26 +1,48 @@
 from __future__ import annotations
 
+import hashlib
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 import sqlite3
 
 import pytest
+from jsonschema import Draft202012Validator
 
+import private_world_runtime
+from private_world_delivery import (
+    DeliveryEvent,
+    DeliveryStatus,
+)
 from private_world_ledger import (
     PRIVATE_WORLD_LEDGER_SCHEMA_VERSION,
     LedgerEvent,
     LedgerWriteError,
     SQLitePrivateWorldLedger,
 )
-from private_world_port import NullPrivateWorldPort, PrivateWorldSnapshot
+
+
+ROOT = Path(__file__).resolve().parents[2]
+from private_world_port import (
+    ContinuationAwareness,
+    HomeAccess,
+    LocalContinuationFact,
+    NullPrivateWorldPort,
+    PrivateWorldSnapshot,
+)
 from private_world_runtime import (
     PRIVATE_WORLD_DEFAULT_RELATIVE_PATH,
     create_private_world_runtime,
     resolve_private_world_database,
 )
+from private_world_reducer import ReducerEventKind
 
 
-def _legacy_v1_database(path: Path) -> None:
+def _legacy_v1_database(
+    path: Path,
+    *,
+    includes_continuation_facts: bool = False,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with sqlite3.connect(path) as connection:
         connection.executescript(
@@ -52,11 +74,36 @@ def _legacy_v1_database(path: Path) -> None:
                 "2026-08-22T00:00:00+00:00",
             ),
         )
-        snapshot = PrivateWorldSnapshot(version=1).to_dict()
+        # This is the historical v1 wire payload.  It intentionally does not
+        # use the current snapshot serializer: v1 had no continuation facts.
+        snapshot = {
+            "version": 1,
+            "view": "snapshot",
+            "familiarity": 0,
+            "trust": 3,
+            "comfort": 0,
+            "closeness": 0,
+            "tension": 0,
+            "relationship_stage": "acquaintance",
+            "nickname_permissions": [],
+            "home_access": "no_access",
+            "continuation_awareness": "control_only",
+        }
+        if includes_continuation_facts:
+            snapshot["continuation_facts"] = []
         connection.execute(
             """INSERT INTO private_world_snapshots
                (version, payload_json, event_id) VALUES (?, ?, ?)""",
-            (1, json.dumps(snapshot, ensure_ascii=False, sort_keys=True, separators=(",", ":")), "legacy-event"),
+            (
+                1,
+                json.dumps(
+                    snapshot,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                "legacy-event",
+            ),
         )
 
 
@@ -68,7 +115,11 @@ def test_legacy_ledger_is_backed_up_and_migrated_once(tmp_path: Path) -> None:
 
     assert ledger.schema_version == PRIVATE_WORLD_LEDGER_SCHEMA_VERSION == 2
     assert ledger.migration_status == "migrated_v1_to_v2"
-    assert ledger.snapshot() == PrivateWorldSnapshot(version=1)
+    assert ledger.snapshot() == PrivateWorldSnapshot(
+        version=1,
+        trust=3,
+        relationship_stage="acquaintance",
+    )
     backups = tuple(tmp_path.glob("private_world.sqlite3.pre-v2-*.bak"))
     assert len(backups) == 1
     assert backups[0].is_file() and backups[0].stat().st_size > 0
@@ -80,6 +131,102 @@ def test_legacy_ledger_is_backed_up_and_migrated_once(tmp_path: Path) -> None:
     reopened = SQLitePrivateWorldLedger(database)
     assert reopened.migration_status == "current_v2"
     assert tuple(tmp_path.glob("private_world.sqlite3.pre-v2-*.bak")) == backups
+
+
+def test_later_metadata_less_v1_payload_with_continuation_facts_migrates(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "private_world.sqlite3"
+    _legacy_v1_database(database, includes_continuation_facts=True)
+
+    ledger = SQLitePrivateWorldLedger(database)
+
+    assert ledger.migration_status == "migrated_v1_to_v2"
+    assert ledger.snapshot() == PrivateWorldSnapshot(
+        version=1,
+        trust=3,
+        relationship_stage="acquaintance",
+    )
+    with sqlite3.connect(database) as connection:
+        stored_payload = connection.execute(
+            "SELECT payload_json FROM private_world_snapshots WHERE version = 1"
+        ).fetchone()[0]
+    assert json.loads(stored_payload)["continuation_facts"] == []
+
+
+def test_v1_migration_locks_the_validated_source_epoch_before_backup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = tmp_path / "private_world.sqlite3"
+    _legacy_v1_database(database)
+    original_backup = SQLitePrivateWorldLedger._backup_legacy_database
+    competing_write: dict[str, str] = {}
+
+    def attempt_legacy_write_during_backup(
+        ledger: SQLitePrivateWorldLedger,
+        *args: object,
+    ) -> None:
+        try:
+            with sqlite3.connect(database, timeout=0) as writer:
+                row = writer.execute(
+                    "SELECT payload_json FROM private_world_snapshots WHERE version = 1"
+                ).fetchone()
+                payload = json.loads(row[0])
+                payload["trust"] = 99
+                writer.execute(
+                    "UPDATE private_world_snapshots SET payload_json = ? WHERE version = 1",
+                    (json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")),),
+                )
+            competing_write["result"] = "wrote"
+        except sqlite3.OperationalError:
+            competing_write["result"] = "locked"
+        original_backup(ledger, *args)
+
+    monkeypatch.setattr(
+        SQLitePrivateWorldLedger,
+        "_backup_legacy_database",
+        attempt_legacy_write_during_backup,
+    )
+
+    ledger = SQLitePrivateWorldLedger(database)
+
+    assert competing_write == {"result": "locked"}
+    assert ledger.snapshot().trust == 3
+    backup = next(tmp_path.glob("private_world.sqlite3.pre-v2-*.bak"))
+    with sqlite3.connect(backup) as connection:
+        backup_payload = connection.execute(
+            "SELECT payload_json FROM private_world_snapshots WHERE version = 1"
+        ).fetchone()[0]
+    assert json.loads(backup_payload)["trust"] == 3
+
+
+def test_invalid_v1_payload_does_not_modify_database_or_create_backup(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "private_world.sqlite3"
+    _legacy_v1_database(database)
+    with sqlite3.connect(database) as connection:
+        payload_json = connection.execute(
+            "SELECT payload_json FROM private_world_snapshots WHERE version = 1"
+        ).fetchone()[0]
+        payload = json.loads(payload_json)
+        payload["not_a_v1_field"] = True
+        connection.execute(
+            "UPDATE private_world_snapshots SET payload_json = ? WHERE version = 1",
+            (json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")),),
+        )
+    original_hash = hashlib.sha256(database.read_bytes()).hexdigest()
+
+    with pytest.raises(LedgerWriteError, match="stored v1 state is invalid"):
+        SQLitePrivateWorldLedger(database)
+
+    assert hashlib.sha256(database.read_bytes()).hexdigest() == original_hash
+    assert not tuple(tmp_path.glob("private_world.sqlite3.pre-v2-*.bak"))
+    with sqlite3.connect(database) as connection:
+        assert connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'private_world_metadata'"
+        ).fetchone() is None
 
 
 def test_new_ledger_records_v2_metadata_without_backup(tmp_path: Path) -> None:
@@ -155,6 +302,384 @@ def test_default_runtime_uses_local_data_root_and_reports_sanitized_health(
     assert "88" not in serialized
 
 
+def test_public_private_world_health_matches_the_sanitized_schema(
+    tmp_path: Path,
+) -> None:
+    schema = json.loads(
+        (ROOT / "contracts" / "private_world_runtime_health.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    status = create_private_world_runtime(
+        {"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path)}
+    ).public_status()
+
+    assert list(Draft202012Validator(schema).iter_errors(status)) == []
+    serialized = json.dumps(status, ensure_ascii=False)
+    assert str(tmp_path) not in serialized
+    assert "trust" not in serialized
+    assert "reply" not in serialized
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "status": "available",
+            "provider": "none",
+            "reason_code": None,
+            "enabled": True,
+            "schema_version": 2,
+            "migration_status": "current_v2",
+            "event_count": 0,
+            "snapshot_count": 0,
+            "probe": "in-process",
+            "network_called": False,
+        },
+        {
+            "status": "unavailable",
+            "provider": "sqlite",
+            "reason_code": "PRIVATE_WORLD_STORAGE_UNAVAILABLE",
+            "enabled": True,
+            "schema_version": None,
+            "migration_status": None,
+            "event_count": 0,
+            "snapshot_count": 0,
+            "probe": "not-run",
+            "network_called": False,
+        },
+        {
+            "status": "disabled",
+            "provider": "none",
+            "reason_code": "PRIVATE_WORLD_DISABLED",
+            "enabled": True,
+            "schema_version": None,
+            "migration_status": None,
+            "event_count": 0,
+            "snapshot_count": 0,
+            "probe": "not-run",
+            "network_called": False,
+        },
+        {
+            "status": "available",
+            "provider": "sqlite",
+            "reason_code": "PRIVATE_WORLD_STORAGE_UNAVAILABLE",
+            "enabled": True,
+            "schema_version": 2,
+            "migration_status": "current_v2",
+            "event_count": 0,
+            "snapshot_count": 0,
+            "probe": "in-process",
+            "network_called": False,
+        },
+        {
+            "status": "unavailable",
+            "provider": "none",
+            "reason_code": None,
+            "enabled": True,
+            "schema_version": None,
+            "migration_status": None,
+            "event_count": 0,
+            "snapshot_count": 0,
+            "probe": "not-run",
+            "network_called": False,
+        },
+    ],
+)
+def test_private_world_health_schema_rejects_contradictory_combinations(
+    payload: dict[str, object],
+) -> None:
+    schema = json.loads(
+        (ROOT / "contracts" / "private_world_runtime_health.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert list(Draft202012Validator(schema).iter_errors(payload))
+
+
+def test_private_world_health_schema_accepts_every_public_runtime_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema = json.loads(
+        (ROOT / "contracts" / "private_world_runtime_health.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    available = create_private_world_runtime(
+        {"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path / "available")}
+    )
+    degraded = create_private_world_runtime(
+        {"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path / "degraded")}
+    )
+    assert isinstance(degraded.port, SQLitePrivateWorldLedger)
+
+    def unavailable_health() -> dict[str, int | str]:
+        raise sqlite3.DatabaseError("synthetic sqlite failure")
+
+    monkeypatch.setattr(degraded.port, "health", unavailable_health)
+    statuses = [
+        available.public_status(),
+        create_private_world_runtime(
+            {"OLIVIA_PRIVATE_WORLD_ENABLED": "0"}
+        ).public_status(),
+        create_private_world_runtime(
+            {"OLIVIA_PRIVATE_WORLD_ENABLED": "maybe"}
+        ).public_status(),
+        create_private_world_runtime({}).public_status(),
+        create_private_world_runtime(
+            {"OLIVIA_PRIVATE_WORLD_DB": "relative.sqlite3"}
+        ).public_status(),
+        degraded.public_status(),
+    ]
+
+    validator = Draft202012Validator(schema)
+    assert all(list(validator.iter_errors(status)) == [] for status in statuses)
+
+
+def test_runtime_health_fails_closed_when_sqlite_becomes_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = create_private_world_runtime(
+        {"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path)}
+    )
+    assert isinstance(runtime.port, SQLitePrivateWorldLedger)
+
+    def unavailable_health() -> dict[str, int | str]:
+        raise sqlite3.DatabaseError("synthetic sqlite failure")
+
+    monkeypatch.setattr(runtime.port, "health", unavailable_health)
+
+    assert runtime.public_status() == {
+        "status": "unavailable",
+        "provider": "none",
+        "reason_code": "PRIVATE_WORLD_STORAGE_UNAVAILABLE",
+        "enabled": True,
+        "schema_version": 2,
+        "migration_status": "created_v2",
+        "event_count": 0,
+        "snapshot_count": 0,
+        "probe": "not-run",
+        "network_called": False,
+    }
+
+
+def test_runtime_health_fails_closed_when_current_snapshot_is_semantically_corrupt(
+    tmp_path: Path,
+) -> None:
+    runtime = create_private_world_runtime(
+        {"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path)}
+    )
+    assert isinstance(runtime.port, SQLitePrivateWorldLedger)
+    runtime.port.apply_once(
+        LedgerEvent(
+            event_id="corrupt-health-event",
+            delivery_id="corrupt-health-delivery",
+            event_type="canonical_reply_delivered",
+            payload={"applied": False},
+            occurred_at="2026-08-22T00:00:00+00:00",
+        ),
+        PrivateWorldSnapshot(version=1),
+    )
+    database = tmp_path / PRIVATE_WORLD_DEFAULT_RELATIVE_PATH
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "UPDATE private_world_snapshots SET payload_json = ?",
+            ("[]",),
+        )
+
+    assert runtime.public_status() == {
+        "status": "unavailable",
+        "provider": "none",
+        "reason_code": "PRIVATE_WORLD_STORAGE_UNAVAILABLE",
+        "enabled": True,
+        "schema_version": 2,
+        "migration_status": "created_v2",
+        "event_count": 0,
+        "snapshot_count": 0,
+        "probe": "not-run",
+        "network_called": False,
+    }
+
+
+def test_unknown_stored_snapshot_field_degrades_health_and_canonical_commit(
+    tmp_path: Path,
+) -> None:
+    runtime = create_private_world_runtime(
+        {"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path)}
+    )
+    assert isinstance(runtime.port, SQLitePrivateWorldLedger)
+    assert runtime.committer is not None
+    runtime.port.apply_once(
+        LedgerEvent(
+            event_id="unknown-field-event",
+            delivery_id="unknown-field-delivery",
+            event_type="canonical_reply_delivered",
+            payload={"applied": False},
+            occurred_at="2026-08-22T00:00:00+00:00",
+        ),
+        PrivateWorldSnapshot(version=1),
+    )
+    payload = PrivateWorldSnapshot(version=1).to_dict()
+    payload["unrecognized_control_state"] = "must-not-be-ignored"
+    database = tmp_path / PRIVATE_WORLD_DEFAULT_RELATIVE_PATH
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "UPDATE private_world_snapshots SET payload_json = ?",
+            (json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")),),
+        )
+
+    assert runtime.public_status()["status"] == "unavailable"
+    assert runtime.committer.commit(
+        DeliveryEvent(
+            delivery_id="unknown-field-commit:1",
+            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
+            occurred_at=datetime(2026, 8, 25, tzinfo=timezone.utc),
+            semantic_key="canonical.unknown-field",
+        )
+    ) is DeliveryStatus.UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    [
+        "unknown_nested_field",
+        "invalid_bounded_value",
+        "row_payload_version_mismatch",
+        "noncanonical_roundtrip",
+    ],
+)
+def test_strict_stored_snapshot_validation_rejects_every_noncanonical_row(
+    tmp_path: Path,
+    corruption: str,
+) -> None:
+    runtime = create_private_world_runtime(
+        {"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path)}
+    )
+    assert isinstance(runtime.port, SQLitePrivateWorldLedger)
+    assert runtime.committer is not None
+    runtime.port.apply_once(
+        LedgerEvent(
+            event_id=f"{corruption}-event",
+            delivery_id=f"{corruption}-delivery",
+            event_type="canonical_reply_delivered",
+            payload={"applied": False},
+            occurred_at="2026-08-22T00:00:00+00:00",
+        ),
+        PrivateWorldSnapshot(version=1),
+    )
+    payload = PrivateWorldSnapshot(version=1).to_dict()
+    if corruption == "unknown_nested_field":
+        payload["continuation_facts"] = [
+            {
+                "fact_id": "known.synthetic",
+                "statement": "合成已知事实。",
+                "awareness": "character_known",
+                "unrecognized_control_state": "must-not-be-ignored",
+            }
+        ]
+    elif corruption == "invalid_bounded_value":
+        payload["trust"] = 101
+    elif corruption == "row_payload_version_mismatch":
+        payload["version"] = 2
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=corruption != "noncanonical_roundtrip",
+        separators=(",", ":") if corruption != "noncanonical_roundtrip" else None,
+    )
+    database = tmp_path / PRIVATE_WORLD_DEFAULT_RELATIVE_PATH
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "UPDATE private_world_snapshots SET payload_json = ?",
+            (encoded,),
+        )
+
+    assert runtime.public_status()["status"] == "unavailable"
+    assert runtime.committer.commit(
+        DeliveryEvent(
+            delivery_id=f"{corruption}-commit:1",
+            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
+            occurred_at=datetime(2026, 8, 25, tzinfo=timezone.utc),
+            semantic_key=f"canonical.{corruption}",
+        )
+    ) is DeliveryStatus.UNAVAILABLE
+
+
+def test_runtime_degrades_when_path_resolution_raises_sqlite_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable_resolution(
+        environ: dict[str, str] | None = None,
+    ) -> tuple[Path | None, str | None, bool]:
+        raise sqlite3.DatabaseError("synthetic sqlite failure")
+
+    monkeypatch.setattr(
+        private_world_runtime,
+        "resolve_private_world_database",
+        unavailable_resolution,
+    )
+
+    runtime = create_private_world_runtime({"OLIVIA_LOCAL_DATA_ROOT": "unused"})
+
+    assert isinstance(runtime.port, NullPrivateWorldPort)
+    assert runtime.committer is None
+    assert runtime.public_status()["status"] == "unavailable"
+    assert runtime.public_status()["reason_code"] == "PRIVATE_WORLD_STORAGE_UNAVAILABLE"
+
+
+def test_runtime_degrades_when_ledger_construction_raises_sqlite_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable_ledger(_path: Path) -> SQLitePrivateWorldLedger:
+        raise sqlite3.DatabaseError("synthetic sqlite failure")
+
+    monkeypatch.setattr(
+        private_world_runtime,
+        "SQLitePrivateWorldLedger",
+        unavailable_ledger,
+    )
+
+    runtime = create_private_world_runtime(
+        {"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path)}
+    )
+
+    assert isinstance(runtime.port, NullPrivateWorldPort)
+    assert runtime.committer is None
+    assert runtime.public_status()["status"] == "unavailable"
+    assert runtime.public_status()["reason_code"] == "PRIVATE_WORLD_STORAGE_UNAVAILABLE"
+
+
+def test_runtime_degrades_when_startup_health_raises_sqlite_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class UnhealthyLedger:
+        def __init__(self, _path: Path) -> None:
+            pass
+
+        def health(self) -> dict[str, int | str]:
+            raise sqlite3.DatabaseError("synthetic sqlite failure")
+
+    monkeypatch.setattr(
+        private_world_runtime,
+        "SQLitePrivateWorldLedger",
+        UnhealthyLedger,
+    )
+
+    runtime = create_private_world_runtime(
+        {"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path)}
+    )
+
+    assert isinstance(runtime.port, NullPrivateWorldPort)
+    assert runtime.committer is None
+    assert runtime.public_status()["status"] == "unavailable"
+    assert runtime.public_status()["reason_code"] == "PRIVATE_WORLD_STORAGE_UNAVAILABLE"
+
+
 def test_explicit_absolute_database_overrides_default(tmp_path: Path) -> None:
     explicit = tmp_path / "custom" / "world.sqlite3"
     path, reason, enabled = resolve_private_world_database(
@@ -170,6 +695,105 @@ def test_explicit_absolute_database_overrides_default(tmp_path: Path) -> None:
     )
     assert runtime.status == "available"
     assert explicit.is_file()
+
+
+def test_available_sqlite_projects_only_character_view_into_reply_context(
+    tmp_path: Path,
+) -> None:
+    from local_server import LetterAdapter
+    from reply_context import ReplyMode
+
+    runtime = create_private_world_runtime(
+        {"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path)}
+    )
+    assert isinstance(runtime.port, SQLitePrivateWorldLedger)
+    runtime.port.apply_once(
+        LedgerEvent(
+            event_id="projection-event",
+            delivery_id="projection-delivery",
+            event_type="canonical_reply_delivered",
+            payload={"applied": False},
+            occurred_at="2026-08-22T00:00:00+00:00",
+        ),
+        PrivateWorldSnapshot(
+            version=1,
+            familiarity=88,
+            trust=91,
+            comfort=77,
+            closeness=74,
+            tension=12,
+            relationship_stage="close",
+            nickname_permissions=("合成称呼",),
+            home_access=HomeAccess.DOMESTIC_ACCESS,
+            continuation_facts=(
+                LocalContinuationFact(
+                    "known.class",
+                    "角色已知的合成课程调整。",
+                    ContinuationAwareness.CHARACTER_KNOWN,
+                ),
+                LocalContinuationFact(
+                    "pending.trip",
+                    "角色未知的合成旅行安排。",
+                    ContinuationAwareness.PENDING,
+                ),
+                LocalContinuationFact(
+                    "control.plan",
+                    "仅控制层可见的合成计划。",
+                    ContinuationAwareness.CONTROL_ONLY,
+                ),
+            ),
+        ),
+    )
+
+    context = LetterAdapter(private_world_port=runtime.port).build_reply_context(
+        ReplyMode.TEXT_LETTER
+    )
+    serialized_model_private_world = json.dumps(
+        {
+            "private_behavior": context.private_behavior.to_dict(),
+            "world_facts": [fact.to_dict() for fact in context.world_facts],
+        },
+        ensure_ascii=False,
+    )
+    serialized_health = json.dumps(runtime.public_status(), ensure_ascii=False)
+
+    assert context.private_behavior.to_dict() == {
+        "familiarity": "high",
+        "trust": "high",
+        "comfort": "high",
+        "closeness": "high",
+        "tension": "low",
+        "relationship_stage": "close",
+        "nickname_permission": "allowed",
+        "home_history_allowed": True,
+        "known_continuations": [
+            {
+                "fact_id": "known.class",
+                "statement": "角色已知的合成课程调整。",
+            }
+        ],
+    }
+    assert "合成称呼" in serialized_model_private_world
+    assert "角色已知的合成课程调整。" in serialized_model_private_world
+    for hidden in (
+        "88",
+        "91",
+        "77",
+        "74",
+        "12",
+        "pending.trip",
+        "control.plan",
+        "角色未知的合成旅行安排。",
+        "仅控制层可见的合成计划。",
+        "pending",
+        "control_only",
+        "no_access",
+        "visit_access",
+        "errand_access",
+        "domestic_access",
+    ):
+        assert hidden not in serialized_model_private_world
+        assert hidden not in serialized_health
 
 
 @pytest.mark.parametrize(

--- a/tests/private_world/test_private_world_runtime_wiring.py
+++ b/tests/private_world/test_private_world_runtime_wiring.py
@@ -95,7 +95,7 @@ print(json.dumps({
     'reply_context': reply_context.to_dict(),
     'gateway_messages': gateway_messages,
     'health': health,
-}, ensure_ascii=False, sort_keys=True))
+}, sort_keys=True))
 """
     environment = os.environ.copy()
     environment["OLIVIA_LOCAL_DATA_ROOT"] = str(data_root)

--- a/tests/private_world/test_private_world_runtime_wiring.py
+++ b/tests/private_world/test_private_world_runtime_wiring.py
@@ -1,0 +1,459 @@
+"""Fresh-process coverage for the local-server PrivateWorld runtime seam."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _fresh_local_server_payload(
+    data_root: Path,
+    *,
+    private_world_environment: dict[str, str] | None = None,
+    seed_available_snapshot: bool = False,
+) -> dict[str, object]:
+    script = """
+import asyncio
+import json
+from pathlib import Path
+
+import local_server
+from private_world_ledger import LedgerEvent
+from private_world_port import (
+    ContinuationAwareness,
+    HomeAccess,
+    LocalContinuationFact,
+    PrivateWorldSnapshot,
+)
+from reply_context import ReplyMode
+
+database = Path(__import__('os').environ['OLIVIA_LOCAL_DATA_ROOT']) / 'private_world' / 'private_world.sqlite3'
+if __import__('os').environ.get('OLIVIA_TEST_SEED_PRIVATE_WORLD') == '1':
+    local_server.private_world_runtime.port.apply_once(
+        LedgerEvent(
+            event_id='gateway-projection-event',
+            delivery_id='gateway-projection-delivery',
+            event_type='canonical_reply_delivered',
+            payload={'applied': False},
+            occurred_at='2026-08-22T00:00:00+00:00',
+        ),
+        PrivateWorldSnapshot(
+            version=1,
+            familiarity=88,
+            trust=91,
+            comfort=77,
+            closeness=74,
+            tension=12,
+            relationship_stage='close',
+            nickname_permissions=('合成称呼',),
+            home_access=HomeAccess.DOMESTIC_ACCESS,
+            continuation_facts=(
+                LocalContinuationFact(
+                    'known.class',
+                    '角色已知的合成课程调整。',
+                    ContinuationAwareness.CHARACTER_KNOWN,
+                ),
+                LocalContinuationFact(
+                    'pending.trip',
+                    '角色未知的合成旅行安排。',
+                    ContinuationAwareness.PENDING,
+                ),
+                LocalContinuationFact(
+                    'control.plan',
+                    '仅控制层可见的合成计划。',
+                    ContinuationAwareness.CONTROL_ONLY,
+                ),
+            ),
+        ),
+    )
+health = asyncio.run(
+    local_server.route('GET', '/health', {}, {'profile': 'core'})
+)['data']['providers']['private_world']
+letter = {'letter_id': 'synthetic-letter'}
+local_server._prepare_private_world_delivery(letter, 'synthetic canonical reply')
+delivery_committed = local_server._commit_private_world_letter(letter)
+reply_context = local_server.letters_adapter.build_reply_context(ReplyMode.TEXT_LETTER)
+gateway_messages = local_server.letters_adapter._messages('synthetic current letter')
+print(json.dumps({
+    'database_exists': database.is_file(),
+    'runtime_port_type': type(local_server.private_world_runtime.port).__name__,
+    'runtime_committer_type': type(local_server.private_world_runtime.committer).__name__,
+    'adapter_uses_runtime_port': local_server.letters_adapter.private_world_port is local_server.private_world_runtime.port,
+    'delivery_uses_runtime_committer': local_server.private_world_committer is local_server.private_world_runtime.committer,
+    'delivery_committed': delivery_committed,
+    'delivery_status': letter['private_world_status'],
+    'delivery_error_code': letter.get('private_world_error_code'),
+    'reply_context': reply_context.to_dict(),
+    'gateway_messages': gateway_messages,
+    'health': health,
+}, ensure_ascii=False, sort_keys=True))
+"""
+    environment = os.environ.copy()
+    environment["OLIVIA_LOCAL_DATA_ROOT"] = str(data_root)
+    environment["OLIVIA_LLM_PROVIDER"] = "none"
+    environment["OLIVIA_MEMORY_ENABLED"] = "0"
+    environment.pop("OLIVIA_PRIVATE_WORLD_DB", None)
+    environment.pop("OLIVIA_PRIVATE_WORLD_ENABLED", None)
+    if private_world_environment:
+        environment.update(private_world_environment)
+    if seed_available_snapshot:
+        environment["OLIVIA_TEST_SEED_PRIVATE_WORLD"] = "1"
+    environment["PYTHONPATH"] = str(ROOT) + os.pathsep + environment.get(
+        "PYTHONPATH", ""
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, "fresh local_server subprocess failed"
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def _fresh_generate_reply_payload(
+    data_root: Path,
+    *,
+    simulate_sqlite_failure: bool = False,
+    simulate_semantic_failure: bool = False,
+) -> dict[str, object]:
+    script = """
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import local_server
+from reply_context import ReplyMode
+from reply_orchestrator import ReplyState
+from reply_pipeline import PipelineResult
+from voice_direction import VoicePerformancePlan
+
+class AcceptedPipeline:
+    async def run(self, request, context):
+        return PipelineResult(
+            'fresh-canonical',
+            ReplyState.COMPLETED,
+            text='synthetic canonical reply',
+            quality_status='accepted',
+        )
+
+class TextTriage:
+    reply_mode = ReplyMode.TEXT_LETTER.value
+    def to_dict(self):
+        return {'reply_mode': self.reply_mode}
+
+class TextTriageService:
+    async def classify(self, content):
+        return TextTriage()
+
+async def fixed_voice_plan(letter, text):
+    return VoicePerformancePlan(
+        reply_text=text,
+        overall_emotion='steady',
+        global_speed=1.0,
+        energy=0.5,
+        breath_before_sentences=(),
+        emphasize_sentences=(),
+    )
+
+def render_reply(text, output_path, **kwargs):
+    Path(output_path).write_bytes(b'synthetic media retry')
+    return {}
+
+local_server.emotion_triage = TextTriageService()
+local_server.reply_pipeline = AcceptedPipeline()
+local_server._schedule_text_reply_delay = lambda *args: None
+local_server._persist_store_state = lambda: None
+local_server._persist_media_state = lambda: None
+local_server.letters_adapter.remember_conversation = lambda *args: None
+local_server._voice_plan_for_letter = fixed_voice_plan
+local_server.render_reply_video = render_reply
+
+if os.environ.get('OLIVIA_TEST_PRIVATE_WORLD_SQLITE_FAILURE') == '1':
+    def unavailable_snapshot():
+        import sqlite3
+        raise sqlite3.DatabaseError('synthetic sqlite failure')
+    local_server.private_world_committer.ledger.snapshot = unavailable_snapshot
+elif os.environ.get('OLIVIA_TEST_PRIVATE_WORLD_SEMANTIC_FAILURE') == '1':
+    def corrupt_snapshot():
+        raise json.JSONDecodeError('synthetic corrupt snapshot', '{', 1)
+    local_server.private_world_committer.ledger.snapshot = corrupt_snapshot
+
+letter = {
+    'letter_id': 'fresh-canonical',
+    'content': 'synthetic current letter',
+    'reply_text': '',
+    'reply_mode': ReplyMode.TEXT_LETTER.value,
+    'letter_status': 'PENDING',
+}
+local_server.store.letters[:] = [letter]
+canonical_result = asyncio.run(
+    local_server.generate_reply('fresh-canonical', 'synthetic current letter')
+)
+event_count_after_canonical = local_server.private_world_runtime.port.health()['event_count']
+recovery_count = local_server.recover_pending_private_world()
+
+scene = Path(os.environ['OLIVIA_LOCAL_DATA_ROOT']) / 'scene.mp4'
+scene.write_bytes(b'synthetic scene')
+for key in ('MORNING', 'DAY', 'DUSK', 'NIGHT'):
+    os.environ['OLIVIA_SCENE_' + key] = str(scene)
+letter['media_status'] = 'UNAVAILABLE'
+asyncio.run(
+    local_server._render_media_job(
+        'fresh-canonical',
+        'synthetic current letter',
+        'synthetic canonical reply',
+        ReplyMode.SPOKEN_VIDEO.value,
+    )
+)
+event_count_after_media_retry = local_server.private_world_runtime.port.health()['event_count']
+
+print(json.dumps({
+    'canonical_result': canonical_result,
+    'private_world_status': letter['private_world_status'],
+    'private_world_error_code': letter.get('private_world_error_code'),
+    'private_world_delivery_id': letter['private_world_delivery_id'],
+    'reply_revision': letter['reply_revision'],
+    'recovery_count': recovery_count,
+    'event_count_after_canonical': event_count_after_canonical,
+    'event_count_after_media_retry': event_count_after_media_retry,
+    'media_status': letter['media_status'],
+}, ensure_ascii=False, sort_keys=True))
+"""
+    environment = os.environ.copy()
+    environment["OLIVIA_LOCAL_DATA_ROOT"] = str(data_root)
+    environment["OLIVIA_LLM_PROVIDER"] = "none"
+    environment["OLIVIA_MEMORY_ENABLED"] = "0"
+    environment.pop("OLIVIA_PRIVATE_WORLD_DB", None)
+    environment.pop("OLIVIA_PRIVATE_WORLD_ENABLED", None)
+    if simulate_sqlite_failure:
+        environment["OLIVIA_TEST_PRIVATE_WORLD_SQLITE_FAILURE"] = "1"
+    if simulate_semantic_failure:
+        environment["OLIVIA_TEST_PRIVATE_WORLD_SEMANTIC_FAILURE"] = "1"
+    environment["PYTHONPATH"] = str(ROOT) + os.pathsep + environment.get(
+        "PYTHONPATH", ""
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, "fresh generate_reply subprocess failed"
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def test_local_server_fresh_process_wires_default_private_world_runtime(
+    tmp_path: Path,
+) -> None:
+    payload = _fresh_local_server_payload(tmp_path / "local-data")
+
+    assert payload["database_exists"] is True
+    assert payload["runtime_port_type"] == "SQLitePrivateWorldLedger"
+    assert payload["runtime_committer_type"] == "PrivateWorldDeliveryCommitter"
+    assert payload["adapter_uses_runtime_port"] is True
+    assert payload["delivery_uses_runtime_committer"] is True
+    assert payload["delivery_committed"] is True
+    assert payload["delivery_status"] == "COMMITTED"
+    assert payload["delivery_error_code"] is None
+    assert payload["health"] == {
+        "status": "available",
+        "provider": "sqlite",
+        "reason_code": None,
+        "enabled": True,
+        "schema_version": 2,
+        "migration_status": "created_v2",
+        "event_count": 0,
+        "snapshot_count": 0,
+        "probe": "in-process",
+        "network_called": False,
+    }
+    serialized = json.dumps(payload["health"], ensure_ascii=False)
+    assert str(tmp_path) not in serialized
+    assert "trust" not in serialized
+    assert "familiarity" not in serialized
+
+
+def test_local_server_import_degrades_a_corrupt_sqlite_database(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "corrupt-private-world.sqlite3"
+    database.write_bytes(b"this is not a sqlite database")
+
+    payload = _fresh_local_server_payload(
+        tmp_path / "local-data",
+        private_world_environment={"OLIVIA_PRIVATE_WORLD_DB": str(database)},
+    )
+
+    assert payload["runtime_port_type"] == "NullPrivateWorldPort"
+    assert payload["runtime_committer_type"] == "NoneType"
+    assert payload["health"]["status"] == "unavailable"
+    assert payload["health"]["provider"] == "none"
+    assert payload["health"]["reason_code"] == "PRIVATE_WORLD_STORAGE_UNAVAILABLE"
+
+
+def test_available_sqlite_private_world_reaches_gateway_only_as_character_view(
+    tmp_path: Path,
+) -> None:
+    payload = _fresh_local_server_payload(
+        tmp_path / "local-data",
+        seed_available_snapshot=True,
+    )
+
+    system_message = next(
+        str(message["content"])
+        for message in payload["gateway_messages"]
+        if message["role"] == "system"
+    )
+
+    assert '"home_history_allowed":true' in system_message
+    assert "合成称呼" in system_message
+    assert "角色已知的合成课程调整。" in system_message
+    private_behavior = re.search(
+        r"<private_behavior>\n(?P<payload>.+?)\n</private_behavior>",
+        system_message,
+        flags=re.DOTALL,
+    )
+    assert private_behavior is not None
+    serialized_private_behavior = private_behavior.group("payload")
+    for hidden in ("88", "91", "77", "74", "12"):
+        assert hidden not in serialized_private_behavior
+    for hidden in (
+        "no_access",
+        "visit_access",
+        "errand_access",
+        "domestic_access",
+        "pending.trip",
+        "control.plan",
+        "角色未知的合成旅行安排。",
+        "仅控制层可见的合成计划。",
+        "pending",
+        "control_only",
+    ):
+        assert hidden not in system_message
+
+
+def test_fresh_generate_reply_commits_once_and_media_retry_never_recommits(
+    tmp_path: Path,
+) -> None:
+    payload = _fresh_generate_reply_payload(tmp_path / "local-data")
+
+    assert payload == {
+        "canonical_result": True,
+        "private_world_status": "COMMITTED",
+        "private_world_error_code": None,
+        "private_world_delivery_id": "fresh-canonical:1",
+        "reply_revision": 1,
+        "recovery_count": 0,
+        "event_count_after_canonical": 1,
+        "event_count_after_media_retry": 1,
+        "media_status": "UNAVAILABLE",
+    }
+
+
+def test_fresh_generate_reply_keeps_canonical_reply_pending_when_sqlite_fails(
+    tmp_path: Path,
+) -> None:
+    payload = _fresh_generate_reply_payload(
+        tmp_path / "local-data",
+        simulate_sqlite_failure=True,
+    )
+
+    assert payload == {
+        "canonical_result": True,
+        "private_world_status": "PENDING",
+        "private_world_error_code": "PRIVATE_WORLD_UNAVAILABLE",
+        "private_world_delivery_id": "fresh-canonical:1",
+        "reply_revision": 1,
+        "recovery_count": 0,
+        "event_count_after_canonical": 0,
+        "event_count_after_media_retry": 0,
+        "media_status": "UNAVAILABLE",
+    }
+
+
+def test_fresh_generate_reply_keeps_canonical_reply_pending_when_snapshot_is_corrupt(
+    tmp_path: Path,
+) -> None:
+    payload = _fresh_generate_reply_payload(
+        tmp_path / "local-data",
+        simulate_semantic_failure=True,
+    )
+
+    assert payload == {
+        "canonical_result": True,
+        "private_world_status": "PENDING",
+        "private_world_error_code": "PRIVATE_WORLD_UNAVAILABLE",
+        "private_world_delivery_id": "fresh-canonical:1",
+        "reply_revision": 1,
+        "recovery_count": 0,
+        "event_count_after_canonical": 0,
+        "event_count_after_media_retry": 0,
+        "media_status": "UNAVAILABLE",
+    }
+
+
+@pytest.mark.parametrize(
+    ("private_world_environment", "expected_status", "expected_reason"),
+    [
+        (
+            {"OLIVIA_PRIVATE_WORLD_ENABLED": "0"},
+            "disabled",
+            "PRIVATE_WORLD_DISABLED",
+        ),
+        (
+            {"OLIVIA_PRIVATE_WORLD_DB": "relative.sqlite3"},
+            "unavailable",
+            "PRIVATE_WORLD_DB_MUST_BE_ABSOLUTE",
+        ),
+    ],
+)
+def test_local_server_private_world_failure_uses_null_port_without_blocking_letters(
+    tmp_path: Path,
+    private_world_environment: dict[str, str],
+    expected_status: str,
+    expected_reason: str,
+) -> None:
+    payload = _fresh_local_server_payload(
+        tmp_path / "local-data",
+        private_world_environment=private_world_environment,
+    )
+
+    assert payload["database_exists"] is False
+    assert payload["runtime_port_type"] == "NullPrivateWorldPort"
+    assert payload["runtime_committer_type"] == "NoneType"
+    assert payload["adapter_uses_runtime_port"] is True
+    assert payload["delivery_uses_runtime_committer"] is True
+    assert payload["delivery_committed"] is False
+    assert payload["delivery_status"] == "PENDING"
+    assert payload["delivery_error_code"] == "PRIVATE_WORLD_UNAVAILABLE"
+    assert payload["health"]["status"] == expected_status
+    assert payload["health"]["provider"] == "none"
+    assert payload["health"]["reason_code"] == expected_reason
+    assert payload["health"]["network_called"] is False
+    private_behavior = payload["reply_context"]["private_behavior"]
+    assert private_behavior == {
+        "familiarity": "unknown",
+        "trust": "unknown",
+        "comfort": "unknown",
+        "closeness": "unknown",
+        "tension": "unknown",
+        "relationship_stage": "unknown",
+        "nickname_permission": "not_allowed",
+            "home_history_allowed": False,
+        "known_continuations": [],
+    }

--- a/tests/test_packaging_local_server.py
+++ b/tests/test_packaging_local_server.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import venv
+import zipfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(command: list[str], *, cwd: Path, env: dict[str, str]) -> None:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise AssertionError("packaging subprocess failed")
+
+
+def test_wheel_installs_every_module_needed_to_import_local_server(
+    tmp_path: Path,
+) -> None:
+    wheel_dir = tmp_path / "wheel"
+    wheel_dir.mkdir()
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    _run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            ".",
+            "--no-deps",
+            "--no-build-isolation",
+            "--wheel-dir",
+            str(wheel_dir),
+        ],
+        cwd=ROOT,
+        env=environment,
+    )
+    wheel = next(wheel_dir.glob("*.whl"))
+    with zipfile.ZipFile(wheel) as archive:
+        packaged_paths = frozenset(archive.namelist())
+    assert "private_world_runtime.py" in packaged_paths
+    assert "music_caption.py" in packaged_paths
+    assert {
+        "linli_character/persona_release_v2.json",
+        "linli_character/persona_release_provenance_v2.json",
+        "contracts/persona_v2.schema.json",
+        "contracts/persona_v2_provenance.schema.json",
+    } <= packaged_paths
+    assert not {
+        "linli_character/persona_v2.json",
+        "linli_character/provenance_v2.json",
+        "linli_character/system_prompt.md",
+        "linli_character/persona_config.json",
+    } & packaged_paths
+    assert not any(
+        path.startswith(".private/")
+        or path.endswith("linli-im-private-constitution-1.0.zh-CN.md")
+        for path in packaged_paths
+    )
+    environment_dir = tmp_path / "environment"
+    venv.EnvBuilder(with_pip=True, system_site_packages=True).create(environment_dir)
+    interpreter = environment_dir / "Scripts" / "python.exe"
+    _run(
+        [str(interpreter), "-m", "pip", "install", "--no-deps", str(wheel)],
+        cwd=tmp_path,
+        env=environment,
+    )
+    installed_environment = environment.copy()
+    installed_environment["OLIVIA_LOCAL_DATA_ROOT"] = str(tmp_path / "data")
+    _run(
+        [
+            str(interpreter),
+            "-c",
+            "import music_caption, song_content; import local_server",
+        ],
+        cwd=tmp_path,
+        env=installed_environment,
+    )
+    _run(
+        [
+            str(interpreter),
+            "-c",
+            "from datetime import datetime, timezone; from pathlib import Path; "
+            "from persona_assembly import assemble_persona; "
+            "from persona_loader import load_persona; "
+            "from reply_context import ReplyContext, ReplyMode, TrustedTime; "
+            "root = Path(__import__('persona_loader').__file__).resolve().parent; "
+            "loaded = load_persona(root / 'linli_character' / 'persona_release_v2.json'); "
+            "assert loaded.ready and loaded.snapshot.status == 'READY'; "
+            "assembly = assemble_persona(loaded.snapshot, ReplyContext.create(ReplyMode.TEXT_LETTER, trusted_time=TrustedTime(datetime(2026, 8, 25, tzinfo=timezone.utc))), user_input='synthetic normal letter', max_units=10000); "
+            "assert assembly.persona_status == 'READY' and 'Persona status is DRAFT' not in assembly.system_content",
+        ],
+        cwd=tmp_path,
+        env=installed_environment,
+    )


### PR DESCRIPTION
Wires the default local PrivateWorld runtime into normal text letters with fail-closed storage handling, finite Character View projection, canonical-once delivery, legacy v1 migration, sanitized health contracts, and installable public Persona resources. Validation: 384 focused passed / 1 deselected; full repository 755 passed / 1 deselected; baseline hardening, schemas, wheel smoke, compileall, and diff checks passed. Excludes Live, music behavior changes, installer, Release, Constitution, and all private corpus/data.