### PR TITLE
fix: bound Mem0 provider calls

### DIFF
--- a/bounded_daemon_call.py
+++ b/bounded_daemon_call.py
@@ -3,9 +3,23 @@
 from __future__ import annotations
 
 import asyncio
+import math
+from numbers import Real
 import threading
 import time
 from typing import Callable
+
+
+def validate_timeout_seconds(value: object) -> float:
+    """Return a finite provider timeout within the shared lifecycle bound."""
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, Real)
+        or not math.isfinite(value)
+        or not 0 < value <= 300
+    ):
+        raise ValueError("timeout_seconds is invalid")
+    return float(value)
 
 
 class BoundedDaemonCall:
@@ -29,6 +43,7 @@ class BoundedDaemonCall:
         *,
         timeout_seconds: float,
     ) -> tuple[str, object | None]:
+        timeout_seconds = validate_timeout_seconds(timeout_seconds)
         pending = self._start(operation)
         if pending is None:
             return "inflight", None
@@ -41,6 +56,7 @@ class BoundedDaemonCall:
         *,
         timeout_seconds: float,
     ) -> tuple[str, object | None]:
+        timeout_seconds = validate_timeout_seconds(timeout_seconds)
         pending = self._start(operation)
         if pending is None:
             return "inflight", None

--- a/bounded_daemon_call.py
+++ b/bounded_daemon_call.py
@@ -1,0 +1,81 @@
+"""Bound one provider operation to one daemon worker at a time."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Callable
+
+
+class BoundedDaemonCall:
+    """Run a blocking provider call without accumulating executor threads."""
+
+    def __init__(self, *, thread_name: str) -> None:
+        if not isinstance(thread_name, str) or not thread_name:
+            raise ValueError("thread_name is required")
+        self._thread_name = thread_name
+        self._lock = threading.Lock()
+        self._inflight = False
+
+    @property
+    def inflight(self) -> bool:
+        with self._lock:
+            return self._inflight
+
+    def call(
+        self,
+        operation: Callable[[], object],
+        *,
+        timeout_seconds: float,
+    ) -> tuple[str, object | None]:
+        pending = self._start(operation)
+        if pending is None:
+            return "inflight", None
+        done, outcome = pending
+        return self._result(outcome) if done.wait(timeout_seconds) else ("timeout", None)
+
+    async def call_async(
+        self,
+        operation: Callable[[], object],
+        *,
+        timeout_seconds: float,
+    ) -> tuple[str, object | None]:
+        pending = self._start(operation)
+        if pending is None:
+            return "inflight", None
+        done, outcome = pending
+        deadline = time.monotonic() + timeout_seconds
+        while not done.is_set():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return "timeout", None
+            await asyncio.sleep(min(0.01, remaining))
+        return self._result(outcome)
+
+    def _start(
+        self,
+        operation: Callable[[], object],
+    ) -> tuple[threading.Event, dict[str, object]] | None:
+        with self._lock:
+            if self._inflight:
+                return None
+            self._inflight = True
+        done, outcome = threading.Event(), {}
+
+        def run() -> None:
+            try:
+                outcome["value"] = operation()
+            except BaseException:
+                outcome["failed"] = True
+            finally:
+                with self._lock:
+                    self._inflight = False
+                done.set()
+
+        threading.Thread(target=run, name=self._thread_name, daemon=True).start()
+        return done, outcome
+
+    @staticmethod
+    def _result(outcome: dict[str, object]) -> tuple[str, object | None]:
+        return ("failed", None) if outcome.get("failed") else ("completed", outcome.get("value"))

--- a/conversation_memory_delivery.py
+++ b/conversation_memory_delivery.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from enum import StrEnum
 import re
 
-from bounded_daemon_call import BoundedDaemonCall
+from bounded_daemon_call import BoundedDaemonCall, validate_timeout_seconds
 from conversation_memory_port import (
     ConversationMemoryPort,
     MemoryWriteResult,
@@ -129,10 +129,8 @@ class ConversationMemoryDeliveryCommitter:
         *,
         timeout_seconds: float = 30.0,
     ) -> None:
-        if timeout_seconds <= 0 or timeout_seconds > 300:
-            raise ValueError("memory delivery timeout is invalid")
         self.memory = memory
-        self.timeout_seconds = float(timeout_seconds)
+        self.timeout_seconds = validate_timeout_seconds(timeout_seconds)
         self._provider_call = BoundedDaemonCall(thread_name="olivia-memory-delivery")
 
     async def commit(

--- a/conversation_memory_delivery.py
+++ b/conversation_memory_delivery.py
@@ -8,14 +8,15 @@ changes the already-persisted reply.
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
 import re
 
+from bounded_daemon_call import BoundedDaemonCall
 from conversation_memory_port import (
     ConversationMemoryPort,
+    MemoryWriteResult,
     MemoryWriteStatus,
 )
 
@@ -132,6 +133,7 @@ class ConversationMemoryDeliveryCommitter:
             raise ValueError("memory delivery timeout is invalid")
         self.memory = memory
         self.timeout_seconds = float(timeout_seconds)
+        self._provider_call = BoundedDaemonCall(thread_name="olivia-memory-delivery")
 
     async def commit(
         self,
@@ -140,42 +142,29 @@ class ConversationMemoryDeliveryCommitter:
         if not isinstance(delivery, CanonicalMemoryDelivery):
             raise TypeError("a canonical memory delivery is required")
 
-        provider_status = _provider_status(self.memory)
-        if provider_status == "disabled":
-            return CanonicalMemoryDeliveryResult(
-                CanonicalMemoryDeliveryStatus.SKIPPED,
-                delivery.source_id,
-            )
-        if provider_status == "unavailable":
-            return CanonicalMemoryDeliveryResult(
-                CanonicalMemoryDeliveryStatus.UNAVAILABLE,
-                delivery.source_id,
-                error_code=_provider_error(self.memory),
-            )
-
-        try:
-            result = await asyncio.wait_for(
-                asyncio.to_thread(
-                    self.memory.remember_exchange,
-                    user_message=delivery.user_message,
-                    assistant_message=delivery.assistant_message,
-                    occurred_at=delivery.occurred_at,
-                    source_id=delivery.source_id,
-                    user_id=delivery.user_id,
-                ),
-                timeout=self.timeout_seconds,
-            )
-        except asyncio.TimeoutError:
+        state, result = await self._provider_call.call_async(
+            lambda: _deliver_to_provider(self.memory, delivery),
+            timeout_seconds=self.timeout_seconds,
+        )
+        if state in {"timeout", "inflight"}:
             return CanonicalMemoryDeliveryResult(
                 CanonicalMemoryDeliveryStatus.UNAVAILABLE,
                 delivery.source_id,
                 error_code="MEM0_WRITE_TIMEOUT",
             )
-        except Exception:
+        if state == "failed":
             return CanonicalMemoryDeliveryResult(
                 CanonicalMemoryDeliveryStatus.UNAVAILABLE,
                 delivery.source_id,
                 error_code="MEM0_WRITE_FAILED",
+            )
+        if isinstance(result, CanonicalMemoryDeliveryResult):
+            return result
+        if not isinstance(result, MemoryWriteResult):
+            return CanonicalMemoryDeliveryResult(
+                CanonicalMemoryDeliveryStatus.UNAVAILABLE,
+                delivery.source_id,
+                error_code="MEM0_WRITE_RESULT_INVALID",
             )
 
         mapping = {
@@ -223,20 +212,48 @@ def _message(value: object, *, field_name: str, maximum: int) -> str:
     return value
 
 
-def _provider_status(memory: ConversationMemoryPort) -> str:
+def _deliver_to_provider(
+    memory: ConversationMemoryPort,
+    delivery: CanonicalMemoryDelivery,
+) -> CanonicalMemoryDeliveryResult | MemoryWriteResult:
     try:
-        status = memory.status().status
+        provider = memory.status()
     except Exception:
-        return "unavailable"
-    return status if status in {"available", "degraded", "unavailable", "disabled"} else "unavailable"
-
-
-def _provider_error(memory: ConversationMemoryPort) -> str:
+        return CanonicalMemoryDeliveryResult(
+            CanonicalMemoryDeliveryStatus.UNAVAILABLE,
+            delivery.source_id,
+            error_code="MEM0_WRITE_FAILED",
+        )
+    if provider.status == "disabled":
+        return CanonicalMemoryDeliveryResult(
+            CanonicalMemoryDeliveryStatus.SKIPPED,
+            delivery.source_id,
+        )
+    if provider.status not in {"available", "degraded"}:
+        return CanonicalMemoryDeliveryResult(
+            CanonicalMemoryDeliveryStatus.UNAVAILABLE,
+            delivery.source_id,
+            error_code=(
+                provider.reason_code
+                if isinstance(provider.reason_code, str)
+                and _ERROR_RE.fullmatch(provider.reason_code)
+                else "MEM0_WRITE_FAILED"
+            ),
+        )
     try:
-        code = memory.status().reason_code
+        return memory.remember_exchange(
+            user_message=delivery.user_message,
+            assistant_message=delivery.assistant_message,
+            occurred_at=delivery.occurred_at,
+            source_id=delivery.source_id,
+            user_id=delivery.user_id,
+        )
     except Exception:
-        code = None
-    return code if isinstance(code, str) and _ERROR_RE.fullmatch(code) else "MEM0_WRITE_FAILED"
+        return CanonicalMemoryDeliveryResult(
+            CanonicalMemoryDeliveryStatus.UNAVAILABLE,
+            delivery.source_id,
+            error_code="MEM0_WRITE_FAILED",
+        )
 
 
 __all__ = [

--- a/mem0_memory.py
+++ b/mem0_memory.py
@@ -305,6 +305,8 @@ def _add_acknowledgements(value: object) -> tuple[tuple[str, str], ...] | None:
         memory = row.get("memory")
         event = row.get("event")
         if (
+            {"error", "status"} & row.keys()
+            or
             memory_id is None
             or not isinstance(memory, str)
             or not memory.strip()
@@ -355,6 +357,8 @@ def _row_to_record(
     user_id: str,
     agent_id: str,
 ) -> ConversationMemoryRecord | None:
+    if {"error", "status"} & row.keys():
+        return None
     metadata = row.get("metadata")
     if not isinstance(metadata, Mapping):
         return None

--- a/mem0_memory.py
+++ b/mem0_memory.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import importlib
+from numbers import Real
 import os
 from pathlib import Path
 import re
 import threading
+import time
 from typing import Callable, Mapping, Protocol, Sequence
 
+from bounded_daemon_call import BoundedDaemonCall
 from conversation_memory_port import (
     ConversationMemoryPort,
     ConversationMemoryRecord,
@@ -70,6 +73,8 @@ class Mem0Config:
     embedding_cache: Path | None = None
     context_max_chars: int = 2400
     config_error: str | None = None
+    write_timeout_seconds: float = 30.0
+    search_timeout_seconds: float = 8.0
 
     def __post_init__(self) -> None:
         if type(self.enabled) is not bool:
@@ -101,6 +106,17 @@ class Mem0Config:
             object.__setattr__(self, "embedding_cache", Path(self.embedding_cache))
         if type(self.context_max_chars) is not int or not 0 <= self.context_max_chars <= 20_000:
             raise ValueError("context_max_chars is invalid")
+        for value, field_name in (
+            (self.write_timeout_seconds, "write_timeout_seconds"),
+            (self.search_timeout_seconds, "search_timeout_seconds"),
+        ):
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, Real)
+                or not 0.1 <= float(value) <= 300
+            ):
+                raise ValueError(f"{field_name} is invalid")
+            object.__setattr__(self, field_name, float(value))
         if self.config_error is not None and not re.fullmatch(
             r"^[A-Z][A-Z0-9_]{0,95}$", self.config_error
         ):
@@ -122,7 +138,7 @@ class Mem0Config:
         self,
         environ: Mapping[str, str] | None = None,
     ) -> dict[str, object]:
-        environment = environ or os.environ
+        environment = environ if environ is not None else os.environ
         return {
             "vector_store": {
                 "provider": "qdrant",
@@ -179,12 +195,22 @@ def _integer(value: object, default: int) -> int:
         return default
 
 
+def _duration(value: object, default: float) -> float:
+    if isinstance(value, bool):
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if 0.1 <= parsed <= 300 else default
+
+
 def load_mem0_config(
     *,
     environ: Mapping[str, str] | None = None,
     project_root: Path | None = None,
 ) -> Mem0Config:
-    environment = environ or os.environ
+    environment = environ if environ is not None else os.environ
     root = Path(project_root or Path(__file__).resolve().parent)
     configured_root = environment.get("OLIVIA_MEMORY_ROOT", "").strip()
     data_root = (
@@ -224,6 +250,12 @@ def load_mem0_config(
     if not 0 <= context_max <= 20_000:
         context_max = 2400
         error = "MEM0_CONTEXT_LIMIT_INVALID"
+    write_timeout = _duration(
+        environment.get("OLIVIA_MEMORY_WRITE_TIMEOUT_SECONDS"), 30.0
+    )
+    search_timeout = _duration(
+        environment.get("OLIVIA_MEMORY_SEARCH_TIMEOUT_SECONDS"), 8.0
+    )
 
     return Mem0Config(
         enabled=enabled,
@@ -246,16 +278,57 @@ def load_mem0_config(
         embedding_dims=dims,
         embedding_cache=embedding_cache,
         context_max_chars=context_max,
+        write_timeout_seconds=write_timeout,
+        search_timeout_seconds=search_timeout,
         config_error=error,
     )
 
 
-def _rows(value: object) -> tuple[Mapping[str, object], ...]:
-    if isinstance(value, Mapping):
-        value = value.get("results", value.get("memories", value.get("data", ())))
+def _rows(value: object) -> tuple[Mapping[str, object], ...] | None:
+    if not isinstance(value, Mapping) or set(value) != {"results"}:
+        return None
+    value = value["results"]
     if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
-        return ()
-    return tuple(item for item in value if isinstance(item, Mapping))
+        return None
+    if not all(isinstance(item, Mapping) for item in value):
+        return None
+    return tuple(value)
+
+
+def _add_acknowledgements(value: object) -> tuple[tuple[str, str], ...] | None:
+    rows = _rows(value)
+    if rows is None:
+        return None
+    acknowledgements: list[tuple[str, str]] = []
+    for row in rows:
+        memory_id = _row_id(row)
+        memory = row.get("memory")
+        event = row.get("event")
+        if (
+            memory_id is None
+            or not isinstance(memory, str)
+            or not memory.strip()
+            or event != "ADD"
+        ):
+            return None
+        acknowledgements.append((memory_id, memory))
+    return tuple(acknowledgements)
+
+
+def _has_delete_acknowledgement(value: object) -> bool:
+    return (
+        isinstance(value, Mapping)
+        and set(value) == {"message"}
+        and value["message"] == "Memory deleted successfully!"
+    )
+
+
+def _has_clear_acknowledgement(value: object) -> bool:
+    return (
+        isinstance(value, Mapping)
+        and set(value) == {"message"}
+        and value["message"] == "Memories deleted successfully!"
+    )
 
 
 def _date(value: object) -> datetime | None:
@@ -272,7 +345,7 @@ def _date(value: object) -> datetime | None:
 
 
 def _row_id(row: Mapping[str, object]) -> str | None:
-    value = row.get("id", row.get("memory_id"))
+    value = row.get("id")
     return value if isinstance(value, str) and _ID_RE.fullmatch(value) else None
 
 
@@ -280,14 +353,16 @@ def _row_to_record(
     row: Mapping[str, object],
     *,
     user_id: str,
+    agent_id: str,
 ) -> ConversationMemoryRecord | None:
     metadata = row.get("metadata")
-    metadata = metadata if isinstance(metadata, Mapping) else {}
+    if not isinstance(metadata, Mapping):
+        return None
     memory_id = _row_id(row)
-    text = row.get("memory", row.get("text"))
-    source_id = metadata.get("source_id", row.get("source_id"))
-    domain = metadata.get("domain", row.get("domain", _DOMAIN))
-    row_user = row.get("user_id", user_id)
+    text = row.get("memory")
+    source_id = metadata.get("source_id")
+    domain = metadata.get("domain")
+    row_user = row.get("user_id")
     if (
         memory_id is None
         or not isinstance(text, str)
@@ -296,6 +371,7 @@ def _row_to_record(
         or not _ID_RE.fullmatch(source_id)
         or domain != _DOMAIN
         or row_user != user_id
+        or row.get("agent_id") != agent_id
     ):
         return None
     score_value = row.get("score")
@@ -336,6 +412,9 @@ class Mem0ConversationMemoryAdapter:
         self.backend = backend
         self.config = config
         self._lock = threading.RLock()
+        self._provider_call = BoundedDaemonCall(thread_name="olivia-mem0-read")
+        self._write_call = BoundedDaemonCall(thread_name="olivia-mem0-write")
+        self._write_gate = threading.Lock()
         self._last_error_code: str | None = None
 
     def _filters(self, user_id: str) -> dict[str, object]:
@@ -353,15 +432,21 @@ class Mem0ConversationMemoryAdapter:
         *,
         user_id: str,
         limit: int,
-    ) -> tuple[ConversationMemoryRecord, ...]:
+    ) -> tuple[ConversationMemoryRecord, ...] | None:
+        rows = _rows(value)
+        if rows is None:
+            return None
         records: list[ConversationMemoryRecord] = []
-        for row in _rows(value):
-            record = _row_to_record(row, user_id=user_id)
-            if record is not None:
-                records.append(record)
-            if len(records) >= limit:
-                break
-        return tuple(records)
+        for row in rows:
+            record = _row_to_record(
+                row,
+                user_id=user_id,
+                agent_id=self.config.agent_id,
+            )
+            if record is None:
+                return None
+            records.append(record)
+        return tuple(records[:limit])
 
     def list_memories(
         self,
@@ -369,19 +454,32 @@ class Mem0ConversationMemoryAdapter:
         user_id: str,
         limit: int = 100,
     ) -> tuple[ConversationMemoryRecord, ...]:
+        records = self._list_records(user_id=user_id, limit=limit)
+        return () if records is None else records
+
+    def _list_records(
+        self,
+        *,
+        user_id: str,
+        limit: int,
+    ) -> tuple[ConversationMemoryRecord, ...] | None:
         if not 1 <= limit <= 1000:
-            return ()
-        try:
-            with self._lock:
-                value = self.backend.get_all(
-                    filters=self._filters(user_id),
-                    top_k=limit,
-                )
-            self._last_error_code = None
-            return self._records(value, user_id=user_id, limit=limit)
-        except Exception:
+            return None
+        value = self._read_with_timeout(
+            lambda: self.backend.get_all(
+                filters=self._filters(user_id),
+                top_k=limit,
+            ),
+            failure_code="MEM0_LIST_FAILED",
+        )
+        if value is None:
+            return None
+        records = self._records(value, user_id=user_id, limit=limit)
+        if records is None:
             self._last_error_code = "MEM0_LIST_FAILED"
-            return ()
+            return None
+        self._last_error_code = None
+        return records
 
     def search_context(
         self,
@@ -392,18 +490,181 @@ class Mem0ConversationMemoryAdapter:
     ) -> tuple[ConversationMemoryRecord, ...]:
         if not isinstance(query, str) or not query.strip() or not 1 <= limit <= 100:
             return ()
-        try:
-            with self._lock:
-                value = self.backend.search(
-                    query.strip(),
-                    filters=self._filters(user_id),
-                    top_k=limit,
-                )
-            self._last_error_code = None
-            return self._records(value, user_id=user_id, limit=limit)
-        except Exception:
+        value = self._read_with_timeout(
+            lambda: self.backend.search(
+                query.strip(),
+                filters=self._filters(user_id),
+                top_k=limit,
+            ),
+            failure_code="MEM0_SEARCH_FAILED",
+        )
+        if value is None:
+            return ()
+        records = self._records(value, user_id=user_id, limit=limit)
+        if records is None:
             self._last_error_code = "MEM0_SEARCH_FAILED"
             return ()
+        self._last_error_code = None
+        return records
+
+    def _read_with_timeout(
+        self,
+        operation: Callable[[], object],
+        *,
+        failure_code: str,
+    ) -> object | None:
+        state, value = self._provider_call.call(
+            lambda: self._locked_provider_call(operation),
+            timeout_seconds=self.config.search_timeout_seconds,
+        )
+        if state in {"timeout", "inflight"}:
+            self._last_error_code = "MEM0_SEARCH_TIMEOUT"
+            return None
+        if state == "failed":
+            self._last_error_code = failure_code
+            return None
+        return value
+
+    def _locked_provider_call(self, operation: Callable[[], object]) -> object:
+        with self._lock:
+            return operation()
+
+    def _source_id_exists_in_exact_response(
+        self,
+        value: object,
+        *,
+        user_id: str,
+        source_id: str,
+    ) -> bool | None:
+        rows = self._exact_source_id_rows(value)
+        if rows is None:
+            return None
+        if any(
+            not isinstance(row.get("metadata"), Mapping)
+            or row.get("user_id") != user_id
+            or row.get("agent_id") != self.config.agent_id
+            or row["metadata"].get("domain") != _DOMAIN
+            for row in rows
+        ):
+            return None
+        records = tuple(
+            _row_to_record(
+                row,
+                user_id=user_id,
+                agent_id=self.config.agent_id,
+            )
+            for row in rows
+        )
+        if any(record is None or record.source_id != source_id for record in records):
+            return None
+        self._last_error_code = None
+        return bool(records)
+
+    def _exact_source_id_rows(
+        self,
+        value: object | None,
+    ) -> tuple[Mapping[str, object], ...] | None:
+        if not isinstance(value, Mapping) or set(value) not in (
+            {"results"}, {"results", "has_more"}
+        ):
+            return None
+        if value.get("has_more", False) is not False:
+            return None
+        value = value["results"]
+        if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+            return None
+        if not all(
+            isinstance(row, Mapping) for row in value
+        ):
+            return None
+        return tuple(value)
+
+    def _write_with_timeout(
+        self,
+        operation: Callable[[], object],
+    ) -> tuple[str, object | None]:
+        deadline = time.monotonic() + self.config.write_timeout_seconds
+        if not self._write_gate.acquire(timeout=self.config.write_timeout_seconds):
+            return "timeout", None
+        try:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return "timeout", None
+            return self._write_call.call(
+                lambda: self._locked_provider_call(operation),
+                timeout_seconds=remaining,
+            )
+        finally:
+            self._write_gate.release()
+
+    def _remember_exchange_transaction(
+        self,
+        *,
+        user_message: str,
+        assistant_message: str,
+        occurred_at: datetime,
+        source_id: str,
+        user_id: str,
+    ) -> MemoryWriteResult:
+        try:
+            exact_response = self.backend.get_all(
+                filters={**self._filters(user_id), "source_id": source_id},
+                top_k=1,
+            )
+        except Exception:
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                source_id,
+                error_code="MEM0_SOURCE_DEDUP_UNAVAILABLE",
+            )
+        source_exists = self._source_id_exists_in_exact_response(
+            exact_response,
+            user_id=user_id,
+            source_id=source_id,
+        )
+        if source_exists is None:
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                source_id,
+                error_code="MEM0_SOURCE_DEDUP_UNAVAILABLE",
+            )
+        if source_exists:
+            return MemoryWriteResult(MemoryWriteStatus.DUPLICATE, source_id)
+        metadata = {
+            "source_id": source_id,
+            "occurred_at": occurred_at.isoformat(),
+            "domain": _DOMAIN,
+            "canonical": True,
+        }
+        try:
+            value = self.backend.add(
+                [
+                    {"role": "user", "content": str(user_message)},
+                    {"role": "assistant", "content": str(assistant_message)},
+                ],
+                user_id=user_id,
+                agent_id=self.config.agent_id,
+                metadata=metadata,
+            )
+        except Exception:
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                source_id,
+                error_code="MEM0_WRITE_FAILED",
+            )
+        acknowledgements = _add_acknowledgements(value)
+        if acknowledgements is None:
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                source_id,
+                error_code="MEM0_WRITE_FAILED",
+            )
+        memory_ids = tuple(memory_id for memory_id, _memory in acknowledgements)
+        return MemoryWriteResult(
+            MemoryWriteStatus.WRITTEN if memory_ids else MemoryWriteStatus.SKIPPED,
+            source_id,
+            memory_ids,
+        )
 
     def remember_exchange(
         self,
@@ -420,44 +681,38 @@ class Mem0ConversationMemoryAdapter:
                 source_id,
                 error_code="MEM0_EXCHANGE_INVALID",
             )
-        try:
-            existing = self.list_memories(user_id=user_id, limit=1000)
-            if any(record.source_id == source_id for record in existing):
-                return MemoryWriteResult(MemoryWriteStatus.DUPLICATE, source_id)
-            metadata = {
-                "source_id": source_id,
-                "occurred_at": occurred_at.isoformat(),
-                "domain": _DOMAIN,
-                "canonical": True,
-            }
-            with self._lock:
-                value = self.backend.add(
-                    [
-                        {"role": "user", "content": str(user_message)},
-                        {"role": "assistant", "content": str(assistant_message)},
-                    ],
-                    user_id=user_id,
-                    agent_id=self.config.agent_id,
-                    metadata=metadata,
-                )
-            ids = tuple(
-                memory_id
-                for row in _rows(value)
-                if (memory_id := _row_id(row)) is not None
-            )
-            self._last_error_code = None
+        if self._provider_call.inflight:
+            self._last_error_code = "MEM0_SOURCE_DEDUP_UNAVAILABLE"
             return MemoryWriteResult(
-                MemoryWriteStatus.WRITTEN if ids else MemoryWriteStatus.SKIPPED,
+                MemoryWriteStatus.UNAVAILABLE,
                 source_id,
-                ids,
+                error_code="MEM0_SOURCE_DEDUP_UNAVAILABLE",
             )
-        except Exception:
+        state, value = self._write_with_timeout(
+            lambda: self._remember_exchange_transaction(
+                user_message=user_message,
+                assistant_message=assistant_message,
+                occurred_at=occurred_at,
+                source_id=source_id,
+                user_id=user_id,
+            )
+        )
+        if state in {"timeout", "inflight"}:
+            self._last_error_code = "MEM0_WRITE_TIMEOUT"
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                source_id,
+                error_code="MEM0_WRITE_TIMEOUT",
+            )
+        if state != "completed" or not isinstance(value, MemoryWriteResult):
             self._last_error_code = "MEM0_WRITE_FAILED"
             return MemoryWriteResult(
                 MemoryWriteStatus.UNAVAILABLE,
                 source_id,
                 error_code="MEM0_WRITE_FAILED",
             )
+        self._last_error_code = value.error_code
+        return value
 
     def add_manual_memory(
         self,
@@ -474,25 +729,52 @@ class Mem0ConversationMemoryAdapter:
             "actor": "local_user",
         }
         try:
-            with self._lock:
-                value = self.backend.add(
+            state, value = self._write_with_timeout(
+                lambda: self.backend.add(
                     str(text),
                     user_id=user_id,
                     agent_id=self.config.agent_id,
                     metadata=metadata,
                     infer=False,
                 )
-            records = self._records(value, user_id=user_id, limit=1)
-            if not records:
-                records = tuple(
-                    record
-                    for record in self.list_memories(user_id=user_id, limit=1000)
-                    if record.source_id == source_id
-                )[:1]
-            if not records:
+            )
+            if state in {"timeout", "inflight"}:
+                self._last_error_code = "MEM0_MANUAL_WRITE_TIMEOUT"
+                raise Mem0AdapterError("MEM0_MANUAL_WRITE_TIMEOUT")
+            if state != "completed":
+                self._last_error_code = "MEM0_MANUAL_WRITE_FAILED"
+                raise Mem0AdapterError("MEM0_MANUAL_WRITE_FAILED")
+            acknowledgements = _add_acknowledgements(value)
+            if acknowledgements is None or len(acknowledgements) != 1:
+                self._last_error_code = "MEM0_MANUAL_WRITE_FAILED"
+                raise Mem0AdapterError("MEM0_MANUAL_WRITE_FAILED")
+            acknowledgement_id, acknowledgement_memory = acknowledgements[0]
+            read_value = self._read_with_timeout(
+                lambda: self.backend.get_all(
+                    filters={**self._filters(user_id), "source_id": source_id},
+                    top_k=1,
+                ),
+                failure_code="MEM0_MANUAL_WRITE_FAILED",
+            )
+            rows = self._exact_source_id_rows(read_value)
+            if rows is None or len(rows) != 1:
+                self._last_error_code = "MEM0_MANUAL_WRITE_FAILED"
+                raise Mem0AdapterError("MEM0_MANUAL_WRITE_FAILED")
+            record = _row_to_record(
+                rows[0],
+                user_id=user_id,
+                agent_id=self.config.agent_id,
+            )
+            if (
+                record is None
+                or record.source_id != source_id
+                or record.memory_id != acknowledgement_id
+                or record.text != acknowledgement_memory
+            ):
+                self._last_error_code = "MEM0_MANUAL_WRITE_FAILED"
                 raise Mem0AdapterError("MEM0_MANUAL_WRITE_FAILED")
             self._last_error_code = None
-            return records[0]
+            return record
         except Mem0AdapterError:
             raise
         except Exception as exc:
@@ -500,14 +782,24 @@ class Mem0ConversationMemoryAdapter:
             raise Mem0AdapterError("MEM0_MANUAL_WRITE_FAILED") from exc
 
     def delete_memory(self, memory_id: str, *, user_id: str) -> bool:
+        if self._write_call.inflight:
+            self._last_error_code = "MEM0_DELETE_TIMEOUT"
+            return False
         try:
             if not any(
                 record.memory_id == memory_id
                 for record in self.list_memories(user_id=user_id, limit=1000)
             ):
                 return False
-            with self._lock:
-                self.backend.delete(memory_id)
+            state, value = self._write_with_timeout(
+                lambda: self.backend.delete(memory_id)
+            )
+            if state in {"timeout", "inflight"}:
+                self._last_error_code = "MEM0_DELETE_TIMEOUT"
+                return False
+            if state != "completed" or not _has_delete_acknowledgement(value):
+                self._last_error_code = "MEM0_DELETE_FAILED"
+                return False
             self._last_error_code = None
             return True
         except Exception:
@@ -515,15 +807,25 @@ class Mem0ConversationMemoryAdapter:
             return False
 
     def clear_user(self, *, user_id: str) -> int:
+        if self._write_call.inflight:
+            self._last_error_code = "MEM0_CLEAR_TIMEOUT"
+            return 0
         records = self.list_memories(user_id=user_id, limit=1000)
         if not records:
             return 0
         try:
-            with self._lock:
-                self.backend.delete_all(
+            state, value = self._write_with_timeout(
+                lambda: self.backend.delete_all(
                     user_id=user_id,
                     agent_id=self.config.agent_id,
                 )
+            )
+            if state in {"timeout", "inflight"}:
+                self._last_error_code = "MEM0_CLEAR_TIMEOUT"
+                return 0
+            if state != "completed" or not _has_clear_acknowledgement(value):
+                self._last_error_code = "MEM0_CLEAR_FAILED"
+                return 0
             self._last_error_code = None
             return len(records)
         except Exception:
@@ -542,6 +844,14 @@ class Mem0ConversationMemoryAdapter:
         }
 
     def status(self) -> ConversationMemoryStatus:
+        if self._provider_call.inflight:
+            return ConversationMemoryStatus(
+                "degraded",
+                True,
+                "mem0",
+                "qdrant-local",
+                reason_code="MEM0_SEARCH_TIMEOUT",
+            )
         records = self.list_memories(user_id=self.config.user_id, limit=1000)
         if self._last_error_code:
             return ConversationMemoryStatus(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ memory-mem0 = [
 [tool.setuptools]
 py-modules = [
     "baseline_hardening_scan",
+    "bounded_daemon_call",
     "companion_memory_context",
     "conversation_memory_admin",
     "conversation_memory_delivery",

--- a/tests/memory/test_bounded_daemon_call.py
+++ b/tests/memory/test_bounded_daemon_call.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import threading
+import time
+
+from bounded_daemon_call import BoundedDaemonCall
+
+
+def test_permanently_blocked_call_times_out_without_starting_another_worker() -> None:
+    release = threading.Event()
+    entered = threading.Event()
+    existing = set(threading.enumerate())
+    call = BoundedDaemonCall(thread_name="mem0-provider-fixture")
+
+    def block() -> str:
+        entered.set()
+        release.wait()
+        return "done"
+
+    try:
+        started = time.monotonic()
+        assert call.call(block, timeout_seconds=0.02) == ("timeout", None)
+        assert time.monotonic() - started < 0.2
+        assert entered.is_set()
+        assert call.call(lambda: "second", timeout_seconds=0.02) == ("inflight", None)
+        workers = [
+            thread
+            for thread in threading.enumerate()
+            if thread.name == "mem0-provider-fixture" and thread not in existing
+        ]
+        assert len(workers) == 1
+        assert workers[0].daemon is True
+    finally:
+        release.set()
+        for thread in threading.enumerate():
+            if thread.name == "mem0-provider-fixture" and thread not in existing:
+                thread.join(timeout=0.5)

--- a/tests/memory/test_bounded_daemon_call.py
+++ b/tests/memory/test_bounded_daemon_call.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import threading
 import time
+
+import pytest
 
 from bounded_daemon_call import BoundedDaemonCall
 
@@ -35,3 +38,19 @@ def test_permanently_blocked_call_times_out_without_starting_another_worker() ->
         for thread in threading.enumerate():
             if thread.name == "mem0-provider-fixture" and thread not in existing:
                 thread.join(timeout=0.5)
+
+
+@pytest.mark.parametrize("timeout_seconds", [float("nan"), float("inf"), -float("inf")])
+def test_calls_reject_non_finite_timeouts_before_starting_workers(
+    timeout_seconds: float,
+) -> None:
+    call = BoundedDaemonCall(thread_name="mem0-provider-invalid-timeout")
+    with pytest.raises(ValueError):
+        call.call(lambda: "unexpected", timeout_seconds=timeout_seconds)
+
+    async def scenario() -> None:
+        with pytest.raises(ValueError):
+            await call.call_async(lambda: "unexpected", timeout_seconds=timeout_seconds)
+
+    asyncio.run(scenario())
+    assert call.inflight is False

--- a/tests/memory/test_conversation_memory_delivery.py
+++ b/tests/memory/test_conversation_memory_delivery.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+import threading
 import time
 
 import pytest
@@ -195,6 +196,80 @@ def test_timeout_returns_without_blocking_canonical_reply_state() -> None:
         assert elapsed < 0.07
 
     asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("blocked_stage", ["status", "write"])
+def test_provider_timeout_uses_one_daemon_worker_for_status_and_write(
+    blocked_stage: str,
+) -> None:
+    release = threading.Event()
+    entered = threading.Event()
+    existing_threads = set(threading.enumerate())
+
+    class BlockingMemory(FakeMemory):
+        def __init__(self) -> None:
+            super().__init__()
+            self.status_calls = 0
+            self.write_calls = 0
+
+        def status(self) -> ConversationMemoryStatus:
+            self.status_calls += 1
+            if blocked_stage == "status":
+                entered.set()
+                release.wait()
+            return super().status()
+
+        def remember_exchange(self, **kwargs: object) -> MemoryWriteResult:
+            self.write_calls += 1
+            if blocked_stage == "write":
+                entered.set()
+                release.wait()
+            return super().remember_exchange(**kwargs)
+
+    async def scenario() -> None:
+        memory = BlockingMemory()
+        committer = ConversationMemoryDeliveryCommitter(memory, timeout_seconds=0.02)
+        started = time.monotonic()
+        results = [
+            await committer.commit(_delivery(revision=revision))
+            for revision in (2, 3, 4)
+        ]
+        assert time.monotonic() - started < 0.2
+        assert all(result.error_code == "MEM0_WRITE_TIMEOUT" for result in results)
+        assert entered.is_set()
+        assert (memory.status_calls, memory.write_calls) == (
+            (1, 0) if blocked_stage == "status" else (1, 1)
+        )
+
+    failure: list[BaseException] = []
+    done = threading.Event()
+
+    def run_scenario() -> None:
+        try:
+            asyncio.run(scenario())
+        except BaseException as exc:
+            failure.append(exc)
+        finally:
+            done.set()
+
+    probe = threading.Thread(target=run_scenario, daemon=True)
+    try:
+        probe.start()
+        assert done.wait(0.3)
+        assert not failure
+        workers = [
+            thread
+            for thread in threading.enumerate()
+            if thread.name == "olivia-memory-delivery" and thread not in existing_threads
+        ]
+        assert len(workers) == 1
+        assert workers[0].daemon is True
+    finally:
+        release.set()
+        probe.join(timeout=0.5)
+        for thread in threading.enumerate():
+            if thread.name == "olivia-memory-delivery" and thread not in existing_threads:
+                thread.join(timeout=0.5)
 
 
 @pytest.mark.parametrize(

--- a/tests/memory/test_conversation_memory_delivery.py
+++ b/tests/memory/test_conversation_memory_delivery.py
@@ -291,14 +291,17 @@ def test_delivery_contract_rejects_invalid_or_ambiguous_inputs(
         _delivery(**changes)
 
 
-def test_committer_requires_typed_delivery_and_bounded_timeout() -> None:
+@pytest.mark.parametrize(
+    "timeout_seconds", [0, 301, True, "0.1", float("nan"), float("inf"), -float("inf")]
+)
+def test_committer_requires_typed_delivery_and_bounded_timeout(
+    timeout_seconds: object,
+) -> None:
     memory = FakeMemory()
-    with pytest.raises(ValueError):
-        ConversationMemoryDeliveryCommitter(memory, timeout_seconds=0)
-    with pytest.raises(ValueError):
-        ConversationMemoryDeliveryCommitter(memory, timeout_seconds=301)
 
     async def scenario() -> None:
+        with pytest.raises(ValueError):
+            ConversationMemoryDeliveryCommitter(memory, timeout_seconds=timeout_seconds)  # type: ignore[arg-type]
         with pytest.raises(TypeError):
             await ConversationMemoryDeliveryCommitter(memory).commit(object())  # type: ignore[arg-type]
 

--- a/tests/memory/test_mem0_memory.py
+++ b/tests/memory/test_mem0_memory.py
@@ -342,6 +342,7 @@ def test_status_and_list_fail_closed_for_malformed_provider_pages(tmp_path: Path
         {"results": [{}]},
         {"results": [{"memory_id": "memory.alias", "text": "synthetic", "user_id": "local-user", "agent_id": "linli", "metadata": {"source_id": "reply:alias:1", "domain": "conversation_memory"}}]},
         {"results": [{"id": "memory.top-level", "memory": "synthetic", "user_id": "local-user", "agent_id": "linli", "source_id": "reply:top-level:1", "metadata": {"domain": "conversation_memory"}}]},
+        *({"results": [{"id": "memory.row-marker", "memory": "synthetic", "user_id": "local-user", "agent_id": "linli", "metadata": {"source_id": "reply:row-marker:1", "domain": "conversation_memory"}, marker: "failed"}]} for marker in ("error", "status")),
     )
     for page in pages:
         adapter = Mem0ConversationMemoryAdapter(PageMem0(page), _config(tmp_path))
@@ -470,6 +471,7 @@ def test_search_fails_closed_for_malformed_provider_pages(tmp_path: Path) -> Non
         {"results": [], "status": "failed"}, {"results": [], "next": None},
         {"results": [{}]},
         {"results": [{"id": "memory.alias-search", "text": "synthetic", "user_id": "local-user", "agent_id": "linli", "metadata": {"source_id": "reply:alias-search:1", "domain": "conversation_memory"}}]},
+        *({"results": [{"id": "memory.row-marker-search", "memory": "synthetic", "user_id": "local-user", "agent_id": "linli", "metadata": {"source_id": "reply:row-marker-search:1", "domain": "conversation_memory"}, marker: "failed"}]} for marker in ("error", "status")),
     )
     for page in pages:
         adapter = Mem0ConversationMemoryAdapter(PageMem0(page), _config(tmp_path))
@@ -495,6 +497,8 @@ def test_exchange_fails_closed_for_malformed_add_acknowledgements(
         {"results": [{}]},
         {"results": [{"id": "memory.fixture.1"}]},
         {"results": [{"memory_id": "memory.fixture.1", "memory": "synthetic", "event": "ADD"}]},
+        {"results": [{"id": "memory.fixture.1", "memory": "synthetic", "event": "ADD", "error": "synthetic provider error"}]},
+        {"results": [{"id": "memory.fixture.1", "memory": "synthetic", "event": "ADD", "status": "failed"}]},
     )
     for response in responses:
         result = Mem0ConversationMemoryAdapter(AddMem0(response), _config(tmp_path)).remember_exchange(
@@ -740,6 +744,9 @@ def test_exchange_fails_closed_when_exact_source_row_scope_is_missing_or_mismatc
         "domain": "other-domain",
     }
     invalid_rows.append(mismatched_domain)
+    invalid_rows.extend(
+        {**base_row, marker: "failed"} for marker in ("error", "status")
+    )
 
     for row in invalid_rows:
         backend = ScopedExactQueryMem0(row)

--- a/tests/memory/test_mem0_memory.py
+++ b/tests/memory/test_mem0_memory.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
+import threading
+import time
 
 from conversation_memory_port import (
     MemoryWriteStatus,
@@ -34,10 +37,17 @@ class FakeMem0:
 
     @staticmethod
     def _assert_filters(filters: object) -> None:
-        assert filters == {
+        assert isinstance(filters, dict)
+        assert {
             "user_id": "local-user",
             "agent_id": "linli",
             "domain": "conversation_memory",
+        }.items() <= filters.items()
+        assert set(filters) <= {
+            "user_id",
+            "agent_id",
+            "domain",
+            "source_id",
         }
 
     def add(self, messages, **kwargs):
@@ -55,7 +65,15 @@ class FakeMem0:
             "created_at": NOW.isoformat(),
         }
         self.rows.append(row)
-        return [row]
+        return {
+            "results": [
+                {
+                    "id": row["id"],
+                    "memory": row["memory"],
+                    "event": "ADD",
+                }
+            ]
+        }
 
     def search(self, query, **kwargs):
         self._raise("search")
@@ -65,15 +83,23 @@ class FakeMem0:
 
     def get_all(self, **kwargs):
         self._raise("get_all")
-        self._assert_filters(kwargs.get("filters"))
+        filters = kwargs.get("filters")
+        self._assert_filters(filters)
         assert 1 <= kwargs.get("top_k", 0) <= 1000
         self.calls.append(("get_all", kwargs))
-        return {"results": list(self.rows)[: kwargs["top_k"]]}
+        source_id = filters.get("source_id") if isinstance(filters, dict) else None
+        rows = [
+            row
+            for row in self.rows
+            if source_id is None or row.get("metadata", {}).get("source_id") == source_id
+        ]
+        return {"results": rows[: kwargs["top_k"]]}
 
     def delete(self, memory_id):
         self._raise("delete")
         self.calls.append(("delete", memory_id))
         self.rows[:] = [row for row in self.rows if row["id"] != memory_id]
+        return {"message": "Memory deleted successfully!"}
 
     def delete_all(self, user_id=None, agent_id=None, run_id=None):
         self._raise("delete_all")
@@ -82,6 +108,7 @@ class FakeMem0:
         assert run_id is None
         self.calls.append(("delete_all", {"user_id": user_id, "agent_id": agent_id}))
         self.rows.clear()
+        return {"message": "Memories deleted successfully!"}
 
 
 def _config(tmp_path: Path) -> Mem0Config:
@@ -118,6 +145,56 @@ def test_version_and_config_match_current_mem0_oss_contract(tmp_path: Path) -> N
     assert mapping["llm"]["config"]["openai_base_url"] == "http://127.0.0.1:9/v1"
     assert mapping["llm"]["config"]["api_key"] == "fixture-secret"
     assert "private_world" not in repr(mapping)
+
+
+def test_config_preserves_legacy_positional_config_error_slot(tmp_path: Path) -> None:
+    config = Mem0Config(
+        True,
+        tmp_path / "legacy-mem0",
+        "legacy-user",
+        "legacy-agent",
+        "legacy-collection",
+        "http://127.0.0.1:9/v1",
+        "legacy-model",
+        "LEGACY_KEY",
+        "BAAI/bge-small-zh-v1.5",
+        512,
+        tmp_path / "legacy-model-cache",
+        1200,
+        "MEM0_LEGACY_CONFIG_ERROR",
+    )
+
+    assert config.config_error == "MEM0_LEGACY_CONFIG_ERROR"
+    assert config.write_timeout_seconds == 30.0
+    assert config.search_timeout_seconds == 8.0
+
+
+def test_config_timeout_values_are_real_numbers_and_normalized_to_float(
+    tmp_path: Path,
+) -> None:
+    low = replace(
+        _config(tmp_path),
+        write_timeout_seconds=1,
+        search_timeout_seconds=0.1,
+    )
+    high = replace(
+        _config(tmp_path),
+        write_timeout_seconds=300.0,
+        search_timeout_seconds=300,
+    )
+
+    assert low.write_timeout_seconds == 1.0
+    assert low.search_timeout_seconds == 0.1
+    assert high.write_timeout_seconds == 300.0
+    assert high.search_timeout_seconds == 300.0
+    for field_name in ("write_timeout_seconds", "search_timeout_seconds"):
+        for invalid in ("0.1", True, None):
+            try:
+                replace(_config(tmp_path), **{field_name: invalid})
+            except ValueError:
+                pass
+            else:
+                raise AssertionError(f"{field_name} must reject {invalid!r}")
 
 
 def test_load_config_reuses_primary_llm_and_fails_closed(tmp_path: Path) -> None:
@@ -249,6 +326,787 @@ def test_provider_failures_degrade_without_echoing_private_text(tmp_path: Path) 
     assert status["reason_code"] == "MEM0_LIST_FAILED"
 
 
+def test_status_and_list_fail_closed_for_malformed_provider_pages(tmp_path: Path) -> None:
+    class PageMem0(FakeMem0):
+        def __init__(self, response: object) -> None:
+            super().__init__()
+            self.response = response
+
+        def get_all(self, **kwargs):
+            super().get_all(**kwargs)
+            return self.response
+
+    pages = (
+        {}, [], {"results": [], "error": "synthetic provider error"},
+        {"results": [], "status": "failed"}, {"results": [], "next": None},
+        {"results": [{}]},
+        {"results": [{"memory_id": "memory.alias", "text": "synthetic", "user_id": "local-user", "agent_id": "linli", "metadata": {"source_id": "reply:alias:1", "domain": "conversation_memory"}}]},
+        {"results": [{"id": "memory.top-level", "memory": "synthetic", "user_id": "local-user", "agent_id": "linli", "source_id": "reply:top-level:1", "metadata": {"domain": "conversation_memory"}}]},
+    )
+    for page in pages:
+        adapter = Mem0ConversationMemoryAdapter(PageMem0(page), _config(tmp_path))
+        assert adapter.list_memories(user_id="local-user", limit=1) == ()
+        assert adapter._last_error_code == "MEM0_LIST_FAILED"
+        assert adapter.status().to_dict()["reason_code"] == "MEM0_LIST_FAILED"
+
+
+def test_search_fails_closed_for_top_level_only_source_id(tmp_path: Path) -> None:
+    class TopLevelSourceIdMem0(FakeMem0):
+        def search(self, query, **kwargs):
+            super().search(query, **kwargs)
+            return {
+                "results": [
+                    {
+                        "id": "memory.top-level-search-source",
+                        "memory": "synthetic memory",
+                        "user_id": "local-user",
+                        "agent_id": "linli",
+                        "source_id": "reply:top-level-search-source:1",
+                        "metadata": {"domain": "conversation_memory"},
+                    }
+                ]
+            }
+
+    adapter = Mem0ConversationMemoryAdapter(TopLevelSourceIdMem0(), _config(tmp_path))
+
+    assert adapter.search_context("synthetic", user_id="local-user", limit=1) == ()
+    assert adapter._last_error_code == "MEM0_SEARCH_FAILED"
+
+
+def test_exact_dedupe_fails_closed_for_top_level_only_source_id(tmp_path: Path) -> None:
+    source_id = "reply:top-level-dedup-source:1"
+
+    class TopLevelSourceIdMem0(FakeMem0):
+        def get_all(self, **kwargs):
+            super().get_all(**kwargs)
+            return {
+                "results": [
+                    {
+                        "id": "memory.top-level-dedup-source",
+                        "memory": "synthetic memory",
+                        "user_id": "local-user",
+                        "agent_id": "linli",
+                        "source_id": source_id,
+                        "metadata": {"domain": "conversation_memory"},
+                    }
+                ]
+            }
+
+    backend = TopLevelSourceIdMem0()
+    result = Mem0ConversationMemoryAdapter(backend, _config(tmp_path)).remember_exchange(
+        user_message="synthetic user",
+        assistant_message="synthetic reply",
+        occurred_at=NOW,
+        source_id=source_id,
+        user_id="local-user",
+    )
+
+    assert result.status is MemoryWriteStatus.UNAVAILABLE
+    assert result.error_code == "MEM0_SOURCE_DEDUP_UNAVAILABLE"
+    assert not [call for call in backend.calls if call[0] == "add"]
+
+
+def test_list_fails_closed_when_limited_page_contains_mixed_valid_and_invalid_rows(
+    tmp_path: Path,
+) -> None:
+    class MixedRowsMem0(FakeMem0):
+        def get_all(self, **kwargs):
+            super().get_all(**kwargs)
+            return {
+                "results": [
+                    {
+                        "id": "memory.valid-row",
+                        "memory": "synthetic memory",
+                        "user_id": "local-user",
+                        "agent_id": "linli",
+                        "metadata": {
+                            "source_id": "reply:valid-row:1",
+                            "domain": "conversation_memory",
+                        },
+                    },
+                    {},
+                ]
+            }
+
+    adapter = Mem0ConversationMemoryAdapter(MixedRowsMem0(), _config(tmp_path))
+
+    assert adapter.list_memories(user_id="local-user", limit=1) == ()
+    assert adapter._last_error_code == "MEM0_LIST_FAILED"
+
+
+def test_list_fails_closed_when_result_row_is_not_fully_scoped(tmp_path: Path) -> None:
+    class UnscopedRowMem0(FakeMem0):
+        def get_all(self, **kwargs):
+            super().get_all(**kwargs)
+            return {
+                "results": [
+                    {
+                        "id": "memory.unscoped-row",
+                        "memory": "synthetic memory",
+                        "user_id": "local-user",
+                        "metadata": {"source_id": "reply:unscoped-row:1"},
+                    }
+                ]
+            }
+
+    adapter = Mem0ConversationMemoryAdapter(UnscopedRowMem0(), _config(tmp_path))
+
+    assert adapter.list_memories(user_id="local-user", limit=1) == ()
+    assert adapter._last_error_code == "MEM0_LIST_FAILED"
+
+
+def test_search_fails_closed_for_malformed_provider_pages(tmp_path: Path) -> None:
+    class PageMem0(FakeMem0):
+        def __init__(self, response: object) -> None:
+            super().__init__()
+            self.response = response
+
+        def search(self, query, **kwargs):
+            super().search(query, **kwargs)
+            return self.response
+
+    pages = (
+        {}, [], {"results": [], "error": "synthetic provider error"},
+        {"results": [], "status": "failed"}, {"results": [], "next": None},
+        {"results": [{}]},
+        {"results": [{"id": "memory.alias-search", "text": "synthetic", "user_id": "local-user", "agent_id": "linli", "metadata": {"source_id": "reply:alias-search:1", "domain": "conversation_memory"}}]},
+    )
+    for page in pages:
+        adapter = Mem0ConversationMemoryAdapter(PageMem0(page), _config(tmp_path))
+        assert adapter.search_context("synthetic", user_id="local-user", limit=1) == ()
+        assert adapter._last_error_code == "MEM0_SEARCH_FAILED"
+
+
+def test_exchange_fails_closed_for_malformed_add_acknowledgements(
+    tmp_path: Path,
+) -> None:
+    class AddMem0(FakeMem0):
+        def __init__(self, response: object) -> None:
+            super().__init__()
+            self.response = response
+
+        def add(self, messages, **kwargs):
+            super().add(messages, **kwargs)
+            return self.response
+
+    responses = (
+        {}, [], {"results": [], "error": "synthetic provider error"},
+        {"results": [], "status": "failed"}, {"results": [], "next": None},
+        {"results": [{}]},
+        {"results": [{"id": "memory.fixture.1"}]},
+        {"results": [{"memory_id": "memory.fixture.1", "memory": "synthetic", "event": "ADD"}]},
+    )
+    for response in responses:
+        result = Mem0ConversationMemoryAdapter(AddMem0(response), _config(tmp_path)).remember_exchange(
+            user_message="synthetic user", assistant_message="synthetic reply",
+            occurred_at=NOW, source_id="reply:malformed-add:1", user_id="local-user",
+        )
+        assert result.status is MemoryWriteStatus.UNAVAILABLE
+        assert result.error_code == "MEM0_WRITE_FAILED"
+
+
+def test_exchange_accepts_results_only_empty_add_response(tmp_path: Path) -> None:
+    class EmptyAddMem0(FakeMem0):
+        def add(self, messages, **kwargs):
+            super().add(messages, **kwargs)
+            return {"results": []}
+
+    result = Mem0ConversationMemoryAdapter(
+        EmptyAddMem0(), _config(tmp_path)
+    ).remember_exchange(
+        user_message="synthetic user",
+        assistant_message="synthetic reply",
+        occurred_at=NOW,
+        source_id="reply:empty-add-response:1",
+        user_id="local-user",
+    )
+
+    assert result.status is MemoryWriteStatus.SKIPPED
+    assert result.error_code is None
+
+
+def test_results_only_empty_pages_remain_valid_for_status_and_search(tmp_path: Path) -> None:
+    class ResultsOnlyMem0(FakeMem0):
+        def get_all(self, **kwargs):
+            super().get_all(**kwargs)
+            return {"results": []}
+
+        def search(self, query, **kwargs):
+            super().search(query, **kwargs)
+            return {"results": []}
+
+    adapter = Mem0ConversationMemoryAdapter(ResultsOnlyMem0(), _config(tmp_path))
+
+    assert adapter.status().to_dict() == {
+        "status": "available",
+        "enabled": True,
+        "provider": "mem0",
+        "storage": "qdrant-local",
+        "memory_count": 0,
+    }
+    assert adapter.search_context("synthetic", user_id="local-user", limit=1) == ()
+    assert adapter._last_error_code is None
+
+
+def test_exchange_deduplicates_exact_source_id_beyond_the_listing_window(
+    tmp_path: Path,
+) -> None:
+    backend = FakeMem0()
+    for index in range(1000):
+        backend.rows.append(
+            {
+                "id": f"memory.seed.{index}",
+                    "memory": "synthetic memory",
+                    "user_id": "local-user",
+                    "agent_id": "linli",
+                    "metadata": {
+                    "source_id": f"reply:seed:{index}",
+                    "domain": "conversation_memory",
+                },
+            }
+        )
+    backend.rows.append(
+        {
+            "id": "memory.duplicate.outside-window",
+            "memory": "synthetic duplicate",
+            "user_id": "local-user",
+            "agent_id": "linli",
+            "metadata": {
+                "source_id": "reply:outside-window:1",
+                "domain": "conversation_memory",
+            },
+        }
+    )
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+    result = adapter.remember_exchange(
+        user_message="synthetic user",
+        assistant_message="synthetic reply",
+        occurred_at=NOW,
+        source_id="reply:outside-window:1",
+        user_id="local-user",
+    )
+
+    assert result.status is MemoryWriteStatus.DUPLICATE
+    dedup_call = next(value for name, value in backend.calls if name == "get_all")
+    assert dedup_call["filters"]["source_id"] == "reply:outside-window:1"
+    assert not [call for call in backend.calls if call[0] == "add"]
+
+
+def test_exchange_fails_closed_when_exact_source_id_query_fails(tmp_path: Path) -> None:
+    backend = FakeMem0()
+    backend.fail.add("get_all")
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+    result = adapter.remember_exchange(
+        user_message="synthetic user",
+        assistant_message="synthetic reply",
+        occurred_at=NOW,
+        source_id="reply:query-failure:1",
+        user_id="local-user",
+    )
+
+    assert result.status is MemoryWriteStatus.UNAVAILABLE
+    assert result.error_code == "MEM0_SOURCE_DEDUP_UNAVAILABLE"
+    assert not [call for call in backend.calls if call[0] == "add"]
+
+
+def test_exchange_fails_closed_when_exact_source_id_response_is_not_a_result_page(
+    tmp_path: Path,
+) -> None:
+    class InvalidExactQueryMem0(FakeMem0):
+        def get_all(self, **kwargs):
+            super().get_all(**kwargs)
+            return {}
+
+    backend = InvalidExactQueryMem0()
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+    result = adapter.remember_exchange(
+        user_message="synthetic user",
+        assistant_message="synthetic reply",
+        occurred_at=NOW,
+        source_id="reply:invalid-query-page:1",
+        user_id="local-user",
+    )
+
+    assert result.status is MemoryWriteStatus.UNAVAILABLE
+    assert result.error_code == "MEM0_SOURCE_DEDUP_UNAVAILABLE"
+    assert not [call for call in backend.calls if call[0] == "add"]
+
+
+def test_exchange_fails_closed_when_exact_source_id_response_is_bare_list(
+    tmp_path: Path,
+) -> None:
+    class BareListExactQueryMem0(FakeMem0):
+        def get_all(self, **kwargs):
+            super().get_all(**kwargs)
+            return []
+
+    backend = BareListExactQueryMem0()
+    result = Mem0ConversationMemoryAdapter(
+        backend, _config(tmp_path)
+    ).remember_exchange(
+        user_message="synthetic user",
+        assistant_message="synthetic reply",
+        occurred_at=NOW,
+        source_id="reply:bare-list-dedup:1",
+        user_id="local-user",
+    )
+
+    assert result.status is MemoryWriteStatus.UNAVAILABLE
+    assert result.error_code == "MEM0_SOURCE_DEDUP_UNAVAILABLE"
+    assert not [call for call in backend.calls if call[0] == "add"]
+
+
+def test_exchange_fails_closed_for_each_invalid_exact_source_id_response(
+    tmp_path: Path,
+) -> None:
+    class InvalidExactQueryMem0(FakeMem0):
+        def __init__(self, response: object) -> None:
+            super().__init__()
+            self.response = response
+
+        def get_all(self, **kwargs):
+            super().get_all(**kwargs)
+            return self.response
+
+    for response in (
+        {"memories": []},
+        {"results": {}},
+        {"results": "not-a-sequence"},
+        {"results": [], "error": "synthetic provider error"},
+        {"results": [], "status": "failed"},
+        7,
+    ):
+        backend = InvalidExactQueryMem0(response)
+        adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+        result = adapter.remember_exchange(
+            user_message="synthetic user",
+            assistant_message="synthetic reply",
+            occurred_at=NOW,
+            source_id="reply:invalid-query-shape:1",
+            user_id="local-user",
+        )
+
+        assert result.status is MemoryWriteStatus.UNAVAILABLE
+        assert result.error_code == "MEM0_SOURCE_DEDUP_UNAVAILABLE"
+        assert not [call for call in backend.calls if call[0] == "add"]
+
+
+def test_exchange_fails_closed_when_exact_source_row_scope_is_missing_or_mismatched(
+    tmp_path: Path,
+) -> None:
+    source_id = "reply:scope-check:1"
+
+    class ScopedExactQueryMem0(FakeMem0):
+        def __init__(self, row: dict[str, object]) -> None:
+            super().__init__()
+            self.row = row
+
+        def get_all(self, **kwargs):
+            super().get_all(**kwargs)
+            return {"results": [self.row]}
+
+    base_row = {
+        "id": "memory.scope-check",
+        "memory": "synthetic prior exchange",
+        "user_id": "local-user",
+        "agent_id": "linli",
+        "metadata": {
+            "source_id": source_id,
+            "domain": "conversation_memory",
+        },
+    }
+    invalid_rows = []
+    for key in ("user_id", "agent_id"):
+        row = dict(base_row)
+        row.pop(key)
+        invalid_rows.append(row)
+    missing_domain = dict(base_row)
+    missing_domain["metadata"] = {"source_id": source_id}
+    invalid_rows.append(missing_domain)
+    for key, value in (
+        ("user_id", "other-user"),
+        ("agent_id", "other-agent"),
+    ):
+        row = dict(base_row)
+        row[key] = value
+        invalid_rows.append(row)
+    mismatched_domain = dict(base_row)
+    mismatched_domain["metadata"] = {
+        "source_id": source_id,
+        "domain": "other-domain",
+    }
+    invalid_rows.append(mismatched_domain)
+
+    for row in invalid_rows:
+        backend = ScopedExactQueryMem0(row)
+        result = Mem0ConversationMemoryAdapter(
+            backend, _config(tmp_path)
+        ).remember_exchange(
+            user_message="synthetic user",
+            assistant_message="synthetic reply",
+            occurred_at=NOW,
+            source_id=source_id,
+            user_id="local-user",
+        )
+
+        assert result.status is MemoryWriteStatus.UNAVAILABLE
+        assert result.error_code == "MEM0_SOURCE_DEDUP_UNAVAILABLE"
+        assert not [call for call in backend.calls if call[0] == "add"]
+
+
+def test_exchange_fails_closed_for_exact_source_read_field_aliases(
+    tmp_path: Path,
+) -> None:
+    source_id = "reply:alias-dedup:1"
+
+    class AliasExactQueryMem0(FakeMem0):
+        def get_all(self, **kwargs):
+            super().get_all(**kwargs)
+            return {
+                "results": [
+                    {
+                        "memory_id": "memory.alias-dedup",
+                        "text": "synthetic memory",
+                        "user_id": "local-user",
+                        "agent_id": "linli",
+                        "metadata": {
+                            "source_id": source_id,
+                            "domain": "conversation_memory",
+                        },
+                    }
+                ]
+            }
+
+    backend = AliasExactQueryMem0()
+    result = Mem0ConversationMemoryAdapter(
+        backend, _config(tmp_path)
+    ).remember_exchange(
+        user_message="synthetic user",
+        assistant_message="synthetic reply",
+        occurred_at=NOW,
+        source_id=source_id,
+        user_id="local-user",
+    )
+
+    assert result.status is MemoryWriteStatus.UNAVAILABLE
+    assert result.error_code == "MEM0_SOURCE_DEDUP_UNAVAILABLE"
+    assert not [call for call in backend.calls if call[0] == "add"]
+
+
+def test_exchange_accepts_results_only_empty_exact_source_id_page(
+    tmp_path: Path,
+) -> None:
+    class ExactQueryMem0(FakeMem0):
+        def __init__(self, response: object) -> None:
+            super().__init__()
+            self.response = response
+
+        def get_all(self, **kwargs):
+            super().get_all(**kwargs)
+            return self.response
+
+    for response in ({"results": []}, {"results": [], "has_more": False}):
+        backend = ExactQueryMem0(response)
+        adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+        result = adapter.remember_exchange(
+            user_message="synthetic user",
+            assistant_message="synthetic reply",
+            occurred_at=NOW,
+            source_id="reply:valid-query-page:1",
+            user_id="local-user",
+        )
+
+        assert result.status is MemoryWriteStatus.WRITTEN
+        assert len([call for call in backend.calls if call[0] == "add"]) == 1
+
+
+def test_exchange_accepts_results_only_existing_exact_source_id_page(
+    tmp_path: Path,
+) -> None:
+    source_id = "reply:results-only-existing:1"
+
+    class ExactQueryMem0(FakeMem0):
+        def get_all(self, **kwargs):
+            response = super().get_all(**kwargs)
+            return {"results": response["results"]}
+
+    backend = ExactQueryMem0()
+    backend.rows.append(
+        {
+            "id": "memory.fixture.existing",
+            "memory": "synthetic prior exchange",
+            "user_id": "local-user",
+            "agent_id": "linli",
+            "metadata": {
+                "source_id": source_id,
+                "domain": "conversation_memory",
+            },
+            "created_at": NOW.isoformat(),
+        }
+    )
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+    result = adapter.remember_exchange(
+        user_message="synthetic user",
+        assistant_message="synthetic reply",
+        occurred_at=NOW,
+        source_id=source_id,
+        user_id="local-user",
+    )
+
+    assert result.status is MemoryWriteStatus.DUPLICATE
+    assert not [call for call in backend.calls if call[0] == "add"]
+
+
+def test_concurrent_exchange_serializes_exact_deduplication_and_write(
+    tmp_path: Path,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+
+    class GatedExactQueryMem0(FakeMem0):
+        def get_all(self, **kwargs):
+            entered.set()
+            assert release.wait(1.0)
+            return super().get_all(**kwargs)
+
+    backend = GatedExactQueryMem0()
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+    results: list[MemoryWriteResult] = []
+
+    def remember() -> None:
+        results.append(
+            adapter.remember_exchange(
+                user_message="synthetic user",
+                assistant_message="synthetic reply",
+                occurred_at=NOW,
+                source_id="reply:concurrent:1",
+                user_id="local-user",
+            )
+        )
+
+    first = threading.Thread(target=remember, daemon=True)
+    second = threading.Thread(target=remember, daemon=True)
+    first.start()
+    assert entered.wait(0.5)
+    second.start()
+    release.set()
+    first.join(timeout=1.0)
+    second.join(timeout=1.0)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert sorted(result.status for result in results) == [
+        MemoryWriteStatus.DUPLICATE,
+        MemoryWriteStatus.WRITTEN,
+    ]
+    assert len([call for call in backend.calls if call[0] == "add"]) == 1
+
+
+def test_exchange_write_timeout_keeps_one_daemon_and_fails_closed_on_retry(
+    tmp_path: Path,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    existing_threads = set(threading.enumerate())
+
+    class BlockingExactQueryMem0(FakeMem0):
+        def get_all(self, **kwargs):
+            entered.set()
+            release.wait()
+            return super().get_all(**kwargs)
+
+    backend = BlockingExactQueryMem0()
+    adapter = Mem0ConversationMemoryAdapter(
+        backend,
+        replace(_config(tmp_path), write_timeout_seconds=0.1),
+    )
+    try:
+        first = adapter.remember_exchange(
+            user_message="synthetic user",
+            assistant_message="synthetic reply",
+            occurred_at=NOW,
+            source_id="reply:write-timeout:1",
+            user_id="local-user",
+        )
+        assert entered.is_set()
+        retry = adapter.remember_exchange(
+            user_message="synthetic user",
+            assistant_message="synthetic reply",
+            occurred_at=NOW,
+            source_id="reply:write-timeout:1",
+            user_id="local-user",
+        )
+
+        assert first.error_code == "MEM0_WRITE_TIMEOUT"
+        assert retry.error_code == "MEM0_WRITE_TIMEOUT"
+        assert not [call for call in backend.calls if call[0] == "add"]
+        workers = [
+            thread
+            for thread in threading.enumerate()
+            if thread.name == "olivia-mem0-write" and thread not in existing_threads
+        ]
+        assert len(workers) == 1
+        assert workers[0].daemon is True
+    finally:
+        release.set()
+        for thread in threading.enumerate():
+            if thread.name == "olivia-mem0-write" and thread not in existing_threads:
+                thread.join(timeout=0.5)
+
+
+def test_exchange_fails_closed_when_exact_source_id_page_is_incomplete(
+    tmp_path: Path,
+) -> None:
+    class IncompletePageMem0(FakeMem0):
+        def __init__(self, marker: str, value: object) -> None:
+            super().__init__()
+            self.marker = marker
+            self.value = value
+
+        def get_all(self, **kwargs):
+            response = super().get_all(**kwargs)
+            return {**response, self.marker: self.value}
+
+    for marker, value in (
+        ("has_more", True),
+        ("has_more", "true"),
+        ("has_more", 1),
+        ("has_more", 0),
+        ("has_more", None),
+        ("next", "synthetic-next-page"),
+        ("next_cursor", "synthetic-next-page"),
+        ("next_page", "synthetic-next-page"),
+        ("next_token", "synthetic-next-page"),
+        ("next", None),
+        ("next", ""),
+        ("next", 0),
+        ("next", False),
+        ("next_cursor", None),
+        ("next_cursor", ""),
+        ("next_cursor", 0),
+        ("next_cursor", False),
+        ("next_page", None),
+        ("next_page", ""),
+        ("next_page", 0),
+        ("next_page", False),
+        ("next_token", None),
+        ("next_token", ""),
+        ("next_token", 0),
+        ("next_token", False),
+    ):
+        backend = IncompletePageMem0(marker, value)
+        adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+        result = adapter.remember_exchange(
+            user_message="synthetic user",
+            assistant_message="synthetic reply",
+            occurred_at=NOW,
+            source_id="reply:incomplete-page:1",
+            user_id="local-user",
+        )
+
+        assert result.status is MemoryWriteStatus.UNAVAILABLE
+        assert result.error_code == "MEM0_SOURCE_DEDUP_UNAVAILABLE"
+        assert not [call for call in backend.calls if call[0] == "add"]
+
+
+def test_model_facing_calls_share_one_bounded_read_slot_and_dedup_fails_closed(
+    tmp_path: Path,
+) -> None:
+    release = threading.Event()
+    entered = threading.Event()
+    existing_threads = set(threading.enumerate())
+
+    class BlockingMem0(FakeMem0):
+        def __init__(self) -> None:
+            super().__init__()
+            self.get_all_calls = 0
+            self.search_calls = 0
+
+        def get_all(self, **kwargs):
+            self.get_all_calls += 1
+            entered.set()
+            release.wait()
+            return super().get_all(**kwargs)
+
+        def search(self, query, **kwargs):
+            self.search_calls += 1
+            return super().search(query, **kwargs)
+
+    backend = BlockingMem0()
+    backend.rows.append(
+        {
+            "id": "memory.existing",
+            "memory": "synthetic memory",
+            "user_id": "local-user",
+            "agent_id": "linli",
+            "metadata": {
+                "source_id": "reply:timeout:1",
+                "domain": "conversation_memory",
+            },
+        }
+    )
+    adapter = Mem0ConversationMemoryAdapter(
+        backend,
+        replace(_config(tmp_path), search_timeout_seconds=0.1),
+    )
+    status_result: list[object] = []
+    status_done = threading.Event()
+
+    def read_status() -> None:
+        status_result.append(adapter.status())
+        status_done.set()
+
+    probe = threading.Thread(target=read_status, daemon=True)
+
+    try:
+        probe.start()
+        assert status_done.wait(0.25)
+        assert status_result[0].reason_code == "MEM0_SEARCH_TIMEOUT"
+        assert entered.is_set()
+        assert adapter.search_context("synthetic", user_id="local-user", limit=1) == ()
+        result = adapter.remember_exchange(
+            user_message="synthetic user",
+            assistant_message="synthetic reply",
+            occurred_at=NOW,
+            source_id="reply:timeout:1",
+            user_id="local-user",
+        )
+        assert result.status is MemoryWriteStatus.UNAVAILABLE
+        assert result.error_code == "MEM0_SOURCE_DEDUP_UNAVAILABLE"
+        assert backend.search_calls == 0
+        assert not [call for call in backend.calls if call[0] == "add"]
+        workers = [
+            thread
+            for thread in threading.enumerate()
+            if thread.name == "olivia-mem0-read" and thread not in existing_threads
+        ]
+        assert len(workers) == 1
+        assert workers[0].daemon is True
+    finally:
+        release.set()
+        probe.join(timeout=0.5)
+        for thread in threading.enumerate():
+            if thread.name == "olivia-mem0-read" and thread not in existing_threads:
+                thread.join(timeout=0.5)
+
+    retry = adapter.remember_exchange(
+        user_message="synthetic user",
+        assistant_message="synthetic reply",
+        occurred_at=NOW,
+        source_id="reply:timeout:1",
+        user_id="local-user",
+    )
+    assert retry.status is MemoryWriteStatus.DUPLICATE
+    assert not [call for call in backend.calls if call[0] == "add"]
+
+
 def test_factory_is_lazy_and_returns_stable_disabled_or_unavailable_ports(tmp_path: Path) -> None:
     assert isinstance(
         create_mem0_adapter(
@@ -305,3 +1163,283 @@ def test_manual_failure_uses_stable_error(tmp_path: Path) -> None:
         assert "private manual fact" not in str(exc)
     else:
         raise AssertionError("manual provider failure must be explicit")
+
+
+def test_delete_memory_fails_closed_when_provider_acknowledgement_is_malformed(
+    tmp_path: Path,
+) -> None:
+    class MalformedDeleteMem0(FakeMem0):
+        def delete(self, memory_id):
+            self._raise("delete")
+            self.calls.append(("delete", memory_id))
+            return {}
+
+    backend = MalformedDeleteMem0()
+    backend.rows.append(
+        {
+            "id": "memory.delete-malformed",
+            "memory": "synthetic manual fact",
+            "user_id": "local-user",
+            "agent_id": "linli",
+            "metadata": {
+                "source_id": "manual:delete-malformed:1",
+                "domain": "conversation_memory",
+            },
+        }
+    )
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+    assert adapter.delete_memory("memory.delete-malformed", user_id="local-user") is False
+    assert adapter._last_error_code == "MEM0_DELETE_FAILED"
+    assert [row["id"] for row in backend.rows] == ["memory.delete-malformed"]
+
+
+def test_clear_user_fails_closed_when_provider_acknowledgement_is_malformed(
+    tmp_path: Path,
+) -> None:
+    class MalformedClearMem0(FakeMem0):
+        def delete_all(self, user_id=None, agent_id=None, run_id=None):
+            self._raise("delete_all")
+            assert user_id == "local-user"
+            assert agent_id == "linli"
+            assert run_id is None
+            self.calls.append(("delete_all", {"user_id": user_id, "agent_id": agent_id}))
+            return None
+
+    backend = MalformedClearMem0()
+    backend.rows.append(
+        {
+            "id": "memory.clear-malformed",
+            "memory": "synthetic manual fact",
+            "user_id": "local-user",
+            "agent_id": "linli",
+            "metadata": {
+                "source_id": "manual:clear-malformed:1",
+                "domain": "conversation_memory",
+            },
+        }
+    )
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+    assert adapter.clear_user(user_id="local-user") == 0
+    assert adapter._last_error_code == "MEM0_CLEAR_FAILED"
+    assert [row["id"] for row in backend.rows] == ["memory.clear-malformed"]
+
+
+def test_delete_and_clear_accept_pinned_success_acknowledgements(tmp_path: Path) -> None:
+    backend = FakeMem0()
+    backend.rows.extend(
+        [
+            {
+                "id": "memory.delete-valid",
+                "memory": "synthetic manual fact",
+                "user_id": "local-user",
+                "agent_id": "linli",
+                "metadata": {
+                    "source_id": "manual:delete-valid:1",
+                    "domain": "conversation_memory",
+                },
+            },
+            {
+                "id": "memory.clear-valid",
+                "memory": "synthetic manual fact",
+                "user_id": "local-user",
+                "agent_id": "linli",
+                "metadata": {
+                    "source_id": "manual:clear-valid:1",
+                    "domain": "conversation_memory",
+                },
+            },
+        ]
+    )
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+    assert adapter.delete_memory("memory.delete-valid", user_id="local-user") is True
+    assert adapter.clear_user(user_id="local-user") == 1
+    assert adapter._last_error_code is None
+    assert backend.rows == []
+
+
+def test_manual_add_timeout_is_bounded_and_retry_does_not_accumulate_workers(
+    tmp_path: Path,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    done = threading.Event()
+    errors: list[str] = []
+    existing_threads = set(threading.enumerate())
+
+    class BlockingManualAddMem0(FakeMem0):
+        def add(self, messages, **kwargs):
+            if isinstance(messages, str):
+                entered.set()
+                release.wait()
+            return super().add(messages, **kwargs)
+
+    adapter = Mem0ConversationMemoryAdapter(
+        BlockingManualAddMem0(),
+        replace(_config(tmp_path), write_timeout_seconds=0.1),
+    )
+
+    def add_manual() -> None:
+        try:
+            adapter.add_manual_memory(
+                "synthetic manual fact",
+                user_id="local-user",
+                source_id="manual:timeout:1",
+            )
+        except Mem0AdapterError as exc:
+            errors.append(exc.code)
+        finally:
+            done.set()
+
+    caller = threading.Thread(target=add_manual, daemon=True)
+    caller.start()
+    try:
+        assert entered.wait(0.2)
+        assert done.wait(0.25)
+        assert errors == ["MEM0_MANUAL_WRITE_TIMEOUT"]
+
+        start = time.monotonic()
+        add_manual()
+        assert time.monotonic() - start < 0.2
+        assert errors == ["MEM0_MANUAL_WRITE_TIMEOUT", "MEM0_MANUAL_WRITE_TIMEOUT"]
+        workers = [
+            thread
+            for thread in threading.enumerate()
+            if thread.name == "olivia-mem0-write" and thread not in existing_threads
+        ]
+        assert len(workers) == 1
+        assert workers[0].daemon is True
+    finally:
+        release.set()
+        caller.join(timeout=0.5)
+        for thread in threading.enumerate():
+            if thread.name == "olivia-mem0-write" and thread not in existing_threads:
+                thread.join(timeout=0.5)
+
+
+def test_manual_delete_timeout_is_bounded_and_retry_does_not_accumulate_workers(
+    tmp_path: Path,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    done = threading.Event()
+    results: list[bool] = []
+    existing_threads = set(threading.enumerate())
+
+    class BlockingManualDeleteMem0(FakeMem0):
+        def delete(self, memory_id):
+            entered.set()
+            release.wait()
+            return super().delete(memory_id)
+
+    backend = BlockingManualDeleteMem0()
+    backend.rows.append(
+        {
+            "id": "memory.manual-timeout",
+            "memory": "synthetic manual fact",
+            "user_id": "local-user",
+            "agent_id": "linli",
+            "metadata": {
+                "source_id": "manual:timeout:delete",
+                "domain": "conversation_memory",
+            },
+        }
+    )
+    adapter = Mem0ConversationMemoryAdapter(
+        backend,
+        replace(_config(tmp_path), write_timeout_seconds=0.1),
+    )
+
+    def delete_manual() -> None:
+        results.append(adapter.delete_memory("memory.manual-timeout", user_id="local-user"))
+        done.set()
+
+    caller = threading.Thread(target=delete_manual, daemon=True)
+    caller.start()
+    try:
+        assert entered.wait(0.2)
+        assert done.wait(0.25)
+        assert results == [False]
+
+        start = time.monotonic()
+        delete_manual()
+        assert time.monotonic() - start < 0.2
+        assert results == [False, False]
+        workers = [
+            thread
+            for thread in threading.enumerate()
+            if thread.name == "olivia-mem0-write" and thread not in existing_threads
+        ]
+        assert len(workers) == 1
+        assert workers[0].daemon is True
+    finally:
+        release.set()
+        caller.join(timeout=0.5)
+        for thread in threading.enumerate():
+            if thread.name == "olivia-mem0-write" and thread not in existing_threads:
+                thread.join(timeout=0.5)
+
+
+def test_manual_clear_timeout_is_bounded_and_retry_does_not_accumulate_workers(
+    tmp_path: Path,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    done = threading.Event()
+    results: list[int] = []
+    existing_threads = set(threading.enumerate())
+
+    class BlockingManualClearMem0(FakeMem0):
+        def delete_all(self, user_id=None, agent_id=None, run_id=None):
+            entered.set()
+            release.wait()
+            return super().delete_all(user_id, agent_id, run_id)
+
+    backend = BlockingManualClearMem0()
+    backend.rows.append(
+        {
+            "id": "memory.manual-clear-timeout",
+            "memory": "synthetic manual fact",
+            "user_id": "local-user",
+            "agent_id": "linli",
+            "metadata": {
+                "source_id": "manual:timeout:clear",
+                "domain": "conversation_memory",
+            },
+        }
+    )
+    adapter = Mem0ConversationMemoryAdapter(
+        backend,
+        replace(_config(tmp_path), write_timeout_seconds=0.1),
+    )
+
+    def clear_manual() -> None:
+        results.append(adapter.clear_user(user_id="local-user"))
+        done.set()
+
+    caller = threading.Thread(target=clear_manual, daemon=True)
+    caller.start()
+    try:
+        assert entered.wait(0.2)
+        assert done.wait(0.25)
+        assert results == [0]
+
+        start = time.monotonic()
+        clear_manual()
+        assert time.monotonic() - start < 0.2
+        assert results == [0, 0]
+        workers = [
+            thread
+            for thread in threading.enumerate()
+            if thread.name == "olivia-mem0-write" and thread not in existing_threads
+        ]
+        assert len(workers) == 1
+        assert workers[0].daemon is True
+    finally:
+        release.set()
+        caller.join(timeout=0.5)
+        for thread in threading.enumerate():
+            if thread.name == "olivia-mem0-write" and thread not in existing_threads:
+                thread.join(timeout=0.5)


### PR DESCRIPTION
## Summary

- add a single-slot daemon boundary for Mem0 provider calls so permanent hangs cannot accumulate non-daemon workers or block process exit
- make read, search, canonical/manual write, delete, and clear operations bounded and fail closed
- enforce the pinned `mem0ai==2.0.18` operation-specific response contracts
- make exact `source_id` deduplication atomic, fully scoped, pagination-safe, and independent of a 1000-row listing window
- preserve the existing positional `Mem0Config.config_error` slot and package the new runtime module

## Validation

- `tests/memory/test_mem0_memory.py`: 37 passed
- focused Mem0/provider files: 55 passed
- full repository: 788 passed, 1 deselected
- baseline hardening: PASS
- compileall: PASS
- `git diff --check`: PASS
- frozen Standards review: PASS
- frozen Spec/boundary review: PASS

## Boundaries

- 7 files, +1784/-125 (1909 changed lines)
- no PrivateWorld or Archive mixing
- no hidden/control values exposed to a model
- no canonical reply resubmission or media retry submission
- no private corpus, derived output, key, or local absolute path
- no PR #116 runtime wiring, Live, music behavior, installer, or Release work
- no real provider or external LLM calls were made