### PR TITLE
PrivateWorld: analyze canonical letters into bounded candidates

### DIFF
--- a/contracts/private_world_candidate_analysis.schema.json
+++ b/contracts/private_world_candidate_analysis.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "p03.private-world-candidate.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "candidate",
+    "confidence",
+    "summary",
+    "evidence_spans"
+  ],
+  "properties": {
+    "schema_version": {"const": "p03.private-world-candidate.v1"},
+    "candidate": {
+      "enum": ["none", "boundary_respected", "conflict", "repair"]
+    },
+    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+    "summary": {"type": "string", "maxLength": 280},
+    "evidence_spans": {
+      "type": "array",
+      "maxItems": 0
+    }
+  }
+}

--- a/local_server.py
+++ b/local_server.py
@@ -73,9 +73,21 @@ from private_world_delivery import (
     DeliveryStatus,
     PrivateWorldDeliveryCommitter,
 )
+from private_world_candidate import (
+    PrivateWorldCandidateAnalyzer,
+    PrivateWorldCandidateRequest,
+    PrivateWorldCandidateRuntime,
+    create_private_world_candidate_runtime,
+    deliver_private_world_candidate,
+)
+from private_world_candidates import SQLitePrivateWorldCandidateStore
 from private_world_reducer import ReducerEventKind
 from private_world_projection import project_private_world
-from private_world_runtime import PrivateWorldRuntime, create_private_world_runtime
+from private_world_runtime import (
+    PrivateWorldRuntime,
+    create_private_world_runtime,
+    resolve_private_world_database,
+)
 from reply_context import (
     ReplyContext,
     ReplyMode,
@@ -578,6 +590,35 @@ letters_adapter = LetterAdapter(
     conversation_memory=conversation_memory_adapter,
     private_world_port=private_world_port,
 )
+
+
+def _create_candidate_runtime() -> PrivateWorldCandidateRuntime:
+    try:
+        database_path, _reason, _enabled = resolve_private_world_database()
+    except (OSError, RuntimeError, ValueError):
+        database_path = None
+    gateway_ready = (
+        not isinstance(letters_adapter.gateway, UnconfiguredAdapter)
+        and (
+            not LLM_CONFIG.requires_api_key
+            or api_key_configured(LLM_CONFIG)
+        )
+    )
+    return create_private_world_candidate_runtime(
+        letters_adapter.gateway,
+        database_path=database_path,
+        gateway_ready=gateway_ready,
+        environ=_os.environ,
+    )
+
+
+private_world_candidate_runtime = _create_candidate_runtime()
+private_world_candidate_analyzer: PrivateWorldCandidateAnalyzer = (
+    private_world_candidate_runtime.analyzer
+)
+private_world_candidate_store: SQLitePrivateWorldCandidateStore | None = (
+    private_world_candidate_runtime.store
+)
 # A file-only Mem0 profile owns the same canonical state root on restart; load
 # only after the validated conversation adapter has selected that root.
 _load_store_state()
@@ -585,6 +626,7 @@ emotion_triage = LetterEmotionTriage(letters_adapter.gateway)
 media_semaphore = asyncio.Semaphore(1)
 media_tasks: set[asyncio.Task] = set()
 reply_tasks: set[asyncio.Task] = set()
+private_world_candidate_tasks: set[asyncio.Task] = set()
 reply_jobs: dict[str, asyncio.Task] = {}
 media_jobs: dict[str, asyncio.Task] = {}
 
@@ -1122,6 +1164,9 @@ def _health_result(profile: str = contract.HEALTH_PROFILE_CORE) -> dict:
                 },
                 "memory": memory_info,
                 "private_world": private_world_runtime.public_status(),
+                "private_world_candidates": (
+                    private_world_candidate_runtime.public_status()
+                ),
                 "music_catalog": {
                     "status": "available",
                     "provider": "sanitized-local-fixture",
@@ -2024,12 +2069,13 @@ async def _start_reply_tasks(_app: web.Application) -> None:
 
 
 async def _stop_reply_tasks(_app: web.Application) -> None:
-    tasks = tuple(reply_tasks | media_tasks)
+    tasks = tuple(reply_tasks | media_tasks | private_world_candidate_tasks)
     for task in tasks:
         task.cancel()
     if tasks:
         await asyncio.gather(*tasks, return_exceptions=True)
     reply_tasks.clear()
+    private_world_candidate_tasks.clear()
     media_tasks.clear()
     reply_jobs.clear()
     media_jobs.clear()
@@ -2057,6 +2103,55 @@ def _prepare_private_world_delivery(letter: dict, canonical_text: str) -> None:
     letter["private_world_occurred_at"] = datetime.now(timezone.utc).isoformat()
     letter["private_world_event_kind"] = ReducerEventKind.CANONICAL_REPLY_DELIVERED.value
     letter["private_world_semantic_key"] = f"canonical.{semantic_digest}"
+
+
+async def _deliver_private_world_candidate(
+    letter: dict,
+    user_message: str,
+    canonical_reply: str,
+) -> None:
+    store = private_world_candidate_store
+    if store is None:
+        return
+    try:
+        snapshot = private_world_port.snapshot()
+        request = PrivateWorldCandidateRequest.create(
+            source_letter_id=str(letter["letter_id"]),
+            source_reply_revision=int(letter["reply_revision"]),
+            user_message=user_message,
+            canonical_reply=canonical_reply,
+            character_view=snapshot.character_view(),
+            occurred_at=datetime.fromisoformat(
+                str(letter["private_world_occurred_at"])
+            ),
+        )
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return
+    await deliver_private_world_candidate(
+        private_world_candidate_analyzer,
+        store,
+        request,
+    )
+
+
+def _schedule_private_world_candidate(
+    letter: dict,
+    user_message: str,
+    canonical_reply: str,
+) -> None:
+    if private_world_candidate_store is None:
+        return
+    task = asyncio.create_task(
+        _deliver_private_world_candidate(letter, user_message, canonical_reply)
+    )
+    private_world_candidate_tasks.add(task)
+    task.add_done_callback(private_world_candidate_tasks.discard)
+
+
+async def wait_for_private_world_candidate_tasks() -> None:
+    tasks = tuple(private_world_candidate_tasks)
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 def _commit_private_world_letter(letter: dict) -> bool:
@@ -2179,8 +2274,10 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
     letter["letter_status"] = "COMPLETED"
     _mark_superseded_failed_retries()
     _persist_store_state()
-    _commit_private_world_letter(letter)
+    private_world_committed = _commit_private_world_letter(letter)
     _persist_store_state()
+    if private_world_committed:
+        _schedule_private_world_candidate(letter, content, result.text)
 
     if exact_mode in {
         ReplyMode.SPOKEN_VIDEO.value,

--- a/private_world_candidate.py
+++ b/private_world_candidate.py
@@ -1,0 +1,371 @@
+"""Optional, bounded analysis that can only create review candidates."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import StrEnum
+import json
+from pathlib import Path
+from typing import Mapping, Protocol
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+
+from llm_gateway import Gateway, GatewayError
+from private_world_candidates import (
+    CandidateStatus,
+    CandidateType,
+    CandidateWriteStatus,
+    PrivateWorldCandidate,
+    PrivateWorldCandidateError,
+    SQLitePrivateWorldCandidateStore,
+    candidate_identity,
+)
+from private_world_port import PrivateWorldCharacterView
+
+
+_EXCERPT_LIMIT = 1200
+_CANDIDATE_LIFETIME = timedelta(days=30)
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parent
+    / "contracts"
+    / "private_world_candidate_analysis.schema.json"
+)
+def _excerpt(value: str) -> str:
+    normalized = " ".join(value.split())
+    return normalized[:_EXCERPT_LIMIT]
+
+
+@dataclass(frozen=True)
+class PrivateWorldCandidateRequest:
+    source_letter_id: str
+    source_reply_revision: int
+    user_excerpt: str
+    canonical_excerpt: str
+    character_view: PrivateWorldCharacterView
+    occurred_at: datetime
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        source_letter_id: str,
+        source_reply_revision: int,
+        user_message: str,
+        canonical_reply: str,
+        character_view: PrivateWorldCharacterView,
+        occurred_at: datetime,
+    ) -> "PrivateWorldCandidateRequest":
+        return cls(
+            source_letter_id=source_letter_id,
+            source_reply_revision=source_reply_revision,
+            user_excerpt=_excerpt(user_message),
+            canonical_excerpt=_excerpt(canonical_reply),
+            character_view=character_view,
+            occurred_at=occurred_at,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "user_excerpt": self.user_excerpt,
+            "canonical_excerpt": self.canonical_excerpt,
+            "character_view": self.character_view.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class PrivateWorldCandidateProposal:
+    candidate_type: CandidateType
+    confidence: float
+    summary: str
+
+
+class PrivateWorldCandidateAnalyzer(Protocol):
+    async def analyze(
+        self,
+        request: PrivateWorldCandidateRequest,
+    ) -> PrivateWorldCandidateProposal | None: ...
+
+
+class NullPrivateWorldCandidateAnalyzer:
+    async def analyze(
+        self,
+        request: PrivateWorldCandidateRequest,
+    ) -> None:
+        return None
+
+
+class PrivateWorldCandidateAnalysisError(RuntimeError):
+    pass
+
+
+def _load_validator() -> Draft202012Validator:
+    try:
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        Draft202012Validator.check_schema(schema)
+        return Draft202012Validator(schema)
+    except (
+        OSError,
+        UnicodeError,
+        json.JSONDecodeError,
+        SchemaError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise PrivateWorldCandidateAnalysisError(
+            "PRIVATE_WORLD_CANDIDATE_SCHEMA_UNAVAILABLE"
+        ) from exc
+
+
+def _reject_json_constant(_value: str) -> None:
+    raise ValueError("non-finite JSON number")
+
+
+class GatewayPrivateWorldCandidateAnalyzer:
+    """Classify a bounded canonical exchange into a review-only proposal."""
+
+    def __init__(
+        self,
+        gateway: Gateway,
+        *,
+        timeout_seconds: float,
+        minimum_confidence: float = 0.7,
+    ) -> None:
+        self.gateway = gateway
+        self.timeout_seconds = timeout_seconds
+        self.minimum_confidence = minimum_confidence
+        self.validator = _load_validator()
+
+    async def analyze(
+        self,
+        request: PrivateWorldCandidateRequest,
+    ) -> PrivateWorldCandidateProposal | None:
+        messages = (
+            {
+                "role": "system",
+                "content": (
+                    "Return exactly one JSON object using schema_version "
+                    "p03.private-world-candidate.v1. Candidate may only be none, "
+                    "boundary_respected, conflict, or repair. This is a review "
+                    "suggestion, never a command. Do not infer or change relationship "
+                    "stage, nicknames, home access, continuation facts, or hidden scores. "
+                    "Use a short summary and an empty evidence_spans array."
+                ),
+            },
+            {
+                "role": "user",
+                "content": json.dumps(
+                    request.to_dict(),
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                ),
+            },
+        )
+        try:
+            response = await asyncio.wait_for(
+                self.gateway.complete(
+                    messages,
+                    request_id=(
+                        "private-world-candidate:"
+                        f"{request.source_letter_id}:{request.source_reply_revision}"
+                    ),
+                ),
+                timeout=self.timeout_seconds,
+            )
+            payload = json.loads(
+                response.text.strip(),
+                parse_constant=_reject_json_constant,
+            )
+            if list(self.validator.iter_errors(payload)):
+                raise ValueError("candidate response does not match schema")
+            candidate = payload["candidate"]
+            confidence = float(payload["confidence"])
+            if candidate == "none" or confidence < self.minimum_confidence:
+                return None
+            return PrivateWorldCandidateProposal(
+                candidate_type=CandidateType(candidate),
+                confidence=confidence,
+                summary=str(payload["summary"]),
+            )
+        except (
+            asyncio.TimeoutError,
+            GatewayError,
+            json.JSONDecodeError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            raise PrivateWorldCandidateAnalysisError(
+                "PRIVATE_WORLD_CANDIDATE_ANALYSIS_UNAVAILABLE"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class PrivateWorldCandidateRuntime:
+    analyzer: PrivateWorldCandidateAnalyzer
+    store: SQLitePrivateWorldCandidateStore | None
+    status: str
+    provider: str
+    reason_code: str | None
+    enabled: bool
+
+    def public_status(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "provider": self.provider if self.status == "available" else "none",
+            "reason_code": self.reason_code,
+            "enabled": self.enabled,
+            "network_called": False,
+        }
+
+
+def _enabled(value: object) -> bool | None:
+    if value is None:
+        return False
+    normalized = str(value).strip().casefold()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
+def create_private_world_candidate_runtime(
+    gateway: Gateway,
+    *,
+    database_path: Path | None,
+    gateway_ready: bool,
+    environ: Mapping[str, str],
+) -> PrivateWorldCandidateRuntime:
+    enabled = _enabled(environ.get("OLIVIA_PRIVATE_WORLD_CANDIDATES_ENABLED"))
+    null = NullPrivateWorldCandidateAnalyzer()
+    if enabled is None:
+        return PrivateWorldCandidateRuntime(
+            null,
+            None,
+            "unavailable",
+            "none",
+            "PRIVATE_WORLD_CANDIDATES_ENABLED_INVALID",
+            False,
+        )
+    if not enabled:
+        return PrivateWorldCandidateRuntime(
+            null,
+            None,
+            "disabled",
+            "none",
+            "PRIVATE_WORLD_CANDIDATES_DISABLED",
+            False,
+        )
+    if not gateway_ready:
+        return PrivateWorldCandidateRuntime(
+            null,
+            None,
+            "unavailable",
+            "none",
+            "PRIVATE_WORLD_CANDIDATE_GATEWAY_UNAVAILABLE",
+            True,
+        )
+    if database_path is None:
+        return PrivateWorldCandidateRuntime(
+            null,
+            None,
+            "unavailable",
+            "none",
+            "PRIVATE_WORLD_CANDIDATE_STORAGE_UNAVAILABLE",
+            True,
+        )
+    try:
+        analyzer = GatewayPrivateWorldCandidateAnalyzer(
+            gateway,
+            timeout_seconds=10.0,
+        )
+    except PrivateWorldCandidateAnalysisError:
+        return PrivateWorldCandidateRuntime(
+            null,
+            None,
+            "unavailable",
+            "none",
+            "PRIVATE_WORLD_CANDIDATE_SCHEMA_UNAVAILABLE",
+            True,
+        )
+    try:
+        store = SQLitePrivateWorldCandidateStore(database_path)
+    except (OSError, PrivateWorldCandidateError, RuntimeError, ValueError):
+        return PrivateWorldCandidateRuntime(
+            null,
+            None,
+            "unavailable",
+            "none",
+            "PRIVATE_WORLD_CANDIDATE_STORAGE_UNAVAILABLE",
+            True,
+        )
+    return PrivateWorldCandidateRuntime(
+        analyzer,
+        store,
+        "available",
+        "llm_gateway",
+        None,
+        True,
+    )
+
+
+class CandidateDeliveryStatus(StrEnum):
+    CREATED = "CREATED"
+    DUPLICATE = "DUPLICATE"
+    SKIPPED = "SKIPPED"
+    UNAVAILABLE = "UNAVAILABLE"
+
+
+async def deliver_private_world_candidate(
+    analyzer: PrivateWorldCandidateAnalyzer,
+    store: SQLitePrivateWorldCandidateStore,
+    request: PrivateWorldCandidateRequest,
+) -> CandidateDeliveryStatus:
+    """Analyze once and persist only a bounded pending proposal."""
+
+    try:
+        proposal = await analyzer.analyze(request)
+        if proposal is None:
+            return CandidateDeliveryStatus.SKIPPED
+        if not isinstance(proposal, PrivateWorldCandidateProposal):
+            return CandidateDeliveryStatus.UNAVAILABLE
+        candidate = PrivateWorldCandidate(
+            candidate_id=candidate_identity(
+                request.source_letter_id,
+                request.source_reply_revision,
+                proposal.candidate_type,
+            ),
+            source_letter_id=request.source_letter_id,
+            source_reply_revision=request.source_reply_revision,
+            candidate_type=proposal.candidate_type,
+            summary=proposal.summary,
+            confidence=proposal.confidence,
+            status=CandidateStatus.PENDING,
+            created_at=request.occurred_at,
+            expires_at=request.occurred_at + _CANDIDATE_LIFETIME,
+        )
+        written = await asyncio.to_thread(store.add, candidate)
+    except (PrivateWorldCandidateError, OSError, RuntimeError, TypeError, ValueError):
+        return CandidateDeliveryStatus.UNAVAILABLE
+    return (
+        CandidateDeliveryStatus.CREATED
+        if written is CandidateWriteStatus.CREATED
+        else CandidateDeliveryStatus.DUPLICATE
+    )
+
+
+__all__ = [
+    "CandidateDeliveryStatus",
+    "GatewayPrivateWorldCandidateAnalyzer",
+    "NullPrivateWorldCandidateAnalyzer",
+    "PrivateWorldCandidateAnalyzer",
+    "PrivateWorldCandidateAnalysisError",
+    "PrivateWorldCandidateProposal",
+    "PrivateWorldCandidateRequest",
+    "PrivateWorldCandidateRuntime",
+    "create_private_world_candidate_runtime",
+    "deliver_private_world_candidate",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ py-modules = [
     "private_world_reducer",
     "private_world_ledger",
     "private_world_admin",
+    "private_world_candidate",
     "private_world_delivery",
     "private_world_projection",
     "private_world_runtime",

--- a/tests/private_world/test_private_world_candidate_delivery.py
+++ b/tests/private_world/test_private_world_candidate_delivery.py
@@ -1,0 +1,373 @@
+"""Canonical-letter candidate analysis is optional and never mutates the ledger."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from llm_gateway import Gateway, GatewayResponse
+from private_world_candidates import (
+    CandidateStatus,
+    CandidateType,
+    SQLitePrivateWorldCandidateStore,
+    candidate_identity,
+)
+from private_world_delivery import PrivateWorldDeliveryCommitter
+from private_world_ledger import SQLitePrivateWorldLedger
+from private_world_port import PrivateWorldSnapshot
+from reply_context import ReplyMode
+from reply_orchestrator import ReplyState
+from reply_pipeline import PipelineResult
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class AcceptedPipeline:
+    async def run(self, request: object, context: object) -> PipelineResult:
+        return PipelineResult(
+            "candidate-letter",
+            ReplyState.COMPLETED,
+            text="synthetic canonical reply",
+            quality_status="accepted",
+        )
+
+
+class TextTriage:
+    reply_mode = ReplyMode.TEXT_LETTER.value
+
+    def to_dict(self) -> dict[str, str]:
+        return {"reply_mode": self.reply_mode}
+
+
+class TextTriageService:
+    async def classify(self, content: str) -> TextTriage:
+        return TextTriage()
+
+
+def test_canonical_reply_creates_pending_candidate_without_mutating_snapshot(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import local_server
+    from private_world_candidate import PrivateWorldCandidateProposal
+
+    database = tmp_path / "private-world.sqlite3"
+    ledger = SQLitePrivateWorldLedger(database)
+    candidate_store = SQLitePrivateWorldCandidateStore(database)
+    snapshot_before = ledger.snapshot()
+    requests: list[object] = []
+
+    class SyntheticAnalyzer:
+        async def analyze(self, request: object) -> PrivateWorldCandidateProposal:
+            requests.append(request)
+            return PrivateWorldCandidateProposal(
+                candidate_type=CandidateType.BOUNDARY_RESPECTED,
+                confidence=0.8,
+                summary="synthetic bounded candidate summary",
+            )
+
+    letter = {
+        "letter_id": "candidate-letter",
+        "content": "synthetic current letter",
+        "reply_text": "",
+        "letter_status": "PENDING",
+    }
+    monkeypatch.setattr(local_server.store, "letters", [letter])
+    monkeypatch.setattr(local_server, "emotion_triage", TextTriageService())
+    monkeypatch.setattr(local_server, "reply_pipeline", AcceptedPipeline())
+    monkeypatch.setattr(
+        local_server,
+        "private_world_committer",
+        PrivateWorldDeliveryCommitter(ledger),
+    )
+    monkeypatch.setattr(local_server, "private_world_port", ledger)
+    monkeypatch.setattr(local_server.letters_adapter, "private_world_port", ledger)
+    monkeypatch.setattr(local_server, "private_world_candidate_analyzer", SyntheticAnalyzer())
+    monkeypatch.setattr(local_server, "private_world_candidate_store", candidate_store)
+    monkeypatch.setattr(local_server, "_schedule_text_reply_delay", lambda *args: None)
+    monkeypatch.setattr(local_server, "_persist_store_state", lambda: None)
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "remember_conversation",
+        lambda *args: None,
+    )
+
+    async def run() -> None:
+        assert await local_server.generate_reply(
+            "candidate-letter", "synthetic current letter"
+        ) is True
+        await local_server.wait_for_private_world_candidate_tasks()
+
+    asyncio.run(run())
+
+    candidate = candidate_store.get(
+        candidate_identity(
+            "candidate-letter", 1, CandidateType.BOUNDARY_RESPECTED
+        ),
+        now=datetime.now(timezone.utc),
+    )
+    assert candidate is not None
+    assert candidate.status is CandidateStatus.PENDING
+    assert candidate.summary == "synthetic bounded candidate summary"
+    assert ledger.snapshot() == snapshot_before
+    assert len(requests) == 1
+
+    blocked_letter = {
+        "letter_id": "candidate-without-delivery",
+        "content": "synthetic current letter",
+        "reply_text": "",
+        "letter_status": "PENDING",
+    }
+    monkeypatch.setattr(local_server.store, "letters", [blocked_letter])
+    monkeypatch.setattr(local_server, "private_world_committer", None)
+
+    async def run_without_delivery() -> None:
+        assert await local_server.generate_reply(
+            "candidate-without-delivery", "synthetic current letter"
+        ) is True
+        await local_server.wait_for_private_world_candidate_tasks()
+
+    asyncio.run(run_without_delivery())
+
+    assert blocked_letter["letter_status"] == "COMPLETED"
+    assert blocked_letter["private_world_status"] == "PENDING"
+    assert len(requests) == 1
+    assert len(candidate_store.list_candidates()) == 1
+
+
+def test_gateway_analyzer_returns_only_a_bounded_low_privilege_proposal() -> None:
+    from private_world_candidate import (
+        GatewayPrivateWorldCandidateAnalyzer,
+        PrivateWorldCandidateRequest,
+    )
+
+    class RecordingGateway(Gateway):
+        def __init__(self) -> None:
+            self.messages: object = None
+
+        async def complete(
+            self, messages: object, *, request_id: str | None = None
+        ) -> GatewayResponse:
+            self.messages = messages
+            return GatewayResponse(
+                text=(
+                    '{"schema_version":"p03.private-world-candidate.v1",'
+                    '"candidate":"boundary_respected","confidence":0.8,'
+                    '"summary":"synthetic bounded candidate summary",'
+                    '"evidence_spans":[]}'
+                ),
+                request_id=request_id or "candidate-test",
+                provider="synthetic",
+                model="synthetic",
+            )
+
+    gateway = RecordingGateway()
+    analyzer = GatewayPrivateWorldCandidateAnalyzer(gateway, timeout_seconds=1.0)
+    request = PrivateWorldCandidateRequest.create(
+        source_letter_id="candidate-letter",
+        source_reply_revision=1,
+        user_message="synthetic current letter",
+        canonical_reply="synthetic canonical reply",
+        character_view=PrivateWorldSnapshot(
+            trust=88,
+            comfort=77,
+        ).character_view(),
+        occurred_at=datetime(2026, 8, 25, tzinfo=timezone.utc),
+    )
+
+    proposal = asyncio.run(analyzer.analyze(request))
+
+    assert proposal is not None
+    assert proposal.candidate_type is CandidateType.BOUNDARY_RESPECTED
+    assert proposal.confidence == 0.8
+    assert proposal.summary == "synthetic bounded candidate summary"
+    serialized = str(gateway.messages)
+    assert "synthetic current letter" in serialized
+    assert "synthetic canonical reply" in serialized
+    assert "88" not in serialized
+    assert "77" not in serialized
+    assert "relationship_stage" in serialized
+    assert "candidate-letter" not in serialized
+    assert "source_reply_revision" not in serialized
+
+
+def test_candidate_delivery_is_idempotent_and_analysis_failure_is_nonblocking(
+    tmp_path: Path,
+) -> None:
+    from private_world_candidate import (
+        CandidateDeliveryStatus,
+        PrivateWorldCandidateProposal,
+        PrivateWorldCandidateRequest,
+        deliver_private_world_candidate,
+    )
+
+    database = tmp_path / "private-world.sqlite3"
+    SQLitePrivateWorldLedger(database)
+    candidate_store = SQLitePrivateWorldCandidateStore(database)
+    request = PrivateWorldCandidateRequest.create(
+        source_letter_id="candidate-idempotency",
+        source_reply_revision=1,
+        user_message="synthetic current letter",
+        canonical_reply="synthetic canonical reply",
+        character_view=PrivateWorldSnapshot().character_view(),
+        occurred_at=datetime(2026, 8, 25, tzinfo=timezone.utc),
+    )
+
+    class SyntheticAnalyzer:
+        async def analyze(self, _request: object) -> PrivateWorldCandidateProposal:
+            return PrivateWorldCandidateProposal(
+                CandidateType.REPAIR,
+                0.8,
+                "synthetic bounded candidate summary",
+            )
+
+    class FailingAnalyzer:
+        async def analyze(self, _request: object) -> None:
+            raise RuntimeError("synthetic provider failure")
+
+    created = asyncio.run(
+        deliver_private_world_candidate(SyntheticAnalyzer(), candidate_store, request)
+    )
+    duplicate = asyncio.run(
+        deliver_private_world_candidate(SyntheticAnalyzer(), candidate_store, request)
+    )
+    unavailable = asyncio.run(
+        deliver_private_world_candidate(FailingAnalyzer(), candidate_store, request)
+    )
+
+    assert (created, duplicate, unavailable) == (
+        CandidateDeliveryStatus.CREATED,
+        CandidateDeliveryStatus.DUPLICATE,
+        CandidateDeliveryStatus.UNAVAILABLE,
+    )
+    assert len(candidate_store.list_candidates()) == 1
+
+
+def test_candidate_runtime_requires_explicit_enablement_and_ready_dependencies(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import private_world_candidate as candidate_module
+    from private_world_candidate import (
+        GatewayPrivateWorldCandidateAnalyzer,
+        NullPrivateWorldCandidateAnalyzer,
+        create_private_world_candidate_runtime,
+    )
+
+    class UnusedGateway(Gateway):
+        async def complete(
+            self, messages: object, *, request_id: str | None = None
+        ) -> GatewayResponse:
+            raise AssertionError("runtime construction must not call the provider")
+
+    database = tmp_path / "private-world.sqlite3"
+    SQLitePrivateWorldLedger(database)
+    disabled = create_private_world_candidate_runtime(
+        UnusedGateway(),
+        database_path=database,
+        gateway_ready=True,
+        environ={},
+    )
+    available = create_private_world_candidate_runtime(
+        UnusedGateway(),
+        database_path=database,
+        gateway_ready=True,
+        environ={"OLIVIA_PRIVATE_WORLD_CANDIDATES_ENABLED": "1"},
+    )
+
+    assert disabled.status == "disabled"
+    assert isinstance(disabled.analyzer, NullPrivateWorldCandidateAnalyzer)
+    assert disabled.store is None
+    assert available.status == "available"
+    assert isinstance(available.analyzer, GatewayPrivateWorldCandidateAnalyzer)
+    assert available.store is not None
+    assert available.public_status() == {
+        "status": "available",
+        "provider": "llm_gateway",
+        "reason_code": None,
+        "enabled": True,
+        "network_called": False,
+    }
+
+    monkeypatch.setattr(
+        candidate_module,
+        "_SCHEMA_PATH",
+        tmp_path / "missing-candidate-schema.json",
+    )
+    schema_unavailable = create_private_world_candidate_runtime(
+        UnusedGateway(),
+        database_path=database,
+        gateway_ready=True,
+        environ={"OLIVIA_PRIVATE_WORLD_CANDIDATES_ENABLED": "1"},
+    )
+    assert schema_unavailable.public_status() == {
+        "status": "unavailable",
+        "provider": "none",
+        "reason_code": "PRIVATE_WORLD_CANDIDATE_SCHEMA_UNAVAILABLE",
+        "enabled": True,
+        "network_called": False,
+    }
+
+
+def test_local_server_wires_explicit_candidate_runtime_and_sanitized_health(
+    tmp_path: Path,
+) -> None:
+    script = """
+import asyncio
+import json
+import local_server
+
+health = asyncio.run(
+    local_server.route('GET', '/health', {}, {'profile': 'core'})
+)['data']['providers']['private_world_candidates']
+print(json.dumps({
+    'runtime_status': local_server.private_world_candidate_runtime.status,
+    'analyzer_type': type(local_server.private_world_candidate_analyzer).__name__,
+    'store_type': type(local_server.private_world_candidate_store).__name__,
+    'health': health,
+}, sort_keys=True))
+"""
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "OLIVIA_LOCAL_DATA_ROOT": str(tmp_path / "local-data"),
+            "OLIVIA_LLM_PROVIDER": "mock",
+            "OLIVIA_LLM_FEATURE_ENABLED": "1",
+            "OLIVIA_MEMORY_ENABLED": "0",
+            "OLIVIA_PRIVATE_WORLD_CANDIDATES_ENABLED": "1",
+            "PYTHONPATH": str(ROOT)
+            + os.pathsep
+            + environment.get("PYTHONPATH", ""),
+        }
+    )
+    environment.pop("OLIVIA_PRIVATE_WORLD_DB", None)
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout.strip().splitlines()[-1])
+    assert payload == {
+        "runtime_status": "available",
+        "analyzer_type": "GatewayPrivateWorldCandidateAnalyzer",
+        "store_type": "SQLitePrivateWorldCandidateStore",
+        "health": {
+            "status": "available",
+            "provider": "llm_gateway",
+            "reason_code": None,
+            "enabled": True,
+            "network_called": False,
+        },
+    }


### PR DESCRIPTION
## Summary

- add an explicitly enabled, low-privilege PrivateWorld candidate analyzer on the normal letter gateway
- schedule analysis only after canonical reply persistence and successful PrivateWorld delivery
- persist only bounded pending candidates; keep hidden values and local letter identifiers out of model payloads
- expose sanitized runtime health and degrade to a null runtime when configuration, gateway, storage, or schema is unavailable

## Boundaries

- Archive, conversation memory, and PrivateWorld storage remain separate
- default is disabled; no provider call occurs during health or runtime construction
- canonical text remains authoritative and is not regenerated
- media retry does not schedule candidate analysis
- no Live, music, installer, release, private corpus, derived memory, local report, media, key, or absolute path is included

## Validation

- `python -m pytest tests/private_world -q`: 165 passed
- `python -m pytest -q`: 824 passed, 1 deselected, 0 failed
- focused candidate tests: 5 passed
- local-only private-original smoke: GREEN, one test original, fake gateway only, no external call, all isolation assertions true
- changed-file hardening scans: comments, runtime dependencies, secrets, sensitive paths, large files, and persona release all zero findings
- `git diff --check`: pass

## Review trail

The first frozen Sol-high review blocked on three P1s: eager schema loading, candidate scheduling after failed PrivateWorld delivery, and local letter identifiers in the provider payload. All three were repaired with RED-to-GREEN tests. A second frozen Standards + Spec review returned PASS with no P0/P1/P2 findings. The reviewed tree is commit `9c034c73faf5d26cc8fa2d128609f310a0cb76a6`.
