### PR TITLE
Mem0: add isolated 19-prefix memory experiment runner

### DIFF
--- a/contracts/memory_isolation_case01_report.schema.json
+++ b/contracts/memory_isolation_case01_report.schema.json
@@ -6,17 +6,9 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "status",
-        "error_code",
-        "case_id",
-        "prefix_case",
-        "validation_mode",
-        "namespace",
-        "train_original_count",
-        "test_original_count",
-        "private_world_arm",
-        "selected_evidence_count",
-        "persona_evaluation",
+        "status", "error_code", "case_id", "prefix_case", "validation_mode",
+        "namespace", "train_original_count", "test_original_count",
+        "private_world_arm", "selected_evidence_count", "persona_evaluation",
         "reference_evaluation"
       ],
       "properties": {
@@ -30,46 +22,22 @@
         "test_original_count": {"const": 1},
         "private_world_arm": {"const": "fixed_disabled"},
         "selected_evidence_count": {"type": "integer", "minimum": 0},
-        "persona_evaluation": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["score", "hard_violation_count", "metrics"],
-          "properties": {
-            "score": {"type": "number"},
-            "hard_violation_count": {"type": "integer", "minimum": 0},
-            "metrics": {
-              "type": "object",
-              "additionalProperties": {"type": "number"}
-            }
-          }
-        },
-        "reference_evaluation": {
-          "type": "object",
-          "minProperties": 1,
-          "additionalProperties": {"type": "number"}
-        }
+        "persona_evaluation": {"$ref": "#/$defs/persona_evaluation"},
+        "reference_evaluation": {"$ref": "#/$defs/reference_evaluation"}
       }
     },
     {
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "status",
-        "error_code",
-        "case_id",
-        "prefix_case",
-        "validation_mode",
-        "namespace",
-        "train_original_count",
-        "test_original_count",
-        "private_world_arm"
+        "status", "error_code", "case_id", "prefix_case", "validation_mode",
+        "namespace", "train_original_count", "test_original_count", "private_world_arm"
       ],
       "properties": {
         "status": {"const": "unavailable"},
         "error_code": {
           "enum": [
-            "CASE01_MEMORY_UNAVAILABLE",
-            "CASE01_GENERATOR_UNAVAILABLE",
+            "CASE01_MEMORY_UNAVAILABLE", "CASE01_GENERATOR_UNAVAILABLE",
             "CASE01_PERSONA_EVALUATION_UNAVAILABLE",
             "CASE01_REFERENCE_EVALUATION_UNAVAILABLE"
           ]
@@ -82,6 +50,152 @@
         "test_original_count": {"const": 1},
         "private_world_arm": {"const": "fixed_disabled"}
       }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status", "error_code", "validation_mode", "private_world_arm",
+        "completed_case_count", "cases"
+      ],
+      "properties": {
+        "status": {"const": "completed"},
+        "error_code": {"type": "null"},
+        "validation_mode": {"enum": ["synthetic_validation", "private_local_validation"]},
+        "private_world_arm": {"const": "fixed_disabled"},
+        "completed_case_count": {"const": 19},
+        "cases": {
+          "type": "array",
+          "minItems": 19,
+          "maxItems": 19,
+          "prefixItems": [
+            {"$ref": "#/$defs/case01"}, {"$ref": "#/$defs/case02"},
+            {"$ref": "#/$defs/case03"}, {"$ref": "#/$defs/case04"},
+            {"$ref": "#/$defs/case05"}, {"$ref": "#/$defs/case06"},
+            {"$ref": "#/$defs/case07"}, {"$ref": "#/$defs/case08"},
+            {"$ref": "#/$defs/case09"}, {"$ref": "#/$defs/case10"},
+            {"$ref": "#/$defs/case11"}, {"$ref": "#/$defs/case12"},
+            {"$ref": "#/$defs/case13"}, {"$ref": "#/$defs/case14"},
+            {"$ref": "#/$defs/case15"}, {"$ref": "#/$defs/case16"},
+            {"$ref": "#/$defs/case17"}, {"$ref": "#/$defs/case18"},
+            {"$ref": "#/$defs/case19"}
+          ],
+          "items": false
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "validation_mode", "private_world_arm", "failed_case"],
+      "properties": {
+        "status": {"const": "unavailable"},
+        "validation_mode": {"enum": ["synthetic_validation", "private_local_validation"]},
+        "private_world_arm": {"const": "fixed_disabled"},
+        "failed_case": {"$ref": "#/$defs/failed_prefix_case"}
+      }
     }
-  ]
+  ],
+  "$defs": {
+    "persona_evaluation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["score", "hard_violation_count", "metrics"],
+      "properties": {
+        "score": {"type": "number", "minimum": 0, "maximum": 1},
+        "hard_violation_count": {"type": "integer", "minimum": 0},
+        "metrics": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "identity": {"type": "number", "minimum": 0, "maximum": 1},
+            "tone": {"type": "number", "minimum": 0, "maximum": 1},
+            "reply_rhythm": {"type": "number", "minimum": 0, "maximum": 1},
+            "boundaries": {"type": "number", "minimum": 0, "maximum": 1},
+            "continuity": {"type": "number", "minimum": 0, "maximum": 1},
+            "non_overintimacy": {"type": "number", "minimum": 0, "maximum": 1},
+            "no_invention": {"type": "number", "minimum": 0, "maximum": 1},
+            "style_stability": {"type": "number", "minimum": 0, "maximum": 1}
+          }
+        }
+      }
+    },
+    "reference_evaluation": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "style_score": {"type": "number", "minimum": 0, "maximum": 1},
+        "focus_score": {"type": "number", "minimum": 0, "maximum": 1}
+      }
+    },
+    "completed_prefix_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status", "error_code", "case_id", "prefix_case",
+        "namespace", "train_original_count", "test_original_count", "private_world_arm",
+        "selected_evidence_count", "persona_evaluation", "reference_status"
+      ],
+      "properties": {
+        "status": {"const": "completed"},
+        "error_code": {"type": "null"},
+        "case_id": {"type": "string"},
+        "prefix_case": {"type": "string", "pattern": "^case(?:0[1-9]|1[0-9])$"},
+        "namespace": {"type": "string"},
+        "train_original_count": {"const": 60},
+        "test_original_count": {"type": "integer", "minimum": 1, "maximum": 19},
+        "private_world_arm": {"const": "fixed_disabled"},
+        "selected_evidence_count": {"type": "integer", "minimum": 0},
+        "persona_evaluation": {"$ref": "#/$defs/persona_evaluation"},
+        "reference_status": {"enum": ["evaluated_text", "not_evaluated_media"]},
+        "reference_evaluation": {"$ref": "#/$defs/reference_evaluation"}
+      },
+      "oneOf": [
+        {"required": ["reference_evaluation"], "properties": {"reference_status": {"const": "evaluated_text"}}},
+        {"properties": {"reference_status": {"const": "not_evaluated_media"}}, "not": {"required": ["reference_evaluation"]}}
+      ]
+    },
+    "failed_prefix_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status", "error_code", "case_id", "prefix_case",
+        "namespace", "private_world_arm"
+      ],
+      "properties": {
+        "status": {"const": "unavailable"},
+        "error_code": {
+          "enum": [
+            "PREFIX19_MEMORY_UNAVAILABLE", "PREFIX19_GENERATOR_UNAVAILABLE",
+            "PREFIX19_PERSONA_EVALUATION_UNAVAILABLE",
+            "PREFIX19_REFERENCE_EVALUATION_UNAVAILABLE"
+          ]
+        },
+        "case_id": {"type": "string"},
+        "prefix_case": {"type": "string", "pattern": "^case(?:0[1-9]|1[0-9])$"},
+        "namespace": {"type": "string"},
+        "private_world_arm": {"const": "fixed_disabled"}
+      }
+    },
+    "case01": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case01"}, "test_original_count": {"const": 1}}}]},
+    "case02": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case02"}, "test_original_count": {"const": 2}}}]},
+    "case03": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case03"}, "test_original_count": {"const": 3}}}]},
+    "case04": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case04"}, "test_original_count": {"const": 4}}}]},
+    "case05": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case05"}, "test_original_count": {"const": 5}}}]},
+    "case06": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case06"}, "test_original_count": {"const": 6}}}]},
+    "case07": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case07"}, "test_original_count": {"const": 7}}}]},
+    "case08": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case08"}, "test_original_count": {"const": 8}}}]},
+    "case09": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case09"}, "test_original_count": {"const": 9}}}]},
+    "case10": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case10"}, "test_original_count": {"const": 10}}}]},
+    "case11": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case11"}, "test_original_count": {"const": 11}}}]},
+    "case12": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case12"}, "test_original_count": {"const": 12}}}]},
+    "case13": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case13"}, "test_original_count": {"const": 13}}}]},
+    "case14": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case14"}, "test_original_count": {"const": 14}}}]},
+    "case15": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case15"}, "test_original_count": {"const": 15}}}]},
+    "case16": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case16"}, "test_original_count": {"const": 16}}}]},
+    "case17": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case17"}, "test_original_count": {"const": 17}}}]},
+    "case18": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case18"}, "test_original_count": {"const": 18}}}]},
+    "case19": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case19"}, "test_original_count": {"const": 19}}}]}
+  }
 }

--- a/docs/P03_03B_MEMORY_ISOLATION_CASE01.md
+++ b/docs/P03_03B_MEMORY_ISOLATION_CASE01.md
@@ -26,5 +26,32 @@ counts, IDs, status, scores, and stable error codes; it excludes corpus text,
 generated replies, reference text, exception messages, secrets, and absolute
 paths.
 
-This narrow slice does not run the 19-prefix series, contact a real provider,
-or enable PrivateWorld state changes.
+`run_case01` does not run the 19-prefix series, contact a real provider, or
+enable PrivateWorld state changes.
+
+## Prefix19 runner
+
+`memory_isolation_case01.run_prefix19` is the corresponding public runner for
+case01 through case19. It accepts the same caller-owned callbacks
+and requires exactly 60 train and 19 test items, sorted by the manifest's
+`split_sequence`, `source_date`, and `source_order` fields. It derives fresh
+namespaces as `<namespace>:case01` through `<namespace>:case19`; every case
+rebuilds the 60 train originals and then ingests only its test-original prefix.
+
+It calls the generator once for the current prefix item, with only
+`persona_authority`, selected evidence, and that original. Generated replies
+are never ingested. Blind persona evaluation occurs before reference handling.
+Only text references are opened for the reference evaluator; video references
+are reported as `not_evaluated_media` and are never opened or uploaded.
+
+The same report schema accepts the completed 19-case aggregate. Its per-case
+records are limited to IDs, namespace, counts, statuses, finite scores, hard
+violation counts, and reference status. Synthetic fixtures use
+`synthetic_validation`; a caller-owned, Git-ignored real run must use
+`private_local_validation`. Both keep `private_world_arm=fixed_disabled`.
+
+Persona metrics are limited to the eight declared authority axes; held-out
+comparison is limited to `style_score` and `focus_score`. Unknown metric names
+are rejected so callback-controlled text cannot become a report key. A failed
+run writes only its redacted `failed_case`, rather than a partial case array
+whose count could disagree with its contents.

--- a/memory_isolation_case01.py
+++ b/memory_isolation_case01.py
@@ -1,10 +1,4 @@
-"""One-case synthetic tracer for the private-memory isolation experiment.
-
-This module deliberately exposes only ``run_case01``.  It builds a fresh
-memory namespace from train originals, generates one reply from the first test
-original, performs the blind persona assessment, and only then opens the held-
-out reference for comparison.
-"""
+"""Synthetic tracers for isolated private-memory prefix experiments."""
 
 from __future__ import annotations
 
@@ -12,6 +6,21 @@ import json
 import math
 from pathlib import Path
 from typing import Any, Callable, Mapping
+
+
+_PERSONA_METRICS = frozenset(
+    {
+        "identity",
+        "tone",
+        "reply_rhythm",
+        "boundaries",
+        "continuity",
+        "non_overintimacy",
+        "no_invention",
+        "style_stability",
+    }
+)
+_REFERENCE_METRICS = frozenset({"style_score", "focus_score"})
 
 
 def _original_text(manifest_root: Path, item: Mapping[str, Any]) -> str:
@@ -24,18 +33,21 @@ def _reference_text(manifest_root: Path, item: Mapping[str, Any]) -> str:
     return (manifest_root / reference["relative_path"]).read_text(encoding="utf-8")
 
 
-def _is_number(value: object) -> bool:
+def _is_score(value: object) -> bool:
     return (
         isinstance(value, (int, float))
         and not isinstance(value, bool)
         and math.isfinite(float(value))
+        and 0 <= float(value) <= 1
     )
 
 
 def _persona_summary(result: Mapping[str, object]) -> dict[str, object]:
     score = result.get("score")
     violations = result.get("hard_violations")
-    if not _is_number(score) or not isinstance(violations, list) or not all(
+    if not set(result).issubset({"score", "hard_violations", *_PERSONA_METRICS}) or not _is_score(
+        score
+    ) or not isinstance(violations, list) or not all(
         isinstance(violation, str) for violation in violations
     ):
         raise ValueError("CASE01_PERSONA_EVALUATION_INVALID")
@@ -44,7 +56,7 @@ def _persona_summary(result: Mapping[str, object]) -> dict[str, object]:
     for key, value in result.items():
         if key in {"score", "hard_violations"}:
             continue
-        if not isinstance(key, str) or not _is_number(value):
+        if not isinstance(key, str) or not _is_score(value):
             raise ValueError("CASE01_PERSONA_EVALUATION_INVALID")
         metrics[key] = value
     return {
@@ -55,11 +67,11 @@ def _persona_summary(result: Mapping[str, object]) -> dict[str, object]:
 
 
 def _reference_summary(result: Mapping[str, object]) -> dict[str, int | float]:
-    if not result:
+    if not result or not set(result).issubset(_REFERENCE_METRICS):
         raise ValueError("CASE01_REFERENCE_EVALUATION_INVALID")
     summary: dict[str, int | float] = {}
     for key, value in result.items():
-        if not isinstance(key, str) or not _is_number(value):
+        if not isinstance(key, str) or not _is_score(value):
             raise ValueError("CASE01_REFERENCE_EVALUATION_INVALID")
         summary[key] = value
     return summary
@@ -143,7 +155,13 @@ def run_case01(
             raise ValueError("CASE01_GENERATOR_REPLY_INVALID")
 
         stage = "persona"
-        persona_result = _persona_summary(persona_evaluator(reply=reply))
+        persona_result = _persona_summary(
+            persona_evaluator(
+                reply=reply,
+                original=case01_original,
+                selected_evidence=selected_evidence,
+            )
+        )
         stage = "reference"
         reference_result = _reference_summary(
             reference_evaluator(
@@ -174,3 +192,145 @@ def run_case01(
     }
     _write_report(output_path, report)
     return report
+
+
+def run_prefix19(
+    *,
+    manifest_path: Path,
+    namespace: str,
+    memory_factory: Callable[[str], Any],
+    generator: Callable[..., str],
+    persona_evaluator: Callable[..., Mapping[str, object]],
+    reference_evaluator: Callable[..., Mapping[str, object]],
+    persona_authority: object,
+    output_path: Path,
+    validation_mode: str,
+) -> dict[str, object]:
+    """Run the 19 fresh-memory prefixes without exposing held-out media."""
+
+    if validation_mode not in {
+        "synthetic_validation",
+        "private_local_validation",
+    }:
+        raise ValueError("PREFIX19_VALIDATION_MODE_INVALID")
+
+    manifest_file = Path(manifest_path)
+    manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+    items = manifest["items"]
+    ordered = lambda item: (item["split_sequence"], item["source_date"], item["source_order"])
+    train_items = sorted((item for item in items if item["split"] == "train"), key=ordered)
+    test_items = sorted((item for item in items if item["split"] == "test"), key=ordered)
+    if len(train_items) != 60 or len(test_items) != 19:
+        raise ValueError("PREFIX19_SPLIT_COUNTS_INVALID")
+    reference_kinds = [item["reference"]["kind"] for item in test_items]
+    if reference_kinds.count("text") != 17 or reference_kinds.count("video") != 2:
+        raise ValueError("PREFIX19_REFERENCE_KINDS_INVALID")
+
+    manifest_root = manifest_file.parent
+    reports: list[dict[str, object]] = []
+    for prefix_count, target in enumerate(test_items, start=1):
+        case_namespace = f"{namespace}:case{prefix_count:02d}"
+        report_base: dict[str, object] = {
+            "case_id": target["case_id"],
+            "prefix_case": f"case{prefix_count:02d}",
+            "namespace": case_namespace,
+            "train_original_count": len(train_items),
+            "test_original_count": prefix_count,
+            "private_world_arm": "fixed_disabled",
+        }
+        stage = "memory"
+        try:
+            memory = memory_factory(case_namespace)
+            for item in train_items:
+                memory.ingest_user_evidence(
+                    source_id=f"train:{item['case_id']}",
+                    text=_original_text(manifest_root, item),
+                )
+            prefix = test_items[:prefix_count]
+            for item in prefix:
+                memory.ingest_user_evidence(
+                    source_id=f"test:{item['case_id']}",
+                    text=_original_text(manifest_root, item),
+                )
+
+            original = _original_text(manifest_root, target)
+            selected_evidence = memory.selected_evidence(original=original)
+            stage = "generator"
+            reply = generator(
+                persona_authority=persona_authority,
+                selected_evidence=selected_evidence,
+                original=original,
+            )
+            if not isinstance(reply, str):
+                raise ValueError("PREFIX19_GENERATOR_REPLY_INVALID")
+
+            stage = "persona"
+            persona_result = _persona_summary(
+                persona_evaluator(
+                    reply=reply,
+                    original=original,
+                    selected_evidence=selected_evidence,
+                )
+            )
+            stage = "reference"
+            if target["reference"]["kind"] == "text":
+                reference_result = _reference_summary(
+                    reference_evaluator(
+                        reply=reply,
+                        reference_text=_reference_text(manifest_root, target),
+                    )
+                )
+                reference_status = "evaluated_text"
+            else:
+                reference_result = None
+                reference_status = "not_evaluated_media"
+        except Exception:
+            error_code = {
+                "memory": "PREFIX19_MEMORY_UNAVAILABLE",
+                "generator": "PREFIX19_GENERATOR_UNAVAILABLE",
+                "persona": "PREFIX19_PERSONA_EVALUATION_UNAVAILABLE",
+                "reference": "PREFIX19_REFERENCE_EVALUATION_UNAVAILABLE",
+            }[stage]
+            failed_case = {
+                key: report_base[key]
+                for key in {
+                    "case_id",
+                    "prefix_case",
+                    "namespace",
+                    "private_world_arm",
+                }
+            }
+            failed_case.update(status="unavailable", error_code=error_code)
+            _write_report(
+                output_path,
+                {
+                    "status": "unavailable",
+                    "validation_mode": validation_mode,
+                    "private_world_arm": "fixed_disabled",
+                    "failed_case": failed_case,
+                },
+            )
+            raise
+
+        report: dict[str, object] = {
+            **report_base,
+            "status": "completed",
+            "error_code": None,
+            "selected_evidence_count": len(selected_evidence),
+            "persona_evaluation": persona_result,
+            "reference_status": reference_status,
+        }
+        if reference_result is not None:
+            report["reference_evaluation"] = reference_result
+        reports.append(report)
+
+    result: dict[str, object] = {
+        "status": "completed",
+        "error_code": None,
+        "validation_mode": validation_mode,
+        "private_world_arm": "fixed_disabled",
+        "completed_case_count": len(reports),
+        "cases": reports,
+    }
+    _write_report(output_path, result)
+    return result

--- a/tests/memory/test_memory_isolation_case01.py
+++ b/tests/memory/test_memory_isolation_case01.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft202012Validator
 
-from memory_isolation_case01 import run_case01
+from memory_isolation_case01 import run_case01, run_prefix19
 
 
 def _entry(relative_path: str, *, kind: str = "text") -> dict[str, str]:
@@ -69,6 +69,50 @@ def _manifest(tmp_path: Path, *, train_count: int = 60) -> Path:
         }
     )
     path = tmp_path / "split-manifest.json"
+    path.write_text(json.dumps({"items": items}), encoding="utf-8")
+    return path
+
+
+def _manifest_19(tmp_path: Path) -> Path:
+    items: list[dict[str, object]] = []
+    for number in range(60, 0, -1):
+        relative = f"originals/train-{number:02d}.txt"
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"synthetic train original {number}", encoding="utf-8")
+        items.append(
+            {
+                "split": "train",
+                "global_sequence": number,
+                "split_sequence": number,
+                "case_id": f"train-{number:02d}",
+                "source_date": f"2025-01-{number:02d}",
+                "source_order": number,
+                "original": _entry(relative),
+                "reference": _entry(f"references/train-{number:02d}.txt"),
+            }
+        )
+    for number in range(19, 0, -1):
+        original = tmp_path / f"originals/case{number:02d}.txt"
+        original.write_text(f"synthetic test original {number}", encoding="utf-8")
+        kind = "video" if number in {7, 19} else "text"
+        reference = tmp_path / f"references/case{number:02d}.{ 'mp4' if kind == 'video' else 'txt'}"
+        if kind == "text":
+            reference.parent.mkdir(parents=True, exist_ok=True)
+            reference.write_text(f"synthetic reference {number}", encoding="utf-8")
+        items.append(
+            {
+                "split": "test",
+                "global_sequence": 60 + number,
+                "split_sequence": number,
+                "case_id": f"test-{number:02d}",
+                "source_date": f"2025-03-{number:02d}",
+                "source_order": number,
+                "original": _entry(str(original.relative_to(tmp_path))),
+                "reference": _entry(str(reference.relative_to(tmp_path)), kind=kind),
+            }
+        )
+    path = tmp_path / "split-manifest-19.json"
     path.write_text(json.dumps({"items": items}), encoding="utf-8")
     return path
 
@@ -136,6 +180,12 @@ def test_case01_orders_blind_persona_before_reference_and_hides_reference_from_g
     def persona_evaluator(**kwargs: object) -> dict[str, object]:
         events.append("persona-evaluate")
         assert kwargs["reply"] == "synthetic generated reply"
+        assert kwargs["original"] == "synthetic case01 original"
+        assert kwargs["selected_evidence"] == ("synthetic selected evidence",)
+        assert "synthetic held-out reference" not in json.dumps(
+            kwargs,
+            ensure_ascii=False,
+        )
         return {"score": 0.9, "hard_violations": []}
 
     def reference_evaluator(**kwargs: object) -> dict[str, float]:
@@ -182,9 +232,216 @@ def test_case01_orders_blind_persona_before_reference_and_hides_reference_from_g
         )
     )
     assert list(Draft202012Validator(schema).iter_errors(report)) == []
+
     assert "synthetic case01 original" not in json.dumps(report)
     assert "synthetic generated reply" not in json.dumps(report)
     assert "synthetic held-out reference" not in json.dumps(report)
+
+
+@pytest.mark.parametrize(
+    "validation_mode",
+    ["synthetic_validation", "private_local_validation"],
+)
+def test_prefix19_rebuilds_isolated_memory_without_reading_video_references(
+    tmp_path: Path,
+    validation_mode: str,
+) -> None:
+    events: list[str] = []
+    ingested: list[tuple[str, str]] = []
+    generator_calls: list[dict[str, object]] = []
+
+    class Memory:
+        def ingest_user_evidence(self, *, source_id: str, text: str) -> None:
+            ingested.append((source_id, text))
+
+        def selected_evidence(self, *, original: str) -> tuple[str, ...]:
+            return (f"evidence for {original[-2:]}",)
+
+    def memory_factory(namespace: str) -> Memory:
+        events.append(f"memory:{namespace}")
+        return Memory()
+
+    def generator(**kwargs: object) -> str:
+        events.append("generator")
+        assert set(kwargs) == {"persona_authority", "selected_evidence", "original"}
+        generator_calls.append(kwargs)
+        return f"synthetic reply {int(str(kwargs['original']).rsplit(' ', 1)[1]):02d}"
+
+    def persona_evaluator(**kwargs: object) -> dict[str, object]:
+        events.append(f"persona:{kwargs['reply']}")
+        assert set(kwargs) == {"reply", "original", "selected_evidence"}
+        assert "synthetic reference" not in json.dumps(kwargs, ensure_ascii=False)
+        return {"score": 0.9, "hard_violations": [], "continuity": 0.8}
+
+    def reference_evaluator(**kwargs: object) -> dict[str, object]:
+        events.append(f"reference:{kwargs['reply']}")
+        assert "synthetic reference" in str(kwargs["reference_text"])
+        return {"style_score": 0.8}
+
+    output_path = tmp_path / "local-only-prefix19-report.json"
+    report = run_prefix19(
+        manifest_path=_manifest_19(tmp_path),
+        namespace="synthetic-run",
+        memory_factory=memory_factory,
+        generator=generator,
+        persona_evaluator=persona_evaluator,
+        reference_evaluator=reference_evaluator,
+        persona_authority={"authority": "synthetic"},
+        output_path=output_path,
+        validation_mode=validation_mode,
+    )
+
+    cases = report["cases"]
+    assert isinstance(cases, list) and len(cases) == 19
+    assert [case["namespace"] for case in cases] == [
+        f"synthetic-run:case{number:02d}" for number in range(1, 20)
+    ]
+    assert len({case["namespace"] for case in cases}) == 19
+    assert len([source_id for source_id, _ in ingested if source_id.startswith("train:")]) == 19 * 60
+    assert len([source_id for source_id, _ in ingested if source_id.startswith("test:")]) == sum(range(1, 20))
+    assert all("synthetic reply" not in text for _, text in ingested)
+    assert len(generator_calls) == 19
+    assert [case["test_original_count"] for case in cases] == list(range(1, 20))
+    assert [case["reference_status"] for case in cases if case["prefix_case"] in {"case07", "case19"}] == [
+        "not_evaluated_media",
+        "not_evaluated_media",
+    ]
+    assert len([event for event in events if event.startswith("persona:")]) == 19
+    assert len([event for event in events if event.startswith("reference:")]) == 17
+    for number in range(1, 20):
+        reply = f"synthetic reply {number:02d}"
+        persona_index = events.index(f"persona:{reply}")
+        if number not in {7, 19}:
+            assert events[persona_index + 1] == f"reference:{reply}"
+    assert report == json.loads(output_path.read_text(encoding="utf-8"))
+    serialized = json.dumps(report, ensure_ascii=False)
+    assert "synthetic test original" not in serialized
+    assert "synthetic reply" not in serialized
+    assert "references/" not in serialized
+    assert str(tmp_path) not in serialized
+    schema = json.loads(
+        (Path(__file__).resolve().parents[2] / "contracts" / "memory_isolation_case01_report.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert list(Draft202012Validator(schema).iter_errors(report)) == []
+
+    unavailable_child = json.loads(json.dumps(report))
+    unavailable_child["cases"][0] = {
+        key: value
+        for key, value in unavailable_child["cases"][0].items()
+        if key
+        in {
+            "case_id",
+            "prefix_case",
+            "validation_mode",
+            "namespace",
+            "train_original_count",
+            "test_original_count",
+            "private_world_arm",
+        }
+    }
+    unavailable_child["cases"][0].update(status="unavailable", error_code=None)
+    missing_text_evaluation = json.loads(json.dumps(report))
+    missing_text_evaluation["cases"][0].pop("reference_evaluation")
+    media_with_text_evaluation = json.loads(json.dumps(report))
+    media_case = next(
+        case
+        for case in media_with_text_evaluation["cases"]
+        if case["reference_status"] == "not_evaluated_media"
+    )
+    media_case["reference_evaluation"] = {"style_score": 0.8}
+    repeated_case = json.loads(json.dumps(report))
+    repeated_case["cases"][1]["prefix_case"] = "case01"
+    repeated_case["cases"][1]["test_original_count"] = 1
+    mismatched_mode = json.loads(json.dumps(report))
+    mismatched_mode["cases"][0]["validation_mode"] = (
+        "private_local_validation"
+        if validation_mode == "synthetic_validation"
+        else "synthetic_validation"
+    )
+
+    assert list(Draft202012Validator(schema).iter_errors(unavailable_child))
+    assert list(Draft202012Validator(schema).iter_errors(missing_text_evaluation))
+    assert list(Draft202012Validator(schema).iter_errors(media_with_text_evaluation))
+    assert list(Draft202012Validator(schema).iter_errors(repeated_case))
+    assert list(Draft202012Validator(schema).iter_errors(mismatched_mode))
+
+
+def test_prefix19_writes_a_schema_valid_unavailable_case(tmp_path: Path) -> None:
+    class Memory:
+        def ingest_user_evidence(self, **_: object) -> None:
+            pass
+
+        def selected_evidence(self, **_: object) -> tuple[str, ...]:
+            return ()
+
+    generator_calls = 0
+
+    def generator(**_: object) -> str:
+        nonlocal generator_calls
+        generator_calls += 1
+        if generator_calls == 2:
+            raise RuntimeError("synthetic generator failure")
+        return "synthetic reply"
+
+    output_path = tmp_path / "unavailable-prefix19-report.json"
+    with pytest.raises(RuntimeError, match="synthetic generator failure"):
+        run_prefix19(
+            manifest_path=_manifest_19(tmp_path),
+            namespace="synthetic-run",
+            memory_factory=lambda _: Memory(),
+            generator=generator,
+            persona_evaluator=lambda **_: {"score": 0.9, "hard_violations": []},
+            reference_evaluator=lambda **_: {"style_score": 0.8},
+            persona_authority={"authority": "synthetic"},
+            output_path=output_path,
+            validation_mode="synthetic_validation",
+        )
+
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report["status"] == "unavailable"
+    assert "completed_case_count" not in report
+    assert "cases" not in report
+    assert report["failed_case"]["prefix_case"] == "case02"
+    assert report["failed_case"]["error_code"] == "PREFIX19_GENERATOR_UNAVAILABLE"
+    schema = json.loads(
+        (Path(__file__).resolve().parents[2] / "contracts" / "memory_isolation_case01_report.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert list(Draft202012Validator(schema).iter_errors(report)) == []
+    mismatched_mode = json.loads(json.dumps(report))
+    mismatched_mode["failed_case"]["validation_mode"] = "private_local_validation"
+    assert list(Draft202012Validator(schema).iter_errors(mismatched_mode))
+
+
+def test_prefix19_rejects_reference_kind_drift_before_callbacks(tmp_path: Path) -> None:
+    manifest_path = _manifest_19(tmp_path)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    test_item = next(item for item in manifest["items"] if item["split"] == "test")
+    test_item["reference"]["kind"] = "txt"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    calls: list[str] = []
+
+    def unexpected(*_: object, **__: object) -> object:
+        calls.append("called")
+        raise AssertionError("manifest validation must run before callbacks")
+
+    with pytest.raises(ValueError, match="^PREFIX19_REFERENCE_KINDS_INVALID$"):
+        run_prefix19(
+            manifest_path=manifest_path,
+            namespace="synthetic-run",
+            memory_factory=unexpected,
+            generator=unexpected,
+            persona_evaluator=unexpected,
+            reference_evaluator=unexpected,
+            persona_authority={"authority": "synthetic"},
+            output_path=tmp_path / "unused.json",
+            validation_mode="synthetic_validation",
+        )
+
+    assert calls == []
 
 
 def test_case01_rejects_a_manifest_without_exactly_sixty_train_items(tmp_path: Path) -> None:
@@ -258,6 +515,16 @@ def test_case01_report_schema_rejects_non_synthetic_mode_in_both_branches(
             {"style_score": float("inf")},
             "CASE01_REFERENCE_EVALUATION_UNAVAILABLE",
         ),
+        (
+            "persona_evaluator",
+            {"score": 1.5, "hard_violations": []},
+            "CASE01_PERSONA_EVALUATION_UNAVAILABLE",
+        ),
+        (
+            "reference_evaluator",
+            {"style_score": -0.1},
+            "CASE01_REFERENCE_EVALUATION_UNAVAILABLE",
+        ),
     ],
 )
 def test_case01_rejects_non_finite_evaluator_results(
@@ -277,6 +544,28 @@ def test_case01_rejects_non_finite_evaluator_results(
     assert report["error_code"] == error_code
     assert "NaN" not in report_text
     assert "Infinity" not in report_text
+
+
+@pytest.mark.parametrize(
+    ("evaluator_name", "result"),
+    [
+        (
+            "persona_evaluator",
+            {"score": 0.9, "hard_violations": [], "D:/private/letter.txt": 1},
+        ),
+        (
+            "reference_evaluator",
+            {"style_score": 0.8, "synthetic private reference": 1},
+        ),
+    ],
+)
+def test_case01_rejects_uncontracted_metric_names(
+    tmp_path: Path,
+    evaluator_name: str,
+    result: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="_EVALUATION_INVALID$"):
+        _run(tmp_path, **{evaluator_name: lambda **_: result})
 
 
 def test_case01_writes_a_redacted_unavailable_report_when_generator_fails(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- extend the public memory-isolation tracer from case01 to the full case01–case19 temporal prefix series
- rebuild each case in a fresh namespace from 60 train originals plus that case's test prefix; generated replies are never re-ingested
- keep PrivateWorld fixed/disabled, run blind persona evaluation before held-out comparison, and never open video references
- emit redacted, schema-validated completed/unavailable reports with fixed evaluator metric names and scores bounded to `[0,1]`

## Validation

- `python -m pytest tests/memory/test_memory_isolation_case01.py -q`: 16 passed
- `python -m pytest tests/memory -q`: 145 passed on the review-fix state
- `python baseline_hardening_scan.py --mode all`: PASS on the review-fix state
- `git diff --check`: PASS
- Sol high frozen-diff review: PASS, no P0/P1

## Boundaries

- no private corpus, manifest, generated reply, evaluation output, video, key, or absolute local path is included
- real provider generation/evaluation remains a Git-ignored local experiment and is not claimed by this PR
- no Live, music, installer, or Release changes