### PR TITLE
Preserve PrivateWorld arm provenance in prefix19 reports

### DIFF
--- a/contracts/memory_isolation_case01_report.schema.json
+++ b/contracts/memory_isolation_case01_report.schema.json
@@ -62,7 +62,7 @@
         "status": {"const": "completed"},
         "error_code": {"type": "null"},
         "validation_mode": {"enum": ["synthetic_validation", "private_local_validation"]},
-        "private_world_arm": {"const": "fixed_disabled"},
+        "private_world_arm": {"enum": ["fixed_disabled", "controlled_projection"]},
         "completed_case_count": {"const": 19},
         "cases": {
           "type": "array",
@@ -91,7 +91,7 @@
       "properties": {
         "status": {"const": "unavailable"},
         "validation_mode": {"enum": ["synthetic_validation", "private_local_validation"]},
-        "private_world_arm": {"const": "fixed_disabled"},
+        "private_world_arm": {"enum": ["fixed_disabled", "controlled_projection"]},
         "failed_case": {"$ref": "#/$defs/failed_prefix_case"}
       }
     }
@@ -145,7 +145,7 @@
         "namespace": {"type": "string"},
         "train_original_count": {"const": 60},
         "test_original_count": {"type": "integer", "minimum": 1, "maximum": 19},
-        "private_world_arm": {"const": "fixed_disabled"},
+        "private_world_arm": {"enum": ["fixed_disabled", "controlled_projection"]},
         "selected_evidence_count": {"type": "integer", "minimum": 0},
         "persona_evaluation": {"$ref": "#/$defs/persona_evaluation"},
         "reference_status": {"enum": ["evaluated_text", "not_evaluated_media"]},
@@ -175,7 +175,7 @@
         "case_id": {"type": "string"},
         "prefix_case": {"type": "string", "pattern": "^case(?:0[1-9]|1[0-9])$"},
         "namespace": {"type": "string"},
-        "private_world_arm": {"const": "fixed_disabled"}
+        "private_world_arm": {"enum": ["fixed_disabled", "controlled_projection"]}
       }
     },
     "case01": {"allOf": [{"$ref": "#/$defs/completed_prefix_case"}, {"properties": {"prefix_case": {"const": "case01"}, "test_original_count": {"const": 1}}}]},

--- a/contracts/memory_isolation_case01_report.schema.json
+++ b/contracts/memory_isolation_case01_report.schema.json
@@ -82,7 +82,29 @@
           ],
           "items": false
         }
-      }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "private_world_arm": {"const": "fixed_disabled"},
+            "cases": {
+              "contains": {"properties": {"private_world_arm": {"const": "controlled_projection"}}},
+              "minContains": 0,
+              "maxContains": 0
+            }
+          }
+        },
+        {
+          "properties": {
+            "private_world_arm": {"const": "controlled_projection"},
+            "cases": {
+              "contains": {"properties": {"private_world_arm": {"const": "fixed_disabled"}}},
+              "minContains": 0,
+              "maxContains": 0
+            }
+          }
+        }
+      ]
     },
     {
       "type": "object",
@@ -93,7 +115,21 @@
         "validation_mode": {"enum": ["synthetic_validation", "private_local_validation"]},
         "private_world_arm": {"enum": ["fixed_disabled", "controlled_projection"]},
         "failed_case": {"$ref": "#/$defs/failed_prefix_case"}
-      }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "private_world_arm": {"const": "fixed_disabled"},
+            "failed_case": {"properties": {"private_world_arm": {"const": "fixed_disabled"}}}
+          }
+        },
+        {
+          "properties": {
+            "private_world_arm": {"const": "controlled_projection"},
+            "failed_case": {"properties": {"private_world_arm": {"const": "controlled_projection"}}}
+          }
+        }
+      ]
     }
   ],
   "$defs": {

--- a/docs/P03_03B_MEMORY_ISOLATION_CASE01.md
+++ b/docs/P03_03B_MEMORY_ISOLATION_CASE01.md
@@ -48,7 +48,12 @@ The same report schema accepts the completed 19-case aggregate. Its per-case
 records are limited to IDs, namespace, counts, statuses, finite scores, hard
 violation counts, and reference status. Synthetic fixtures use
 `synthetic_validation`; a caller-owned, Git-ignored real run must use
-`private_local_validation`. Both keep `private_world_arm=fixed_disabled`.
+`private_local_validation`. The default remains
+`private_world_arm=fixed_disabled`. A caller running a separate controlled
+PrivateWorld arm may explicitly declare
+`private_world_arm=controlled_projection`; the runner preserves that label in
+completed and unavailable reports. This declaration does not provide
+PrivateWorld state to callbacks or verify caller-owned projection behavior.
 
 Persona metrics are limited to the eight declared authority axes; held-out
 comparison is limited to `style_score` and `focus_score`. Unknown metric names

--- a/memory_isolation_case01.py
+++ b/memory_isolation_case01.py
@@ -205,6 +205,7 @@ def run_prefix19(
     persona_authority: object,
     output_path: Path,
     validation_mode: str,
+    private_world_arm: str = "fixed_disabled",
 ) -> dict[str, object]:
     """Run the 19 fresh-memory prefixes without exposing held-out media."""
 
@@ -213,6 +214,8 @@ def run_prefix19(
         "private_local_validation",
     }:
         raise ValueError("PREFIX19_VALIDATION_MODE_INVALID")
+    if private_world_arm not in {"fixed_disabled", "controlled_projection"}:
+        raise ValueError("PREFIX19_PRIVATE_WORLD_ARM_INVALID")
 
     manifest_file = Path(manifest_path)
     manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
@@ -236,7 +239,7 @@ def run_prefix19(
             "namespace": case_namespace,
             "train_original_count": len(train_items),
             "test_original_count": prefix_count,
-            "private_world_arm": "fixed_disabled",
+            "private_world_arm": private_world_arm,
         }
         stage = "memory"
         try:
@@ -306,7 +309,7 @@ def run_prefix19(
                 {
                     "status": "unavailable",
                     "validation_mode": validation_mode,
-                    "private_world_arm": "fixed_disabled",
+                    "private_world_arm": private_world_arm,
                     "failed_case": failed_case,
                 },
             )
@@ -328,7 +331,7 @@ def run_prefix19(
         "status": "completed",
         "error_code": None,
         "validation_mode": validation_mode,
-        "private_world_arm": "fixed_disabled",
+        "private_world_arm": private_world_arm,
         "completed_case_count": len(reports),
         "cases": reports,
     }

--- a/tests/memory/test_memory_isolation_case01.py
+++ b/tests/memory/test_memory_isolation_case01.py
@@ -239,12 +239,17 @@ def test_case01_orders_blind_persona_before_reference_and_hides_reference_from_g
 
 
 @pytest.mark.parametrize(
-    "validation_mode",
-    ["synthetic_validation", "private_local_validation"],
+    ("validation_mode", "private_world_arm"),
+    [
+        ("synthetic_validation", "fixed_disabled"),
+        ("private_local_validation", "fixed_disabled"),
+        ("synthetic_validation", "controlled_projection"),
+    ],
 )
 def test_prefix19_rebuilds_isolated_memory_without_reading_video_references(
     tmp_path: Path,
     validation_mode: str,
+    private_world_arm: str,
 ) -> None:
     events: list[str] = []
     ingested: list[tuple[str, str]] = []
@@ -289,10 +294,13 @@ def test_prefix19_rebuilds_isolated_memory_without_reading_video_references(
         persona_authority={"authority": "synthetic"},
         output_path=output_path,
         validation_mode=validation_mode,
+        private_world_arm=private_world_arm,
     )
 
     cases = report["cases"]
     assert isinstance(cases, list) and len(cases) == 19
+    assert report["private_world_arm"] == private_world_arm
+    assert all(case["private_world_arm"] == private_world_arm for case in cases)
     assert [case["namespace"] for case in cases] == [
         f"synthetic-run:case{number:02d}" for number in range(1, 20)
     ]
@@ -414,6 +422,45 @@ def test_prefix19_writes_a_schema_valid_unavailable_case(tmp_path: Path) -> None
     mismatched_mode = json.loads(json.dumps(report))
     mismatched_mode["failed_case"]["validation_mode"] = "private_local_validation"
     assert list(Draft202012Validator(schema).iter_errors(mismatched_mode))
+
+
+def test_prefix19_preserves_controlled_arm_on_failure(tmp_path: Path) -> None:
+    class Memory:
+        def ingest_user_evidence(self, **_: object) -> None:
+            pass
+
+        def selected_evidence(self, **_: object) -> tuple[str, ...]:
+            return ()
+
+    def generator(**_: object) -> str:
+        raise RuntimeError("synthetic controlled failure")
+
+    output_path = tmp_path / "controlled-unavailable-prefix19-report.json"
+    with pytest.raises(RuntimeError, match="synthetic controlled failure"):
+        run_prefix19(
+            manifest_path=_manifest_19(tmp_path),
+            namespace="synthetic-controlled-run",
+            memory_factory=lambda _: Memory(),
+            generator=generator,
+            persona_evaluator=lambda **_: {"score": 0.9, "hard_violations": []},
+            reference_evaluator=lambda **_: {"style_score": 0.8},
+            persona_authority={"authority": "synthetic"},
+            output_path=output_path,
+            validation_mode="synthetic_validation",
+            private_world_arm="controlled_projection",
+        )
+
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report["private_world_arm"] == "controlled_projection"
+    assert report["failed_case"]["private_world_arm"] == "controlled_projection"
+    schema = json.loads(
+        (
+            Path(__file__).resolve().parents[2]
+            / "contracts"
+            / "memory_isolation_case01_report.schema.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert list(Draft202012Validator(schema).iter_errors(report)) == []
 
 
 def test_prefix19_rejects_reference_kind_drift_before_callbacks(tmp_path: Path) -> None:

--- a/tests/memory/test_memory_isolation_case01.py
+++ b/tests/memory/test_memory_isolation_case01.py
@@ -334,6 +334,14 @@ def test_prefix19_rebuilds_isolated_memory_without_reading_video_references(
     )
     assert list(Draft202012Validator(schema).iter_errors(report)) == []
 
+    mixed_arm = json.loads(json.dumps(report))
+    mixed_arm["cases"][0]["private_world_arm"] = (
+        "controlled_projection"
+        if private_world_arm == "fixed_disabled"
+        else "fixed_disabled"
+    )
+    assert list(Draft202012Validator(schema).iter_errors(mixed_arm))
+
     unavailable_child = json.loads(json.dumps(report))
     unavailable_child["cases"][0] = {
         key: value
@@ -460,7 +468,11 @@ def test_prefix19_preserves_controlled_arm_on_failure(tmp_path: Path) -> None:
             / "memory_isolation_case01_report.schema.json"
         ).read_text(encoding="utf-8")
     )
-    assert list(Draft202012Validator(schema).iter_errors(report)) == []
+    validator = Draft202012Validator(schema)
+    assert list(validator.iter_errors(report)) == []
+    mixed_arm = json.loads(json.dumps(report))
+    mixed_arm["failed_case"]["private_world_arm"] = "fixed_disabled"
+    assert list(validator.iter_errors(mixed_arm))
 
 
 def test_prefix19_rejects_reference_kind_drift_before_callbacks(tmp_path: Path) -> None:


### PR DESCRIPTION
## Outcome

Prefix19 callers can explicitly declare controlled_projection, and both completed and unavailable reports preserve that arm from the first write.

## Scope

- add a validated private_world_arm argument to run_prefix19
- update the report schema for fixed_disabled and controlled_projection prefix19 reports
- cover completed and failure provenance with synthetic tests
- document that projection behavior remains caller-owned

## Validation

- python -m pytest tests\memory\test_memory_isolation_case01.py -q
  - 18 passed
- private local driver module
  - 8 passed
- schema JSON parse: passed
- git diff --check: passed

## Boundaries

No private corpus, generated reply, evaluation output, video, credential, or machine-absolute path is committed. This PR labels caller-owned controlled runs; it does not itself inject PrivateWorld state or claim real-provider acceptance.