### PR TITLE
Fix same-turn memory self-recall in prefix runs

### DIFF
--- a/docs/P03_03B_MEMORY_ISOLATION_CASE01.md
+++ b/docs/P03_03B_MEMORY_ISOLATION_CASE01.md
@@ -38,6 +38,12 @@ and requires exactly 60 train and 19 test items, sorted by the manifest's
 namespaces as `<namespace>:case01` through `<namespace>:case19`; every case
 rebuilds the 60 train originals and then ingests only its test-original prefix.
 
+The memory selector remains compatible with callbacks that accept only
+`selected_evidence(original=...)`. Selectors that also declare the optional
+`exclude_source_id` keyword receive the exact `test:<case_id>` for the current
+original. This lets a real memory adapter retain the current original for later
+prefixes without returning it as same-turn historical evidence.
+
 It calls the generator once for the current prefix item, with only
 `persona_authority`, selected evidence, and that original. Generated replies
 are never ingested. Blind persona evaluation occurs before reference handling.

--- a/memory_isolation_case01.py
+++ b/memory_isolation_case01.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import math
+from inspect import signature
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
@@ -26,6 +27,26 @@ _REFERENCE_METRICS = frozenset({"style_score", "focus_score"})
 def _original_text(manifest_root: Path, item: Mapping[str, Any]) -> str:
     original = item["original"]
     return (manifest_root / original["relative_path"]).read_text(encoding="utf-8")
+
+
+def _select_memory_evidence(
+    memory: Any,
+    *,
+    original: str,
+    exclude_source_id: str,
+) -> Any:
+    selector = memory.selected_evidence
+    try:
+        signature(selector).bind(
+            original=original,
+            exclude_source_id=exclude_source_id,
+        )
+    except TypeError:
+        return selector(original=original)
+    return selector(
+        original=original,
+        exclude_source_id=exclude_source_id,
+    )
 
 
 def _reference_text(manifest_root: Path, item: Mapping[str, Any]) -> str:
@@ -257,7 +278,8 @@ def run_prefix19(
                 )
 
             original = _original_text(manifest_root, target)
-            selected_evidence = memory.selected_evidence(
+            selected_evidence = _select_memory_evidence(
+                memory,
                 original=original,
                 exclude_source_id=f"test:{target['case_id']}",
             )

--- a/memory_isolation_case01.py
+++ b/memory_isolation_case01.py
@@ -257,7 +257,10 @@ def run_prefix19(
                 )
 
             original = _original_text(manifest_root, target)
-            selected_evidence = memory.selected_evidence(original=original)
+            selected_evidence = memory.selected_evidence(
+                original=original,
+                exclude_source_id=f"test:{target['case_id']}",
+            )
             stage = "generator"
             reply = generator(
                 persona_authority=persona_authority,

--- a/tests/memory/test_memory_isolation_case01.py
+++ b/tests/memory/test_memory_isolation_case01.py
@@ -8,7 +8,23 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft202012Validator
 
-from memory_isolation_case01 import run_case01, run_prefix19
+from memory_isolation_case01 import (
+    _select_memory_evidence,
+    run_case01,
+    run_prefix19,
+)
+
+
+def test_prefix19_keeps_legacy_memory_selector_compatible() -> None:
+    class LegacyMemory:
+        def selected_evidence(self, *, original: str) -> tuple[str, ...]:
+            return (f"legacy evidence for {original}",)
+
+    assert _select_memory_evidence(
+        LegacyMemory(),
+        original="synthetic current original",
+        exclude_source_id="test:test-01",
+    ) == ("legacy evidence for synthetic current original",)
 
 
 def _entry(relative_path: str, *, kind: str = "text") -> dict[str, str]:

--- a/tests/memory/test_memory_isolation_case01.py
+++ b/tests/memory/test_memory_isolation_case01.py
@@ -8,23 +8,53 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft202012Validator
 
-from memory_isolation_case01 import (
-    _select_memory_evidence,
-    run_case01,
-    run_prefix19,
-)
+from memory_isolation_case01 import run_case01, run_prefix19
 
 
-def test_prefix19_keeps_legacy_memory_selector_compatible() -> None:
+def test_prefix19_routes_optional_exclusion_and_keeps_legacy_selector_compatible(
+    tmp_path: Path,
+) -> None:
+    legacy_originals: list[str] = []
+    keyword_calls: list[dict[str, str]] = []
+
     class LegacyMemory:
+        def ingest_user_evidence(self, **_: object) -> None:
+            pass
+
         def selected_evidence(self, *, original: str) -> tuple[str, ...]:
+            legacy_originals.append(original)
             return (f"legacy evidence for {original}",)
 
-    assert _select_memory_evidence(
-        LegacyMemory(),
-        original="synthetic current original",
-        exclude_source_id="test:test-01",
-    ) == ("legacy evidence for synthetic current original",)
+    class KeywordMemory:
+        def ingest_user_evidence(self, **_: object) -> None:
+            pass
+
+        def selected_evidence(self, **kwargs: str) -> tuple[str, ...]:
+            keyword_calls.append(kwargs)
+            return ()
+
+    def run(memory_type: type[object], name: str) -> dict[str, object]:
+        return run_prefix19(
+            manifest_path=_manifest_19(tmp_path),
+            namespace=f"synthetic-{name}",
+            memory_factory=lambda _namespace: memory_type(),
+            generator=lambda **_: "synthetic reply",
+            persona_evaluator=lambda **_: {
+                "score": 0.9,
+                "hard_violations": [],
+            },
+            reference_evaluator=lambda **_: {"style_score": 0.8},
+            persona_authority={"authority": "synthetic"},
+            output_path=tmp_path / f"{name}.json",
+            validation_mode="synthetic_validation",
+        )
+
+    assert run(LegacyMemory, "legacy")["completed_case_count"] == 19
+    assert run(KeywordMemory, "keyword")["completed_case_count"] == 19
+    assert len(legacy_originals) == 19
+    assert [call["exclude_source_id"] for call in keyword_calls] == [
+        f"test:test-{number:02d}" for number in range(1, 20)
+    ]
 
 
 def _entry(relative_path: str, *, kind: str = "text") -> dict[str, str]:

--- a/tests/memory/test_memory_isolation_case01.py
+++ b/tests/memory/test_memory_isolation_case01.py
@@ -254,12 +254,19 @@ def test_prefix19_rebuilds_isolated_memory_without_reading_video_references(
     events: list[str] = []
     ingested: list[tuple[str, str]] = []
     generator_calls: list[dict[str, object]] = []
+    selection_exclusions: list[str] = []
 
     class Memory:
         def ingest_user_evidence(self, *, source_id: str, text: str) -> None:
             ingested.append((source_id, text))
 
-        def selected_evidence(self, *, original: str) -> tuple[str, ...]:
+        def selected_evidence(
+            self,
+            *,
+            original: str,
+            exclude_source_id: str,
+        ) -> tuple[str, ...]:
+            selection_exclusions.append(exclude_source_id)
             return (f"evidence for {original[-2:]}",)
 
     def memory_factory(namespace: str) -> Memory:
@@ -309,6 +316,9 @@ def test_prefix19_rebuilds_isolated_memory_without_reading_video_references(
     assert len([source_id for source_id, _ in ingested if source_id.startswith("test:")]) == sum(range(1, 20))
     assert all("synthetic reply" not in text for _, text in ingested)
     assert len(generator_calls) == 19
+    assert selection_exclusions == [
+        f"test:test-{number:02d}" for number in range(1, 20)
+    ]
     assert [case["test_original_count"] for case in cases] == list(range(1, 20))
     assert [case["reference_status"] for case in cases if case["prefix_case"] in {"case07", "case19"}] == [
         "not_evaluated_media",


### PR DESCRIPTION
## Summary`n`n- keep each test original in its isolated prefix namespace for later cases`n- exclude the current test original from same-turn memory recall`n- verify all 19 prefixes pass the exact current source id to the memory selector`n`n## Validation`n`n- `python -m pytest -q tests/memory/test_memory_isolation_case01.py` — 18 passed`n- private local driver synthetic tests — 12 passed`n- controlled local run completed 19/19 with current-source exclusion, 19 canonical commits, independent databases, and no hidden/control-only exposure`n`n## Boundary`n`nNo private corpus, generated replies, reports, local paths, credentials, or reference media are included. Controlled persona acceptance is still not complete because two final-window cases retained hard violations; this PR only fixes current-letter self-recall and makes no release or production-acceptance claim.