### PR TITLE
fix(letters): enforce 1200-character limits

### DIFF
--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -905,25 +905,27 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
 
   let scheduled = false;
   const constrainLetterInputs = () => {
-    const matches = Array.from(
-      document.querySelectorAll('[role="dialog"], .el-dialog')
-    ).filter((dialog) => {
-      if (dialog.closest(`[${DIALOG_ATTR}]`)) {
-        return false;
-      }
-      const textareas = dialog.querySelectorAll("textarea");
-      const titles = Array.from(
-        dialog.querySelectorAll('h1,h2,h3,[class*="title"]')
-      ).filter((item) => item.textContent.trim() === LETTER_COMPOSER_TITLE);
-      const submitButtons = Array.from(
-        dialog.querySelectorAll("button")
-      ).filter((item) => item.textContent.trim() === LETTER_SUBMIT_LABEL);
-      return textareas.length === 1 && titles.length === 1 && submitButtons.length === 1;
-    });
-    if (matches.length !== 1) {
+    const matches = new Set(
+      Array.from(
+        document.querySelectorAll('[role="dialog"], .el-dialog')
+      ).filter((dialog) => {
+        if (dialog.closest(`[${DIALOG_ATTR}]`)) {
+          return false;
+        }
+        const textareas = dialog.querySelectorAll("textarea");
+        const titles = Array.from(
+          dialog.querySelectorAll('h1,h2,h3,[class*="title"]')
+        ).filter((item) => item.textContent.trim() === LETTER_COMPOSER_TITLE);
+        const submitButtons = Array.from(
+          dialog.querySelectorAll("button")
+        ).filter((item) => item.textContent.trim() === LETTER_SUBMIT_LABEL);
+        return textareas.length === 1 && titles.length === 1 && submitButtons.length === 1;
+      }).map((dialog) => dialog.querySelector("textarea"))
+    );
+    if (matches.size !== 1) {
       return;
     }
-    matches[0].querySelector("textarea").maxLength = LETTER_CHARACTER_LIMIT;
+    matches.values().next().value.maxLength = LETTER_CHARACTER_LIMIT;
   };
 
   const schedule = () => {

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -20,6 +20,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const MEMORY_DELETE_PATH = "/toy/companion/memory/delete";
   const CONFIRM_HEADER = "X-Olivia-Companion-Action";
   const CONFIRM_VALUE = "confirmed";
+  const LETTER_CHARACTER_LIMIT = 1200;
 
   const parseApiBase = (value) => {
     let url;
@@ -901,6 +902,24 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   };
 
   let scheduled = false;
+  const constrainLetterInputs = () => {
+    for (const input of document.querySelectorAll("textarea")) {
+      if (input.closest(`[${DIALOG_ATTR}]`)) {
+        continue;
+      }
+      const dialog = input.closest('[role="dialog"], .el-dialog');
+      if (!dialog) {
+        continue;
+      }
+      const isLetterEditor = Array.from(dialog.querySelectorAll("button")).some(
+        (item) => item.textContent.trim() === "寄出信件"
+      );
+      if (isLetterEditor) {
+        input.maxLength = LETTER_CHARACTER_LIMIT;
+      }
+    }
+  };
+
   const schedule = () => {
     if (scheduled) {
       return;
@@ -908,6 +927,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     scheduled = true;
     window.requestAnimationFrame(() => {
       scheduled = false;
+      constrainLetterInputs();
       mountShell();
     });
   };

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -21,6 +21,8 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const CONFIRM_HEADER = "X-Olivia-Companion-Action";
   const CONFIRM_VALUE = "confirmed";
   const LETTER_CHARACTER_LIMIT = 1200;
+  const LETTER_COMPOSER_TITLE = "写下你的感受";
+  const LETTER_SUBMIT_LABEL = "寄出信件";
 
   const parseApiBase = (value) => {
     let url;
@@ -903,21 +905,25 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
 
   let scheduled = false;
   const constrainLetterInputs = () => {
-    for (const input of document.querySelectorAll("textarea")) {
-      if (input.closest(`[${DIALOG_ATTR}]`)) {
-        continue;
+    const matches = Array.from(
+      document.querySelectorAll('[role="dialog"], .el-dialog')
+    ).filter((dialog) => {
+      if (dialog.closest(`[${DIALOG_ATTR}]`)) {
+        return false;
       }
-      const dialog = input.closest('[role="dialog"], .el-dialog');
-      if (!dialog) {
-        continue;
-      }
-      const isLetterEditor = Array.from(dialog.querySelectorAll("button")).some(
-        (item) => item.textContent.trim() === "寄出信件"
-      );
-      if (isLetterEditor) {
-        input.maxLength = LETTER_CHARACTER_LIMIT;
-      }
+      const textareas = dialog.querySelectorAll("textarea");
+      const titles = Array.from(
+        dialog.querySelectorAll('h1,h2,h3,[class*="title"]')
+      ).filter((item) => item.textContent.trim() === LETTER_COMPOSER_TITLE);
+      const submitButtons = Array.from(
+        dialog.querySelectorAll("button")
+      ).filter((item) => item.textContent.trim() === LETTER_SUBMIT_LABEL);
+      return textareas.length === 1 && titles.length === 1 && submitButtons.length === 1;
+    });
+    if (matches.length !== 1) {
+      return;
     }
+    matches[0].querySelector("textarea").maxLength = LETTER_CHARACTER_LIMIT;
   };
 
   const schedule = () => {

--- a/reply_context.py
+++ b/reply_context.py
@@ -211,7 +211,7 @@ class PrivateBehaviorView:
 @dataclass(frozen=True)
 class OutputConstraints:
     channel: OutputChannel
-    max_characters: int = 1_200
+    max_characters: int = 12_000
     plain_text_only: bool = True
     allow_stage_directions: bool = False
     allow_control_markup: bool = False
@@ -246,7 +246,7 @@ class OutputConstraints:
     @classmethod
     def for_mode(cls, mode: ReplyMode) -> "OutputConstraints":
         if mode is ReplyMode.TEXT_LETTER:
-            return cls(OutputChannel.LETTER)
+            return cls(OutputChannel.LETTER, max_characters=1_200)
         if mode in {ReplyMode.SPOKEN_VIDEO, ReplyMode.MUSICAL_VIDEO}:
             return cls(OutputChannel.SPOKEN_TEXT)
         if mode is ReplyMode.FUTURE_IM:

--- a/reply_context.py
+++ b/reply_context.py
@@ -211,7 +211,7 @@ class PrivateBehaviorView:
 @dataclass(frozen=True)
 class OutputConstraints:
     channel: OutputChannel
-    max_characters: int = 12_000
+    max_characters: int = 1_200
     plain_text_only: bool = True
     allow_stage_directions: bool = False
     allow_control_markup: bool = False

--- a/reply_policy.py
+++ b/reply_policy.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 import re
 
-from reply_context import ReplyContext, ReplyMode
+from reply_context import OutputConstraints, ReplyContext, ReplyMode
 
 
 class ViolationSeverity(StrEnum):
@@ -110,7 +110,10 @@ def scan_reply(
     if not isinstance(context, ReplyContext):
         raise TypeError("context must be ReplyContext")
     violations: list[Violation] = []
-    limit = context.output_constraints.max_characters
+    limit = min(
+        context.output_constraints.max_characters,
+        OutputConstraints.for_mode(context.mode).max_characters,
+    )
     if len(candidate) > limit:
         violations.append(
             Violation(

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -29,6 +29,9 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
     assert BOOTSTRAP_JAVASCRIPT.count('method: "POST"') == 1
     assert "limit: 50" in BOOTSTRAP_JAVASCRIPT
     assert "input.maxLength = 500" in BOOTSTRAP_JAVASCRIPT
+    assert "const LETTER_CHARACTER_LIMIT = 1200;" in BOOTSTRAP_JAVASCRIPT
+    assert "input.maxLength = LETTER_CHARACTER_LIMIT;" in BOOTSTRAP_JAVASCRIPT
+    assert 'input.closest(`[${DIALOG_ATTR}]`)' in BOOTSTRAP_JAVASCRIPT
     assert "Promise.allSettled" in BOOTSTRAP_JAVASCRIPT
     assert "window.confirm" in BOOTSTRAP_JAVASCRIPT
     assert "crypto.randomUUID" in BOOTSTRAP_JAVASCRIPT

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -32,8 +32,7 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
     assert "input.maxLength = 500" in BOOTSTRAP_JAVASCRIPT
     assert "const LETTER_CHARACTER_LIMIT = 1200;" in BOOTSTRAP_JAVASCRIPT
     assert (
-        'matches[0].querySelector("textarea").maxLength = '
-        "LETTER_CHARACTER_LIMIT;"
+        "matches.values().next().value.maxLength = LETTER_CHARACTER_LIMIT;"
     ) in BOOTSTRAP_JAVASCRIPT
     assert 'const LETTER_COMPOSER_TITLE = "写下你的感受";' in BOOTSTRAP_JAVASCRIPT
     assert 'const LETTER_SUBMIT_LABEL = "寄出信件";' in BOOTSTRAP_JAVASCRIPT
@@ -112,8 +111,13 @@ const vm = require("vm");
 const source = fs.readFileSync(0, "utf8");
 
 const run = (spec) => {
+  const sharedAreas = new Map();
   const makeDialog = (item) => {
-    const areas = Array.from({ length: item.textareas }, () => ({ maxLength: null }));
+    let areas = item.shared ? sharedAreas.get(item.shared) : null;
+    if (!areas) {
+      areas = Array.from({ length: item.textareas }, () => ({ maxLength: null }));
+      if (item.shared) sharedAreas.set(item.shared, areas);
+    }
     const nodes = (values) => values.map((textContent) => ({ textContent }));
     return {
       areas,
@@ -164,6 +168,10 @@ process.stdout.write(JSON.stringify([
   run({ initial: [], late: [letter] }),
   run({ initial: [{ ...letter, title: "其他弹窗" }] }),
   run({ initial: [letter, letter] }),
+  run({ initial: [
+    { ...letter, shared: "nested" },
+    { ...letter, shared: "nested" },
+  ] }),
   run({ initial: [letter, { ...letter, companion: true }] }),
 ]));
 '''
@@ -180,5 +188,6 @@ process.stdout.write(JSON.stringify([
         [[1200]],
         [[None]],
         [[None], [None]],
+        [[1200], [1200]],
         [[1200], [None]],
     ]

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import json
 
 import pytest
 
@@ -30,8 +31,12 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
     assert "limit: 50" in BOOTSTRAP_JAVASCRIPT
     assert "input.maxLength = 500" in BOOTSTRAP_JAVASCRIPT
     assert "const LETTER_CHARACTER_LIMIT = 1200;" in BOOTSTRAP_JAVASCRIPT
-    assert "input.maxLength = LETTER_CHARACTER_LIMIT;" in BOOTSTRAP_JAVASCRIPT
-    assert 'input.closest(`[${DIALOG_ATTR}]`)' in BOOTSTRAP_JAVASCRIPT
+    assert (
+        'matches[0].querySelector("textarea").maxLength = '
+        "LETTER_CHARACTER_LIMIT;"
+    ) in BOOTSTRAP_JAVASCRIPT
+    assert 'const LETTER_COMPOSER_TITLE = "写下你的感受";' in BOOTSTRAP_JAVASCRIPT
+    assert 'const LETTER_SUBMIT_LABEL = "寄出信件";' in BOOTSTRAP_JAVASCRIPT
     assert "Promise.allSettled" in BOOTSTRAP_JAVASCRIPT
     assert "window.confirm" in BOOTSTRAP_JAVASCRIPT
     assert "crypto.randomUUID" in BOOTSTRAP_JAVASCRIPT
@@ -95,3 +100,85 @@ def test_original_settings_management_ui_javascript_is_parseable() -> None:
     )
     output = (result.stderr or result.stdout).decode("utf-8", errors="replace")
     assert result.returncode == 0, output
+
+
+def test_letter_limit_handles_late_mount_and_fails_closed_on_ambiguous_dialogs() -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is not installed")
+    harness = r'''
+const fs = require("fs");
+const vm = require("vm");
+const source = fs.readFileSync(0, "utf8");
+
+const run = (spec) => {
+  const makeDialog = (item) => {
+    const areas = Array.from({ length: item.textareas }, () => ({ maxLength: null }));
+    const nodes = (values) => values.map((textContent) => ({ textContent }));
+    return {
+      areas,
+      closest: () => item.companion ? {} : null,
+      querySelector: (selector) => selector === "textarea" ? areas[0] || null : null,
+      querySelectorAll: (selector) => {
+        if (selector === "textarea") return areas;
+        if (selector === "button") return nodes(item.buttons);
+        if (selector === 'h1,h2,h3,[class*="title"]') return nodes([item.title]);
+        return [];
+      },
+    };
+  };
+  const dialogs = spec.initial.map(makeDialog);
+  let mutationCallback = () => {};
+  const document = {
+    currentScript: { dataset: { apiBase: "http://127.0.0.1:8899" } },
+    documentElement: {},
+    querySelectorAll: (selector) => selector === '[role="dialog"], .el-dialog' ? dialogs : [],
+    querySelector: () => null,
+  };
+  const context = {
+    URL,
+    document,
+    window: {
+      location: { pathname: "/collection", hash: "" },
+      requestAnimationFrame: (callback) => callback(),
+      addEventListener: () => {},
+    },
+    MutationObserver: class {
+      constructor(callback) { mutationCallback = callback; }
+      observe() {}
+    },
+  };
+  vm.runInNewContext(source, context);
+  for (const item of spec.late || []) dialogs.push(makeDialog(item));
+  if (spec.late) mutationCallback();
+  return dialogs.map((dialog) => dialog.areas.map((area) => area.maxLength));
+};
+
+const letter = {
+  title: "写下你的感受",
+  buttons: ["寄出信件"],
+  textareas: 1,
+  companion: false,
+};
+process.stdout.write(JSON.stringify([
+  run({ initial: [], late: [letter] }),
+  run({ initial: [{ ...letter, title: "其他弹窗" }] }),
+  run({ initial: [letter, letter] }),
+  run({ initial: [letter, { ...letter, companion: true }] }),
+]));
+'''
+    result = subprocess.run(
+        [node, "-e", harness],
+        input=BOOTSTRAP_JAVASCRIPT.encode("utf-8"),
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    output = (result.stderr or result.stdout).decode("utf-8", errors="replace")
+    assert result.returncode == 0, output
+    assert json.loads(result.stdout.decode("utf-8")) == [
+        [[1200]],
+        [[None]],
+        [[None], [None]],
+        [[1200], [None]],
+    ]

--- a/tests/persona/test_reply_context.py
+++ b/tests/persona/test_reply_context.py
@@ -33,6 +33,7 @@ def test_text_wire_mode_builds_an_immutable_letter_context() -> None:
     assert mode is ReplyMode.TEXT_LETTER
     assert context.to_dict()["wire_mode"] == "text"
     assert context.to_dict()["output_constraints"]["channel"] == "letter"
+    assert context.output_constraints.max_characters == 1200
 
 
 def test_trusted_time_normalizes_to_utc_and_rejects_unstable_inputs() -> None:

--- a/tests/persona/test_reply_context.py
+++ b/tests/persona/test_reply_context.py
@@ -99,6 +99,7 @@ def test_legacy_video_mapping_is_preserved_and_future_im_requires_opt_in() -> No
     )
     assert context.to_dict()["wire_mode"] is None
     assert context.to_dict()["output_constraints"]["channel"] == "instant_message"
+    assert context.output_constraints.max_characters == 12000
 
 
 def test_schema_matches_runtime_mode_and_privacy_invariants() -> None:

--- a/tests/persona/test_reply_policy.py
+++ b/tests/persona/test_reply_policy.py
@@ -92,6 +92,19 @@ def test_text_letter_accepts_1200_characters_and_rejects_1201() -> None:
         ViolationCode.OUTPUT_LIMIT_EXCEEDED,
     )
 
+    oversized_configuration = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+        output_constraints=OutputConstraints(
+            OutputChannel.LETTER,
+            max_characters=12000,
+        ),
+    )
+    bypass_attempt = scan_reply("林" * 1201, oversized_configuration)
+    assert tuple(item.code for item in bypass_attempt.violations) == (
+        ViolationCode.OUTPUT_LIMIT_EXCEEDED,
+    )
+
 
 def test_only_explicit_permanent_or_exclusive_commitments_are_blocked() -> None:
     context = ReplyContext.create(

--- a/tests/persona/test_reply_policy.py
+++ b/tests/persona/test_reply_policy.py
@@ -79,6 +79,20 @@ def test_video_reply_requires_delivery_length_without_affecting_text_letters() -
     ).passed is True
 
 
+def test_text_letter_accepts_1200_characters_and_rejects_1201() -> None:
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    )
+
+    assert scan_reply("林" * 1200, context).passed is True
+    result = scan_reply("林" * 1201, context)
+
+    assert tuple(item.code for item in result.violations) == (
+        ViolationCode.OUTPUT_LIMIT_EXCEEDED,
+    )
+
+
 def test_only_explicit_permanent_or_exclusive_commitments_are_blocked() -> None:
     context = ReplyContext.create(
         ReplyMode.TEXT_LETTER,


### PR DESCRIPTION
## Scope
- constrain the original-client letter textarea to 1200 characters before submission
- cap canonical text-letter output at 1200 characters
- keep companion settings inputs excluded from the letter limit

## Validation
- focused frontend injection, ReplyContext, and reply-policy tests passed
- JavaScript parse check included

## Boundaries
- backend request safety ceiling is unchanged
- ordinary short reply style is unchanged; no padding or target-length rule
- no installer or release artifact update
- no private letter data