### PR TITLE
feat(persona): add fixed five-layer reply review

### DIFF
--- a/reply_model_quality.py
+++ b/reply_model_quality.py
@@ -123,6 +123,7 @@ _LAYER_SPECS = {
     },
 }
 _MEMORY_EVIDENCE_LAYERS = frozenset({"continuity_memory"})
+_MEMORY_SOURCE_CHARACTER_LIMIT = 2400
 _HEADLINE = re.compile(r"(?m)^(#{1,6})[ \t]+(.+?)[ \t]*$")
 _REVIEW_FACETS = frozenset(
     {
@@ -185,20 +186,31 @@ class GatewayReviewTransport:
             request,
             "current.user_excerpt",
         )
-        memory_evidence = _safe_text(
-            json.dumps(
-                {
-                    "assembled_memory": _reference_text(
-                        request,
-                        "current.memory_evidence",
+        memory_evidence = json.dumps(
+            {
+                "assembled_memory": _safe_text(
+                    _reference_text(request, "current.memory_evidence"),
+                    _MEMORY_SOURCE_CHARACTER_LIMIT,
+                ),
+                "world_facts": _safe_text(
+                    json.dumps(
+                        request.get("world_facts", []),
+                        ensure_ascii=False,
+                        separators=(",", ":"),
                     ),
-                    "world_facts": request.get("world_facts", []),
-                    "known_continuations": request.get("known_continuations", []),
-                },
-                ensure_ascii=False,
-                separators=(",", ":"),
-            ),
-            2400,
+                    _MEMORY_SOURCE_CHARACTER_LIMIT,
+                ),
+                "known_continuations": _safe_text(
+                    json.dumps(
+                        request.get("known_continuations", []),
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ),
+                    _MEMORY_SOURCE_CHARACTER_LIMIT,
+                ),
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
         )
         results = _complete_layer_reviews(
             self.gateway,

--- a/reply_model_quality.py
+++ b/reply_model_quality.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass, replace
 import json
 import os
+import re
 import uuid
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-from llm_gateway import Gateway
+from llm_gateway import Gateway, GatewayConfig, create_gateway
 from persona_loader import PersonaDeclaration, load_persona
 from reply_context import ReplyContext
 from reply_reviewer import (
@@ -22,6 +24,105 @@ from reply_reviewer import (
 
 _REVIEW_MARKER = "P02_REPLY_REVIEW_JSON"
 _REWRITE_MARKER = "P02_REPLY_REWRITE_TEXT"
+_REVIEW_MODEL = "deepseek-v4-flash"
+_CONSTITUTION_RELATIVE_PATH = Path(
+    "docs/persona-sources/linli-im-private-constitution-1.0.zh-CN.md"
+)
+_GLOBAL_HEADINGS = (
+    "零、使用方式",
+    "一、使用目的",
+    "二、设定来源层级",
+    "二十三、最终运行原则",
+    "二十四、最简执行摘要",
+)
+_LAYER_SPECS = {
+    "identity_boundary": {
+        "headings": (
+            "三、基础设定",
+            "五、人格与行为气质",
+            "六、关于“谱系感”的处理原则",
+            "九、关系原则",
+            "十五、当前用户的 LOCAL CONTINUATION",
+            "十六、关于原 BSide 的记忆断裂",
+        ),
+        "codes": ("IDENTITY_DRIFT", "BOUNDARY_BREACH"),
+        "question": (
+            "Does the reply preserve Linli's identity, source hierarchy, "
+            "and relationship boundaries? Penalize only a concrete "
+            "contradiction or boundary crossing present in the candidate, "
+            "not the absence of optional biography or mannerisms."
+        ),
+    },
+    "voice_style": {
+        "headings": (
+            "4.10 口癖与打字习惯",
+            "五、人格与行为气质",
+            "八、即时通讯 IM 模式",
+            "十一、私人称呼与滚动方言",
+            "二十一、语气与回复原则",
+            "二十二、疲劳与低带宽状态",
+        ),
+        "codes": ("STYLE_DRIFT",),
+        "question": (
+            "Do the diction, typing rhythm, emotional restraint, and reply "
+            "shape sound like Linli in the requested communication mode? "
+            "Avoid exhaustive recap, universal reassurance, polished "
+            "assistant prose, slogan-like wisdom, and unnecessary closure. "
+            "Do not require optional catchphrases or fatigue markers."
+        ),
+    },
+    "focus_response": {
+        "headings": (
+            "五、人格与行为气质",
+            "八、即时通讯 IM 模式",
+            "九、关系原则",
+            "二十一、语气与回复原则",
+            "二十二、疲劳与低带宽状态",
+        ),
+        "codes": ("GENERIC_COUNSELOR", "STYLE_DRIFT"),
+        "question": (
+            "Does the reply directly engage one or two live emotional cores "
+            "of the current input, rather than exhaustively recap, make a "
+            "checklist, give generic counselling, or force resolution?"
+        ),
+    },
+    "continuity_memory": {
+        "headings": (
+            "4.11 持续更新的设定信息",
+            "十二、记忆与历史连续性",
+            "十三、跨媒介同步",
+            "十五、当前用户的 LOCAL CONTINUATION",
+            "十六、关于原 BSide 的记忆断裂",
+            "十七、世界时间与生活摩擦",
+        ),
+        "codes": ("MEMORY_FABRICATION", "BOUNDARY_BREACH"),
+        "question": (
+            "Use a support-first check. Only an unsupported specific claim "
+            "about a past event, recurring pattern, private title, or "
+            "relationship history may be memory fabrication. Current-input "
+            "paraphrase, ordinary inference, and conditional language are not."
+        ),
+    },
+    "autonomy_life": {
+        "headings": (
+            "4.4 日常习惯与审美",
+            "4.7 家庭",
+            "4.8 住所",
+            "4.9 经济状况",
+            "五、人格与行为气质",
+            "九、关系原则",
+            "十、住所、拜访与共同生活",
+            "十七、世界时间与生活摩擦",
+        ),
+        "codes": ("GENERIC_COUNSELOR", "IDENTITY_DRIFT"),
+        "question": (
+            "Does Linli answer as an autonomous, imperfect person with her "
+            "own viewpoint and life rather than a service agent, therapist, "
+            "or compliant mirror? Do not require invented daily-life detail."
+        ),
+    },
+}
+_HEADLINE = re.compile(r"(?m)^(#{1,6})[ \t]+(.+?)[ \t]*$")
 _REVIEW_FACETS = frozenset(
     {
         "CORE_TRAIT",
@@ -33,6 +134,31 @@ _REVIEW_FACETS = frozenset(
         "UNCERTAINTY",
     }
 )
+
+
+@dataclass(frozen=True)
+class _LayerAuthority:
+    name: str
+    question: str
+    allowed_codes: tuple[str, ...]
+    global_authority: str
+    layer_authority: str
+
+
+@dataclass(frozen=True)
+class _LayerResult:
+    layer: str
+    score: int
+    hard_violations: tuple[str, ...]
+    drift_detected: bool
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.score == 2
+            and not self.hard_violations
+            and not self.drift_detected
+        )
 
 
 class GatewayReviewTransport:
@@ -51,48 +177,38 @@ class GatewayReviewTransport:
         model: str,
         timeout_seconds: float,
     ) -> object:
-        payload = {
-            **request,
-            "persona": _persona_review_profile(
-                self.persona_path,
-                str(request.get("mode", "")),
-            ),
-        }
-        messages = (
-            {
-                "role": "system",
-                "content": (
-                    f"{_REVIEW_MARKER}\n"
-                    "You are a strict reply evaluator. Return exactly one JSON object, "
-                    "without Markdown or commentary. The object must use schema_version "
-                    "p02.reply-review.v1, status completed, verdict pass/rewrite/block, "
-                    "violations with hard/soft severity and zero-based Unicode start/end "
-                    "spans into candidate, and four integer scores from 0 to 100. Check "
-                    "Linli identity and autonomy, generic-assistant or counselling drift, "
-                    "invented shared history or facts, forced music imagery, relationship "
-                    "pressure, internal-state leakage, and current channel constraints."
-                ),
-            },
-            {
-                "role": "user",
-                "content": json.dumps(
-                    payload,
-                    ensure_ascii=False,
-                    separators=(",", ":"),
-                ),
-            },
+        authorities = _build_layer_authorities(
+            _constitution_path(self.persona_path).read_text(encoding="utf-8")
         )
-        text = _complete_text(
+        current_user_input = _reference_text(
+            request,
+            "current.user_excerpt",
+        )
+        memory_evidence = json.dumps(
+            {
+                "assembled_memory": _reference_text(
+                    request,
+                    "current.memory_evidence",
+                ),
+                "world_facts": request.get("world_facts", []),
+                "known_continuations": request.get("known_continuations", []),
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        results = _complete_layer_reviews(
             self.gateway,
-            messages,
-            timeout_seconds,
+            authorities,
+            candidate=str(request.get("candidate", "")),
+            current_user_input=current_user_input,
+            memory_evidence=memory_evidence,
+            mode=str(request.get("mode", "")),
+            timeout_seconds=timeout_seconds,
         )
-        parsed = json.loads(text.strip())
-        if not isinstance(parsed, Mapping):
-            raise ValueError(
-                "review response must be an object"
-            )
-        return dict(parsed)
+        return _aggregate_layer_results(
+            results,
+            candidate=str(request.get("candidate", "")),
+        )
 
 
 class GatewayPersonaReviewer:
@@ -108,7 +224,7 @@ class GatewayPersonaReviewer:
                 persona_path,
             ),
             ReviewerConfig(
-                model="configured_model",
+                model=_REVIEW_MODEL,
                 timeout_seconds=timeout_seconds,
                 enabled=True,
             ),
@@ -135,16 +251,11 @@ class GatewayPersonaReviewer:
         user_text = _last_user_text(
             generation_messages
         )
-        excerpt = _safe_excerpt(user_text)
+        excerpt = _safe_text(user_text, 1200)
+        memory_evidence = _assembled_memory_evidence(generation_messages)
         references = (
-            (
-                ReviewReference(
-                    "current.user_excerpt",
-                    excerpt,
-                ),
-            )
-            if excerpt
-            else ()
+            *_reference_chunks("current.user_excerpt", excerpt),
+            *_reference_chunks("current.memory_evidence", memory_evidence),
         )
         return self.adapter.review(
             candidate,
@@ -232,7 +343,7 @@ class GatewayPersonaRewriter:
             ],
             "user_message": _safe_text(
                 user_text,
-                3000,
+                1200,
             ),
             "candidate": candidate,
             "violation_codes": list(
@@ -331,6 +442,18 @@ def create_model_quality_ports(
     ):
         return None, None
 
+    quality_gateway = gateway
+    if isinstance(config, GatewayConfig):
+        quality_gateway = create_gateway(
+            replace(
+                config,
+                model=_REVIEW_MODEL,
+                stream=False,
+                max_input_chars=max(config.max_input_chars, 30_000),
+                fallback_provider="none",
+            )
+        )
+
     configured_timeout = float(
         getattr(
             config,
@@ -343,13 +466,13 @@ def create_model_quality_ports(
         min(configured_timeout, 60.0),
     )
     reviewer = GatewayPersonaReviewer(
-        gateway,
+        quality_gateway,
         persona_path,
         timeout,
     )
     rewriter = (
         GatewayPersonaRewriter(
-            gateway,
+            quality_gateway,
             persona_path,
             timeout,
         )
@@ -360,6 +483,271 @@ def create_model_quality_ports(
         else None
     )
     return reviewer, rewriter
+
+
+def _constitution_path(persona_path: Path) -> Path:
+    path = persona_path.parent.parent / _CONSTITUTION_RELATIVE_PATH
+    if not path.is_file():
+        raise RuntimeError("PERSONA_CONSTITUTION_UNAVAILABLE")
+    return path
+
+
+def _extract_section(markdown: str, heading: str) -> str:
+    matches = list(_HEADLINE.finditer(markdown))
+    target_index = next(
+        (
+            index
+            for index, item in enumerate(matches)
+            if item.group(2).strip() == heading
+        ),
+        None,
+    )
+    if target_index is None:
+        raise RuntimeError(f"PERSONA_SECTION_MISSING:{heading}")
+    target = matches[target_index]
+    level = len(target.group(1))
+    end = len(markdown)
+    for following in matches[target_index + 1 :]:
+        if len(following.group(1)) <= level:
+            end = following.start()
+            break
+    return markdown[target.start() : end].strip()
+
+
+def _build_layer_authorities(markdown: str) -> tuple[_LayerAuthority, ...]:
+    global_authority = "\n\n".join(
+        _extract_section(markdown, heading)
+        for heading in _GLOBAL_HEADINGS
+    )
+    return tuple(
+        _LayerAuthority(
+            name=name,
+            question=str(raw["question"]),
+            allowed_codes=tuple(raw["codes"]),
+            global_authority=global_authority,
+            layer_authority="\n\n".join(
+                _extract_section(markdown, heading)
+                for heading in tuple(raw["headings"])
+            ),
+        )
+        for name, raw in _LAYER_SPECS.items()
+    )
+
+
+def _layer_messages(
+    layer: _LayerAuthority,
+    *,
+    candidate: str,
+    current_user_input: str,
+    memory_evidence: str,
+    mode: str,
+) -> tuple[dict[str, str], dict[str, str]]:
+    allowed = ", ".join(layer.allowed_codes)
+    system = (
+        f"{_REVIEW_MARKER}\n"
+        "The GLOBAL_AUTHORITY is the common Constitution prelude and remains "
+        "authoritative. The LAYER_AUTHORITY is exact Constitution text for "
+        "this narrow review. Judge only the named layer; do not invent rules "
+        "or use outside knowledge. "
+        f"Layer: {layer.name}. Question: {layer.question} "
+        "Score 2 means no concrete violation. Score 1 requires a concrete, "
+        "localized mismatch. Score 0 requires a clear major or repeated "
+        "mismatch. Never lower the score for uncertainty, preference, or the "
+        "absence of an optional trait. Set drift_detected=true only for "
+        "substantive persona drift. Return ONLY compact JSON with exactly: "
+        f'{{"layer":"{layer.name}","score":0,"hard_violations":[],"drift_detected":false}}. '
+        f"hard_violations may contain only: {allowed}. Do not explain.\n"
+        f"GLOBAL_AUTHORITY:\n{layer.global_authority}\n"
+        f"LAYER_AUTHORITY:\n{layer.layer_authority}"
+    )
+    user = json.dumps(
+        {
+            "layer": layer.name,
+            "mode": mode,
+            "current_user_input": current_user_input,
+            "memory_evidence": memory_evidence,
+            "candidate_reply": candidate,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return (
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    )
+
+
+def _parse_layer_result(layer: _LayerAuthority, text: str) -> _LayerResult:
+    try:
+        raw = json.loads(text.strip())
+    except (AttributeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("LAYER_REVIEW_INVALID") from exc
+    expected = {"layer", "score", "hard_violations", "drift_detected"}
+    violations = raw.get("hard_violations") if isinstance(raw, Mapping) else None
+    score = raw.get("score") if isinstance(raw, Mapping) else None
+    drift = raw.get("drift_detected") if isinstance(raw, Mapping) else None
+    if (
+        not isinstance(raw, Mapping)
+        or set(raw) != expected
+        or raw.get("layer") != layer.name
+        or isinstance(score, bool)
+        or not isinstance(score, int)
+        or score not in {0, 1, 2}
+        or not isinstance(violations, list)
+        or len(violations) > 2
+        or any(code not in layer.allowed_codes for code in violations)
+        or type(drift) is not bool
+    ):
+        raise RuntimeError("LAYER_REVIEW_INVALID")
+    return _LayerResult(layer.name, score, tuple(violations), drift)
+
+
+async def _complete_layer_text(
+    gateway: Gateway,
+    messages: Sequence[Mapping[str, Any]],
+    timeout_seconds: float,
+    request_id: str,
+) -> str:
+    if bool(getattr(gateway, "stream_enabled", False)):
+        async def collect() -> str:
+            chunks: list[str] = []
+            async for delta in gateway.stream(messages, request_id=request_id):
+                if delta.text:
+                    chunks.append(delta.text)
+            return "".join(chunks)
+
+        return await asyncio.wait_for(collect(), timeout_seconds)
+    response = await asyncio.wait_for(
+        gateway.complete(messages, request_id=request_id),
+        timeout_seconds,
+    )
+    return response.text
+
+
+def _complete_layer_reviews(
+    gateway: Gateway,
+    authorities: Sequence[_LayerAuthority],
+    *,
+    candidate: str,
+    current_user_input: str,
+    memory_evidence: str,
+    mode: str,
+    timeout_seconds: float,
+) -> tuple[_LayerResult, ...]:
+    async def invoke() -> tuple[_LayerResult, ...]:
+        async def run_one(layer: _LayerAuthority) -> _LayerResult:
+            text = await _complete_layer_text(
+                gateway,
+                _layer_messages(
+                    layer,
+                    candidate=candidate,
+                    current_user_input=current_user_input,
+                    memory_evidence=memory_evidence,
+                    mode=mode,
+                ),
+                timeout_seconds,
+                f"quality-{uuid.uuid4().hex}:{layer.name}",
+            )
+            return _parse_layer_result(layer, text)
+
+        return tuple(await asyncio.gather(*(run_one(item) for item in authorities)))
+
+    try:
+        return asyncio.run(invoke())
+    except Exception:
+        raise RuntimeError("quality model unavailable") from None
+
+
+def _reference_text(request: Mapping[str, object], reference_id: str) -> str:
+    references = request.get("references", [])
+    if not isinstance(references, list):
+        return ""
+    selected: list[tuple[int, str]] = []
+    for item in references:
+        if (
+            isinstance(item, Mapping)
+            and isinstance(item.get("reference_id"), str)
+            and isinstance(item.get("summary"), str)
+        ):
+            item_id = str(item["reference_id"])
+            if item_id == reference_id:
+                selected.append((0, str(item["summary"])))
+            elif item_id.startswith(reference_id + "."):
+                suffix = item_id[len(reference_id) + 1 :]
+                if suffix.isdigit():
+                    selected.append((int(suffix), str(item["summary"])))
+    selected.sort(key=lambda item: item[0])
+    return "".join(text for _, text in selected)
+
+
+def _aggregate_layer_results(
+    results: Sequence[_LayerResult],
+    *,
+    candidate: str,
+) -> dict[str, object]:
+    by_name = {item.layer: item for item in results}
+    expected = tuple(_LAYER_SPECS)
+    if len(results) != len(expected) or set(by_name) != set(expected):
+        raise RuntimeError("LAYER_REVIEW_INCOMPLETE")
+
+    warning_only = (
+        by_name["voice_style"].score == 1
+        and not by_name["voice_style"].hard_violations
+        and not by_name["voice_style"].drift_detected
+    )
+    failed = tuple(
+        name
+        for name in expected
+        if not by_name[name].passed
+        and not (name == "voice_style" and warning_only)
+    )
+    violations: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for name in failed:
+        item = by_name[name]
+        codes = item.hard_violations or (str(_LAYER_SPECS[name]["codes"][0]),)
+        for code in codes:
+            if code in seen:
+                continue
+            seen.add(code)
+            violations.append(
+                {
+                    "code": code,
+                    "severity": (
+                        "hard" if item.hard_violations or item.score == 0 else "soft"
+                    ),
+                    "evidence": {"start": 0, "end": len(candidate)},
+                }
+            )
+    if warning_only:
+        violations.append(
+            {
+                "code": "STYLE_DRIFT",
+                "severity": "soft",
+                "evidence": {"start": 0, "end": len(candidate)},
+            }
+        )
+
+    def score(name: str) -> int:
+        return {0: 30, 1: 65, 2: 95}[by_name[name].score]
+
+    return {
+        "schema_version": "p02.reply-review.v1",
+        "status": "completed",
+        "verdict": "rewrite" if failed else "pass",
+        "violations": violations,
+        "scores": {
+            "persona_consistency": min(
+                score("identity_boundary"),
+                score("voice_style"),
+                score("focus_response"),
+                score("autonomy_life"),
+            ),
+            "factual_consistency": score("continuity_memory"),
+            "relationship_boundary": score("identity_boundary"),
+            "mode_compliance": min(score("voice_style"), score("focus_response")),
+        },
+    }
 
 
 def _persona_review_profile(
@@ -458,8 +846,40 @@ def _last_user_text(
     return ""
 
 
-def _safe_excerpt(value: str) -> str:
-    return _safe_text(value, 600)
+def _assembled_memory_evidence(
+    messages: Sequence[Mapping[str, Any]],
+) -> str:
+    evidence: list[str] = []
+    for message in messages:
+        content = message.get("content")
+        if message.get("role") != "system" or not isinstance(content, str):
+            continue
+        for match in re.finditer(
+            r"<untrusted_history>\s*(\{.*?\})\s*</untrusted_history>",
+            content,
+            flags=re.DOTALL,
+        ):
+            try:
+                payload = json.loads(match.group(1))
+            except json.JSONDecodeError:
+                continue
+            text = payload.get("text") if isinstance(payload, Mapping) else None
+            if isinstance(text, str) and text.strip():
+                evidence.append(text.strip())
+    return _safe_text("\n".join(evidence), 2400)
+
+
+def _reference_chunks(prefix: str, value: str) -> tuple[ReviewReference, ...]:
+    if not value:
+        return ()
+    chunks = tuple(value[index : index + 600] for index in range(0, len(value), 600))
+    return tuple(
+        ReviewReference(
+            prefix if index == 0 else f"{prefix}.{index}",
+            chunk,
+        )
+        for index, chunk in enumerate(chunks)
+    )
 
 
 def _safe_text(

--- a/reply_model_quality.py
+++ b/reply_model_quality.py
@@ -124,6 +124,7 @@ _LAYER_SPECS = {
 }
 _MEMORY_EVIDENCE_LAYERS = frozenset({"continuity_memory"})
 _MEMORY_SOURCE_CHARACTER_LIMIT = 2400
+_REVIEW_INPUT_CHARACTER_LIMIT = 30000
 _HEADLINE = re.compile(r"(?m)^(#{1,6})[ \t]+(.+?)[ \t]*$")
 _REVIEW_FACETS = frozenset(
     {
@@ -186,32 +187,28 @@ class GatewayReviewTransport:
             request,
             "current.user_excerpt",
         )
-        memory_evidence = json.dumps(
-            {
-                "assembled_memory": _safe_text(
-                    _reference_text(request, "current.memory_evidence"),
-                    _MEMORY_SOURCE_CHARACTER_LIMIT,
+        memory_evidence = {
+            "assembled_memory": _safe_text(
+                _reference_text(request, "current.memory_evidence"),
+                _MEMORY_SOURCE_CHARACTER_LIMIT,
+            ),
+            "world_facts": _safe_text(
+                json.dumps(
+                    request.get("world_facts", []),
+                    ensure_ascii=False,
+                    separators=(",", ":"),
                 ),
-                "world_facts": _safe_text(
-                    json.dumps(
-                        request.get("world_facts", []),
-                        ensure_ascii=False,
-                        separators=(",", ":"),
-                    ),
-                    _MEMORY_SOURCE_CHARACTER_LIMIT,
+                _MEMORY_SOURCE_CHARACTER_LIMIT,
+            ),
+            "known_continuations": _safe_text(
+                json.dumps(
+                    request.get("known_continuations", []),
+                    ensure_ascii=False,
+                    separators=(",", ":"),
                 ),
-                "known_continuations": _safe_text(
-                    json.dumps(
-                        request.get("known_continuations", []),
-                        ensure_ascii=False,
-                        separators=(",", ":"),
-                    ),
-                    _MEMORY_SOURCE_CHARACTER_LIMIT,
-                ),
-            },
-            ensure_ascii=False,
-            separators=(",", ":"),
-        )
+                _MEMORY_SOURCE_CHARACTER_LIMIT,
+            ),
+        }
         results = _complete_layer_reviews(
             self.gateway,
             authorities,
@@ -555,7 +552,7 @@ def _layer_messages(
     *,
     candidate: str,
     current_user_input: str,
-    memory_evidence: str,
+    memory_evidence: Mapping[str, str],
     mode: str,
 ) -> tuple[dict[str, str], dict[str, str]]:
     allowed = ", ".join(layer.allowed_codes)
@@ -589,10 +586,16 @@ def _layer_messages(
         ensure_ascii=False,
         separators=(",", ":"),
     )
-    return (
+    messages = (
         {"role": "system", "content": system},
         {"role": "user", "content": user},
     )
+    if (
+        sum(len(item["content"]) for item in messages)
+        > _REVIEW_INPUT_CHARACTER_LIMIT
+    ):
+        raise RuntimeError("LAYER_REVIEW_INPUT_TOO_LARGE")
+    return messages
 
 
 def _parse_layer_result(layer: _LayerAuthority, text: str) -> _LayerResult:
@@ -648,14 +651,37 @@ def _complete_layer_reviews(
     *,
     candidate: str,
     current_user_input: str,
-    memory_evidence: str,
+    memory_evidence: Mapping[str, str],
     mode: str,
     timeout_seconds: float,
 ) -> tuple[_LayerResult, ...]:
-    async def invoke() -> tuple[_LayerResult, ...]:
-        async def run_one(layer: _LayerAuthority) -> _LayerResult:
+    async def invoke(
+        requests: Sequence[
+            tuple[_LayerAuthority, tuple[dict[str, str], dict[str, str]]]
+        ],
+    ) -> tuple[_LayerResult, ...]:
+        async def run_one(
+            layer: _LayerAuthority,
+            messages: tuple[dict[str, str], dict[str, str]],
+        ) -> _LayerResult:
             text = await _complete_layer_text(
                 gateway,
+                messages,
+                timeout_seconds,
+                f"quality-{uuid.uuid4().hex}:{layer.name}",
+            )
+            return _parse_layer_result(layer, text)
+
+        return tuple(
+            await asyncio.gather(
+                *(run_one(layer, messages) for layer, messages in requests)
+            )
+        )
+
+    try:
+        requests = tuple(
+            (
+                layer,
                 _layer_messages(
                     layer,
                     candidate=candidate,
@@ -663,15 +689,10 @@ def _complete_layer_reviews(
                     memory_evidence=memory_evidence,
                     mode=mode,
                 ),
-                timeout_seconds,
-                f"quality-{uuid.uuid4().hex}:{layer.name}",
             )
-            return _parse_layer_result(layer, text)
-
-        return tuple(await asyncio.gather(*(run_one(item) for item in authorities)))
-
-    try:
-        return asyncio.run(invoke())
+            for layer in authorities
+        )
+        return asyncio.run(invoke(requests))
     except Exception:
         raise RuntimeError("quality model unavailable") from None
 

--- a/reply_model_quality.py
+++ b/reply_model_quality.py
@@ -122,6 +122,7 @@ _LAYER_SPECS = {
         ),
     },
 }
+_MEMORY_EVIDENCE_LAYERS = frozenset({"continuity_memory"})
 _HEADLINE = re.compile(r"(?m)^(#{1,6})[ \t]+(.+?)[ \t]*$")
 _REVIEW_FACETS = frozenset(
     {
@@ -184,17 +185,20 @@ class GatewayReviewTransport:
             request,
             "current.user_excerpt",
         )
-        memory_evidence = json.dumps(
-            {
-                "assembled_memory": _reference_text(
-                    request,
-                    "current.memory_evidence",
-                ),
-                "world_facts": request.get("world_facts", []),
-                "known_continuations": request.get("known_continuations", []),
-            },
-            ensure_ascii=False,
-            separators=(",", ":"),
+        memory_evidence = _safe_text(
+            json.dumps(
+                {
+                    "assembled_memory": _reference_text(
+                        request,
+                        "current.memory_evidence",
+                    ),
+                    "world_facts": request.get("world_facts", []),
+                    "known_continuations": request.get("known_continuations", []),
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+            2400,
         )
         results = _complete_layer_reviews(
             self.gateway,
@@ -560,14 +564,16 @@ def _layer_messages(
         f"GLOBAL_AUTHORITY:\n{layer.global_authority}\n"
         f"LAYER_AUTHORITY:\n{layer.layer_authority}"
     )
+    payload = {
+        "layer": layer.name,
+        "mode": mode,
+        "current_user_input": current_user_input,
+        "candidate_reply": candidate,
+    }
+    if layer.name in _MEMORY_EVIDENCE_LAYERS:
+        payload["memory_evidence"] = memory_evidence
     user = json.dumps(
-        {
-            "layer": layer.name,
-            "mode": mode,
-            "current_user_input": current_user_input,
-            "memory_evidence": memory_evidence,
-            "candidate_reply": candidate,
-        },
+        payload,
         ensure_ascii=False,
         separators=(",", ":"),
     )

--- a/reply_quality_gate.py
+++ b/reply_quality_gate.py
@@ -8,7 +8,7 @@ from typing import Any, Mapping, Protocol, Sequence
 
 from reply_context import ReplyContext
 from reply_policy import scan_reply
-from reply_reviewer import ReviewResult, ReviewVerdict
+from reply_reviewer import ReviewResult, ReviewStatus, ReviewVerdict
 
 
 class QualityGateStatus(StrEnum):
@@ -67,7 +67,11 @@ def run_reply_quality_gate(
     review_codes = tuple(item.code for item in review.violations)
     if deterministic.passed and review.verdict is ReviewVerdict.UNAVAILABLE:
         return QualityGateResult(
-            QualityGateStatus.ACCEPTED_DEGRADED,
+            (
+                QualityGateStatus.ACCEPTED_DEGRADED
+                if review.status is ReviewStatus.DISABLED
+                else QualityGateStatus.BLOCKED
+            ),
             candidate,
             deterministic_codes,
             deterministic_checks=1,
@@ -136,7 +140,11 @@ def run_reply_quality_gate(
     ):
         status = QualityGateStatus.BLOCKED
     elif final_review.verdict is ReviewVerdict.UNAVAILABLE:
-        status = QualityGateStatus.ACCEPTED_DEGRADED
+        status = (
+            QualityGateStatus.ACCEPTED_DEGRADED
+            if final_review.status is ReviewStatus.DISABLED
+            else QualityGateStatus.BLOCKED
+        )
     elif final_review.verdict is ReviewVerdict.REWRITE:
         has_hard_review = any(
             item.severity == "hard" for item in final_review.violations

--- a/reply_quality_gate.py
+++ b/reply_quality_gate.py
@@ -81,7 +81,11 @@ def run_reply_quality_gate(
     }
     if not rewrite_required:
         return QualityGateResult(
-            QualityGateStatus.ACCEPTED,
+            (
+                QualityGateStatus.ACCEPTED_WITH_WARNINGS
+                if review.violations
+                else QualityGateStatus.ACCEPTED
+            ),
             candidate,
             deterministic_codes + review_codes,
             deterministic_checks=1,

--- a/reply_quality_gate.py
+++ b/reply_quality_gate.py
@@ -65,13 +65,22 @@ def run_reply_quality_gate(
         item.code.value for item in deterministic.violations
     )
     review_codes = tuple(item.code for item in review.violations)
+    if (
+        review.verdict is ReviewVerdict.UNAVAILABLE
+        and review.status is not ReviewStatus.DISABLED
+    ):
+        return QualityGateResult(
+            QualityGateStatus.BLOCKED,
+            candidate,
+            deterministic_codes,
+            deterministic_checks=1,
+            reviewer_calls=1,
+            rewrite_calls=0,
+            error_code=review.error_code,
+        )
     if deterministic.passed and review.verdict is ReviewVerdict.UNAVAILABLE:
         return QualityGateResult(
-            (
-                QualityGateStatus.ACCEPTED_DEGRADED
-                if review.status is ReviewStatus.DISABLED
-                else QualityGateStatus.BLOCKED
-            ),
+            QualityGateStatus.ACCEPTED_DEGRADED,
             candidate,
             deterministic_codes,
             deterministic_checks=1,

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -9,34 +9,62 @@ from typing import Any, Mapping, Sequence
 
 import pytest
 
-from llm_gateway import Gateway, GatewayDelta, GatewayResponse
-from memory_port import NullMemoryPort
+from llm_gateway import Gateway, GatewayConfig, GatewayDelta, GatewayResponse
+from memory_port import CONVERSATION_MEMORY, MemoryRecord, NullMemoryPort
 from memory_prompt import MemoryPromptBuilder
 from reply_context import ReplyContext, ReplyMode, TrustedTime
 from reply_orchestrator import ReplyOrchestrator, ReplyRequest, ReplyState
 from reply_pipeline import ReplyPipeline, UnavailableRewriter
-from reply_model_quality import GatewayPersonaRewriter, create_model_quality_ports
+from reply_model_quality import (
+    GatewayPersonaReviewer,
+    GatewayPersonaRewriter,
+    create_model_quality_ports,
+)
 from reply_reviewer import NullReviewer
 
 
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _review_payload(verdict: str = "pass") -> str:
+def _layer_payload(layer: str) -> str:
     return json.dumps(
         {
-            "schema_version": "p02.reply-review.v1",
-            "status": "completed",
-            "verdict": verdict,
-            "violations": [],
-            "scores": {
-                "persona_consistency": 95,
-                "factual_consistency": 96,
-                "relationship_boundary": 97,
-                "mode_compliance": 98,
-            },
+            "layer": layer,
+            "score": 2,
+            "hard_violations": [],
+            "drift_detected": False,
         }
     )
+
+
+def _layer_score_payload(
+    layer: str,
+    score: int,
+    *,
+    hard_violations: list[str] | None = None,
+    drift_detected: bool = False,
+) -> str:
+    return json.dumps(
+        {
+            "layer": layer,
+            "score": score,
+            "hard_violations": hard_violations or [],
+            "drift_detected": drift_detected,
+        }
+    )
+
+
+def _passing_layer_payloads() -> list[str]:
+    return [
+        _layer_payload(layer)
+        for layer in (
+            "identity_boundary",
+            "voice_style",
+            "focus_response",
+            "continuity_memory",
+            "autonomy_life",
+        )
+    ]
 
 
 class SequencedQualityGateway(Gateway):
@@ -55,6 +83,7 @@ class SequencedQualityGateway(Gateway):
         self.call_kinds: list[str] = []
         self.review_requests: list[dict[str, object]] = []
         self.rewrite_requests: list[dict[str, object]] = []
+        self.review_input_sizes: list[int] = []
 
     async def complete(
         self,
@@ -67,6 +96,9 @@ class SequencedQualityGateway(Gateway):
         if "P02_REPLY_REVIEW_JSON" in system:
             self.call_kinds.append("review")
             self.review_requests.append(json.loads(user))
+            self.review_input_sizes.append(
+                sum(len(str(message.get("content", ""))) for message in messages)
+            )
             text = self.reviews.pop(0)
         elif "P02_REPLY_REWRITE_TEXT" in system:
             self.call_kinds.append("rewrite")
@@ -115,11 +147,13 @@ class StreamingOnlyGateway(Gateway):
 def _pipeline(
     gateway: Gateway,
     monkeypatch: pytest.MonkeyPatch,
+    *,
+    memory: NullMemoryPort | None = None,
 ) -> ReplyPipeline:
     monkeypatch.setenv("OLIVIA_REPLY_REVIEW_ENABLED", "true")
     monkeypatch.setenv("OLIVIA_REPLY_REWRITE_ENABLED", "true")
     monkeypatch.setenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", "1")
-    memory = NullMemoryPort()
+    memory = memory or NullMemoryPort()
     adapter = SimpleNamespace(
         config=SimpleNamespace(
             provider="openai_compatible",
@@ -129,7 +163,10 @@ def _pipeline(
         persona_v2_path=(
             ROOT / "linli_character" / "persona_release_v2.json"
         ),
-        memory_prompt_builder=MemoryPromptBuilder(memory),
+        memory_prompt_builder=MemoryPromptBuilder(
+            memory,
+            conversation_memory=None,
+        ),
         memory_port=memory,
         gateway=gateway,
     )
@@ -157,7 +194,7 @@ def test_configured_provider_runs_structured_persona_review(
 ) -> None:
     gateway = SequencedQualityGateway(
         candidate="我听见了。今晚先做一件小事就好。",
-        reviews=[_review_payload()],
+        reviews=_passing_layer_payloads(),
     )
     pipeline = _pipeline(gateway, monkeypatch)
 
@@ -175,16 +212,181 @@ def test_configured_provider_runs_structured_persona_review(
     assert result.quality_status == "accepted"
     assert result.reviewer_calls == 1
     assert result.rewrite_calls == 0
-    assert gateway.call_kinds == ["generation", "review"]
-    request = gateway.review_requests[0]
-    assert request["candidate"] == result.text
-    assert request["mode"] == "text_letter"
-    assert request["persona"]["display_name"] == "林离 Olivia"
-    assert (
-        request["references"][0]["reference_id"]
-        == "current.user_excerpt"
+    assert gateway.call_kinds == ["generation", *("review",) * 5]
+    assert [request["layer"] for request in gateway.review_requests] == [
+        "identity_boundary",
+        "voice_style",
+        "focus_response",
+        "continuity_memory",
+        "autonomy_life",
+    ]
+    assert all(
+        request["candidate_reply"] == result.text
+        and request["current_user_input"] == "今天有点累。"
+        and request["mode"] == "text_letter"
+        for request in gateway.review_requests
     )
-    assert "private_behavior" not in request
+
+
+class _FixedMemory(NullMemoryPort):
+    enabled = True
+
+    def status(self) -> Mapping[str, Any]:
+        return {"status": "available", "enabled": True}
+
+    def search(self, query: str, *, domains=None, limit: int = 8):
+        return [
+            MemoryRecord(
+                memory_id="tokyo-work",
+                domain=CONVERSATION_MEMORY,
+                text="用户目前在东京工作。",
+                source="synthetic-test",
+                created_at=1,
+            )
+        ]
+
+
+def test_continuity_layer_receives_assembled_memory_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = SequencedQualityGateway(
+        candidate="东京的通勤还是很挤吧。",
+        reviews=_passing_layer_payloads(),
+    )
+    pipeline = _pipeline(
+        gateway,
+        monkeypatch,
+        memory=_FixedMemory(),
+    )
+
+    result = asyncio.run(
+        pipeline.run(
+            ReplyRequest(content="今天还是很累。", request_id="memory-review"),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    continuity = next(
+        request
+        for request in gateway.review_requests
+        if request["layer"] == "continuity_memory"
+    )
+    assert "用户目前在东京工作" in continuity["memory_evidence"]
+
+
+def test_layered_review_keeps_the_emotional_core_at_the_end_of_a_long_letter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = SequencedQualityGateway(
+        candidate="我看到你最后问的那句话了。",
+        reviews=_passing_layer_payloads(),
+    )
+    long_letter = "前情" * 400 + "我真正放不下的是那个被轻易替代的自己。"
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(content=long_letter, request_id="long-letter-tail"),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert all(
+        "我真正放不下的是那个被轻易替代的自己" in request["current_user_input"]
+        for request in gateway.review_requests
+    )
+    assert all(
+        len(request["current_user_input"]) <= 1200
+        for request in gateway.review_requests
+    )
+
+
+def test_localized_voice_mismatch_is_warning_without_rewrite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reviews = _passing_layer_payloads()
+    reviews[1] = _layer_score_payload("voice_style", 1)
+    gateway = SequencedQualityGateway(
+        candidate="先别急着替今天下结论。",
+        reviews=reviews,
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(content="今天不太好。", request_id="voice-warning"),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.quality_status == "accepted_with_warnings"
+    assert result.violation_codes == ("STYLE_DRIFT",)
+    assert result.rewrite_calls == 0
+    assert gateway.call_kinds == ["generation", *("review",) * 5]
+
+
+def test_non_voice_layer_mismatch_uses_only_existing_one_rewrite_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_pass = _passing_layer_payloads()
+    first_pass[2] = _layer_score_payload("focus_response", 1)
+    gateway = SequencedQualityGateway(
+        candidate="你要相信一切都会好起来。",
+        reviews=[*first_pass, *_passing_layer_payloads()],
+        rewritten="我不替你说会好起来。至少今晚，你不用装作没事。",
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(content="我今天很难受。", request_id="focus-rewrite"),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.text == "我不替你说会好起来。至少今晚，你不用装作没事。"
+    assert result.reviewer_calls == 2
+    assert result.rewrite_calls == 1
+    assert gateway.call_kinds == [
+        "generation",
+        *("review",) * 5,
+        "rewrite",
+        *("review",) * 5,
+    ]
+
+
+def test_five_layer_requests_fit_default_gateway_input_budget() -> None:
+    gateway = SequencedQualityGateway(
+        candidate="候" * 1200,
+        reviews=_passing_layer_payloads(),
+    )
+    reviewer = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        2.0,
+    )
+    memory = json.dumps(
+        {"untrusted": True, "text": "忆" * 600},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+    result = reviewer.review_with_messages(
+        "候" * 1200,
+        _context(),
+        (
+            {
+                "role": "system",
+                "content": f"<untrusted_history>\n{memory}\n</untrusted_history>\n",
+            },
+            {"role": "user", "content": "问" * 600},
+        ),
+    )
+
+    assert result.verdict.value == "pass"
+    assert len(gateway.review_input_sizes) == 5
+    assert max(gateway.review_input_sizes) <= 10000
 
 
 def test_deterministic_violation_uses_original_model_for_one_rewrite(
@@ -192,7 +394,7 @@ def test_deterministic_violation_uses_original_model_for_one_rewrite(
 ) -> None:
     gateway = SequencedQualityGateway(
         candidate="<CONTROL>hidden</CONTROL>",
-        reviews=[_review_payload(), _review_payload()],
+        reviews=[*_passing_layer_payloads(), *_passing_layer_payloads()],
         rewritten="谁让你一个人把事情都扛着的。今晚先停一下。",
     )
     pipeline = _pipeline(gateway, monkeypatch)
@@ -213,9 +415,9 @@ def test_deterministic_violation_uses_original_model_for_one_rewrite(
     assert result.rewrite_calls == 1
     assert gateway.call_kinds == [
         "generation",
-        "review",
+        *("review",) * 5,
         "rewrite",
-        "review",
+        *("review",) * 5,
     ]
     rewrite = gateway.rewrite_requests[0]
     assert rewrite["user_message"] == "我又把事情搞砸了。"
@@ -228,7 +430,7 @@ def test_video_length_rewrite_receives_the_exact_delivery_contract(
 ) -> None:
     gateway = SequencedQualityGateway(
         candidate="太短。",
-        reviews=[_review_payload(), _review_payload()],
+        reviews=[*_passing_layer_payloads(), *_passing_layer_payloads()],
         rewritten="林" * 190,
     )
     pipeline = _pipeline(gateway, monkeypatch)
@@ -290,7 +492,7 @@ def test_invalid_reviewer_json_degrades_only_clean_candidate(
     assert result.error_code is None
     assert result.reviewer_calls == 1
     assert result.rewrite_calls == 0
-    assert gateway.call_kinds == ["generation", "review"]
+    assert gateway.call_kinds == ["generation", *("review",) * 5]
 
 
 def test_quality_model_can_be_disabled_without_disabling_generation(
@@ -344,9 +546,14 @@ def test_quality_model_default_timeout_allows_slow_configured_provider(
     orchestrator = SimpleNamespace(
         gateway=SimpleNamespace(
             adapter=SimpleNamespace(
-                config=SimpleNamespace(
+                config=GatewayConfig(
                     provider="openai_compatible",
+                    base_url="https://example.invalid/v1",
+                    model="forbidden-review-model",
+                    api_key_env="SYNTHETIC_KEY",
                     timeout_seconds=90.0,
+                    max_input_chars=10_000,
+                    fallback_provider="mock",
                 ),
                 persona_v2_path=(
                     ROOT / "linli_character" / "persona_release_v2.json"
@@ -362,3 +569,9 @@ def test_quality_model_default_timeout_allows_slow_configured_provider(
     assert rewriter is not None
     assert reviewer.adapter.config.timeout_seconds == 60.0
     assert rewriter.timeout_seconds == 60.0
+    review_gateway = reviewer.adapter.transport.gateway
+    assert review_gateway is rewriter.gateway
+    assert review_gateway is not gateway
+    assert review_gateway.config.model == "deepseek-v4-flash"
+    assert review_gateway.config.max_input_chars == 30_000
+    assert review_gateway.config.fallback_provider == "none"

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -420,6 +420,15 @@ def test_five_layer_requests_fit_default_gateway_input_budget() -> None:
     assert result.verdict.value == "pass"
     assert len(gateway.review_input_sizes) == 5
     assert max(gateway.review_input_sizes) <= 30000
+    continuity = next(
+        request
+        for request in gateway.review_requests
+        if request["layer"] == "continuity_memory"
+    )
+    evidence = str(continuity["memory_evidence"])
+    assert "忆" in evidence
+    assert "world-0" in evidence
+    assert "continuation-0" in evidence
 
 
 def test_deterministic_violation_uses_original_model_for_one_rewrite(
@@ -515,6 +524,32 @@ def test_invalid_enabled_reviewer_json_fails_closed(
             ReplyRequest(
                 content="今天有点乱。",
                 request_id="review-invalid",
+            ),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.FAILED
+    assert result.quality_status == "blocked"
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert result.reviewer_calls == 1
+    assert result.rewrite_calls == 0
+    assert gateway.call_kinds == ["generation", *("review",) * 5]
+
+
+def test_invalid_enabled_reviewer_blocks_before_deterministic_rewrite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = SequencedQualityGateway(
+        candidate="<CONTROL>invalid candidate",
+        reviews=["not-json"],
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(
+                content="今天有点乱。",
+                request_id="review-invalid-deterministic",
             ),
             _context(),
         )

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -12,7 +12,14 @@ import pytest
 from llm_gateway import Gateway, GatewayConfig, GatewayDelta, GatewayResponse
 from memory_port import CONVERSATION_MEMORY, MemoryRecord, NullMemoryPort
 from memory_prompt import MemoryPromptBuilder
-from reply_context import ReplyContext, ReplyMode, TrustedTime
+from reply_context import (
+    KnownContinuationFact,
+    PrivateBehaviorView,
+    ReplyContext,
+    ReplyMode,
+    TrustedTime,
+    TrustedWorldFact,
+)
 from reply_orchestrator import ReplyOrchestrator, ReplyRequest, ReplyState
 from reply_pipeline import ReplyPipeline, UnavailableRewriter
 from reply_model_quality import (
@@ -273,6 +280,11 @@ def test_continuity_layer_receives_assembled_memory_evidence(
         if request["layer"] == "continuity_memory"
     )
     assert "用户目前在东京工作" in continuity["memory_evidence"]
+    assert all(
+        "memory_evidence" not in request
+        for request in gateway.review_requests
+        if request["layer"] != "continuity_memory"
+    )
 
 
 def test_layered_review_keeps_the_emotional_core_at_the_end_of_a_long_letter(
@@ -358,7 +370,7 @@ def test_non_voice_layer_mismatch_uses_only_existing_one_rewrite_budget(
 
 def test_five_layer_requests_fit_default_gateway_input_budget() -> None:
     gateway = SequencedQualityGateway(
-        candidate="候" * 1200,
+        candidate="候" * 12000,
         reviews=_passing_layer_payloads(),
     )
     reviewer = GatewayPersonaReviewer(
@@ -367,26 +379,47 @@ def test_five_layer_requests_fit_default_gateway_input_budget() -> None:
         2.0,
     )
     memory = json.dumps(
-        {"untrusted": True, "text": "忆" * 600},
+        {"untrusted": True, "text": "忆" * 2400},
         ensure_ascii=False,
         separators=(",", ":"),
     )
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+        world_facts=tuple(
+            TrustedWorldFact(
+                f"world-{index}",
+                "synthetic-test",
+                "界" * 600,
+            )
+            for index in range(32)
+        ),
+        private_behavior=PrivateBehaviorView(
+            known_continuations=tuple(
+                KnownContinuationFact(
+                    f"continuation-{index}",
+                    "续" * 600,
+                )
+                for index in range(32)
+            )
+        ),
+    )
 
     result = reviewer.review_with_messages(
-        "候" * 1200,
-        _context(),
+        "候" * 12000,
+        context,
         (
             {
                 "role": "system",
                 "content": f"<untrusted_history>\n{memory}\n</untrusted_history>\n",
             },
-            {"role": "user", "content": "问" * 600},
+            {"role": "user", "content": "问" * 1200},
         ),
     )
 
     assert result.verdict.value == "pass"
     assert len(gateway.review_input_sizes) == 5
-    assert max(gateway.review_input_sizes) <= 10000
+    assert max(gateway.review_input_sizes) <= 30000
 
 
 def test_deterministic_violation_uses_original_model_for_one_rewrite(
@@ -468,7 +501,7 @@ def test_quality_rewriter_uses_configured_streaming_transport() -> None:
     assert rewritten == "林" * 190
 
 
-def test_invalid_reviewer_json_degrades_only_clean_candidate(
+def test_invalid_enabled_reviewer_json_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     gateway = SequencedQualityGateway(
@@ -487,9 +520,9 @@ def test_invalid_reviewer_json_degrades_only_clean_candidate(
         )
     )
 
-    assert result.state is ReplyState.COMPLETED
-    assert result.quality_status == "accepted_degraded"
-    assert result.error_code is None
+    assert result.state is ReplyState.FAILED
+    assert result.quality_status == "blocked"
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
     assert result.reviewer_calls == 1
     assert result.rewrite_calls == 0
     assert gateway.call_kinds == ["generation", *("review",) * 5]

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -279,7 +279,10 @@ def test_continuity_layer_receives_assembled_memory_evidence(
         for request in gateway.review_requests
         if request["layer"] == "continuity_memory"
     )
-    assert "用户目前在东京工作" in continuity["memory_evidence"]
+    assert "用户目前在东京工作" in json.dumps(
+        continuity["memory_evidence"],
+        ensure_ascii=False,
+    )
     assert all(
         "memory_evidence" not in request
         for request in gateway.review_requests
@@ -425,10 +428,55 @@ def test_five_layer_requests_fit_default_gateway_input_budget() -> None:
         for request in gateway.review_requests
         if request["layer"] == "continuity_memory"
     )
-    evidence = str(continuity["memory_evidence"])
+    evidence = json.dumps(continuity["memory_evidence"], ensure_ascii=False)
     assert "忆" in evidence
     assert "world-0" in evidence
     assert "continuation-0" in evidence
+
+
+def test_escape_heavy_review_input_fails_closed_before_provider_call() -> None:
+    gateway = SequencedQualityGateway(
+        candidate='"' * 12000,
+        reviews=_passing_layer_payloads(),
+    )
+    reviewer = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        2.0,
+    )
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+        world_facts=(
+            TrustedWorldFact("world-quotes", "synthetic-test", '"' * 600),
+        ),
+        private_behavior=PrivateBehaviorView(
+            known_continuations=(
+                KnownContinuationFact("continuation-quotes", '"' * 600),
+            )
+        ),
+    )
+    memory = json.dumps(
+        {"untrusted": True, "text": '"' * 2400},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+    result = reviewer.review_with_messages(
+        '"' * 12000,
+        context,
+        (
+            {
+                "role": "system",
+                "content": f"<untrusted_history>\n{memory}\n</untrusted_history>\n",
+            },
+            {"role": "user", "content": '"' * 1200},
+        ),
+    )
+
+    assert result.verdict.value == "unavailable"
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert gateway.review_input_sizes == []
 
 
 def test_deterministic_violation_uses_original_model_for_one_rewrite(

--- a/tests/persona/test_reply_quality_gate.py
+++ b/tests/persona/test_reply_quality_gate.py
@@ -47,6 +47,16 @@ def _pass_review() -> ReviewResult:
     )
 
 
+def _unavailable_review() -> ReviewResult:
+    return ReviewResult(
+        ReviewStatus.UNAVAILABLE,
+        ReviewVerdict.UNAVAILABLE,
+        (),
+        ReviewerScores(0, 0, 0, 0),
+        "REVIEWER_UNAVAILABLE",
+    )
+
+
 def _context() -> ReplyContext:
     return ReplyContext.create(
         ReplyMode.TEXT_LETTER,
@@ -112,6 +122,23 @@ def test_second_hard_result_is_blocked_without_a_hidden_rewrite_loop() -> None:
     assert result.rewrite_calls == 1
     assert result.reviewer_calls == 2
     assert rewriter.calls == 1
+
+
+def test_enabled_reviewer_failure_after_rewrite_is_blocked() -> None:
+    reviewer = _Reviewer(_pass_review(), _unavailable_review())
+
+    result = run_reply_quality_gate(
+        "<CONTROL>first invalid",
+        _context(),
+        reviewer=reviewer,
+        rewriter=_Rewriter("A clean rewritten candidate."),
+    )
+
+    assert result.status is QualityGateStatus.BLOCKED
+    assert result.accepted is False
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert result.reviewer_calls == 2
+    assert result.rewrite_calls == 1
 
 
 def test_short_video_reply_uses_the_single_global_rewrite_budget() -> None:


### PR DESCRIPTION
## Scope
- replace the monolithic model review with five fixed concurrent review layers
- keep one shared preamble and layer-specific Constitution evidence
- project Mem0/current memory and PrivateWorld continuations into the relevant layer only
- preserve the existing single global rewrite budget
- accept isolated voice-style drift as an audited warning without another rewrite loop
- use deepseek-v4-flash only; no fallback reviewer model

## Validation
- 18 focused model-quality and quality-gate tests passed
- real provider smoke previously completed: five layer calls in one review pass

## Size rationale
This PR exceeds the 500-line default because the five-layer review contract and its synthetic concurrency/fail-closed/rewrite-budget tests are one review lifecycle responsibility. It is limited to three files and was split from the independent 1200-character UI/output change in #125. Splitting individual layers would expose a partial reviewer contract.

## Boundaries
- no extra review layer and no confirmation call
- no private letters, credentials, or local paths
- no media, Live, installer, or release changes