### PR TITLE
fix(memory): gate Mem0 embedding on verified offline cache

### DIFF
--- a/docs/P03_03_LONG_TERM_MEMORY_MEM0.md
+++ b/docs/P03_03_LONG_TERM_MEMORY_MEM0.md
@@ -268,6 +268,14 @@ BAAI/bge-m3
 
 Embedding 模型必须固定 revision 或哈希，并由安装器显式下载；服务启动不得悄悄联网下载。
 
+当前安全门固定 `mem0ai==2.0.18`、`sentence-transformers==5.7.0`，以及
+`BAAI/bge-small-zh-v1.5` 的 Hugging Face immutable revision
+`7999e1d3359715c523056ef9478215996d62a620`。运行时只接受与该 revision
+匹配的本地快照和 `olivia-mem0-embedding-manifest.json` 中逐文件 SHA-256；
+缓存缺失、内容损坏或 revision 不符时，Mem0 必须以稳定
+`MEM0_EMBEDDING_CACHE_UNAVAILABLE` 降级，且不得联网、创建空缓存或让 health
+报告 READY。显式下载和生成 manifest 属于后续独立安装 PR。
+
 ### 7.3 Vector Store
 
 使用 Qdrant local path：

--- a/docs/P03_03_LONG_TERM_MEMORY_MEM0.md
+++ b/docs/P03_03_LONG_TERM_MEMORY_MEM0.md
@@ -276,6 +276,13 @@ Embedding 模型必须固定 revision 或哈希，并由安装器显式下载；
 `MEM0_EMBEDDING_CACHE_UNAVAILABLE` 降级，且不得联网、创建空缓存或让 health
 报告 READY。显式下载和生成 manifest 属于后续独立安装 PR。
 
+`mem0ai==2.0.18` 的 telemetry 也属于运行期外联边界：在首次 import `mem0` 或
+调用 `Memory.from_config` 前，产品必须无条件把真实进程环境的
+`MEM0_TELEMETRY` 设为 `False`，不接受配置 mapping 或既有环境中的 `true`。如果
+`mem0` 已提前载入而无法证明 telemetry 未初始化，必须以稳定
+`MEM0_TELEMETRY_STATE_UNAVAILABLE` fail closed；health 只能公开该原因码，正文
+仍按可选记忆降级路径成功。
+
 ### 7.3 Vector Store
 
 使用 Qdrant local path：

--- a/mem0_memory.py
+++ b/mem0_memory.py
@@ -260,7 +260,7 @@ def _duration(value: object, default: float, *, maximum: float = 300.0) -> float
 
 
 def _verified_embedding_cache(config: Mem0Config) -> bool:
-    """Accept only the pinned, manifest-verified Hugging Face snapshot."""
+    """Accept only the pinned, manifest-verified local embedding files."""
 
     if config.embedding_model != MEM0_EMBEDDING_MODEL:
         return False

--- a/mem0_memory.py
+++ b/mem0_memory.py
@@ -36,6 +36,8 @@ from conversation_memory_port import (
 MEM0_OSS_VERSION = "2.0.18"
 MEM0_EMBEDDING_MODEL = "BAAI/bge-small-zh-v1.5"
 MEM0_EMBEDDING_MODEL_REVISION = "7999e1d3359715c523056ef9478215996d62a620"
+_MEM0_IMPORT_LOCK = threading.Lock()
+_SAFE_MEM0_MODULE: object | None = None
 _EMBEDDING_MANIFEST_NAME = "olivia-mem0-embedding-manifest.json"
 _EMBEDDING_SNAPSHOT_FILES = frozenset(
     {
@@ -976,11 +978,29 @@ class Mem0ConversationMemoryAdapter:
         )
 
 
+def _require_safe_mem0_import_state() -> None:
+    with _MEM0_IMPORT_LOCK:
+        os.environ["MEM0_TELEMETRY"] = "False"
+        module = sys.modules.get("mem0")
+        if module is not None and module is not _SAFE_MEM0_MODULE:
+            raise Mem0AdapterError("MEM0_TELEMETRY_STATE_UNAVAILABLE")
+
+
+def _load_product_mem0_module() -> object:
+    global _SAFE_MEM0_MODULE
+    with _MEM0_IMPORT_LOCK:
+        os.environ["MEM0_TELEMETRY"] = "False"
+        module = sys.modules.get("mem0")
+        if module is None:
+            module = importlib.import_module("mem0")
+            _SAFE_MEM0_MODULE = module
+        elif module is not _SAFE_MEM0_MODULE:
+            raise Mem0AdapterError("MEM0_TELEMETRY_STATE_UNAVAILABLE")
+        return module
+
+
 def _default_factory(config: Mapping[str, object]) -> Mem0Backend:
-    os.environ["MEM0_TELEMETRY"] = "False"
-    if "mem0" in sys.modules:
-        raise Mem0AdapterError("MEM0_TELEMETRY_STATE_UNAVAILABLE")
-    module = importlib.import_module("mem0")
+    module = _load_product_mem0_module()
     memory_type = getattr(module, "Memory", None)
     if memory_type is None or not hasattr(memory_type, "from_config"):
         raise ImportError("Mem0 Memory.from_config is unavailable")
@@ -1002,12 +1022,8 @@ def create_mem0_adapter(
         return UnavailableConversationMemoryPort(
             "MEM0_EMBEDDING_CACHE_UNAVAILABLE", config=active
         )
-    os.environ["MEM0_TELEMETRY"] = "False"
-    if "mem0" in sys.modules:
-        return UnavailableConversationMemoryPort(
-            "MEM0_TELEMETRY_STATE_UNAVAILABLE", config=active
-        )
     try:
+        _require_safe_mem0_import_state()
         active.qdrant_path.parent.mkdir(parents=True, exist_ok=True)
         active.history_path.parent.mkdir(parents=True, exist_ok=True)
         backend = (memory_factory or _default_factory)(active.provider_config(environ))

--- a/mem0_memory.py
+++ b/mem0_memory.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import hashlib
 import importlib
+import json
 from numbers import Real
 import os
 from pathlib import Path
@@ -31,6 +33,23 @@ from conversation_memory_port import (
 
 
 MEM0_OSS_VERSION = "2.0.18"
+MEM0_EMBEDDING_MODEL = "BAAI/bge-small-zh-v1.5"
+MEM0_EMBEDDING_MODEL_REVISION = "7999e1d3359715c523056ef9478215996d62a620"
+_EMBEDDING_MANIFEST_NAME = "olivia-mem0-embedding-manifest.json"
+_EMBEDDING_SNAPSHOT_FILES = frozenset(
+    {
+        "1_Pooling/config.json",
+        "config.json",
+        "config_sentence_transformers.json",
+        "model.safetensors",
+        "modules.json",
+        "sentence_bert_config.json",
+        "special_tokens_map.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocab.txt",
+    }
+)
 _DOMAIN = "conversation_memory"
 _ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
 
@@ -68,7 +87,7 @@ class Mem0Config:
     llm_base_url: str = ""
     llm_model: str = ""
     llm_api_key_env: str = "DEEPSEEK_API_KEY"
-    embedding_model: str = "BAAI/bge-small-zh-v1.5"
+    embedding_model: str = MEM0_EMBEDDING_MODEL
     embedding_dims: int = 512
     embedding_cache: Path | None = None
     context_max_chars: int = 2400
@@ -156,6 +175,15 @@ class Mem0Config:
     def model_cache(self) -> Path:
         return self.embedding_cache or self.data_root.parent / "model-cache"
 
+    @property
+    def embedding_snapshot(self) -> Path:
+        return (
+            self.model_cache
+            / "models--BAAI--bge-small-zh-v1.5"
+            / "snapshots"
+            / MEM0_EMBEDDING_MODEL_REVISION
+        )
+
     def provider_config(
         self,
         environ: Mapping[str, str] | None = None,
@@ -189,6 +217,7 @@ class Mem0Config:
                         "device": "cpu",
                         "cache_folder": str(self.model_cache),
                         "local_files_only": True,
+                        "revision": MEM0_EMBEDDING_MODEL_REVISION,
                     },
                 },
             },
@@ -225,6 +254,43 @@ def _duration(value: object, default: float, *, maximum: float = 300.0) -> float
     except (TypeError, ValueError):
         return default
     return parsed if 0.1 <= parsed <= maximum else default
+
+
+def _verified_embedding_cache(config: Mem0Config) -> bool:
+    """Accept only the pinned, manifest-verified Hugging Face snapshot."""
+
+    if config.embedding_model != MEM0_EMBEDDING_MODEL:
+        return False
+    try:
+        manifest = json.loads(
+            (config.model_cache / _EMBEDDING_MANIFEST_NAME).read_text(encoding="utf-8")
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(manifest, dict) or set(manifest) != {"model", "revision", "files"}:
+        return False
+    files = manifest.get("files")
+    if (
+        manifest.get("model") != MEM0_EMBEDDING_MODEL
+        or manifest.get("revision") != MEM0_EMBEDDING_MODEL_REVISION
+        or not isinstance(files, dict)
+        or set(files) != _EMBEDDING_SNAPSHOT_FILES
+    ):
+        return False
+    for relative_path, expected_sha256 in files.items():
+        if not isinstance(expected_sha256, str) or not re.fullmatch(
+            r"[0-9a-f]{64}", expected_sha256
+        ):
+            return False
+        candidate = config.embedding_snapshot.joinpath(*relative_path.split("/"))
+        try:
+            with candidate.open("rb") as snapshot_file:
+                digest = hashlib.file_digest(snapshot_file, "sha256").hexdigest()
+        except OSError:
+            return False
+        if digest != expected_sha256:
+            return False
+    return True
 
 
 def load_mem0_config(
@@ -928,10 +994,13 @@ def create_mem0_adapter(
         return UnavailableConversationMemoryPort(active.config_error, config=active)
     if not active.enabled:
         return NullConversationMemoryPort()
+    if not _verified_embedding_cache(active):
+        return UnavailableConversationMemoryPort(
+            "MEM0_EMBEDDING_CACHE_UNAVAILABLE", config=active
+        )
     try:
         active.qdrant_path.parent.mkdir(parents=True, exist_ok=True)
         active.history_path.parent.mkdir(parents=True, exist_ok=True)
-        active.model_cache.mkdir(parents=True, exist_ok=True)
         backend = (memory_factory or _default_factory)(active.provider_config(environ))
         return Mem0ConversationMemoryAdapter(backend, active)
     except (ModuleNotFoundError, ImportError):
@@ -943,6 +1012,8 @@ def create_mem0_adapter(
 
 
 __all__ = [
+    "MEM0_EMBEDDING_MODEL",
+    "MEM0_EMBEDDING_MODEL_REVISION",
     "MEM0_OSS_VERSION",
     "Mem0AdapterError",
     "Mem0Config",

--- a/mem0_memory.py
+++ b/mem0_memory.py
@@ -16,6 +16,7 @@ from numbers import Real
 import os
 from pathlib import Path
 import re
+import sys
 import threading
 import time
 from typing import Callable, Mapping, Protocol, Sequence
@@ -976,6 +977,9 @@ class Mem0ConversationMemoryAdapter:
 
 
 def _default_factory(config: Mapping[str, object]) -> Mem0Backend:
+    os.environ["MEM0_TELEMETRY"] = "False"
+    if "mem0" in sys.modules:
+        raise Mem0AdapterError("MEM0_TELEMETRY_STATE_UNAVAILABLE")
     module = importlib.import_module("mem0")
     memory_type = getattr(module, "Memory", None)
     if memory_type is None or not hasattr(memory_type, "from_config"):
@@ -998,11 +1002,18 @@ def create_mem0_adapter(
         return UnavailableConversationMemoryPort(
             "MEM0_EMBEDDING_CACHE_UNAVAILABLE", config=active
         )
+    os.environ["MEM0_TELEMETRY"] = "False"
+    if "mem0" in sys.modules:
+        return UnavailableConversationMemoryPort(
+            "MEM0_TELEMETRY_STATE_UNAVAILABLE", config=active
+        )
     try:
         active.qdrant_path.parent.mkdir(parents=True, exist_ok=True)
         active.history_path.parent.mkdir(parents=True, exist_ok=True)
         backend = (memory_factory or _default_factory)(active.provider_config(environ))
         return Mem0ConversationMemoryAdapter(backend, active)
+    except Mem0AdapterError as exc:
+        return UnavailableConversationMemoryPort(exc.code, config=active)
     except (ModuleNotFoundError, ImportError):
         return UnavailableConversationMemoryPort("MEM0_IMPORT_FAILED", config=active)
     except (OSError, RuntimeError, TypeError, ValueError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
 ]
 memory-mem0 = [
     "mem0ai==2.0.18",
-    "sentence-transformers>=5.2,<6",
+    "sentence-transformers==5.7.0",
 ]
 
 [tool.setuptools]

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -127,7 +127,10 @@ def test_memory_health_fails_closed_when_mem0_is_unavailable_but_archive_is_avai
     monkeypatch.setattr(
         local_server,
         "conversation_memory_adapter",
-        UnavailableConversationMemoryPort("MEM0_IMPORT_FAILED"),
+        UnavailableConversationMemoryPort(
+            "MEM0_EMBEDDING_CACHE_UNAVAILABLE",
+            config={"cache": "private-synthetic-cache-detail"},
+        ),
     )
 
     result = asyncio.run(local_server.route("GET", "/health", {}, {"profile": "memory"}))
@@ -137,6 +140,9 @@ def test_memory_health_fails_closed_when_mem0_is_unavailable_but_archive_is_avai
     conversation = result["data"]["capabilities"]["memory.conversation"]
     assert conversation["status"] == "unavailable"
     assert conversation["provider"] == "none"
+    health = json.dumps(result)
+    assert "MEM0_EMBEDDING_CACHE_UNAVAILABLE" in health
+    assert "private-synthetic-cache-detail" not in health
 
 
 def test_memory_health_reflects_degraded_canonical_delivery_runtime(

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -128,8 +128,8 @@ def test_memory_health_fails_closed_when_mem0_is_unavailable_but_archive_is_avai
         local_server,
         "conversation_memory_adapter",
         UnavailableConversationMemoryPort(
-            "MEM0_EMBEDDING_CACHE_UNAVAILABLE",
-            config={"cache": "private-synthetic-cache-detail"},
+            "MEM0_TELEMETRY_STATE_UNAVAILABLE",
+            config={"telemetry": "private-synthetic-telemetry-detail"},
         ),
     )
 
@@ -141,8 +141,8 @@ def test_memory_health_fails_closed_when_mem0_is_unavailable_but_archive_is_avai
     assert conversation["status"] == "unavailable"
     assert conversation["provider"] == "none"
     health = json.dumps(result)
-    assert "MEM0_EMBEDDING_CACHE_UNAVAILABLE" in health
-    assert "private-synthetic-cache-detail" not in health
+    assert "MEM0_TELEMETRY_STATE_UNAVAILABLE" in health
+    assert "private-synthetic-telemetry-detail" not in health
 
 
 def test_memory_health_reflects_degraded_canonical_delivery_runtime(

--- a/tests/memory/test_local_memory.py
+++ b/tests/memory/test_local_memory.py
@@ -18,7 +18,7 @@ from local_memory import (
     create_memory_adapter,
     load_memory_config,
 )
-from mem0_memory import load_mem0_config
+from mem0_memory import MEM0_EMBEDDING_MODEL_REVISION, load_mem0_config
 from memory_import import ImportOptions, LegacyLetterImporter
 from memory_port import CONVERSATION_MEMORY, LEGACY_LETTERS, LegacyLetter, MemoryUnavailable
 from memory_prompt import MEMORY_CONTEXT_BEGIN, MEMORY_CONTEXT_END, MemoryPromptBuilder
@@ -250,11 +250,12 @@ def test_independent_mem0_file_configuration_reaches_provider_without_a_key_valu
         "config": {
             "model": "BAAI/bge-small-zh-v1.5",
             "embedding_dims": 512,
-            "model_kwargs": {
-                "device": "cpu",
-                "cache_folder": str(tmp_path / "memory" / "model-cache"),
-                "local_files_only": True,
-            },
+                "model_kwargs": {
+                    "device": "cpu",
+                    "cache_folder": str(tmp_path / "memory" / "model-cache"),
+                    "local_files_only": True,
+                    "revision": MEM0_EMBEDDING_MODEL_REVISION,
+                },
         },
     }
     assert provider["vector_store"] == {

--- a/tests/memory/test_mem0_memory.py
+++ b/tests/memory/test_mem0_memory.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import asyncio
 from dataclasses import replace
 from datetime import datetime, timezone
+import hashlib
 import json
 from pathlib import Path
 import threading
 import time
+import tomllib
 
 from conversation_memory_delivery import ConversationMemoryDeliveryCommitter
 from conversation_memory_outbox import CanonicalMemoryOutbox
@@ -16,6 +18,8 @@ from conversation_memory_port import (
     UnavailableConversationMemoryPort,
 )
 from mem0_memory import (
+    MEM0_EMBEDDING_MODEL,
+    MEM0_EMBEDDING_MODEL_REVISION,
     MEM0_OSS_VERSION,
     Mem0AdapterError,
     Mem0Config,
@@ -125,6 +129,38 @@ def _config(tmp_path: Path) -> Mem0Config:
     )
 
 
+def _write_verified_embedding_cache(config: Mem0Config) -> None:
+    files = {
+        "1_Pooling/config.json": b"{\"word_embedding_dimension\": 512}",
+        "config.json": b"{\"model_type\": \"bert\"}",
+        "config_sentence_transformers.json": b"{}",
+        "model.safetensors": b"synthetic weights",
+        "modules.json": b"[]",
+        "sentence_bert_config.json": b"{}",
+        "special_tokens_map.json": b"{}",
+        "tokenizer.json": b"{}",
+        "tokenizer_config.json": b"{}",
+        "vocab.txt": b"synthetic\n",
+    }
+    for relative_path, content in files.items():
+        destination = config.embedding_snapshot.joinpath(*relative_path.split("/"))
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(content)
+    (config.model_cache / "olivia-mem0-embedding-manifest.json").write_text(
+        json.dumps(
+            {
+                "model": MEM0_EMBEDDING_MODEL,
+                "revision": MEM0_EMBEDDING_MODEL_REVISION,
+                "files": {
+                    relative_path: hashlib.sha256(content).hexdigest()
+                    for relative_path, content in files.items()
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_version_and_config_match_current_mem0_oss_contract(tmp_path: Path) -> None:
     assert MEM0_OSS_VERSION == "2.0.18"
     config = _config(tmp_path)
@@ -145,10 +181,20 @@ def test_version_and_config_match_current_mem0_oss_contract(tmp_path: Path) -> N
         "device": "cpu",
         "cache_folder": str(config.model_cache),
         "local_files_only": True,
+        "revision": MEM0_EMBEDDING_MODEL_REVISION,
     }
     assert mapping["llm"]["config"]["openai_base_url"] == "http://127.0.0.1:9/v1"
     assert mapping["llm"]["config"]["api_key"] == "fixture-secret"
     assert "private_world" not in repr(mapping)
+
+
+def test_memory_extra_pins_the_verified_mem0_embedding_dependencies() -> None:
+    project = tomllib.loads((Path(__file__).parents[2] / "pyproject.toml").read_text("utf-8"))
+
+    assert project["project"]["optional-dependencies"]["memory-mem0"] == [
+        "mem0ai==2.0.18",
+        "sentence-transformers==5.7.0",
+    ]
 
 
 def test_config_preserves_legacy_positional_config_error_slot(tmp_path: Path) -> None:
@@ -1194,6 +1240,7 @@ def test_factory_is_lazy_and_returns_stable_disabled_or_unavailable_ports(tmp_pa
         captured.update(config)
         return backend
 
+    _write_verified_embedding_cache(_config(tmp_path))
     adapter = create_mem0_adapter(
         _config(tmp_path),
         environ={"DEEPSEEK_API_KEY": "fixture-secret"},
@@ -1212,6 +1259,50 @@ def test_factory_is_lazy_and_returns_stable_disabled_or_unavailable_ports(tmp_pa
     assert isinstance(unavailable, UnavailableConversationMemoryPort)
     assert unavailable.reason_code == "MEM0_INITIALIZATION_FAILED"
     assert unavailable.config.data_root == _config(tmp_path).data_root
+
+
+def test_factory_refuses_an_unverified_local_embedding_cache(tmp_path: Path) -> None:
+    factory_called = False
+
+    def factory(_config):
+        nonlocal factory_called
+        factory_called = True
+        return FakeMem0()
+
+    port = create_mem0_adapter(_config(tmp_path), memory_factory=factory)
+
+    assert isinstance(port, UnavailableConversationMemoryPort)
+    assert port.reason_code == "MEM0_EMBEDDING_CACHE_UNAVAILABLE"
+    assert factory_called is False
+    assert "model" not in port.status().to_dict()
+    assert "cache" not in port.status().to_dict()
+
+
+def test_factory_refuses_corrupt_or_revision_mismatched_embedding_caches(
+    tmp_path: Path,
+) -> None:
+    corrupt = _config(tmp_path / "corrupt")
+    _write_verified_embedding_cache(corrupt)
+    (corrupt.embedding_snapshot / "model.safetensors").write_bytes(b"corrupt")
+
+    corrupt_port = create_mem0_adapter(corrupt, memory_factory=lambda _: FakeMem0())
+
+    assert isinstance(corrupt_port, UnavailableConversationMemoryPort)
+    assert corrupt_port.reason_code == "MEM0_EMBEDDING_CACHE_UNAVAILABLE"
+
+    mismatched_revision = _config(tmp_path / "mismatched-revision")
+    _write_verified_embedding_cache(mismatched_revision)
+    manifest_path = mismatched_revision.model_cache / "olivia-mem0-embedding-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["revision"] = "0" * 40
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    mismatched_port = create_mem0_adapter(
+        mismatched_revision, memory_factory=lambda _: FakeMem0()
+    )
+
+    assert isinstance(mismatched_port, UnavailableConversationMemoryPort)
+    assert mismatched_port.reason_code == "MEM0_EMBEDDING_CACHE_UNAVAILABLE"
 
 
 def test_manual_failure_uses_stable_error(tmp_path: Path) -> None:

--- a/tests/memory/test_mem0_memory.py
+++ b/tests/memory/test_mem0_memory.py
@@ -5,10 +5,13 @@ from dataclasses import replace
 from datetime import datetime, timezone
 import hashlib
 import json
+import os
 from pathlib import Path
+import sys
 import threading
 import time
 import tomllib
+from types import SimpleNamespace
 
 from conversation_memory_delivery import ConversationMemoryDeliveryCommitter
 from conversation_memory_outbox import CanonicalMemoryOutbox
@@ -27,6 +30,7 @@ from mem0_memory import (
     create_mem0_adapter,
     load_mem0_config,
 )
+import mem0_memory
 
 
 NOW = datetime(2026, 8, 23, 2, 0, tzinfo=timezone.utc)
@@ -1276,6 +1280,60 @@ def test_factory_refuses_an_unverified_local_embedding_cache(tmp_path: Path) -> 
     assert factory_called is False
     assert "model" not in port.status().to_dict()
     assert "cache" not in port.status().to_dict()
+
+
+def test_factory_forces_telemetry_off_before_first_mem0_import(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    _write_verified_embedding_cache(config)
+    observed: dict[str, str | None] = {}
+
+    class FakeMemory:
+        @staticmethod
+        def from_config(_config):
+            observed["from_config"] = os.environ.get("MEM0_TELEMETRY")
+            return FakeMem0()
+
+    def import_mem0(name: str):
+        assert name == "mem0"
+        observed["import"] = os.environ.get("MEM0_TELEMETRY")
+        return SimpleNamespace(Memory=FakeMemory)
+
+    monkeypatch.delitem(sys.modules, "mem0", raising=False)
+    monkeypatch.setenv("MEM0_TELEMETRY", "true")
+    monkeypatch.setattr(mem0_memory.importlib, "import_module", import_mem0)
+
+    port = create_mem0_adapter(
+        config,
+        environ={"MEM0_TELEMETRY": "true"},
+    )
+
+    assert isinstance(port, Mem0ConversationMemoryAdapter)
+    assert observed == {"import": "False", "from_config": "False"}
+    assert os.environ["MEM0_TELEMETRY"] == "False"
+
+
+def test_factory_fails_closed_when_mem0_was_preloaded(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    _write_verified_embedding_cache(config)
+    factory_called = False
+
+    def factory(_config):
+        nonlocal factory_called
+        factory_called = True
+        return FakeMem0()
+
+    monkeypatch.setenv("MEM0_TELEMETRY", "true")
+    monkeypatch.setitem(sys.modules, "mem0", SimpleNamespace())
+
+    port = create_mem0_adapter(config, memory_factory=factory)
+
+    assert isinstance(port, UnavailableConversationMemoryPort)
+    assert port.reason_code == "MEM0_TELEMETRY_STATE_UNAVAILABLE"
+    assert factory_called is False
+    assert os.environ["MEM0_TELEMETRY"] == "False"
+    assert "path" not in repr(port.status().to_dict())
 
 
 def test_factory_refuses_corrupt_or_revision_mismatched_embedding_caches(

--- a/tests/memory/test_mem0_memory.py
+++ b/tests/memory/test_mem0_memory.py
@@ -1298,7 +1298,9 @@ def test_factory_forces_telemetry_off_before_first_mem0_import(
     def import_mem0(name: str):
         assert name == "mem0"
         observed["import"] = os.environ.get("MEM0_TELEMETRY")
-        return SimpleNamespace(Memory=FakeMemory)
+        module = SimpleNamespace(Memory=FakeMemory)
+        sys.modules[name] = module
+        return module
 
     monkeypatch.delitem(sys.modules, "mem0", raising=False)
     monkeypatch.setenv("MEM0_TELEMETRY", "true")
@@ -1312,6 +1314,94 @@ def test_factory_forces_telemetry_off_before_first_mem0_import(
     assert isinstance(port, Mem0ConversationMemoryAdapter)
     assert observed == {"import": "False", "from_config": "False"}
     assert os.environ["MEM0_TELEMETRY"] == "False"
+
+
+def test_factory_reuses_a_product_verified_mem0_import(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    _write_verified_embedding_cache(config)
+    observed: dict[str, object] = {"imports": 0, "from_config": []}
+
+    class FakeMemory:
+        @staticmethod
+        def from_config(_config):
+            observed["from_config"].append(os.environ.get("MEM0_TELEMETRY"))
+            return FakeMem0()
+
+    module = SimpleNamespace(Memory=FakeMemory)
+
+    def import_mem0(name: str):
+        assert name == "mem0"
+        observed["imports"] += 1
+        sys.modules[name] = module
+        return module
+
+    monkeypatch.delitem(sys.modules, "mem0", raising=False)
+    monkeypatch.setattr(mem0_memory, "_SAFE_MEM0_MODULE", None, raising=False)
+    monkeypatch.setattr(mem0_memory.importlib, "import_module", import_mem0)
+
+    first = create_mem0_adapter(config)
+    second = create_mem0_adapter(config)
+
+    assert isinstance(first, Mem0ConversationMemoryAdapter)
+    assert isinstance(second, Mem0ConversationMemoryAdapter)
+    assert observed == {"imports": 1, "from_config": ["False", "False"]}
+
+
+def test_concurrent_factories_reuse_one_product_verified_mem0_import(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    _write_verified_embedding_cache(config)
+    import_entered = threading.Event()
+    release_import = threading.Event()
+    second_started = threading.Event()
+    first_finished = threading.Event()
+    second_finished = threading.Event()
+    observed: dict[str, object] = {"imports": 0, "from_config": []}
+
+    class FakeMemory:
+        @staticmethod
+        def from_config(_config):
+            observed["from_config"].append(os.environ.get("MEM0_TELEMETRY"))
+            return FakeMem0()
+
+    module = SimpleNamespace(Memory=FakeMemory)
+
+    def import_mem0(name: str):
+        assert name == "mem0"
+        observed["imports"] += 1
+        sys.modules[name] = module
+        import_entered.set()
+        assert release_import.wait(1)
+        return module
+
+    results: dict[str, object] = {}
+
+    def construct(name: str, finished: threading.Event) -> None:
+        if name == "second":
+            second_started.set()
+        results[name] = create_mem0_adapter(config)
+        finished.set()
+
+    monkeypatch.delitem(sys.modules, "mem0", raising=False)
+    monkeypatch.setattr(mem0_memory, "_SAFE_MEM0_MODULE", None, raising=False)
+    monkeypatch.setattr(mem0_memory.importlib, "import_module", import_mem0)
+    first = threading.Thread(target=construct, args=("first", first_finished))
+    second = threading.Thread(target=construct, args=("second", second_finished))
+    first.start()
+    assert import_entered.wait(1)
+    second.start()
+    assert second_started.wait(1)
+    assert second_finished.is_set() is False
+    release_import.set()
+    assert first_finished.wait(1)
+    assert second_finished.wait(1)
+    first.join()
+    second.join()
+
+    assert isinstance(results["first"], Mem0ConversationMemoryAdapter)
+    assert isinstance(results["second"], Mem0ConversationMemoryAdapter)
+    assert observed == {"imports": 1, "from_config": ["False", "False"]}
 
 
 def test_factory_fails_closed_when_mem0_was_preloaded(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Scope

- Pin `mem0ai==2.0.18`, `sentence-transformers==5.7.0`, and `BAAI/bge-small-zh-v1.5` to immutable revision `7999e1d3359715c523056ef9478215996d62a620`.
- Require a local manifest-verified embedding cache before Mem0 initialization; missing, corrupt, or revision-mismatched caches degrade as `MEM0_EMBEDDING_CACHE_UNAVAILABLE` without backend initialization.
- Disable Mem0 telemetry before product import/configuration. A product-verified `MEM0_TELEMETRY=False` import is safely reused under a process lock; a module preloaded before product entry remains `MEM0_TELEMETRY_STATE_UNAVAILABLE` fail-closed.
- Keep health limited to stable reason codes and preserve canonical-text fallback.

## Verification

- Parent head: `103 passed, 1 deselected` for memory/local-memory/http/canonical-fallback focused tests.
- Latest CI repair: `python baseline_hardening_scan.py --mode all` — PASS; `python -m pytest -q tests/memory/test_mem0_memory.py` — `45 passed`; `git diff --check` — PASS.

## Boundary

No installer/download UI, model download, full-suite run, real Mem0/provider/socket startup, PrivateWorld, Persona, Live, music, or media changes. This PR does not claim real-provider or human acceptance.