### PR TITLE
fix(memory): exclude current letter source from retrieval

### DIFF
--- a/companion_memory_context.py
+++ b/companion_memory_context.py
@@ -9,7 +9,7 @@ Archive.  Both domains are rendered by the existing untrusted-data formatter.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Mapping, Sequence
+from typing import Iterable, Mapping, Sequence
 
 from conversation_memory_port import (
     ConversationMemoryPort,
@@ -138,14 +138,24 @@ class CompanionMemoryPromptBuilder:
             conversation_memory=None,
         )
 
-    def build(self, query: str, *, max_chars: int | None = None) -> MemoryPrompt:
+    def build(
+        self,
+        query: str,
+        *,
+        max_chars: int | None = None,
+        exclude_source_ids: Iterable[str] = (),
+    ) -> MemoryPrompt:
         budget = max(0, int(max_chars if max_chars is not None else 2400))
         if budget <= 0 or not isinstance(query, str) or not query.strip():
             return MemoryPrompt(status="disabled")
 
         conversation_status = _port_status(self.conversation_memory)
         if conversation_status == "disabled":
-            return self._fallback.build(query, max_chars=budget)
+            return self._fallback.build(
+                query,
+                max_chars=budget,
+                exclude_source_ids=exclude_source_ids,
+            )
 
         current_budget = max(0, int(budget * self.current_share))
         archive_budget = max(0, budget - current_budget)
@@ -158,7 +168,11 @@ class CompanionMemoryPromptBuilder:
             legacy_budget=0,
             conversation_budget=current_budget,
             conversation_memory=None,
-        ).build(query, max_chars=current_budget)
+        ).build(
+            query,
+            max_chars=current_budget,
+            exclude_source_ids=exclude_source_ids,
+        )
         archive = MemoryPromptBuilder(
             _LegacyArchiveView(self.archive_memory),
             max_results=self.max_results,

--- a/local_server.py
+++ b/local_server.py
@@ -6,6 +6,7 @@
 #   letter_adapter.reply(content)  -> 本地 LLM 生成回信
 #   music_adapter.generate(midi)   -> 本地音乐模型生成演奏
 import asyncio
+from contextvars import ContextVar
 import json
 import os as _os
 import re as _re
@@ -159,6 +160,12 @@ class LLMError(RuntimeError):
         super().__init__(code)
 
 
+_CURRENT_LETTER_MEMORY_SOURCE: ContextVar[str | None] = ContextVar(
+    "current_letter_memory_source",
+    default=None,
+)
+
+
 class _LetterGateway(Gateway):
     """Bridge the legacy sync facade to the async reply orchestrator."""
 
@@ -309,7 +316,7 @@ class LetterAdapter:
             self.config.max_input_chars - len(snapshot.system_prompt) - len(user_content) - 2,
         )
         if remaining:
-            memory_context = self.memory_prompt_builder.build(
+            memory_context = self._build_memory_prompt(
                 content,
                 max_chars=min(
                     remaining,
@@ -329,7 +336,7 @@ class LetterAdapter:
         user_content = content + ("\n\n" + context if context else "")
         loaded = load_persona(self.persona_v2_path)
         reply_context = self.build_reply_context(ReplyMode.TEXT_LETTER)
-        memory_context = self.memory_prompt_builder.build(
+        memory_context = self._build_memory_prompt(
             content,
             max_chars=min(
                 self.config.max_input_chars,
@@ -348,6 +355,21 @@ class LetterAdapter:
             max_units=self.config.max_input_chars,
             history=history,
         ).to_messages()
+
+    @staticmethod
+    def _memory_source_exclusions() -> tuple[str, ...]:
+        source_id = _CURRENT_LETTER_MEMORY_SOURCE.get()
+        return (source_id,) if source_id else ()
+
+    def _build_memory_prompt(self, content: str, *, max_chars: int):
+        excluded = self._memory_source_exclusions()
+        if excluded:
+            return self.memory_prompt_builder.build(
+                content,
+                max_chars=max_chars,
+                exclude_source_ids=excluded,
+            )
+        return self.memory_prompt_builder.build(content, max_chars=max_chars)
 
     def _memory_context_limit(self) -> int:
         """Keep Mem0 and Archive prompt budgets independently bounded."""
@@ -2193,6 +2215,44 @@ def recover_pending_private_world() -> int:
     return recovered
 
 
+async def _run_reply_pipeline_for_letter(
+    letter: dict,
+    content: str,
+    exact_mode: str,
+    *,
+    idempotency_key: str | None,
+):
+    letter_id = str(letter["letter_id"])
+    revision = max(0, int(letter.get("reply_revision", 0))) + 1
+    source_token = _CURRENT_LETTER_MEMORY_SOURCE.set(
+        f"reply:{letter_id}:{revision}"
+    )
+    try:
+        reply_input = (
+            build_ordinary_video_llm_content(content)
+            if exact_mode
+            in {ReplyMode.SPOKEN_VIDEO.value, ReplyMode.MUSICAL_VIDEO.value}
+            else content
+        )
+        request = ReplyRequest(
+            content=reply_input,
+            request_id=f"letter-reply:{letter_id}",
+            idempotency_key=(
+                f"{idempotency_key}:{letter_id}" if idempotency_key else None
+            ),
+            max_input_chars=LLM_CONFIG.max_input_chars,
+        )
+        return await asyncio.wait_for(
+            reply_pipeline.run(
+                request,
+                letters_adapter.build_reply_context(ReplyMode(exact_mode)),
+            ),
+            timeout=_reply_pipeline_timeout_seconds(),
+        )
+    finally:
+        _CURRENT_LETTER_MEMORY_SOURCE.reset(source_token)
+
+
 async def generate_reply(letter_id, content, *, idempotency_key=None):
     """Run one routed current-letter reply to its canonical terminal state."""
 
@@ -2218,26 +2278,11 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
     _persist_store_state()
 
     try:
-        reply_input = (
-            build_ordinary_video_llm_content(content)
-            if exact_mode
-            in {ReplyMode.SPOKEN_VIDEO.value, ReplyMode.MUSICAL_VIDEO.value}
-            else content
-        )
-        request = ReplyRequest(
-            content=reply_input,
-            request_id=f"letter-reply:{letter_id}",
-            idempotency_key=(
-                f"{idempotency_key}:{letter_id}" if idempotency_key else None
-            ),
-            max_input_chars=LLM_CONFIG.max_input_chars,
-        )
-        result = await asyncio.wait_for(
-            reply_pipeline.run(
-                request,
-                letters_adapter.build_reply_context(ReplyMode(exact_mode)),
-            ),
-            timeout=_reply_pipeline_timeout_seconds(),
+        result = await _run_reply_pipeline_for_letter(
+            letter,
+            content,
+            exact_mode,
+            idempotency_key=idempotency_key,
         )
     except asyncio.CancelledError:
         letter["letter_status"] = "FAILED"

--- a/memory_prompt.py
+++ b/memory_prompt.py
@@ -160,7 +160,10 @@ class MemoryPromptBuilder:
             record
             for record in records
             if record.domain in {CONVERSATION_MEMORY, LEGACY_LETTERS}
-            and _record_source_id(record) not in excluded
+            and (
+                record.domain != CONVERSATION_MEMORY
+                or _record_source_id(record) not in excluded
+            )
         ]
         if not records:
             return MemoryPrompt(status=status)

--- a/memory_prompt.py
+++ b/memory_prompt.py
@@ -6,7 +6,7 @@ import json
 import os
 import re
 from dataclasses import dataclass, field
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
 from conversation_memory_port import ConversationMemoryPort
 from memory_port import CONVERSATION_MEMORY, LEGACY_LETTERS, MemoryPort, MemoryRecord
@@ -108,7 +108,18 @@ class MemoryPromptBuilder:
             conversation_memory,
         )
 
-    def build(self, query: str, *, max_chars: int | None = None) -> MemoryPrompt:
+    def build(
+        self,
+        query: str,
+        *,
+        max_chars: int | None = None,
+        exclude_source_ids: Iterable[str] = (),
+    ) -> MemoryPrompt:
+        excluded = frozenset(
+            source_id
+            for source_id in exclude_source_ids
+            if isinstance(source_id, str) and source_id
+        )
         budget = max(
             0,
             int(max_chars if max_chars is not None else self.legacy_budget + self.conversation_budget),
@@ -130,7 +141,11 @@ class MemoryPromptBuilder:
                     self.conversation_budget,
                     self.legacy_budget,
                 ),
-            ).build(query, max_chars=budget)
+            ).build(
+                query,
+                max_chars=budget,
+                exclude_source_ids=excluded,
+            )
 
         try:
             records = self.memory.search(
@@ -145,6 +160,7 @@ class MemoryPromptBuilder:
             record
             for record in records
             if record.domain in {CONVERSATION_MEMORY, LEGACY_LETTERS}
+            and _record_source_id(record) not in excluded
         ]
         if not records:
             return MemoryPrompt(status=status)
@@ -217,6 +233,14 @@ class MemoryPromptBuilder:
             truncated=truncated,
             domains=tuple(used_domains),
         )
+
+
+def _record_source_id(record: MemoryRecord) -> str | None:
+    provenance = record.provenance
+    if not isinstance(provenance, Mapping):
+        return None
+    source_id = provenance.get("source_record_id")
+    return source_id if isinstance(source_id, str) else None
 
 
 def _default_conversation_memory() -> ConversationMemoryPort | None:

--- a/reply_pipeline.py
+++ b/reply_pipeline.py
@@ -145,13 +145,24 @@ def _prepare_generation_request(
         raise ValueError("persona generation boundary is unavailable")
 
     loaded = load_persona(persona_path)
-    memory_context = memory_builder.build(
-        request.content,
-        max_chars=min(
-            request.max_input_chars,
-            int(getattr(memory_port, "context_max_chars", 2400)),
-        ),
+    memory_limit = min(
+        request.max_input_chars,
+        int(getattr(memory_port, "context_max_chars", 2400)),
     )
+    build_memory_prompt = getattr(adapter, "_build_memory_prompt", None)
+    if callable(build_memory_prompt):
+        memory_context = build_memory_prompt(
+            request.content,
+            max_chars=memory_limit,
+        )
+    else:
+        # Test and third-party bridges may retain the original builder-only
+        # surface; source selection is unavailable only outside the local
+        # LetterAdapter production boundary.
+        memory_context = memory_builder.build(
+            request.content,
+            max_chars=memory_limit,
+        )
     history = (
         (UntrustedFragment("memory.references", memory_context.text),)
         if memory_context.text

--- a/tests/llm/test_b04_memory_integration.py
+++ b/tests/llm/test_b04_memory_integration.py
@@ -7,6 +7,7 @@ import time
 from types import SimpleNamespace
 
 from conversation_memory_port import (
+    ConversationMemoryRecord,
     ConversationMemoryStatus,
     MemoryWriteResult,
     MemoryWriteStatus,
@@ -81,6 +82,29 @@ class CountingConversationMemory:
         return {"records": []}
 
 
+class SourceAwareConversationMemory(CountingConversationMemory):
+    """Synthetic Mem0 rows whose text is intentionally identical."""
+
+    def search_context(self, query, *, user_id, limit):
+        self.calls.append(
+            {"query": query, "user_id": user_id, "limit": limit}
+        )
+        return (
+            ConversationMemoryRecord(
+                memory_id="memory.current",
+                text="同文的合成记忆。",
+                user_id=user_id,
+                source_id="reply:current-letter:1",
+            ),
+            ConversationMemoryRecord(
+                memory_id="memory.older",
+                text="同文的合成记忆。",
+                user_id=user_id,
+                source_id="reply:older-letter:1",
+            ),
+        )[:limit]
+
+
 class CountingPrivateWorldCommitter:
     def __init__(self) -> None:
         self.deliveries = []
@@ -152,6 +176,80 @@ def test_unavailable_memory_falls_back_and_health_is_truthful(monkeypatch) -> No
     assert core["data"]["status"] == "HEALTHY"
     assert memory["data"]["status"] == "UNAVAILABLE"
     assert memory["data"]["capabilities"]["memory.local"]["status"] == "disabled"
+
+
+def test_current_letter_memory_excludes_only_its_exact_source_identity(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Production generation must not retrieve its own canonical exchange."""
+
+    import local_server
+
+    memory = SourceAwareConversationMemory(tmp_path / "mem0")
+    gateway = CaptureGateway()
+    letter = {
+        "letter_id": "current-letter",
+        "content": "请记住这封合成信。",
+        "reply_text": "",
+        "reply_mode": ReplyMode.TEXT_LETTER.value,
+        "letter_status": "PENDING",
+    }
+    local_server.store.letters[:] = [letter]
+    local_server.store.request_keys.clear()
+    monkeypatch.setattr(local_server.letters_adapter, "conversation_memory", memory)
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "memory_prompt_builder",
+        MemoryPromptBuilder(NullMemoryPort(), conversation_memory=memory),
+    )
+    monkeypatch.setattr(local_server.letters_adapter, "gateway", gateway)
+
+    assert asyncio.run(local_server.generate_reply("current-letter", letter["content"]))
+
+    rendered = "\n".join(message["content"] for message in gateway.messages)
+    assert "reply:current-letter:1" not in rendered
+    assert "reply:older-letter:1" in rendered
+    assert "同文的合成记忆。" in rendered
+
+
+def test_memory_prompt_legacy_selector_remains_compatible() -> None:
+    builder = MemoryPromptBuilder(NullMemoryPort(), conversation_memory=None)
+
+    prompt = builder.build("legacy compatible query", max_chars=2400)
+
+    assert prompt.status == "disabled"
+
+
+def test_mem0_unavailable_keeps_production_letter_generation_available(
+    monkeypatch,
+) -> None:
+    import local_server
+
+    unavailable = UnavailableConversationMemoryPort("MEM0_IMPORT_FAILED")
+    gateway = CaptureGateway()
+    letter = {
+        "letter_id": "mem0-unavailable-letter",
+        "content": "Mem0 不可用时仍应生成这封合成信。",
+        "reply_text": "",
+        "reply_mode": ReplyMode.TEXT_LETTER.value,
+        "letter_status": "PENDING",
+    }
+    local_server.store.letters[:] = [letter]
+    local_server.store.request_keys.clear()
+    monkeypatch.setattr(local_server.letters_adapter, "conversation_memory", unavailable)
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "memory_prompt_builder",
+        MemoryPromptBuilder(NullMemoryPort(), conversation_memory=unavailable),
+    )
+    monkeypatch.setattr(local_server.letters_adapter, "gateway", gateway)
+
+    assert asyncio.run(
+        local_server.generate_reply(letter["letter_id"], letter["content"])
+    )
+    assert letter["letter_status"] == "COMPLETED"
+    assert gateway.messages[-1]["content"] == letter["content"]
 
 
 def test_legacy_import_activates_read_only_library_without_enabling_chat_memory(tmp_path, monkeypatch) -> None:

--- a/tests/memory/test_memory_prompt_mem0_wiring.py
+++ b/tests/memory/test_memory_prompt_mem0_wiring.py
@@ -18,6 +18,9 @@ NOW = datetime(2026, 8, 23, 4, 30, tzinfo=timezone.utc)
 class ArchiveMemory:
     enabled = True
 
+    def __init__(self, *, source_id: str = "legacy-1") -> None:
+        self.source_id = source_id
+
     def status(self):
         return {"status": "available", "enabled": True, "provider": "sqlite"}
 
@@ -41,7 +44,7 @@ class ArchiveMemory:
                 provenance={
                     "domain": LEGACY_LETTERS,
                     "source": "archive",
-                    "source_record_id": "legacy-1",
+                    "source_record_id": self.source_id,
                     "read_only": True,
                 },
             ),
@@ -126,6 +129,20 @@ def test_explicit_none_keeps_internal_builder_from_recursively_loading_mem0(monk
 
     assert "旧 SQLite 当前事实" in prompt.text
     assert "旧信只读证据" in prompt.text
+
+
+def test_archive_source_id_collision_is_not_filtered_by_current_selector() -> None:
+    prompt = MemoryPromptBuilder(
+        ArchiveMemory(source_id="reply:letter-1:1"),
+        conversation_memory=None,
+    ).build(
+        "东京",
+        max_chars=2400,
+        exclude_source_ids=("reply:letter-1:1",),
+    )
+
+    assert "旧信只读证据" in prompt.text
+    assert any(record.domain == LEGACY_LETTERS for record in prompt.references)
 
 
 def test_configured_but_unavailable_mem0_does_not_restore_stale_sqlite_current_facts() -> None:

--- a/tests/persona/test_reply_pipeline.py
+++ b/tests/persona/test_reply_pipeline.py
@@ -5,7 +5,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from llm_gateway import GatewayResponse
+from conversation_memory_port import ConversationMemoryRecord, ConversationMemoryStatus
+from llm_gateway import GatewayConfig, GatewayResponse
 from memory_port import NullMemoryPort
 from memory_prompt import MemoryPromptBuilder
 from reply_context import ReplyContext, ReplyMode, TrustedTime
@@ -159,6 +160,33 @@ class CompatibilityBridge:
         )
 
 
+class SourceAwareConversationMemory:
+    enabled = True
+
+    def __init__(self) -> None:
+        self.config = SimpleNamespace(user_id="local-user")
+
+    def status(self) -> ConversationMemoryStatus:
+        return ConversationMemoryStatus("available", True, "mem0", "synthetic")
+
+    def search_context(self, query, *, user_id, limit):
+        del query
+        return (
+            ConversationMemoryRecord(
+                memory_id="memory.current",
+                text="same synthetic memory text",
+                user_id=user_id,
+                source_id="reply:current-letter:1",
+            ),
+            ConversationMemoryRecord(
+                memory_id="memory.older",
+                text="same synthetic memory text",
+                user_id=user_id,
+                source_id="reply:older-letter:1",
+            ),
+        )[:limit]
+
+
 @pytest.mark.parametrize(
     ("mode", "style_id"),
     [
@@ -212,6 +240,51 @@ def test_generation_receives_the_same_mode_context_as_quality_gate(
     assert f'"mode":"{mode.value}"' in system
     assert style_id in system
     assert "林离 Olivia" in system
+
+
+def test_configured_persona_v2_preparation_excludes_current_memory_source() -> None:
+    """Release-default Persona v2 must use the production source selector."""
+
+    import local_server
+
+    memory = SourceAwareConversationMemory()
+    provider = RecordingProvider()
+    adapter = local_server.LetterAdapter(
+        GatewayConfig(
+            provider="openai_compatible",
+            base_url="http://127.0.0.1:9/v1",
+            model="synthetic",
+            persona_v2_enabled=True,
+        ),
+        memory_port=NullMemoryPort(),
+        conversation_memory=memory,
+    )
+    adapter.gateway = provider
+    pipeline = ReplyPipeline(
+        ReplyOrchestrator(CompatibilityBridge(adapter), timeout_seconds=1),  # type: ignore[arg-type]
+        reviewer=NullReviewer(),
+        rewriter=UnavailableRewriter(),
+    )
+    token = local_server._CURRENT_LETTER_MEMORY_SOURCE.set(
+        "reply:current-letter:1"
+    )
+    try:
+        result = asyncio.run(
+            pipeline.run(
+                ReplyRequest(
+                    content="synthetic current letter",
+                    request_id="current-letter-request",
+                ),
+                _context(),
+            )
+        )
+    finally:
+        local_server._CURRENT_LETTER_MEMORY_SOURCE.reset(token)
+
+    assert result.state is ReplyState.COMPLETED
+    rendered = "\n".join(message["content"] for message in provider.messages)
+    assert "reply:current-letter:1" not in rendered
+    assert "reply:older-letter:1" in rendered
 
 
 class FakeTriage:


### PR DESCRIPTION
## Scope

Production letter generation now passes the exact current `reply:<letter_id>:<revision>` source identity to memory retrieval, excluding only that identity. An older memory with identical text and a different source remains eligible.

## Verification

- RED: production source exclusion test failed before the change because the current source was rendered.
- GREEN: `python -m pytest -q tests/llm/test_b04_memory_integration.py tests/memory/test_companion_memory_context.py tests/memory/test_memory_prompt_mem0_wiring.py` (18 passed)
- `git diff --check` passed.

## Boundaries

No Persona facts, five-layer review count, 1200-character constraint, canonical single commit, media, Archive ownership, or PrivateWorld behavior changed. Mem0 unavailability continues to permit normal letter-body generation.