### PR TITLE
feat(memory): add explicit embedding install in settings

### DIFF
--- a/contracts/original_client_memory_lifecycle.schema.json
+++ b/contracts/original_client_memory_lifecycle.schema.json
@@ -31,8 +31,7 @@
       "properties": {
         "state": {"enum": ["available", "degraded", "unavailable", "disabled"]},
         "reason_code": {"$ref": "#/$defs/reason_code"},
-        "count": {"type": "integer", "minimum": 0},
-        "embedding": {"$ref": "#/$defs/embedding"}
+        "count": {"type": "integer", "minimum": 0}
       }
     },
     "embedding": {
@@ -45,8 +44,16 @@
       }
     },
     "memory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state"],
+      "properties": {
+        "state": {"enum": ["available", "degraded", "unavailable", "disabled"]},
+        "reason_code": {"$ref": "#/$defs/reason_code"},
+        "count": {"type": "integer", "minimum": 0},
+        "embedding": {"$ref": "#/$defs/embedding"}
+      },
       "allOf": [
-        {"$ref": "#/$defs/capability"},
         {
           "if": {"properties": {"reason_code": {"const": "MEMORY_ADMIN_PAUSED"}}, "required": ["reason_code"]},
           "then": {"properties": {"state": {"const": "degraded"}}}

--- a/contracts/original_client_memory_lifecycle.schema.json
+++ b/contracts/original_client_memory_lifecycle.schema.json
@@ -31,7 +31,17 @@
       "properties": {
         "state": {"enum": ["available", "degraded", "unavailable", "disabled"]},
         "reason_code": {"$ref": "#/$defs/reason_code"},
-        "count": {"type": "integer", "minimum": 0}
+        "count": {"type": "integer", "minimum": 0},
+        "embedding": {"$ref": "#/$defs/embedding"}
+      }
+    },
+    "embedding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state"],
+      "properties": {
+        "state": {"enum": ["missing", "installing", "ready", "error"]},
+        "reason_code": {"$ref": "#/$defs/reason_code"}
       }
     },
     "memory": {

--- a/docs/P03_ORIGINAL_CLIENT_MEMORY_LIFECYCLE.md
+++ b/docs/P03_ORIGINAL_CLIENT_MEMORY_LIFECYCLE.md
@@ -6,11 +6,26 @@ operations:
 
 - `/toy/companion/memory/pause`
 - `/toy/companion/memory/resume`
+- `/toy/companion/memory/embedding/install`
 
-Both use the existing `p03.original-companion-mutation.v1` envelope, require a
-loopback origin and `X-Olivia-Companion-Action: confirmed`, and are idempotent
-by request ID. There is no clear operation in this contract; data deletion is a
-separate, independently reviewable change.
+All use the existing `p03.original-companion-mutation.v1` envelope and require
+a loopback origin plus `X-Olivia-Companion-Action: confirmed`. Pause and resume
+are idempotent by request ID; embedding installation is single-flight per cache
+and returns `NOOP` after verified readiness. There is no clear operation in this
+contract; data deletion is a separate, independently reviewable change.
+
+## Explicit embedding installation
+
+When the existing Mem0 runtime reports `MEM0_EMBEDDING_CACHE_UNAVAILABLE`, the
+same original Settings memory panel shows the concise `安装 Embedding` action.
+Only this confirmed action may contact Hugging Face, anonymously and without an
+API key. It downloads the fixed `BAAI/bge-small-zh-v1.5` revision
+`7999e1d3359715c523056ef9478215996d62a620` into a staging directory, calculates
+the existing manifest's per-file SHA-256 values, verifies the exact snapshot
+contract, and promotes it only after verification. Any download, hash, or
+promotion failure is path-free, leaves no READY cache, cleans staging, and can
+be retried. The installed runtime still passes `local_files_only=True`; a
+subsequent local service start reuses the verified cache offline.
 
 ## Pause and resume boundary
 

--- a/docs/P03_ORIGINAL_CLIENT_MEMORY_LIFECYCLE.md
+++ b/docs/P03_ORIGINAL_CLIENT_MEMORY_LIFECYCLE.md
@@ -27,6 +27,14 @@ promotion failure is path-free, leaves no READY cache, cleans staging, and can
 be retried. The installed runtime still passes `local_files_only=True`; a
 subsequent local service start reuses the verified cache offline.
 
+The confirmed mutation starts the single background job and returns promptly;
+it does not use the ordinary short mutation timeout as a download deadline.
+`/toy/companion/status` exposes the shared embedding state as `missing`,
+`installing`, `ready`, or `error` under `capabilities.memory.embedding`. The
+same Settings panel polls that read state while installing, then shows either a
+retryable error or the offline-ready restart instruction. A ready embedding does
+not by itself claim that the already-started Mem0 runtime is ready.
+
 ## Pause and resume boundary
 
 `pause` persists its state in the existing memory-admin audit SQLite file. The

--- a/docs/P03_ORIGINAL_CLIENT_MEMORY_LIFECYCLE.md
+++ b/docs/P03_ORIGINAL_CLIENT_MEMORY_LIFECYCLE.md
@@ -23,9 +23,12 @@ API key. It downloads the fixed `BAAI/bge-small-zh-v1.5` revision
 `7999e1d3359715c523056ef9478215996d62a620` into a staging directory, calculates
 the existing manifest's per-file SHA-256 values, verifies the exact snapshot
 contract, and promotes it only after verification. Any download, hash, or
-promotion failure is path-free, leaves no READY cache, cleans staging, and can
-be retried. The installed runtime still passes `local_files_only=True`; a
-subsequent local service start reuses the verified cache offline.
+ordinary promotion failure is path-free, leaves no READY cache, cleans staging,
+and can be retried. The sole exception is a pre-commit rollback restore failure:
+it returns the stable rejected result without claiming READY and retains the
+recoverable staging/backup for diagnosis or recovery. The installed runtime
+still passes `local_files_only=True`; a subsequent local service start reuses
+the verified cache offline.
 
 The confirmed mutation starts the single background job and returns promptly;
 it does not use the ordinary short mutation timeout as a download deadline.

--- a/mem0_embedding_install.py
+++ b/mem0_embedding_install.py
@@ -90,7 +90,6 @@ class HuggingFaceEmbeddingDownloader:
             filename=relative_path,
             revision=revision,
             local_dir=str(local_root),
-            local_dir_use_symlinks=False,
             token=False,
         )
         fetched_path = Path(fetched)
@@ -148,6 +147,7 @@ class Mem0EmbeddingInstaller:
         self.expected_hashes = expected_hashes
         self._state = EmbeddingInstallState(EmbeddingInstallStatus.MISSING)
         self._state_lock = threading.Lock()
+        self._thread: threading.Thread | None = None
 
     def status(self) -> EmbeddingInstallState:
         if verified_embedding_cache(self.config):
@@ -182,6 +182,25 @@ class Mem0EmbeddingInstaller:
                 shutil.rmtree(stage_root, ignore_errors=True)
             self._set_state(EmbeddingInstallStatus.READY)
             return EmbeddingInstallResult("APPLIED")
+
+    def start(self) -> EmbeddingInstallResult:
+        """Begin one background installation and return without waiting for I/O."""
+
+        if verified_embedding_cache(self.config):
+            self._set_state(EmbeddingInstallStatus.READY)
+            return EmbeddingInstallResult("NOOP")
+        with self._state_lock:
+            if self._state.state is EmbeddingInstallStatus.INSTALLING:
+                return EmbeddingInstallResult("APPLIED")
+            self._state = EmbeddingInstallState(EmbeddingInstallStatus.INSTALLING)
+            worker = threading.Thread(
+                target=self.install,
+                name="olivia-mem0-embedding-install",
+                daemon=True,
+            )
+            self._thread = worker
+            worker.start()
+        return EmbeddingInstallResult("APPLIED")
 
     def _download_and_hash(self, staged: Mem0Config) -> dict[str, str]:
         hashes: dict[str, str] = {}
@@ -219,16 +238,57 @@ class Mem0EmbeddingInstaller:
 
     def _promote(self, stage_root: Path, staged: Mem0Config) -> None:
         target = self.config.embedding_snapshot
-        if target.exists():
-            shutil.rmtree(target)
+        manifest = self.config.model_cache / _MANIFEST_NAME
+        target_backup = stage_root / "rollback-model"
+        manifest_backup = stage_root / "rollback-manifest.json"
         target.parent.mkdir(parents=True, exist_ok=True)
-        os.replace(staged.embedding_snapshot, target)
-        os.replace(stage_root / _MANIFEST_NAME, self.config.model_cache / _MANIFEST_NAME)
+        try:
+            if target.exists():
+                os.replace(target, target_backup)
+            if manifest.exists():
+                os.replace(manifest, manifest_backup)
+            os.replace(staged.embedding_snapshot, target)
+            os.replace(stage_root / _MANIFEST_NAME, manifest)
+        except OSError:
+            self._rollback_promotion(
+                target=target,
+                manifest=manifest,
+                target_backup=target_backup,
+                manifest_backup=manifest_backup,
+            )
+            raise
 
-    def _set_state(self, state: EmbeddingInstallStatus, reason_code: str | None = None) -> None:
+    @staticmethod
+    def _rollback_promotion(
+        *,
+        target: Path,
+        manifest: Path,
+        target_backup: Path,
+        manifest_backup: Path,
+    ) -> None:
+        _remove_path(target)
+        _remove_path(manifest)
+        try:
+            if target_backup.exists():
+                os.replace(target_backup, target)
+            if manifest_backup.exists():
+                os.replace(manifest_backup, manifest)
+        except OSError:
+            _remove_path(target)
+            _remove_path(manifest)
+
+    def _set_state(
+        self, state: EmbeddingInstallStatus, reason_code: str | None = None
+    ) -> None:
         with self._state_lock:
             self._state = EmbeddingInstallState(state, reason_code)
 
+
+def _remove_path(path: Path) -> None:
+    if path.is_dir():
+        shutil.rmtree(path, ignore_errors=True)
+    else:
+        path.unlink(missing_ok=True)
 
 class _InstallFailure(RuntimeError):
     def __init__(self, code: str) -> None:

--- a/mem0_embedding_install.py
+++ b/mem0_embedding_install.py
@@ -57,6 +57,18 @@ class EmbeddingInstallResult:
             raise ValueError("embedding install result reason is invalid")
 
 
+@dataclass
+class _PromotionState:
+    target: Path
+    manifest: Path
+    target_backup: Path
+    manifest_backup: Path
+    snapshot_backed_up: bool = False
+    manifest_backed_up: bool = False
+    snapshot_promoted: bool = False
+    manifest_promoted: bool = False
+
+
 class EmbeddingDownloader(Protocol):
     def download(
         self,
@@ -163,19 +175,25 @@ class Mem0EmbeddingInstaller:
                 return EmbeddingInstallResult("NOOP")
             self._set_state(EmbeddingInstallStatus.INSTALLING)
             stage_root = self.config.model_cache / f"{_STAGE_PREFIX}{uuid.uuid4().hex}"
+            promotion: _PromotionState | None = None
             try:
                 staged = _stage_config(self.config, stage_root)
                 hashes = self._download_and_hash(staged)
                 self._write_manifest(stage_root, hashes)
                 if not verified_embedding_cache(staged):
                     raise _InstallFailure("MEM0_EMBEDDING_VERIFICATION_FAILED")
-                self._promote(stage_root, staged)
+                promotion = self._promote(stage_root, staged)
                 if not verified_embedding_cache(self.config):
                     raise _InstallFailure("MEM0_EMBEDDING_VERIFICATION_FAILED")
+                self._complete_promotion(promotion)
             except _InstallFailure as exc:
+                if promotion is not None:
+                    self._rollback_promotion(promotion)
                 self._set_state(EmbeddingInstallStatus.ERROR, exc.code)
                 return EmbeddingInstallResult("REJECTED", exc.code)
             except (OSError, RuntimeError, TypeError, ValueError):
+                if promotion is not None:
+                    self._rollback_promotion(promotion)
                 self._set_state(EmbeddingInstallStatus.ERROR, "MEM0_EMBEDDING_INSTALL_FAILED")
                 return EmbeddingInstallResult("REJECTED", "MEM0_EMBEDDING_INSTALL_FAILED")
             finally:
@@ -236,46 +254,51 @@ class Mem0EmbeddingInstaller:
             encoding="utf-8",
         )
 
-    def _promote(self, stage_root: Path, staged: Mem0Config) -> None:
-        target = self.config.embedding_snapshot
-        manifest = self.config.model_cache / _MANIFEST_NAME
-        target_backup = stage_root / "rollback-model"
-        manifest_backup = stage_root / "rollback-manifest.json"
-        target.parent.mkdir(parents=True, exist_ok=True)
+    def _promote(self, stage_root: Path, staged: Mem0Config) -> _PromotionState:
+        promotion = _PromotionState(
+            target=self.config.embedding_snapshot,
+            manifest=self.config.model_cache / _MANIFEST_NAME,
+            target_backup=stage_root / "rollback-model",
+            manifest_backup=stage_root / "rollback-manifest.json",
+        )
+        promotion.target.parent.mkdir(parents=True, exist_ok=True)
         try:
-            if target.exists():
-                os.replace(target, target_backup)
-            if manifest.exists():
-                os.replace(manifest, manifest_backup)
-            os.replace(staged.embedding_snapshot, target)
-            os.replace(stage_root / _MANIFEST_NAME, manifest)
+            if promotion.target.exists():
+                os.replace(promotion.target, promotion.target_backup)
+                promotion.snapshot_backed_up = True
+            if promotion.manifest.exists():
+                os.replace(promotion.manifest, promotion.manifest_backup)
+                promotion.manifest_backed_up = True
+            os.replace(staged.embedding_snapshot, promotion.target)
+            promotion.snapshot_promoted = True
+            os.replace(stage_root / _MANIFEST_NAME, promotion.manifest)
+            promotion.manifest_promoted = True
         except OSError:
-            self._rollback_promotion(
-                target=target,
-                manifest=manifest,
-                target_backup=target_backup,
-                manifest_backup=manifest_backup,
-            )
+            self._rollback_promotion(promotion)
             raise
+        return promotion
 
     @staticmethod
-    def _rollback_promotion(
-        *,
-        target: Path,
-        manifest: Path,
-        target_backup: Path,
-        manifest_backup: Path,
-    ) -> None:
-        _remove_path(target)
-        _remove_path(manifest)
-        try:
-            if target_backup.exists():
-                os.replace(target_backup, target)
-            if manifest_backup.exists():
-                os.replace(manifest_backup, manifest)
-        except OSError:
-            _remove_path(target)
-            _remove_path(manifest)
+    def _complete_promotion(promotion: _PromotionState) -> None:
+        _remove_path(promotion.target_backup)
+        _remove_path(promotion.manifest_backup)
+
+    @staticmethod
+    def _rollback_promotion(promotion: _PromotionState) -> None:
+        if promotion.snapshot_promoted:
+            _remove_path(promotion.target)
+        if promotion.manifest_promoted:
+            _remove_path(promotion.manifest)
+        if promotion.snapshot_backed_up and promotion.target_backup.exists():
+            try:
+                os.replace(promotion.target_backup, promotion.target)
+            except OSError:
+                _remove_path(promotion.target)
+        if promotion.manifest_backed_up and promotion.manifest_backup.exists():
+            try:
+                os.replace(promotion.manifest_backup, promotion.manifest)
+            except OSError:
+                _remove_path(promotion.manifest)
 
     def _set_state(
         self, state: EmbeddingInstallStatus, reason_code: str | None = None

--- a/mem0_embedding_install.py
+++ b/mem0_embedding_install.py
@@ -61,6 +61,7 @@ class EmbeddingInstallResult:
 class _PromotionState:
     target: Path
     manifest: Path
+    staged_manifest: Path
     target_backup: Path
     manifest_backup: Path
     snapshot_backed_up: bool = False
@@ -176,28 +177,33 @@ class Mem0EmbeddingInstaller:
             self._set_state(EmbeddingInstallStatus.INSTALLING)
             stage_root = self.config.model_cache / f"{_STAGE_PREFIX}{uuid.uuid4().hex}"
             promotion: _PromotionState | None = None
+            committed = False
+            preserve_stage = False
             try:
                 staged = _stage_config(self.config, stage_root)
                 hashes = self._download_and_hash(staged)
                 self._write_manifest(stage_root, hashes)
                 if not verified_embedding_cache(staged):
                     raise _InstallFailure("MEM0_EMBEDDING_VERIFICATION_FAILED")
-                promotion = self._promote(stage_root, staged)
+                promotion = self._new_promotion(stage_root)
+                self._promote(promotion, staged)
                 if not verified_embedding_cache(self.config):
                     raise _InstallFailure("MEM0_EMBEDDING_VERIFICATION_FAILED")
+                committed = True
                 self._complete_promotion(promotion)
             except _InstallFailure as exc:
-                if promotion is not None:
-                    self._rollback_promotion(promotion)
+                if promotion is not None and not committed:
+                    preserve_stage = not self._rollback_promotion(promotion)
                 self._set_state(EmbeddingInstallStatus.ERROR, exc.code)
                 return EmbeddingInstallResult("REJECTED", exc.code)
             except (OSError, RuntimeError, TypeError, ValueError):
-                if promotion is not None:
-                    self._rollback_promotion(promotion)
+                if promotion is not None and not committed:
+                    preserve_stage = not self._rollback_promotion(promotion)
                 self._set_state(EmbeddingInstallStatus.ERROR, "MEM0_EMBEDDING_INSTALL_FAILED")
                 return EmbeddingInstallResult("REJECTED", "MEM0_EMBEDDING_INSTALL_FAILED")
             finally:
-                shutil.rmtree(stage_root, ignore_errors=True)
+                if not preserve_stage:
+                    shutil.rmtree(stage_root, ignore_errors=True)
             self._set_state(EmbeddingInstallStatus.READY)
             return EmbeddingInstallResult("APPLIED")
 
@@ -254,37 +260,40 @@ class Mem0EmbeddingInstaller:
             encoding="utf-8",
         )
 
-    def _promote(self, stage_root: Path, staged: Mem0Config) -> _PromotionState:
-        promotion = _PromotionState(
+    def _new_promotion(self, stage_root: Path) -> _PromotionState:
+        return _PromotionState(
             target=self.config.embedding_snapshot,
             manifest=self.config.model_cache / _MANIFEST_NAME,
+            staged_manifest=stage_root / _MANIFEST_NAME,
             target_backup=stage_root / "rollback-model",
             manifest_backup=stage_root / "rollback-manifest.json",
         )
+
+    @staticmethod
+    def _promote(promotion: _PromotionState, staged: Mem0Config) -> None:
         promotion.target.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            if promotion.target.exists():
-                os.replace(promotion.target, promotion.target_backup)
-                promotion.snapshot_backed_up = True
-            if promotion.manifest.exists():
-                os.replace(promotion.manifest, promotion.manifest_backup)
-                promotion.manifest_backed_up = True
-            os.replace(staged.embedding_snapshot, promotion.target)
-            promotion.snapshot_promoted = True
-            os.replace(stage_root / _MANIFEST_NAME, promotion.manifest)
-            promotion.manifest_promoted = True
-        except OSError:
-            self._rollback_promotion(promotion)
-            raise
-        return promotion
+        if promotion.target.exists():
+            os.replace(promotion.target, promotion.target_backup)
+            promotion.snapshot_backed_up = True
+        if promotion.manifest.exists():
+            os.replace(promotion.manifest, promotion.manifest_backup)
+            promotion.manifest_backed_up = True
+        os.replace(staged.embedding_snapshot, promotion.target)
+        promotion.snapshot_promoted = True
+        os.replace(promotion.staged_manifest, promotion.manifest)
+        promotion.manifest_promoted = True
 
     @staticmethod
     def _complete_promotion(promotion: _PromotionState) -> None:
-        _remove_path(promotion.target_backup)
-        _remove_path(promotion.manifest_backup)
+        for backup in (promotion.target_backup, promotion.manifest_backup):
+            try:
+                _remove_path(backup)
+            except Exception:
+                pass
 
     @staticmethod
-    def _rollback_promotion(promotion: _PromotionState) -> None:
+    def _rollback_promotion(promotion: _PromotionState) -> bool:
+        restore_failed = False
         if promotion.snapshot_promoted:
             _remove_path(promotion.target)
         if promotion.manifest_promoted:
@@ -294,11 +303,14 @@ class Mem0EmbeddingInstaller:
                 os.replace(promotion.target_backup, promotion.target)
             except OSError:
                 _remove_path(promotion.target)
+                restore_failed = True
         if promotion.manifest_backed_up and promotion.manifest_backup.exists():
             try:
                 os.replace(promotion.manifest_backup, promotion.manifest)
             except OSError:
                 _remove_path(promotion.manifest)
+                restore_failed = True
+        return not restore_failed
 
     def _set_state(
         self, state: EmbeddingInstallStatus, reason_code: str | None = None

--- a/mem0_embedding_install.py
+++ b/mem0_embedding_install.py
@@ -1,0 +1,253 @@
+"""Explicit, verified installation of the optional local Mem0 embedding.
+
+The running Mem0 adapter remains offline-only.  This module is the one narrow
+place allowed to download the pinned public model after a user confirms the
+action in the original Olivia Settings surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import threading
+import uuid
+from typing import Protocol
+
+from mem0_memory import (
+    MEM0_EMBEDDING_MODEL,
+    MEM0_EMBEDDING_MODEL_REVISION,
+    Mem0Config,
+    verified_embedding_cache,
+)
+
+
+_MANIFEST_NAME = "olivia-mem0-embedding-manifest.json"
+_STAGE_PREFIX = ".olivia-mem0-embedding-stage-"
+_INSTALL_LOCKS: dict[str, threading.Lock] = {}
+_INSTALL_LOCKS_GUARD = threading.Lock()
+
+
+class EmbeddingInstallStatus(StrEnum):
+    MISSING = "missing"
+    INSTALLING = "installing"
+    READY = "ready"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class EmbeddingInstallState:
+    state: EmbeddingInstallStatus
+    reason_code: str | None = None
+
+
+@dataclass(frozen=True)
+class EmbeddingInstallResult:
+    status: str
+    reason_code: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status not in {"APPLIED", "NOOP", "REJECTED"}:
+            raise ValueError("embedding install result status is invalid")
+        if self.reason_code is not None and not self.reason_code.startswith("MEM0_"):
+            raise ValueError("embedding install result reason is invalid")
+
+
+class EmbeddingDownloader(Protocol):
+    def download(
+        self,
+        *,
+        revision: str,
+        relative_path: str,
+        destination: Path,
+    ) -> None: ...
+
+
+class HuggingFaceEmbeddingDownloader:
+    """Anonymous per-file downloader used only after explicit confirmation."""
+
+    def download(
+        self,
+        *,
+        revision: str,
+        relative_path: str,
+        destination: Path,
+    ) -> None:
+        try:
+            from huggingface_hub import hf_hub_download
+        except ImportError as exc:
+            raise RuntimeError("MEM0_EMBEDDING_DOWNLOADER_UNAVAILABLE") from exc
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        local_root = destination
+        for _ in relative_path.split("/"):
+            local_root = local_root.parent
+        fetched = hf_hub_download(
+            repo_id=MEM0_EMBEDDING_MODEL,
+            filename=relative_path,
+            revision=revision,
+            local_dir=str(local_root),
+            local_dir_use_symlinks=False,
+            token=False,
+        )
+        fetched_path = Path(fetched)
+        if fetched_path.resolve() != destination.resolve():
+            shutil.copyfile(fetched_path, destination)
+
+
+def _install_lock(cache_root: Path) -> threading.Lock:
+    key = str(cache_root.resolve()).casefold()
+    with _INSTALL_LOCKS_GUARD:
+        return _INSTALL_LOCKS.setdefault(key, threading.Lock())
+
+
+def _stage_config(config: Mem0Config, stage_root: Path) -> Mem0Config:
+    return Mem0Config(
+        enabled=config.enabled,
+        data_root=config.data_root,
+        user_id=config.user_id,
+        agent_id=config.agent_id,
+        collection_name=config.collection_name,
+        llm_base_url=config.llm_base_url,
+        llm_model=config.llm_model,
+        llm_api_key_env=config.llm_api_key_env,
+        embedding_model=config.embedding_model,
+        embedding_dims=config.embedding_dims,
+        embedding_cache=stage_root,
+        context_max_chars=config.context_max_chars,
+        config_error=config.config_error,
+        write_timeout_seconds=config.write_timeout_seconds,
+        search_timeout_seconds=config.search_timeout_seconds,
+        outbox_data_root=config.outbox_data_root,
+        outbox_enabled=config.outbox_enabled,
+        outbox_interval_seconds=config.outbox_interval_seconds,
+    )
+
+
+class Mem0EmbeddingInstaller:
+    """Install exactly one pinned embedding into the existing cache contract."""
+
+    def __init__(
+        self,
+        config: Mem0Config,
+        *,
+        downloader: EmbeddingDownloader | None = None,
+        expected_hashes: dict[str, str] | None = None,
+    ) -> None:
+        if not isinstance(config, Mem0Config):
+            raise TypeError("a Mem0 config is required")
+        if config.embedding_model != MEM0_EMBEDDING_MODEL:
+            raise ValueError("the pinned embedding model is required")
+        if expected_hashes is not None and set(expected_hashes) != set(_snapshot_files()):
+            raise ValueError("expected embedding hashes are incomplete")
+        self.config = config
+        self.downloader = downloader or HuggingFaceEmbeddingDownloader()
+        self.expected_hashes = expected_hashes
+        self._state = EmbeddingInstallState(EmbeddingInstallStatus.MISSING)
+        self._state_lock = threading.Lock()
+
+    def status(self) -> EmbeddingInstallState:
+        if verified_embedding_cache(self.config):
+            return EmbeddingInstallState(EmbeddingInstallStatus.READY)
+        with self._state_lock:
+            return self._state
+
+    def install(self) -> EmbeddingInstallResult:
+        lock = _install_lock(self.config.model_cache)
+        with lock:
+            if verified_embedding_cache(self.config):
+                self._set_state(EmbeddingInstallStatus.READY)
+                return EmbeddingInstallResult("NOOP")
+            self._set_state(EmbeddingInstallStatus.INSTALLING)
+            stage_root = self.config.model_cache / f"{_STAGE_PREFIX}{uuid.uuid4().hex}"
+            try:
+                staged = _stage_config(self.config, stage_root)
+                hashes = self._download_and_hash(staged)
+                self._write_manifest(stage_root, hashes)
+                if not verified_embedding_cache(staged):
+                    raise _InstallFailure("MEM0_EMBEDDING_VERIFICATION_FAILED")
+                self._promote(stage_root, staged)
+                if not verified_embedding_cache(self.config):
+                    raise _InstallFailure("MEM0_EMBEDDING_VERIFICATION_FAILED")
+            except _InstallFailure as exc:
+                self._set_state(EmbeddingInstallStatus.ERROR, exc.code)
+                return EmbeddingInstallResult("REJECTED", exc.code)
+            except (OSError, RuntimeError, TypeError, ValueError):
+                self._set_state(EmbeddingInstallStatus.ERROR, "MEM0_EMBEDDING_INSTALL_FAILED")
+                return EmbeddingInstallResult("REJECTED", "MEM0_EMBEDDING_INSTALL_FAILED")
+            finally:
+                shutil.rmtree(stage_root, ignore_errors=True)
+            self._set_state(EmbeddingInstallStatus.READY)
+            return EmbeddingInstallResult("APPLIED")
+
+    def _download_and_hash(self, staged: Mem0Config) -> dict[str, str]:
+        hashes: dict[str, str] = {}
+        for relative_path in sorted(_snapshot_files()):
+            destination = staged.embedding_snapshot.joinpath(*relative_path.split("/"))
+            self.downloader.download(
+                revision=MEM0_EMBEDDING_MODEL_REVISION,
+                relative_path=relative_path,
+                destination=destination,
+            )
+            try:
+                with destination.open("rb") as handle:
+                    digest = hashlib.file_digest(handle, "sha256").hexdigest()
+            except OSError as exc:
+                raise _InstallFailure("MEM0_EMBEDDING_INSTALL_FAILED") from exc
+            expected = self.expected_hashes.get(relative_path) if self.expected_hashes else None
+            if expected is not None and digest != expected:
+                raise _InstallFailure("MEM0_EMBEDDING_HASH_MISMATCH")
+            hashes[relative_path] = digest
+        return hashes
+
+    def _write_manifest(self, stage_root: Path, hashes: dict[str, str]) -> None:
+        (stage_root / _MANIFEST_NAME).write_text(
+            json.dumps(
+                {
+                    "model": MEM0_EMBEDDING_MODEL,
+                    "revision": MEM0_EMBEDDING_MODEL_REVISION,
+                    "files": hashes,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            encoding="utf-8",
+        )
+
+    def _promote(self, stage_root: Path, staged: Mem0Config) -> None:
+        target = self.config.embedding_snapshot
+        if target.exists():
+            shutil.rmtree(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(staged.embedding_snapshot, target)
+        os.replace(stage_root / _MANIFEST_NAME, self.config.model_cache / _MANIFEST_NAME)
+
+    def _set_state(self, state: EmbeddingInstallStatus, reason_code: str | None = None) -> None:
+        with self._state_lock:
+            self._state = EmbeddingInstallState(state, reason_code)
+
+
+class _InstallFailure(RuntimeError):
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def _snapshot_files() -> frozenset[str]:
+    # Kept in one place: this is the exact #127 file/manifest contract.
+    from mem0_memory import embedding_snapshot_files
+
+    return embedding_snapshot_files()
+
+
+__all__ = [
+    "EmbeddingDownloader",
+    "EmbeddingInstallResult",
+    "EmbeddingInstallState",
+    "EmbeddingInstallStatus",
+    "HuggingFaceEmbeddingDownloader",
+    "Mem0EmbeddingInstaller",
+]

--- a/mem0_memory.py
+++ b/mem0_memory.py
@@ -259,7 +259,13 @@ def _duration(value: object, default: float, *, maximum: float = 300.0) -> float
     return parsed if 0.1 <= parsed <= maximum else default
 
 
-def _verified_embedding_cache(config: Mem0Config) -> bool:
+def embedding_snapshot_files() -> frozenset[str]:
+    """Return the one pinned model file set shared by verifier and installer."""
+
+    return _EMBEDDING_SNAPSHOT_FILES
+
+
+def verified_embedding_cache(config: Mem0Config) -> bool:
     """Accept only the pinned, manifest-verified local embedding files."""
 
     if config.embedding_model != MEM0_EMBEDDING_MODEL:
@@ -1018,7 +1024,7 @@ def create_mem0_adapter(
         return UnavailableConversationMemoryPort(active.config_error, config=active)
     if not active.enabled:
         return NullConversationMemoryPort()
-    if not _verified_embedding_cache(active):
+    if not verified_embedding_cache(active):
         return UnavailableConversationMemoryPort(
             "MEM0_EMBEDDING_CACHE_UNAVAILABLE", config=active
         )
@@ -1046,5 +1052,7 @@ __all__ = [
     "Mem0Config",
     "Mem0ConversationMemoryAdapter",
     "create_mem0_adapter",
+    "embedding_snapshot_files",
     "load_mem0_config",
+    "verified_embedding_cache",
 ]

--- a/original_client_companion_api.py
+++ b/original_client_companion_api.py
@@ -32,6 +32,7 @@ _CODE_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,95}$")
 _LOCAL_ORIGIN_RE = re.compile(r"^http://(?:127\.0\.0\.1|localhost):[0-9]{1,5}$")
 _LEVELS = frozenset({"unknown", "low", "medium", "high"})
 _CAPABILITY_STATES = frozenset({"available", "degraded", "unavailable", "disabled"})
+_EMBEDDING_INSTALL_STATES = frozenset({"missing", "installing", "ready", "error"})
 _AWARENESS = frozenset({"control_only", "pending", "character_known"})
 _HOME_ACCESS = frozenset({"no_access", "visit_access", "errand_access", "domestic_access"})
 _CANDIDATE_TYPES = frozenset({"boundary_respected", "conflict", "repair"})
@@ -89,10 +90,29 @@ def _timestamp(value: object, *, code: str, optional: bool = False) -> str | Non
 
 
 @dataclass(frozen=True)
+class CompanionEmbeddingInstall:
+    state: str
+    reason_code: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.state not in _EMBEDDING_INSTALL_STATES:
+            raise ValueError("embedding install state is invalid")
+        if self.reason_code is not None and not _CODE_RE.fullmatch(self.reason_code):
+            raise ValueError("embedding install reason is invalid")
+
+    def to_dict(self) -> dict[str, str]:
+        payload = {"state": self.state}
+        if self.reason_code is not None:
+            payload["reason_code"] = self.reason_code
+        return payload
+
+
+@dataclass(frozen=True)
 class CompanionCapability:
     state: str
     reason_code: str | None = None
     count: int | None = None
+    embedding: CompanionEmbeddingInstall | None = None
 
     def __post_init__(self) -> None:
         if self.state not in _CAPABILITY_STATES:
@@ -101,6 +121,10 @@ class CompanionCapability:
             raise ValueError("companion capability reason is invalid")
         if self.count is not None and (type(self.count) is not int or self.count < 0):
             raise ValueError("companion capability count is invalid")
+        if self.embedding is not None and not isinstance(
+            self.embedding, CompanionEmbeddingInstall
+        ):
+            raise ValueError("companion embedding state is invalid")
 
     def to_dict(self) -> dict[str, object]:
         payload: dict[str, object] = {"state": self.state}
@@ -108,6 +132,8 @@ class CompanionCapability:
             payload["reason_code"] = self.reason_code
         if self.count is not None:
             payload["count"] = self.count
+        if self.embedding is not None:
+            payload["embedding"] = self.embedding.to_dict()
         return payload
 
 
@@ -500,6 +526,7 @@ __all__ = [
     "STATUS_PATH",
     "CompanionCandidateSummary",
     "CompanionCapability",
+    "CompanionEmbeddingInstall",
     "CompanionContinuationSummary",
     "CompanionMemorySummary",
     "CompanionPrivateWorldSummary",

--- a/original_client_companion_backend.py
+++ b/original_client_companion_backend.py
@@ -13,9 +13,11 @@ from typing import Protocol, runtime_checkable
 
 from conversation_memory_admin import MemoryAdminStatus
 from conversation_memory_port import ConversationMemoryRecord
+from mem0_embedding_install import EmbeddingInstallState
 from original_client_companion_api import (
     CompanionCandidateSummary,
     CompanionCapability,
+    CompanionEmbeddingInstall,
     CompanionContinuationSummary,
     CompanionMemorySummary,
     CompanionPrivateWorldSummary,
@@ -77,6 +79,11 @@ class CandidateReadPort(Protocol):
     ) -> Sequence[PrivateWorldCandidate]: ...
 
 
+@runtime_checkable
+class EmbeddingInstallReadPort(Protocol):
+    def status(self) -> EmbeddingInstallState: ...
+
+
 def _capability_failure(code: str) -> CompanionCapability:
     return CompanionCapability("unavailable", reason_code=code)
 
@@ -133,18 +140,21 @@ class OriginalClientCompanionServiceBackend(OriginalClientCompanionReadBackend):
         memory_admin: MemoryAdminReadPort | None = None,
         private_world: PrivateWorldReadPort | None = None,
         candidates: CandidateReadPort | None = None,
+        embedding_installer: EmbeddingInstallReadPort | None = None,
         now: Callable[[], datetime] | None = None,
     ) -> None:
         for value, protocol, name in (
             (memory_admin, MemoryAdminReadPort, "memory admin"),
             (private_world, PrivateWorldReadPort, "PrivateWorld read port"),
             (candidates, CandidateReadPort, "candidate read port"),
+            (embedding_installer, EmbeddingInstallReadPort, "embedding installer"),
         ):
             if value is not None and not isinstance(value, protocol):
                 raise TypeError(f"{name} is invalid")
         self._memory_admin = memory_admin
         self._private_world = private_world
         self._candidates = candidates
+        self._embedding_installer = embedding_installer
         self._now = now or (lambda: datetime.now(timezone.utc))
 
     def _memory_status(self) -> CompanionCapability:
@@ -166,9 +176,23 @@ class OriginalClientCompanionServiceBackend(OriginalClientCompanionReadBackend):
                 status.status,
                 reason_code=status.reason_code,
                 count=count,
+                embedding=self._embedding_status(),
             )
         except (OSError, RuntimeError, TypeError, ValueError):
             return _capability_failure("COMPANION_MEMORY_UNAVAILABLE")
+
+    def _embedding_status(self) -> CompanionEmbeddingInstall | None:
+        if self._embedding_installer is None:
+            return None
+        try:
+            state = self._embedding_installer.status()
+            if not isinstance(state, EmbeddingInstallState):
+                raise TypeError("invalid embedding install state")
+            return CompanionEmbeddingInstall(state.state.value, state.reason_code)
+        except (OSError, RuntimeError, TypeError, ValueError):
+            return CompanionEmbeddingInstall(
+                "error", "MEM0_EMBEDDING_STATUS_UNAVAILABLE"
+            )
 
     def _private_world_status(self) -> CompanionCapability:
         if self._private_world is None:
@@ -392,6 +416,7 @@ class OriginalClientCompanionServiceBackend(OriginalClientCompanionReadBackend):
 
 __all__ = [
     "CandidateReadPort",
+    "EmbeddingInstallReadPort",
     "MemoryAdminReadPort",
     "OriginalClientCompanionBackendError",
     "OriginalClientCompanionServiceBackend",

--- a/original_client_companion_mutation_api.py
+++ b/original_client_companion_mutation_api.py
@@ -23,6 +23,7 @@ MEMORY_CORRECT_PATH = "/toy/companion/memory/correct"
 MEMORY_DELETE_PATH = "/toy/companion/memory/delete"
 MEMORY_PAUSE_PATH = "/toy/companion/memory/pause"
 MEMORY_RESUME_PATH = "/toy/companion/memory/resume"
+MEMORY_EMBEDDING_INSTALL_PATH = "/toy/companion/memory/embedding/install"
 CANDIDATE_DECISION_PATH = "/toy/companion/private-world/candidates/{candidate_id}/{decision}"
 CONFIRM_HEADER = "X-Olivia-Companion-Action"
 CONFIRM_VALUE = "confirmed"
@@ -120,6 +121,16 @@ class OriginalClientCompanionMutationBackend(Protocol):
         request_id: str,
         reason: str,
         decided_at: str,
+    ) -> CompanionMutationResult: ...
+
+
+@runtime_checkable
+class EmbeddingInstallMutationBackend(Protocol):
+    def install_embedding(
+        self,
+        *,
+        request_id: str,
+        reason: str,
     ) -> CompanionMutationResult: ...
 
 
@@ -401,6 +412,35 @@ async def _resume_memory(request: web.Request) -> web.Response:
     return await _lifecycle_memory(request, "resume")
 
 
+async def _install_embedding(request: web.Request) -> web.Response:
+    origin: str | None = None
+    try:
+        origin = _authorize(request, require_confirm=True)
+        value = await _body(request, fields=frozenset({"request_id", "reason"}))
+        backend = _backend(request)
+        if not isinstance(backend, EmbeddingInstallMutationBackend):
+            raise OriginalClientCompanionMutationError(
+                "MEM0_EMBEDDING_INSTALL_UNAVAILABLE", status=503
+            )
+        result = await asyncio.to_thread(
+            backend.install_embedding,
+            request_id=_identifier(
+                value["request_id"], code="COMPANION_REQUEST_ID_INVALID", request=True
+            ),
+            reason=_text(value["reason"], maximum=500, code="COMPANION_REASON_INVALID"),
+        )
+        if not isinstance(result, CompanionMutationResult):
+            raise OriginalClientCompanionMutationError("COMPANION_MUTATION_INVALID", status=503)
+        return web.json_response(result.to_dict(), headers=_headers(origin))
+    except OriginalClientCompanionMutationError as exc:
+        return _error(exc, origin)
+    except (OSError, RuntimeError, ValueError, TypeError):
+        return _error(
+            OriginalClientCompanionMutationError("COMPANION_MUTATION_UNAVAILABLE", status=503),
+            origin,
+        )
+
+
 async def _decide_candidate(request: web.Request) -> web.Response:
     origin: str | None = None
     try:
@@ -467,6 +507,7 @@ def mount_original_client_companion_mutation_api(
     for path, handler in (
         (MEMORY_PAUSE_PATH, _pause_memory),
         (MEMORY_RESUME_PATH, _resume_memory),
+        (MEMORY_EMBEDDING_INSTALL_PATH, _install_embedding),
     ):
         app.router.add_post(path, handler)
         app.router.add_options(path, _preflight)
@@ -480,8 +521,10 @@ __all__ = [
     "CONFIRM_HEADER",
     "CONFIRM_VALUE",
     "CompanionMutationResult",
+    "EmbeddingInstallMutationBackend",
     "MEMORY_CORRECT_PATH",
     "MEMORY_DELETE_PATH",
+    "MEMORY_EMBEDDING_INSTALL_PATH",
     "MEMORY_PAUSE_PATH",
     "MEMORY_RESUME_PATH",
     "OriginalClientCompanionMutationBackend",

--- a/original_client_companion_mutation_backend.py
+++ b/original_client_companion_mutation_backend.py
@@ -19,6 +19,7 @@ from conversation_memory_admin import (
     MemoryAdminMutationResult,
     MemoryAdminMutationStatus,
 )
+from mem0_embedding_install import EmbeddingInstallResult
 from original_client_companion_mutation_api import (
     CompanionMutationResult,
     OriginalClientCompanionMutationError,
@@ -51,6 +52,11 @@ class CandidateDecisionService(Protocol):
         self,
         request: CandidateDecisionRequest,
     ) -> CandidateDecisionResult: ...
+
+
+@runtime_checkable
+class EmbeddingInstallService(Protocol):
+    def install(self) -> EmbeddingInstallResult: ...
 
 
 def _memory_error(exc: ConversationMemoryAdminError) -> OriginalClientCompanionMutationError:
@@ -128,6 +134,7 @@ class DirectOriginalClientCompanionMutationBackend:
         *,
         memory_admin: MemoryAdminMutationService | None = None,
         candidate_decisions: CandidateDecisionService | None = None,
+        embedding_installer: EmbeddingInstallService | None = None,
     ) -> None:
         if memory_admin is not None and not isinstance(
             memory_admin,
@@ -139,8 +146,38 @@ class DirectOriginalClientCompanionMutationBackend:
             CandidateDecisionService,
         ):
             raise TypeError("an explicit candidate decision service is required")
+        if embedding_installer is not None and not isinstance(
+            embedding_installer, EmbeddingInstallService
+        ):
+            raise TypeError("an explicit embedding install service is required")
         self.memory_admin = memory_admin
         self.candidate_decisions = candidate_decisions
+        self.embedding_installer = embedding_installer
+
+    def install_embedding(
+        self, *, request_id: str, reason: str
+    ) -> CompanionMutationResult:
+        del reason
+        if self.embedding_installer is None:
+            raise OriginalClientCompanionMutationError(
+                "MEM0_EMBEDDING_INSTALL_DISABLED", status=503
+            )
+        try:
+            result = self.embedding_installer.install()
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            raise OriginalClientCompanionMutationError(
+                "MEM0_EMBEDDING_INSTALL_UNAVAILABLE", status=503
+            ) from exc
+        if not isinstance(result, EmbeddingInstallResult):
+            raise OriginalClientCompanionMutationError(
+                "MEM0_EMBEDDING_INSTALL_UNAVAILABLE", status=503
+            )
+        return CompanionMutationResult(
+            request_id=request_id,
+            status=result.status,
+            affected_count=1 if result.status == "APPLIED" else 0,
+            reason_code=result.reason_code,
+        )
 
     def correct_memory(
         self,
@@ -240,5 +277,6 @@ class DirectOriginalClientCompanionMutationBackend:
 __all__ = [
     "CandidateDecisionService",
     "DirectOriginalClientCompanionMutationBackend",
+    "EmbeddingInstallService",
     "MemoryAdminMutationService",
 ]

--- a/original_client_companion_mutation_backend.py
+++ b/original_client_companion_mutation_backend.py
@@ -56,7 +56,7 @@ class CandidateDecisionService(Protocol):
 
 @runtime_checkable
 class EmbeddingInstallService(Protocol):
-    def install(self) -> EmbeddingInstallResult: ...
+    def start(self) -> EmbeddingInstallResult: ...
 
 
 def _memory_error(exc: ConversationMemoryAdminError) -> OriginalClientCompanionMutationError:
@@ -163,7 +163,7 @@ class DirectOriginalClientCompanionMutationBackend:
                 "MEM0_EMBEDDING_INSTALL_DISABLED", status=503
             )
         try:
-            result = self.embedding_installer.install()
+            result = self.embedding_installer.start()
         except (OSError, RuntimeError, TypeError, ValueError) as exc:
             raise OriginalClientCompanionMutationError(
                 "MEM0_EMBEDDING_INSTALL_UNAVAILABLE", status=503

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -27,6 +27,8 @@ from conversation_memory_admin import (
     ConversationMemoryAdminService,
 )
 from conversation_memory_port import ConversationMemoryPort
+from mem0_embedding_install import Mem0EmbeddingInstaller
+from mem0_memory import Mem0Config
 from original_client_companion_api import mount_original_companion_read_api
 from original_client_companion_backend import (
     OriginalClientCompanionServiceBackend,
@@ -310,6 +312,7 @@ def create_original_client_server_runtime(
     private_world: PrivateWorldPort | None = None,
     candidates: SQLitePrivateWorldCandidateStore | None = None,
     candidate_decisions: CandidateReviewBackend | None = None,
+    embedding_installer: Mem0EmbeddingInstaller | None = None,
     letter_collection: LetterCollection | None = None,
     trusted_origins: Sequence[str] = (),
 ) -> OriginalClientServerRuntime:
@@ -335,6 +338,7 @@ def create_original_client_server_runtime(
     mutation_backend = DirectOriginalClientCompanionMutationBackend(
         memory_admin=mutation_memory,
         candidate_decisions=candidate_decisions,
+        embedding_installer=embedding_installer,
     )
     app = web.Application()
     origins = tuple(trusted_origins)
@@ -478,6 +482,23 @@ def _configured_private_world(
     return port, candidates, candidate_decisions
 
 
+def _configured_embedding_installer(
+    server_module: ModuleType | Any,
+) -> Mem0EmbeddingInstaller | None:
+    builder = getattr(
+        getattr(server_module, "letters_adapter", None),
+        "memory_prompt_builder",
+        None,
+    )
+    config = getattr(getattr(builder, "conversation_memory", None), "config", None)
+    if not isinstance(config, Mem0Config) or not config.enabled:
+        return None
+    try:
+        return Mem0EmbeddingInstaller(config)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+
+
 def create_configured_original_client_server_runtime(
     *,
     server_module: ModuleType | Any | None = None,
@@ -494,6 +515,7 @@ def create_configured_original_client_server_runtime(
         getattr(server_module, "TRUSTED_FRONTEND_ORIGINS", ())
     )
     memory_admin = _configured_memory_admin(server_module, values)
+    embedding_installer = _configured_embedding_installer(server_module)
     private_world, candidates, candidate_decisions = _configured_private_world(
         server_module,
         values,
@@ -505,6 +527,7 @@ def create_configured_original_client_server_runtime(
         private_world=private_world,
         candidates=candidates,
         candidate_decisions=candidate_decisions,
+        embedding_installer=embedding_installer,
         letter_collection=collection if callable(collection) else None,
         trusted_origins=origins,
     )

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -329,6 +329,7 @@ def create_original_client_server_runtime(
         memory_admin=memory_admin,
         private_world=private_read,
         candidates=candidates,
+        embedding_installer=embedding_installer,
     )
     mutation_memory = (
         memory_admin

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -413,9 +413,19 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     if (state === "disabled" || state === "unavailable") {
       if (state === "unavailable" && capability && capability.reason_code === "MEM0_EMBEDDING_CACHE_UNAVAILABLE") {
         const heading = text("h3", "长期记忆", "text-text-title text-title-m");
+        const embedding = capability.embedding && typeof capability.embedding === "object"
+          ? capability.embedding
+          : { state: "missing" };
+        const installState = typeof embedding.state === "string" ? embedding.state : "error";
         const summary = text(
           "p",
-          "Embedding 尚未安装，长期记忆暂不可用。",
+          installState === "ready"
+            ? "Embedding 已就绪。重启本机服务后，长期记忆会离线运行。"
+            : installState === "installing"
+            ? "正在安装 Embedding，请保持此页面打开。"
+            : installState === "error"
+            ? "Embedding 安装失败，请重试。"
+            : "Embedding 尚未安装，长期记忆暂不可用。",
           "text-text-secondary text-body-m font-regular"
         );
         const resultState = text(
@@ -424,6 +434,28 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
           "text-text-secondary text-body-m font-regular"
         );
         resultState.setAttribute("aria-live", "polite");
+        const refresh = async () => {
+          try {
+            const payload = await requestJson(STATUS_PATH);
+            const capabilities = payload.capabilities && typeof payload.capabilities === "object"
+              ? payload.capabilities
+              : {};
+            const latest = capabilities.memory;
+            await renderMemoryPanel(panel, latest);
+          } catch (_error) {
+            resultState.textContent = "安装仍在进行，可稍后刷新。";
+            window.setTimeout(refresh, 1000);
+          }
+        };
+        if (installState === "installing") {
+          panel.replaceChildren(heading, summary, resultState);
+          window.setTimeout(refresh, 1000);
+          return;
+        }
+        if (installState === "ready") {
+          panel.replaceChildren(heading, summary, resultState);
+          return;
+        }
         const install = button("安装 Embedding", async () => {
           if (!window.confirm("确认下载本地 Embedding 模型？下载仅在此次确认后开始。")) {
             return;
@@ -436,7 +468,8 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
               reason: "用户在原版 Olivia 设置中明确安装 Mem0 Embedding。",
             });
             if (payload.status === "APPLIED" || payload.status === "NOOP") {
-              resultState.textContent = "Embedding 已就绪。重启本机服务后，长期记忆会离线运行。";
+              resultState.textContent = "正在安装 Embedding……";
+              await refresh();
             } else {
               resultState.textContent = "Embedding 安装失败，请重试。";
             }

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -20,6 +20,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const MEMORY_DELETE_PATH = "/toy/companion/memory/delete";
   const MEMORY_PAUSE_PATH = "/toy/companion/memory/pause";
   const MEMORY_RESUME_PATH = "/toy/companion/memory/resume";
+  const MEMORY_EMBEDDING_INSTALL_PATH = "/toy/companion/memory/embedding/install";
   const CONFIRM_HEADER = "X-Olivia-Companion-Action";
   const CONFIRM_VALUE = "confirmed";
   const LETTER_CHARACTER_LIMIT = 1200;
@@ -410,6 +411,44 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const renderMemoryPanel = async (panel, capability) => {
     const state = capabilityState(capability);
     if (state === "disabled" || state === "unavailable") {
+      if (state === "unavailable" && capability && capability.reason_code === "MEM0_EMBEDDING_CACHE_UNAVAILABLE") {
+        const heading = text("h3", "长期记忆", "text-text-title text-title-m");
+        const summary = text(
+          "p",
+          "Embedding 尚未安装，长期记忆暂不可用。",
+          "text-text-secondary text-body-m font-regular"
+        );
+        const resultState = text(
+          "p",
+          "",
+          "text-text-secondary text-body-m font-regular"
+        );
+        resultState.setAttribute("aria-live", "polite");
+        const install = button("安装 Embedding", async () => {
+          if (!window.confirm("确认下载本地 Embedding 模型？下载仅在此次确认后开始。")) {
+            return;
+          }
+          setButtonsBusy([install], true);
+          resultState.textContent = "正在安装 Embedding……";
+          try {
+            const payload = await requestMutation(MEMORY_EMBEDDING_INSTALL_PATH, {
+              request_id: requestId("memory.embedding.install"),
+              reason: "用户在原版 Olivia 设置中明确安装 Mem0 Embedding。",
+            });
+            if (payload.status === "APPLIED" || payload.status === "NOOP") {
+              resultState.textContent = "Embedding 已就绪。重启本机服务后，长期记忆会离线运行。";
+            } else {
+              resultState.textContent = "Embedding 安装失败，请重试。";
+            }
+          } catch (_error) {
+            resultState.textContent = "Embedding 安装失败，请重试。";
+          } finally {
+            setButtonsBusy([install], false);
+          }
+        });
+        panel.replaceChildren(heading, summary, install, resultState);
+        return;
+      }
       renderUnavailable(panel, state, "长期记忆");
       return;
     }

--- a/tests/memory/test_mem0_embedding_install.py
+++ b/tests/memory/test_mem0_embedding_install.py
@@ -294,6 +294,107 @@ def test_post_promotion_verifier_failure_restores_the_previously_damaged_pair(
     assert not list(config.model_cache.glob(".olivia-mem0-embedding-stage-*"))
 
 
+@pytest.mark.parametrize(
+    "cleanup_error", [OSError("synthetic cleanup failure"), RuntimeError("synthetic cleanup failure")]
+)
+def test_snapshot_backup_cleanup_fault_after_commit_keeps_the_new_cache_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cleanup_error: Exception
+) -> None:
+    config = _config(tmp_path)
+    files = _files()
+    assert Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files)).install().status == "APPLIED"
+    (config.embedding_snapshot / "config.json").write_bytes(b"damaged")
+    assert not verified_embedding_cache(config)
+
+    remove_path = install_module._remove_path
+
+    def fail_snapshot_backup_cleanup(path: Path) -> None:
+        if path.name == "rollback-model":
+            raise cleanup_error
+        remove_path(path)
+
+    monkeypatch.setattr(install_module, "_remove_path", fail_snapshot_backup_cleanup)
+
+    installed = Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files)).install()
+
+    assert installed.status == "APPLIED"
+    assert installed.reason_code is None
+    assert verified_embedding_cache(config)
+    assert not list(config.model_cache.glob(".olivia-mem0-embedding-stage-*"))
+
+
+def test_manifest_backup_cleanup_fault_after_commit_keeps_the_new_cache_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(tmp_path)
+    files = _files()
+    assert Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files)).install().status == "APPLIED"
+    (config.embedding_snapshot / "config.json").write_bytes(b"damaged")
+    assert not verified_embedding_cache(config)
+
+    remove_path = install_module._remove_path
+
+    def fail_manifest_backup_cleanup(path: Path) -> None:
+        if path.name == "rollback-manifest.json":
+            raise OSError("synthetic manifest backup cleanup failure")
+        remove_path(path)
+
+    monkeypatch.setattr(install_module, "_remove_path", fail_manifest_backup_cleanup)
+
+    installed = Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files)).install()
+
+    assert installed.status == "APPLIED"
+    assert installed.reason_code is None
+    assert verified_embedding_cache(config)
+    assert not list(config.model_cache.glob(".olivia-mem0-embedding-stage-*"))
+
+
+@pytest.mark.parametrize("restore_name", ["snapshot", "manifest"])
+def test_restore_fault_preserves_recoverable_staging_without_fake_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, restore_name: str
+) -> None:
+    config = _config(tmp_path)
+    files = _files()
+    assert Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files)).install().status == "APPLIED"
+    (config.embedding_snapshot / "config.json").write_bytes(b"damaged")
+    assert not verified_embedding_cache(config)
+
+    replace = install_module.os.replace
+
+    def fail_final_manifest_and_one_restore(source: Path | str, destination: Path | str) -> None:
+        source_path = Path(source)
+        destination_path = Path(destination)
+        if (
+            source_path.name == "olivia-mem0-embedding-manifest.json"
+            and source_path.parent.name.startswith(".olivia-mem0-embedding-stage-")
+        ):
+            raise OSError("synthetic final manifest failure")
+        is_snapshot_restore = source_path.name == "rollback-model" and destination_path == config.embedding_snapshot
+        is_manifest_restore = (
+            source_path.name == "rollback-manifest.json"
+            and destination_path == config.model_cache / "olivia-mem0-embedding-manifest.json"
+        )
+        if (restore_name == "snapshot" and is_snapshot_restore) or (
+            restore_name == "manifest" and is_manifest_restore
+        ):
+            raise OSError("synthetic restore failure")
+        replace(source, destination)
+
+    monkeypatch.setattr(install_module.os, "replace", fail_final_manifest_and_one_restore)
+
+    installer = Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files))
+    failed = installer.install()
+
+    assert failed.status == "REJECTED"
+    assert failed.reason_code == "MEM0_EMBEDDING_INSTALL_FAILED"
+    assert installer.status().state is EmbeddingInstallStatus.ERROR
+    assert not verified_embedding_cache(config)
+    stages = list(config.model_cache.glob(".olivia-mem0-embedding-stage-*"))
+    assert len(stages) == 1
+    expected_backup = "rollback-model" if restore_name == "snapshot" else "rollback-manifest.json"
+    assert (stages[0] / expected_backup).exists()
+
+
 def test_read_and_mutation_share_fast_background_install_state(tmp_path: Path) -> None:
     class SharedInstaller:
         def __init__(self) -> None:

--- a/tests/memory/test_mem0_embedding_install.py
+++ b/tests/memory/test_mem0_embedding_install.py
@@ -1,13 +1,25 @@
 from __future__ import annotations
 
 import hashlib
+import inspect
+import json
+import sys
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
+
+import mem0_embedding_install as install_module
 from conversation_memory_port import UnavailableConversationMemoryPort
-from mem0_embedding_install import EmbeddingInstallStatus, Mem0EmbeddingInstaller
-from mem0_memory import Mem0Config, create_mem0_adapter
+from mem0_embedding_install import (
+    EmbeddingInstallStatus,
+    HuggingFaceEmbeddingDownloader,
+    Mem0EmbeddingInstaller,
+)
+from mem0_memory import Mem0Config, create_mem0_adapter, verified_embedding_cache
 from mem0_memory import MEM0_EMBEDDING_MODEL_REVISION
 from original_client_companion_backend import OriginalClientCompanionServiceBackend
 from original_client_companion_mutation_backend import (
@@ -15,6 +27,7 @@ from original_client_companion_mutation_backend import (
 )
 from original_client_settings_ui import BOOTSTRAP_JAVASCRIPT
 from conversation_memory_admin import ConversationMemoryAdminService
+from original_client_companion_api import CompanionReadStatus
 
 
 @dataclass
@@ -116,6 +129,189 @@ def test_hash_mismatch_never_promotes_ready_cache_and_cleanup_allows_retry(tmp_p
     assert retry.status().state is EmbeddingInstallStatus.READY
 
 
+def test_manifest_promotion_failure_restores_the_previously_damaged_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(tmp_path)
+    files = _files()
+    assert Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files)).install().status == "APPLIED"
+    (config.embedding_snapshot / "config.json").write_bytes(b"damaged")
+    assert not verified_embedding_cache(config)
+
+    replace = install_module.os.replace
+
+    def fail_manifest(source: Path | str, destination: Path | str) -> None:
+        if (
+            Path(source).name == "olivia-mem0-embedding-manifest.json"
+            and Path(source).parent.name.startswith(".olivia-mem0-embedding-stage-")
+        ):
+            raise OSError("synthetic manifest promotion failure")
+        replace(source, destination)
+
+    monkeypatch.setattr(install_module.os, "replace", fail_manifest)
+
+    failed = Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files)).install()
+
+    assert failed.status == "REJECTED"
+    assert not verified_embedding_cache(config)
+
+
+@pytest.mark.parametrize("failed_name", ["snapshot", "manifest"])
+def test_replace_failures_leave_a_new_cache_unverified(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failed_name: str
+) -> None:
+    config = _config(tmp_path)
+    replace = install_module.os.replace
+
+    def fail_replace(source: Path | str, destination: Path | str) -> None:
+        is_stage = any(
+            parent.name.startswith(".olivia-mem0-embedding-stage-")
+            for parent in Path(source).parents
+        )
+        is_snapshot = Path(source).name == MEM0_EMBEDDING_MODEL_REVISION
+        is_manifest = Path(source).name == "olivia-mem0-embedding-manifest.json"
+        if is_stage and (
+            (failed_name == "snapshot" and is_snapshot)
+            or (failed_name == "manifest" and is_manifest)
+        ):
+            raise OSError(f"synthetic {failed_name} promotion failure")
+        replace(source, destination)
+
+    monkeypatch.setattr(install_module.os, "replace", fail_replace)
+
+    failed = Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(_files())).install()
+
+    assert failed.status == "REJECTED"
+    assert not config.embedding_snapshot.exists()
+    assert not verified_embedding_cache(config)
+
+
+def test_read_and_mutation_share_fast_background_install_state(tmp_path: Path) -> None:
+    class SharedInstaller:
+        def __init__(self) -> None:
+            self.state = EmbeddingInstallStatus.MISSING
+            self.start_calls = 0
+
+        def status(self):
+            from mem0_embedding_install import EmbeddingInstallState
+
+            return EmbeddingInstallState(self.state)
+
+        def start(self):
+            from mem0_embedding_install import EmbeddingInstallResult
+
+            self.start_calls += 1
+            self.state = EmbeddingInstallStatus.INSTALLING
+            return EmbeddingInstallResult("APPLIED")
+
+    memory = UnavailableConversationMemoryPort("MEM0_EMBEDDING_CACHE_UNAVAILABLE")
+    admin = ConversationMemoryAdminService(memory, tmp_path / "memory-admin.sqlite3")
+    installer = SharedInstaller()
+    read = OriginalClientCompanionServiceBackend(
+        memory_admin=admin,
+        embedding_installer=installer,
+    )
+    mutate = DirectOriginalClientCompanionMutationBackend(embedding_installer=installer)
+
+    before = read.read_status()
+    assert isinstance(before, CompanionReadStatus)
+    before_payload = before.to_dict()
+    assert before_payload["capabilities"]["memory"]["embedding"] == {
+        "state": "missing"
+    }
+    from jsonschema import Draft202012Validator
+
+    schema = json.loads(
+        (Path(__file__).parents[2] / "contracts" / "original_client_memory_lifecycle.schema.json").read_text("utf-8")
+    )
+    assert not list(Draft202012Validator(schema).iter_errors(before_payload))
+
+    accepted = mutate.install_embedding(
+        request_id="request.memory.embedding.install.1",
+        reason="synthetic explicit confirmation",
+    )
+
+    assert accepted.status == "APPLIED"
+    assert installer.start_calls == 1
+    assert read.read_status().to_dict()["capabilities"]["memory"]["embedding"] == {
+        "state": "installing"
+    }
+
+
+def test_start_returns_before_download_and_reuses_one_background_worker(tmp_path: Path) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    completed = threading.Event()
+
+    class BlockingDownloader(SyntheticDownloader):
+        def download(self, **kwargs: object) -> None:
+            if kwargs["relative_path"] == "config.json":
+                entered.set()
+                assert release.wait(1)
+            super().download(**kwargs)  # type: ignore[arg-type]
+            if kwargs["relative_path"] == "vocab.txt":
+                completed.set()
+
+    downloader = BlockingDownloader(_files())
+    installer = Mem0EmbeddingInstaller(_config(tmp_path), downloader=downloader)
+
+    assert installer.start().status == "APPLIED"
+    assert entered.wait(1)
+    assert installer.status().state is EmbeddingInstallStatus.INSTALLING
+    assert installer.start().status == "APPLIED"
+    assert [path for _revision, path in downloader.calls] == ["1_Pooling/config.json"]
+
+    release.set()
+    assert completed.wait(1)
+    deadline = time.monotonic() + 1
+    while (
+        installer.status().state is EmbeddingInstallStatus.INSTALLING
+        and time.monotonic() < deadline
+    ):
+        threading.Event().wait(0.01)
+    assert installer.status().state is EmbeddingInstallStatus.READY
+    assert len(downloader.calls) == len(_files())
+
+
+def test_huggingface_download_call_shape_uses_only_supported_pinned_arguments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    observed: dict[str, object] = {}
+
+    def hf_hub_download(
+        *, repo_id: str, filename: str, revision: str, local_dir: str, token: bool
+    ) -> str:
+        observed.update(
+            repo_id=repo_id,
+            filename=filename,
+            revision=revision,
+            local_dir=local_dir,
+            token=token,
+        )
+        destination = Path(local_dir) / filename
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"synthetic")
+        return str(destination)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(hf_hub_download=hf_hub_download),
+    )
+    destination = tmp_path / "stage" / "1_Pooling" / "config.json"
+
+    HuggingFaceEmbeddingDownloader().download(
+        revision=MEM0_EMBEDDING_MODEL_REVISION,
+        relative_path="1_Pooling/config.json",
+        destination=destination,
+    )
+
+    inspect.signature(hf_hub_download).bind(**observed)
+    assert observed["revision"] == MEM0_EMBEDDING_MODEL_REVISION
+    assert observed["token"] is False
+    assert destination.read_bytes() == b"synthetic"
+
+
 def test_download_fault_cleans_staging_and_concurrent_or_ready_retries_are_idempotent(
     tmp_path: Path,
 ) -> None:
@@ -163,6 +359,8 @@ def test_settings_exposes_only_the_confirmed_embedding_action_and_health_is_hone
     assert "安装 Embedding" in BOOTSTRAP_JAVASCRIPT
     assert "正在安装 Embedding" in BOOTSTRAP_JAVASCRIPT
     assert "Embedding 安装失败，请重试。" in BOOTSTRAP_JAVASCRIPT
+    assert "capability.embedding" in BOOTSTRAP_JAVASCRIPT
+    assert "window.setTimeout(refresh, 1000);" in BOOTSTRAP_JAVASCRIPT
     assert "http://" not in BOOTSTRAP_JAVASCRIPT
     assert "https://" not in BOOTSTRAP_JAVASCRIPT
 
@@ -175,7 +373,7 @@ def test_settings_exposes_only_the_confirmed_embedding_action_and_health_is_hone
     }
 
     class RejectingInstaller:
-        def install(self):
+        def start(self):
             from mem0_embedding_install import EmbeddingInstallResult
 
             return EmbeddingInstallResult("REJECTED", "MEM0_EMBEDDING_HASH_MISMATCH")

--- a/tests/memory/test_mem0_embedding_install.py
+++ b/tests/memory/test_mem0_embedding_install.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import hashlib
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+from conversation_memory_port import UnavailableConversationMemoryPort
+from mem0_embedding_install import EmbeddingInstallStatus, Mem0EmbeddingInstaller
+from mem0_memory import Mem0Config, create_mem0_adapter
+from mem0_memory import MEM0_EMBEDDING_MODEL_REVISION
+from original_client_companion_backend import OriginalClientCompanionServiceBackend
+from original_client_companion_mutation_backend import (
+    DirectOriginalClientCompanionMutationBackend,
+)
+from original_client_settings_ui import BOOTSTRAP_JAVASCRIPT
+from conversation_memory_admin import ConversationMemoryAdminService
+
+
+@dataclass
+class SyntheticDownloader:
+    files: dict[str, bytes]
+    failures: set[str] | None = None
+
+    def __post_init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+        self.failures = self.failures or set()
+
+    def download(self, *, revision: str, relative_path: str, destination: Path) -> None:
+        self.calls.append((revision, relative_path))
+        if relative_path in self.failures:
+            raise OSError("synthetic download failure")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(self.files[relative_path])
+
+
+def _config(tmp_path: Path) -> Mem0Config:
+    return Mem0Config(
+        enabled=True,
+        data_root=tmp_path / "memory" / "mem0",
+        llm_base_url="http://127.0.0.1:9/v1",
+        llm_model="fixture-model",
+        embedding_cache=tmp_path / "model-cache",
+    )
+
+
+def _files() -> dict[str, bytes]:
+    return {
+        "1_Pooling/config.json": b'{"word_embedding_dimension":512}',
+        "config.json": b'{"model_type":"bert"}',
+        "config_sentence_transformers.json": b"{}",
+        "model.safetensors": b"synthetic weights",
+        "modules.json": b"[]",
+        "sentence_bert_config.json": b"{}",
+        "special_tokens_map.json": b"{}",
+        "tokenizer.json": b"{}",
+        "tokenizer_config.json": b"{}",
+        "vocab.txt": b"synthetic\n",
+    }
+
+
+def test_missing_explicit_install_verifies_then_runtime_reuses_offline_cache(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    downloader = SyntheticDownloader(_files())
+    installer = Mem0EmbeddingInstaller(config, downloader=downloader)
+
+    assert installer.status().state is EmbeddingInstallStatus.MISSING
+    assert isinstance(create_mem0_adapter(config), UnavailableConversationMemoryPort)
+
+    result = installer.install()
+
+    assert result.status == "APPLIED"
+    assert installer.status().state is EmbeddingInstallStatus.READY
+    assert len(downloader.calls) == len(_files())
+    assert {revision for revision, _path in downloader.calls} == {
+        MEM0_EMBEDDING_MODEL_REVISION
+    }
+
+    captured: dict[str, object] = {}
+
+    def factory(mapping: dict[str, object]):
+        captured.update(mapping)
+        return object()
+
+    # A fake factory is sufficient: installation must only unblock the existing
+    # runtime's local-files-only path, not call a real provider.
+    port = create_mem0_adapter(config, memory_factory=factory)
+    assert port.config is config  # type: ignore[attr-defined]
+    model_kwargs = captured["embedder"]["config"]["model_kwargs"]  # type: ignore[index]
+    assert model_kwargs["local_files_only"] is True  # type: ignore[index]
+
+
+def test_hash_mismatch_never_promotes_ready_cache_and_cleanup_allows_retry(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    files = _files()
+    corrupted = dict(files)
+    corrupted["model.safetensors"] = b"corrupt"
+    installer = Mem0EmbeddingInstaller(
+        config,
+        downloader=SyntheticDownloader(corrupted),
+        expected_hashes={
+            name: hashlib.sha256(content).hexdigest() for name, content in files.items()
+        },
+    )
+
+    failed = installer.install()
+
+    assert failed.status == "REJECTED"
+    assert failed.reason_code == "MEM0_EMBEDDING_HASH_MISMATCH"
+    assert installer.status().state is EmbeddingInstallStatus.ERROR
+    assert not config.embedding_snapshot.exists()
+    assert not list(config.model_cache.glob(".olivia-mem0-embedding-stage-*"))
+
+    retry = Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files))
+    assert retry.install().status == "APPLIED"
+    assert retry.status().state is EmbeddingInstallStatus.READY
+
+
+def test_download_fault_cleans_staging_and_concurrent_or_ready_retries_are_idempotent(
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    files = _files()
+    failed = Mem0EmbeddingInstaller(
+        config,
+        downloader=SyntheticDownloader(files, failures={"tokenizer.json"}),
+    )
+    assert failed.install().reason_code == "MEM0_EMBEDDING_INSTALL_FAILED"
+    assert not list(config.model_cache.glob(".olivia-mem0-embedding-stage-*"))
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    class BlockingDownloader(SyntheticDownloader):
+        def download(self, **kwargs: object) -> None:
+            if kwargs["relative_path"] == "config.json":
+                entered.set()
+                assert release.wait(1)
+            super().download(**kwargs)  # type: ignore[arg-type]
+
+    downloader = BlockingDownloader(files)
+    installer = Mem0EmbeddingInstaller(config, downloader=downloader)
+    results: list[str] = []
+    first = threading.Thread(target=lambda: results.append(installer.install().status))
+    second = threading.Thread(target=lambda: results.append(installer.install().status))
+    first.start()
+    assert entered.wait(1)
+    second.start()
+    release.set()
+    first.join(timeout=1)
+    second.join(timeout=1)
+
+    assert sorted(results) == ["APPLIED", "NOOP"]
+    assert len(downloader.calls) == len(files)
+    assert installer.install().status == "NOOP"
+
+
+def test_settings_exposes_only_the_confirmed_embedding_action_and_health_is_honest(
+    tmp_path: Path,
+) -> None:
+    assert 'const MEMORY_EMBEDDING_INSTALL_PATH = "/toy/companion/memory/embedding/install";' in BOOTSTRAP_JAVASCRIPT
+    assert "MEM0_EMBEDDING_CACHE_UNAVAILABLE" in BOOTSTRAP_JAVASCRIPT
+    assert "安装 Embedding" in BOOTSTRAP_JAVASCRIPT
+    assert "正在安装 Embedding" in BOOTSTRAP_JAVASCRIPT
+    assert "Embedding 安装失败，请重试。" in BOOTSTRAP_JAVASCRIPT
+    assert "http://" not in BOOTSTRAP_JAVASCRIPT
+    assert "https://" not in BOOTSTRAP_JAVASCRIPT
+
+    memory = UnavailableConversationMemoryPort("MEM0_EMBEDDING_CACHE_UNAVAILABLE")
+    admin = ConversationMemoryAdminService(memory, tmp_path / "memory-admin.sqlite3")
+    status = OriginalClientCompanionServiceBackend(memory_admin=admin).read_status().to_dict()
+    assert status["capabilities"]["memory"] == {
+        "state": "unavailable",
+        "reason_code": "MEM0_EMBEDDING_CACHE_UNAVAILABLE",
+    }
+
+    class RejectingInstaller:
+        def install(self):
+            from mem0_embedding_install import EmbeddingInstallResult
+
+            return EmbeddingInstallResult("REJECTED", "MEM0_EMBEDDING_HASH_MISMATCH")
+
+    result = DirectOriginalClientCompanionMutationBackend(
+        embedding_installer=RejectingInstaller()
+    ).install_embedding(
+        request_id="request.memory.embedding.install.1",
+        reason="synthetic explicit confirmation",
+    )
+    assert result.status == "REJECTED"
+    assert result.reason_code == "MEM0_EMBEDDING_HASH_MISMATCH"

--- a/tests/memory/test_mem0_embedding_install.py
+++ b/tests/memory/test_mem0_embedding_install.py
@@ -156,6 +156,78 @@ def test_manifest_promotion_failure_restores_the_previously_damaged_cache(
     assert not verified_embedding_cache(config)
 
 
+def test_snapshot_backup_fault_preserves_a_previously_ready_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(tmp_path)
+    files = _files()
+    assert Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files)).install().status == "APPLIED"
+    snapshot_before = (config.embedding_snapshot / "config.json").read_bytes()
+    manifest_before = (config.model_cache / "olivia-mem0-embedding-manifest.json").read_bytes()
+
+    verifier = install_module.verified_embedding_cache
+
+    def force_one_reinstall(candidate: Mem0Config) -> bool:
+        if candidate is config:
+            monkeypatch.setattr(install_module, "verified_embedding_cache", verifier)
+            return False
+        return verifier(candidate)
+
+    monkeypatch.setattr(install_module, "verified_embedding_cache", force_one_reinstall)
+    replace = install_module.os.replace
+
+    def fail_snapshot_backup(source: Path | str, destination: Path | str) -> None:
+        if Path(source) == config.embedding_snapshot and Path(destination).name == "rollback-model":
+            raise OSError("synthetic snapshot backup failure")
+        replace(source, destination)
+
+    monkeypatch.setattr(install_module.os, "replace", fail_snapshot_backup)
+
+    failed = Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files)).install()
+
+    assert failed.status == "REJECTED"
+    assert verified_embedding_cache(config)
+    assert (config.embedding_snapshot / "config.json").read_bytes() == snapshot_before
+    assert (config.model_cache / "olivia-mem0-embedding-manifest.json").read_bytes() == manifest_before
+    assert not list(config.model_cache.glob(".olivia-mem0-embedding-stage-*"))
+
+
+def test_manifest_backup_fault_preserves_a_previously_ready_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(tmp_path)
+    files = _files()
+    assert Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files)).install().status == "APPLIED"
+    snapshot_before = (config.embedding_snapshot / "config.json").read_bytes()
+    manifest_before = (config.model_cache / "olivia-mem0-embedding-manifest.json").read_bytes()
+
+    verifier = install_module.verified_embedding_cache
+
+    def force_one_reinstall(candidate: Mem0Config) -> bool:
+        if candidate is config:
+            monkeypatch.setattr(install_module, "verified_embedding_cache", verifier)
+            return False
+        return verifier(candidate)
+
+    monkeypatch.setattr(install_module, "verified_embedding_cache", force_one_reinstall)
+    replace = install_module.os.replace
+
+    def fail_manifest_backup(source: Path | str, destination: Path | str) -> None:
+        if Path(source).name == "olivia-mem0-embedding-manifest.json" and Path(destination).name == "rollback-manifest.json":
+            raise OSError("synthetic manifest backup failure")
+        replace(source, destination)
+
+    monkeypatch.setattr(install_module.os, "replace", fail_manifest_backup)
+
+    failed = Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files)).install()
+
+    assert failed.status == "REJECTED"
+    assert verified_embedding_cache(config)
+    assert (config.embedding_snapshot / "config.json").read_bytes() == snapshot_before
+    assert (config.model_cache / "olivia-mem0-embedding-manifest.json").read_bytes() == manifest_before
+    assert not list(config.model_cache.glob(".olivia-mem0-embedding-stage-*"))
+
+
 @pytest.mark.parametrize("failed_name", ["snapshot", "manifest"])
 def test_replace_failures_leave_a_new_cache_unverified(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failed_name: str
@@ -184,6 +256,42 @@ def test_replace_failures_leave_a_new_cache_unverified(
     assert failed.status == "REJECTED"
     assert not config.embedding_snapshot.exists()
     assert not verified_embedding_cache(config)
+    assert not list(config.model_cache.glob(".olivia-mem0-embedding-stage-*"))
+
+
+@pytest.mark.parametrize("verifier_outcome", [False, RuntimeError("synthetic verifier failure")])
+def test_post_promotion_verifier_failure_restores_the_previously_damaged_pair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, verifier_outcome: bool | RuntimeError
+) -> None:
+    config = _config(tmp_path)
+    files = _files()
+    assert Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files)).install().status == "APPLIED"
+    (config.embedding_snapshot / "config.json").write_bytes(b"damaged")
+    manifest_before = (config.model_cache / "olivia-mem0-embedding-manifest.json").read_bytes()
+    assert not verified_embedding_cache(config)
+
+    verifier = install_module.verified_embedding_cache
+    config_checks = 0
+
+    def fail_after_promotion(candidate: Mem0Config) -> bool:
+        nonlocal config_checks
+        if candidate is config:
+            config_checks += 1
+            if config_checks == 2:
+                if isinstance(verifier_outcome, Exception):
+                    raise verifier_outcome
+                return verifier_outcome
+        return verifier(candidate)
+
+    monkeypatch.setattr(install_module, "verified_embedding_cache", fail_after_promotion)
+
+    failed = Mem0EmbeddingInstaller(config, downloader=SyntheticDownloader(files)).install()
+
+    assert failed.status == "REJECTED"
+    assert not verified_embedding_cache(config)
+    assert (config.embedding_snapshot / "config.json").read_bytes() == b"damaged"
+    assert (config.model_cache / "olivia-mem0-embedding-manifest.json").read_bytes() == manifest_before
+    assert not list(config.model_cache.glob(".olivia-mem0-embedding-stage-*"))
 
 
 def test_read_and_mutation_share_fast_background_install_state(tmp_path: Path) -> None:
@@ -236,6 +344,36 @@ def test_read_and_mutation_share_fast_background_install_state(tmp_path: Path) -
     assert read.read_status().to_dict()["capabilities"]["memory"]["embedding"] == {
         "state": "installing"
     }
+
+
+def test_schema_allows_embedding_only_under_memory() -> None:
+    from jsonschema import Draft202012Validator
+
+    schema = json.loads(
+        (Path(__file__).parents[2] / "contracts" / "original_client_memory_lifecycle.schema.json").read_text("utf-8")
+    )
+    validator = Draft202012Validator(schema)
+
+    def payload() -> dict[str, object]:
+        return {
+            "schema_version": "p03.original-companion-read.v1",
+            "status": "READY",
+            "capabilities": {
+                "memory": {"state": "unavailable"},
+                "private_world": {"state": "available"},
+                "candidates": {"state": "available"},
+            },
+        }
+
+    for state in ("missing", "installing", "ready", "error"):
+        candidate = payload()
+        candidate["capabilities"]["memory"]["embedding"] = {"state": state}  # type: ignore[index]
+        assert not list(validator.iter_errors(candidate))
+
+    for capability in ("private_world", "candidates"):
+        candidate = payload()
+        candidate["capabilities"][capability]["embedding"] = {"state": "ready"}  # type: ignore[index]
+        assert list(validator.iter_errors(candidate))
 
 
 def test_start_returns_before_download_and_reuses_one_background_worker(tmp_path: Path) -> None:


### PR DESCRIPTION
## Scope

Original-client Settings remains the sole explicit embedding-install entry point. R4 is documentation-only: it corrects the P03 staging-cleanup contract to match the already-reviewed promotion behavior. No runtime code, schema, or test was changed.

## Frozen pair and exact diff

- Base: `455ffcb24fa0f79c9102ec86fb047599f99c4b69`
- Head: `73a2aec56f34a60e5c1d18dd6ac2dc373f06eedd`
- Diff: 11 files, `+1262/-7`
- Commits: `f4d4bc9`, `f5eba90`, `cbee006`, `873d6ca`, `73a2aec`

The coherent Settings action remains above the normal size preference because its explicit download requires the coupled verifier/cache contract, HTTP representation, and fail-closed synthetic fault proof. Splitting them would create an unsafe partial entry point.

## R4 documentation contract

P03 now says that ordinary download, hash, and promotion failures are path-free, leave no READY cache, clean staging, and can be retried. The sole stated exception is a pre-commit rollback restore failure: it returns the stable rejected result without claiming READY and retains recoverable staging/backup for diagnosis or recovery.

## Existing implementation evidence

The preceding R3 implementation made a successful post-promotion #127 verifier the irreversible commit point. Post-commit backup cleanup is best-effort and cannot rollback a verified new pair; a pre-commit restore failure retains the recoverable staging/backup and remains non-READY. The async shared state, Settings polling, HF-compatible call, schema, and offline runtime are unchanged.

## Validation and boundary

R4 validation is documentation-only: `git diff --check` and `baseline_hardening_scan.py --mode all` passed. No test was rerun because no executable code changed. Earlier synthetic focused evidence remains limited to local behavior; no real model/provider download, API key, private corpus, Live/music/video, installer/release, clear, PrivateWorld, canonical, or persona change was made.
