### PR TITLE
feat(tts): adopt accepted A voice direction

### DIFF
--- a/contracts/http_contract.example.json
+++ b/contracts/http_contract.example.json
@@ -66,6 +66,27 @@
       "optional_capabilities": ["llm.gateway", "llm.streaming"]
     }
   },
+  "letter_detail_media": {
+    "fields": ["media_status", "media_error_code", "media_retryable"],
+    "statuses": [
+      "NOT_REQUESTED",
+      "PENDING",
+      "PROCESSING",
+      "COMPLETED",
+      "FAILED",
+      "UNAVAILABLE"
+    ],
+    "error_codes": {
+      "TTS_CONTENT_GATE_UNAVAILABLE": {
+        "status": "UNAVAILABLE",
+        "retryable": true
+      },
+      "TTS_CONTENT_GATE_REJECTED": {
+        "status": "FAILED",
+        "retryable": false
+      }
+    }
+  },
   "privacy": {
     "logs_include_request_body": false,
     "logs_include_query_values": false,

--- a/contracts/http_contract.example.json
+++ b/contracts/http_contract.example.json
@@ -77,6 +77,7 @@
       "UNAVAILABLE"
     ],
     "error_codes": {
+      "MEDIA_PROVIDER_UNAVAILABLE": {"status": "UNAVAILABLE", "retryable": true},
       "TTS_CONTENT_GATE_UNAVAILABLE": {
         "status": "UNAVAILABLE",
         "retryable": true

--- a/contracts/http_contract.schema.json
+++ b/contracts/http_contract.schema.json
@@ -4,7 +4,7 @@
   "title": "B02 local HTTP contract",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "contract_version", "base_path", "routes", "capabilities", "profiles", "privacy"],
+  "required": ["schema_version", "contract_version", "base_path", "routes", "capabilities", "profiles", "letter_detail_media", "privacy"],
   "properties": {
     "schema_version": {"const": 1},
     "contract_version": {"const": "b02.v1"},

--- a/contracts/http_contract.schema.json
+++ b/contracts/http_contract.schema.json
@@ -44,6 +44,36 @@
         "additionalProperties": false
       }
     },
+    "letter_detail_media": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fields", "statuses", "error_codes"],
+      "properties": {
+        "fields": {
+          "const": ["media_status", "media_error_code", "media_retryable"]
+        },
+        "statuses": {
+          "type": "array",
+          "items": {
+            "enum": ["NOT_REQUESTED", "PENDING", "PROCESSING", "COMPLETED", "FAILED", "UNAVAILABLE"]
+          },
+          "uniqueItems": true
+        },
+        "error_codes": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["TTS_CONTENT_GATE_UNAVAILABLE", "TTS_CONTENT_GATE_REJECTED"],
+          "properties": {
+            "TTS_CONTENT_GATE_UNAVAILABLE": {
+              "$ref": "#/$defs/media_error"
+            },
+            "TTS_CONTENT_GATE_REJECTED": {
+              "$ref": "#/$defs/media_error"
+            }
+          }
+        }
+      }
+    },
     "privacy": {
       "type": "object",
       "additionalProperties": false,
@@ -57,6 +87,15 @@
     }
   },
   "$defs": {
+    "media_error": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "retryable"],
+      "properties": {
+        "status": {"enum": ["FAILED", "UNAVAILABLE"]},
+        "retryable": {"type": "boolean"}
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/contracts/http_contract.schema.json
+++ b/contracts/http_contract.schema.json
@@ -62,8 +62,9 @@
         "error_codes": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["TTS_CONTENT_GATE_UNAVAILABLE", "TTS_CONTENT_GATE_REJECTED"],
+          "required": ["MEDIA_PROVIDER_UNAVAILABLE", "TTS_CONTENT_GATE_UNAVAILABLE", "TTS_CONTENT_GATE_REJECTED"],
           "properties": {
+            "MEDIA_PROVIDER_UNAVAILABLE": {"$ref": "#/$defs/media_error"},
             "TTS_CONTENT_GATE_UNAVAILABLE": {
               "$ref": "#/$defs/media_error"
             },

--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -33,6 +33,8 @@
 | 410 | `LETTER_SUPERSEDED` | SUPERSEDED | 否 | 失败副本已由成功重试替代；仅返回替代信件 ID |
 | 200 detail | `LLM_PROVIDER_REJECTED` / `LLM_PROTOCOL_ERROR` | FAILED | 否 | 上游非重试 4xx、坏 JSON 或空响应；不回显 provider body |
 | 200 detail | `LLM_REPLY_LENGTH_INVALID` | FAILED | 否 | 普通说话视频正文经一次独立修复后仍不在 180–200 个紧凑字符内；不得伪装成 provider 不可用 |
+| 200 detail media | `TTS_CONTENT_GATE_REJECTED` | FAILED | 否 | 三条时长有效的普通说话候选均未通过内容门；不自动重试 |
+| 200 detail media | `TTS_CONTENT_GATE_UNAVAILABLE` | UNAVAILABLE | 是 | 显式配置的离线 ASR 运行时、checkpoint 或临时质量门不可用；可在修复依赖后恢复 |
 
 ## P03 clear mutation registry
 

--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -32,6 +32,7 @@
 | 503 | `VIDEO_REPLY_SETTING_UNAVAILABLE` | UNAVAILABLE | 是 | 设置 state root、持久化读取或原子写入不可用；服务端 fail-closed |
 | 410 | `LETTER_SUPERSEDED` | SUPERSEDED | 否 | 失败副本已由成功重试替代；仅返回替代信件 ID |
 | 200 detail | `LLM_PROVIDER_REJECTED` / `LLM_PROTOCOL_ERROR` | FAILED | 否 | 上游非重试 4xx、坏 JSON 或空响应；不回显 provider body |
+| 200 detail | `LLM_REPLY_LENGTH_INVALID` | FAILED | 否 | 普通说话视频正文经一次独立修复后仍不在 180–200 个紧凑字符内；不得伪装成 provider 不可用 |
 
 ## P03 clear mutation registry
 

--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -35,6 +35,7 @@
 | 200 detail | `LLM_REPLY_LENGTH_INVALID` | FAILED | 否 | 普通说话视频正文经一次独立修复后仍不在 180–200 个紧凑字符内；不得伪装成 provider 不可用 |
 | 200 detail media | `TTS_CONTENT_GATE_REJECTED` | FAILED | 否 | 三条时长有效的普通说话候选均未通过内容门；不自动重试 |
 | 200 detail media | `TTS_CONTENT_GATE_UNAVAILABLE` | UNAVAILABLE | 是 | 显式配置的离线 ASR 运行时、checkpoint 或临时质量门不可用；可在修复依赖后恢复 |
+| 200 detail media | `MEDIA_PROVIDER_UNAVAILABLE` | UNAVAILABLE | 是 | 未登记的媒体异常或本地媒体依赖不可用；公开 detail 不回显内部异常、provider 文本或本机路径 |
 
 ## P03 clear mutation registry
 

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -17,6 +17,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 - 真正未实现能力：HTTP `501`，`data.status=NOT_IMPLEMENTED`。
 - 已知但不可用的可选能力：HTTP `501`，`data.status=UNAVAILABLE`，并带 `capability`；不会返回 200 假成功。
 - HTTP 发信先返回 `200`/`PENDING`；LLM 超时或不可用随后写入信件 `FAILED` 终态，detail 返回稳定 `error_code` 与 `retryable`。重启只恢复尚未派发的 `PENDING`；不确定是否已到达 provider 的 `PROCESSING` 会 fail closed 为 `LLM_INTERRUPTED`，不自动重复生成。
+- 普通说话视频的 detail 额外公开 `media_status`、`media_error_code` 与布尔值 `media_retryable`。`TTS_CONTENT_GATE_UNAVAILABLE` 为可重试的 `UNAVAILABLE`；三条有效候选均被内容门拒绝时，`TTS_CONTENT_GATE_REJECTED` 为不可重试的 `FAILED`。
 
 机器可读定义：
 

--- a/docs/B06_LOCAL_TTS_ACCEPTANCE.md
+++ b/docs/B06_LOCAL_TTS_ACCEPTANCE.md
@@ -93,3 +93,19 @@ Real profile lifecycle evidence covered `doctor` (`HEALTHY`), `disable`, disable
 - B02, B04, B06, P01, and B10A scope scanners: all PASS with B06 composition enabled. Clean-state simulation PASS; unrelated dirty-path simulation FAIL; forced B06 failure propagates FAIL to P01 and B10A.
 
 No model weights, reference audio, generated media, credentials, or absolute private asset paths are included in this note.
+
+## Directed ordinary-reply quality boundary
+
+The accepted A profile renders one frozen ordinary spoken-video reply in one
+CosyVoice `inference_instruct2` call. The LLM tool emits only one positive
+12–24 Chinese-character non-spoken instruction; pace is fixed at `1.0` and the
+worker verifies the pinned base `llm.pt` SHA-256 before model load.
+
+Up to three seeds may be attempted. A duration-valid candidate is published
+only after the offline pinned Whisper `base` checkpoint passes its own SHA-256
+check and ASR rejects instruction contamination, any detected insertion or
+omission, added repetition, or excessive substitutions. Missing runtime,
+checkpoint, invalid report, timeout, or subprocess failure is
+`TTS_CONTENT_GATE_UNAVAILABLE`; three duration-valid ASR rejections end as
+`TTS_CONTENT_GATE_REJECTED`. Candidate files remain temporary and are never
+atomically moved onto the destination until every gate passes.

--- a/docs/B06_LOCAL_TTS_ACCEPTANCE.md
+++ b/docs/B06_LOCAL_TTS_ACCEPTANCE.md
@@ -96,26 +96,8 @@ No model weights, reference audio, generated media, credentials, or absolute pri
 
 ## Directed ordinary-reply quality boundary
 
-The accepted A profile renders one frozen ordinary spoken-video reply in one
-CosyVoice `inference_instruct2` call. The LLM tool emits only one positive
-12–24 Chinese-character non-spoken instruction; pace is fixed at `1.0` and the
-worker verifies the pinned base `llm.pt` SHA-256 before model load.
+The accepted A profile renders one frozen ordinary spoken-video reply in one CosyVoice `inference_instruct2` call. The LLM tool emits only one positive 12–24 Chinese-character non-spoken instruction; pace is fixed at `1.0` and the worker verifies the pinned base `llm.pt` SHA-256 before model load.
 
-Up to three seeds may be attempted. A duration-valid candidate is published
-only after the offline pinned Whisper `base` checkpoint passes its own SHA-256
-check and ASR rejects instruction contamination, any detected insertion or
-omission, added repetition, or excessive substitutions. Missing runtime,
-checkpoint, invalid report, timeout, or subprocess failure is
-`TTS_CONTENT_GATE_UNAVAILABLE`; three duration-valid ASR rejections end as
-`TTS_CONTENT_GATE_REJECTED`. Candidate files remain temporary and are never
-atomically moved onto the destination until every gate passes.
+Up to three seeds may be attempted. A duration-valid candidate is published only after the offline pinned Whisper `base` checkpoint passes its own SHA-256 check and ASR rejects instruction contamination, any detected insertion or omission, added repetition, or excessive substitutions. Missing runtime, checkpoint, invalid report, timeout, or subprocess failure is `TTS_CONTENT_GATE_UNAVAILABLE`; three duration-valid ASR rejections end as `TTS_CONTENT_GATE_REJECTED`. Candidate files remain temporary and are never atomically moved onto the destination until every gate passes.
 
-The quality runtime is the external `openai-whisper==20250625` package at
-upstream tag `v20250625` / commit
-`31243bad24cc746f07d4c8bfdd2d974872cb1803` (MIT). Install it into the same
-external Python environment used by the CosyVoice worker, following the
-upstream instructions. The official `base.pt` artifact is pinned to SHA-256
-`ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e`.
-The cache directory must be set explicitly in `provider_options` as
-`quality_gate_cache_root`, or through
-`OLIVIA_TTS_QUALITY_GATE_CACHE_ROOT`; no home-directory fallback is used.
+The quality runtime is the external `openai-whisper==20250625` package at upstream tag `v20250625` / commit `31243bad24cc746f07d4c8bfdd2d974872cb1803` (MIT). Install it into the same external Python environment used by the CosyVoice worker, following the upstream instructions. The official `base.pt` artifact is pinned to SHA-256 `ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e`. The cache directory must be set explicitly in `provider_options` as `quality_gate_cache_root`, or through `OLIVIA_TTS_QUALITY_GATE_CACHE_ROOT`; no home-directory fallback is used.

--- a/docs/B06_LOCAL_TTS_ACCEPTANCE.md
+++ b/docs/B06_LOCAL_TTS_ACCEPTANCE.md
@@ -109,3 +109,13 @@ checkpoint, invalid report, timeout, or subprocess failure is
 `TTS_CONTENT_GATE_UNAVAILABLE`; three duration-valid ASR rejections end as
 `TTS_CONTENT_GATE_REJECTED`. Candidate files remain temporary and are never
 atomically moved onto the destination until every gate passes.
+
+The quality runtime is the external `openai-whisper==20250625` package at
+upstream tag `v20250625` / commit
+`31243bad24cc746f07d4c8bfdd2d974872cb1803` (MIT). Install it into the same
+external Python environment used by the CosyVoice worker, following the
+upstream instructions. The official `base.pt` artifact is pinned to SHA-256
+`ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e`.
+The cache directory must be set explicitly in `provider_options` as
+`quality_gate_cache_root`, or through
+`OLIVIA_TTS_QUALITY_GATE_CACHE_ROOT`; no home-directory fallback is used.

--- a/docs/THIRD_PARTY_DOWNLOADS.md
+++ b/docs/THIRD_PARTY_DOWNLOADS.md
@@ -47,6 +47,8 @@ $thirdPartyRoot = Join-Path $env:LOCALAPPDATA 'BSideOliviaLocal\third-party'
 | Nemotron 3.5 ASR Streaming 0.6B | [nvidia/nemotron-3.5-asr-streaming-0.6b](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b) | `1c8deaecc64b91f034d73e08dd8b64625eb3395d` | OpenMDW-1.1 | 上游来源页/手动下载 |
 | CosyVoice runtime | [FunAudioLLM/CosyVoice](https://github.com/FunAudioLLM/CosyVoice) | `074ca6dc9e80a2f424f1f74b48bdd7d3fea531cc` | Apache-2.0 | 上游来源页/手动下载 |
 | Fun-CosyVoice3-0.5B-2512 | [FunAudioLLM/Fun-CosyVoice3-0.5B-2512](https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512) | `29e01c4e8d000f4bcd70751be16fa94bf3d85a18` | Apache-2.0 | 上游来源页/手动下载 |
+| openai-whisper runtime | [openai/whisper](https://github.com/openai/whisper) | `31243bad24cc746f07d4c8bfdd2d974872cb1803` (`v20250625`) | MIT | 安装到外部 CosyVoice Python 环境 |
+| Whisper base.pt | [OpenAI official artifact](https://openaipublic.azureedge.net/main/whisper/models/ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e/base.pt) | `ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e` (SHA-256) | MIT | 手动下载到显式配置的外部 cache |
 | LiveTalking runtime | [lipku/LiveTalking](https://github.com/lipku/LiveTalking) | `a97f01ba366e55eeed94e88d6bae38ed77b3a1b9` | Apache-2.0 | 上游来源页/手动下载 |
 
 这些条目不会带入原版游戏素材、私有参考音频、模型权重或任何生成媒体。只有维护者取得稳定、无凭据的直接 artifact URL，并完成许可证确认和 SHA-256 固定后，才允许把条目加入自动下载 manifest。

--- a/http_contract.py
+++ b/http_contract.py
@@ -69,11 +69,13 @@ ERROR_CODES: dict[str, dict[str, Any]] = {
     "TTS_UNAVAILABLE": {"http_status": 501, "retryable": False},
     "TTS_CONTENT_GATE_UNAVAILABLE": {"http_status": 200, "retryable": True},
     "TTS_CONTENT_GATE_REJECTED": {"http_status": 200, "retryable": False},
+    "MEDIA_PROVIDER_UNAVAILABLE": {"http_status": 200, "retryable": True},
     "LIVE_UNAVAILABLE": {"http_status": 501, "retryable": False},
     "ROUTE_NOT_IMPLEMENTED": {"http_status": 501, "retryable": False},
 }
 
 LETTER_DETAIL_MEDIA_ERROR_CODES: dict[str, dict[str, Any]] = {
+    "MEDIA_PROVIDER_UNAVAILABLE": {"status": "UNAVAILABLE", "retryable": True},
     "TTS_CONTENT_GATE_UNAVAILABLE": {
         "status": "UNAVAILABLE",
         "retryable": True,
@@ -503,19 +505,19 @@ def project_letter_detail_media(
 ) -> dict[str, object]:
     """Project internal/recovery states onto the stable public detail contract."""
 
+    del retryable
     raw_status = str(status or "NOT_REQUESTED")
     raw_error = str(error_code).strip() if error_code is not None else ""
-    public_status, default_error, public_retryable = {
-        "QUEUED": ("PENDING", "", bool(retryable)),
-        "UNAVAILABLE_DATA_ROOT_NOT_CONFIGURED": ("UNAVAILABLE", "UNAVAILABLE_DATA_ROOT_NOT_CONFIGURED", True),
-        "UNAVAILABLE_THIRD_PARTY_NOT_INSTALLED": ("UNAVAILABLE", "UNAVAILABLE_THIRD_PARTY_NOT_INSTALLED", True),
-    }.get(raw_status, (raw_status, "", bool(retryable)))
-    if public_status not in LETTER_DETAIL_MEDIA_CONTRACT["statuses"]:
-        public_status, default_error, public_retryable = (
-            "UNAVAILABLE", "MEDIA_PROVIDER_UNAVAILABLE", False
-        )
+    metadata = letter_detail_media_error_metadata(raw_error)
+    if metadata is not None:
+        return {"status": metadata["status"], "error_code": raw_error,
+                "retryable": metadata["retryable"]}
+    public_status = "PENDING" if raw_status == "QUEUED" else raw_status
+    if not raw_error and public_status in {"NOT_REQUESTED", "PENDING", "PROCESSING", "COMPLETED"}:
+        return {"status": public_status, "error_code": None, "retryable": False}
+    fallback = LETTER_DETAIL_MEDIA_ERROR_CODES["MEDIA_PROVIDER_UNAVAILABLE"]
     return {
-        "status": public_status,
-        "error_code": raw_error or default_error or None,
-        "retryable": public_retryable,
+        "status": fallback["status"],
+        "error_code": "MEDIA_PROVIDER_UNAVAILABLE",
+        "retryable": fallback["retryable"],
     }

--- a/http_contract.py
+++ b/http_contract.py
@@ -46,6 +46,7 @@ ERROR_CODES: dict[str, dict[str, Any]] = {
     "LLM_INTERRUPTED": {"http_status": 503, "retryable": True},
     "LLM_PROVIDER_REJECTED": {"http_status": 503, "retryable": False},
     "LLM_PROTOCOL_ERROR": {"http_status": 503, "retryable": False},
+    "LLM_REPLY_LENGTH_INVALID": {"http_status": 503, "retryable": False},
     "LETTER_RESEND_NOT_IMPLEMENTED": {"http_status": 501, "retryable": False},
     "LETTER_SHARE_NOT_IMPLEMENTED": {"http_status": 501, "retryable": False},
     "PREFERENCE_SURVEY_NOT_IMPLEMENTED": {"http_status": 501, "retryable": False},

--- a/http_contract.py
+++ b/http_contract.py
@@ -494,3 +494,28 @@ def letter_detail_media_error_metadata(error_code: str) -> dict[str, Any] | None
 
     metadata = LETTER_DETAIL_MEDIA_ERROR_CODES.get(error_code)
     return deepcopy(metadata) if metadata is not None else None
+
+
+def project_letter_detail_media(
+    status: object,
+    error_code: object,
+    retryable: object,
+) -> dict[str, object]:
+    """Project internal/recovery states onto the stable public detail contract."""
+
+    raw_status = str(status or "NOT_REQUESTED")
+    raw_error = str(error_code).strip() if error_code is not None else ""
+    public_status, default_error, public_retryable = {
+        "QUEUED": ("PENDING", "", bool(retryable)),
+        "UNAVAILABLE_DATA_ROOT_NOT_CONFIGURED": ("UNAVAILABLE", "UNAVAILABLE_DATA_ROOT_NOT_CONFIGURED", True),
+        "UNAVAILABLE_THIRD_PARTY_NOT_INSTALLED": ("UNAVAILABLE", "UNAVAILABLE_THIRD_PARTY_NOT_INSTALLED", True),
+    }.get(raw_status, (raw_status, "", bool(retryable)))
+    if public_status not in LETTER_DETAIL_MEDIA_CONTRACT["statuses"]:
+        public_status, default_error, public_retryable = (
+            "UNAVAILABLE", "MEDIA_PROVIDER_UNAVAILABLE", False
+        )
+    return {
+        "status": public_status,
+        "error_code": raw_error or default_error or None,
+        "retryable": public_retryable,
+    }

--- a/http_contract.py
+++ b/http_contract.py
@@ -67,8 +67,34 @@ ERROR_CODES: dict[str, dict[str, Any]] = {
     "ASR_MODEL_CORRUPT": {"http_status": 503, "retryable": False},
     "ASR_PROVIDER_UNAVAILABLE": {"http_status": 503, "retryable": True},
     "TTS_UNAVAILABLE": {"http_status": 501, "retryable": False},
+    "TTS_CONTENT_GATE_UNAVAILABLE": {"http_status": 200, "retryable": True},
+    "TTS_CONTENT_GATE_REJECTED": {"http_status": 200, "retryable": False},
     "LIVE_UNAVAILABLE": {"http_status": 501, "retryable": False},
     "ROUTE_NOT_IMPLEMENTED": {"http_status": 501, "retryable": False},
+}
+
+LETTER_DETAIL_MEDIA_ERROR_CODES: dict[str, dict[str, Any]] = {
+    "TTS_CONTENT_GATE_UNAVAILABLE": {
+        "status": "UNAVAILABLE",
+        "retryable": True,
+    },
+    "TTS_CONTENT_GATE_REJECTED": {
+        "status": "FAILED",
+        "retryable": False,
+    },
+}
+
+LETTER_DETAIL_MEDIA_CONTRACT: dict[str, Any] = {
+    "fields": ["media_status", "media_error_code", "media_retryable"],
+    "statuses": [
+        "NOT_REQUESTED",
+        "PENDING",
+        "PROCESSING",
+        "COMPLETED",
+        "FAILED",
+        "UNAVAILABLE",
+    ],
+    "error_codes": LETTER_DETAIL_MEDIA_ERROR_CODES,
 }
 
 
@@ -402,6 +428,7 @@ def contract_document() -> dict[str, Any]:
         "routes": deepcopy(ROUTES),
         "capabilities": deepcopy(CAPABILITIES),
         "profiles": deepcopy(PROFILES),
+        "letter_detail_media": deepcopy(LETTER_DETAIL_MEDIA_CONTRACT),
         "privacy": {
             "logs_include_request_body": False,
             "logs_include_query_values": False,
@@ -460,3 +487,10 @@ def error_metadata(error_code: str) -> dict[str, Any]:
     """Return stable retry metadata without exposing provider details."""
 
     return deepcopy(ERROR_CODES.get(error_code, {"http_status": 500, "retryable": False}))
+
+
+def letter_detail_media_error_metadata(error_code: str) -> dict[str, Any] | None:
+    """Return the registered media-detail terminal state, when applicable."""
+
+    metadata = LETTER_DETAIL_MEDIA_ERROR_CODES.get(error_code)
+    return deepcopy(metadata) if metadata is not None else None

--- a/local_server.py
+++ b/local_server.py
@@ -107,6 +107,7 @@ from reply_context import (
 )
 from reply_pipeline import ReplyPipeline, UnavailableRewriter
 from reply_reviewer import NullReviewer
+from tts import DIRECTED_DELIVERY_ERROR_CODES
 
 PORT = int(_os.environ.get("OLIVIA_PORT", "8899"))
 LLM_TIMEOUT_SECONDS = 30
@@ -1730,6 +1731,7 @@ async def route(method, path, body, query, *, defer_reply: bool = False):
             "triage": l.get("triage", {"status": "unavailable"}),
             "media_status": l.get("media_status", "NOT_REQUESTED"),
             "media_error_code": l.get("media_error_code"),
+            "media_retryable": bool(l.get("media_retryable", False)),
             "is_read": 1 if l.get("is_read") else 0,
             "replied_at": l.get("replied_at"),
             "created_at": l.get("created_at", int(time.time())),
@@ -2033,10 +2035,12 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
                     latentsync_root=Path(_os.environ.get("OLIVIA_LATENTSYNC_ROOT", "")),
                     adaptive_delivery=True,
                     voice_performance_plan=voice_plan,
+                    enforce_content_gate=True,
                 )
             letter["reply_video_url"] = f"http://127.0.0.1:{PORT}/toy/media/{output_path.name}"
             letter["media_status"] = "COMPLETED"
             letter["media_error_code"] = None
+            letter["media_retryable"] = False
             _persist_media_state()
         except (
             ReplyMediaError,
@@ -2047,8 +2051,17 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
             ValueError,
             OSError,
         ) as exc:
-            letter["media_status"] = "UNAVAILABLE"
-            letter["media_error_code"] = str(exc)[:80] or "MEDIA_PROVIDER_UNAVAILABLE"
+            error_code = str(exc)[:80] or "MEDIA_PROVIDER_UNAVAILABLE"
+            error_contract = DIRECTED_DELIVERY_ERROR_CODES.get(error_code)
+            letter["media_status"] = (
+                str(error_contract["status"])
+                if error_contract is not None
+                else "UNAVAILABLE"
+            )
+            letter["media_error_code"] = error_code
+            letter["media_retryable"] = bool(
+                error_contract and error_contract["retryable"]
+            )
             _persist_media_state()
 
 

--- a/local_server.py
+++ b/local_server.py
@@ -1459,6 +1459,8 @@ def _letter_list_payload(scope: str) -> dict:
 def _public_llm_error(code: str | None) -> tuple[str, bool]:
     if code in {"REPLY_QUALITY_BLOCKED", "REWRITE_FAILED"}:
         return "REPLY_QUALITY_BLOCKED", False
+    if code == "LLM_REPLY_LENGTH_INVALID":
+        return "LLM_REPLY_LENGTH_INVALID", False
     if code in {"LLM_TIMEOUT", "PROVIDER_TIMEOUT"}:
         return "LLM_TIMEOUT", True
     if code == "LLM_INTERRUPTED":
@@ -2402,8 +2404,7 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
         )
         if (
             result.state is ReplyState.COMPLETED
-            and exact_mode
-            in {ReplyMode.SPOKEN_VIDEO.value, ReplyMode.MUSICAL_VIDEO.value}
+            and exact_mode == ReplyMode.SPOKEN_VIDEO.value
             and not ordinary_video_reply_length_ok(result.text)
         ):
             result = await _run_reply_pipeline_for_letter(
@@ -2444,8 +2445,7 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
         _safe_log("letter_failed", error_code=public_code)
         return False
     if (
-        exact_mode
-        in {ReplyMode.SPOKEN_VIDEO.value, ReplyMode.MUSICAL_VIDEO.value}
+        exact_mode == ReplyMode.SPOKEN_VIDEO.value
         and not ordinary_video_reply_length_ok(result.text)
     ):
         letter["letter_status"] = "FAILED"

--- a/local_server.py
+++ b/local_server.py
@@ -734,34 +734,27 @@ async def _music_voice_plan_for_letter(
 ) -> VoicePerformancePlan:
     """Keep the musical prelude on its pre-A director and persistence lane."""
 
-    for key in ("music_voice_performance_plan", "voice_performance_plan"):
-        stored = letter.get(key)
-        if stored is None:
-            continue
+    stored = letter.get("voice_performance_plan")
+    if stored is not None:
         try:
             if not isinstance(stored, dict):
                 raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
             plan = VoicePerformancePlan.from_music_dict(stored)
         except VoiceDirectionError:
-            if key == "voice_performance_plan":
-                continue
             raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_PLAN_INVALID") from None
         if plan.reply_text != reply_text:
             raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_PLAN_INVALID")
-        if key == "voice_performance_plan":
-            letter["music_voice_performance_plan"] = plan.to_dict()
-            _persist_media_state()
         return plan
 
     letter_id = str(letter.get("letter_id", "")).strip()
     if not letter_id:
         raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_REQUEST_INVALID")
-    request_id = f"letter-reply:{letter_id}:music-voice-direction"
-    persisted_request_id = letter.get("music_voice_direction_request_id")
+    request_id = f"letter-reply:{letter_id}:voice-direction"
+    persisted_request_id = letter.get("voice_direction_request_id")
     if persisted_request_id is not None and persisted_request_id != request_id:
         raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_REQUEST_INVALID")
     if persisted_request_id is None:
-        letter["music_voice_direction_request_id"] = request_id
+        letter["voice_direction_request_id"] = request_id
         _persist_media_state()
     plan = await asyncio.wait_for(
         direct_music_voice_performance(
@@ -773,7 +766,7 @@ async def _music_voice_plan_for_letter(
     )
     if plan.reply_text != reply_text:
         raise VoiceDirectionError("VOICE_DIRECTION_TEXT_MISMATCH")
-    letter["music_voice_performance_plan"] = plan.to_dict()
+    letter["voice_performance_plan"] = plan.to_dict()
     _persist_media_state()
     return plan
 
@@ -2041,7 +2034,7 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
         output_dir = data_root / "media" if data_root.is_absolute() else None
         if output_dir is None:
             letter["media_status"] = "UNAVAILABLE"
-            letter["media_error_code"] = "UNAVAILABLE_DATA_ROOT_NOT_CONFIGURED"
+            letter["media_error_code"] = "MEDIA_PROVIDER_UNAVAILABLE"
             letter["media_retryable"] = True
             _persist_media_state()
             return
@@ -2112,7 +2105,9 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
             ValueError,
             OSError,
         ) as exc:
-            error_code = str(exc)[:80] or "MEDIA_PROVIDER_UNAVAILABLE"
+            candidate = str(exc)[:80]
+            error_contract = contract.letter_detail_media_error_metadata(candidate)
+            error_code = candidate if error_contract is not None else "MEDIA_PROVIDER_UNAVAILABLE"
             error_contract = contract.letter_detail_media_error_metadata(error_code)
             letter["media_status"] = (
                 str(error_contract["status"])
@@ -2466,7 +2461,7 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
         ReplyMode.MUSICAL_VIDEO.value,
     }:
         letter["media_status"] = "UNAVAILABLE"
-        letter["media_error_code"] = "UNAVAILABLE_THIRD_PARTY_NOT_INSTALLED"
+        letter["media_error_code"] = "MEDIA_PROVIDER_UNAVAILABLE"
         letter["media_retryable"] = True
     _schedule_text_reply_delay(letter, exact_mode)
     _persist_store_state()

--- a/local_server.py
+++ b/local_server.py
@@ -51,7 +51,11 @@ from letter_triage import LetterEmotionTriage, TriageResult, _current_music_perf
 from music_reply import MusicReplyError, render_musical_reply, select_speaking_scene, speaking_scene_candidates
 from music_duration import MUSIC_DURATION_OPTIONS
 from reply_media import ReplyMediaError, render_reply_video
-from reply_delivery import build_ordinary_video_llm_content
+from reply_delivery import (
+    build_ordinary_video_llm_content,
+    build_ordinary_video_repair_content,
+    ordinary_video_reply_length_ok,
+)
 from voice_direction import (
     VoiceDirectionError,
     VoicePerformancePlan,
@@ -711,6 +715,7 @@ async def _voice_plan_for_letter(
         direct_voice_performance(
             reply_text,
             letters_adapter.gateway,
+            letter_content=str(letter.get("content", "")),
             request_id=request_id,
         ),
         timeout=LLM_TIMEOUT_SECONDS,
@@ -2315,6 +2320,8 @@ async def _run_reply_pipeline_for_letter(
     exact_mode: str,
     *,
     idempotency_key: str | None,
+    reply_input_override: str | None = None,
+    request_suffix: str = "",
 ):
     letter_id = str(letter["letter_id"])
     revision = max(0, int(letter.get("reply_revision", 0))) + 1
@@ -2322,17 +2329,21 @@ async def _run_reply_pipeline_for_letter(
         f"reply:{letter_id}:{revision}"
     )
     try:
-        reply_input = (
-            build_ordinary_video_llm_content(content)
-            if exact_mode
-            in {ReplyMode.SPOKEN_VIDEO.value, ReplyMode.MUSICAL_VIDEO.value}
-            else content
-        )
+        reply_input = reply_input_override
+        if reply_input is None:
+            reply_input = (
+                build_ordinary_video_llm_content(content)
+                if exact_mode
+                in {ReplyMode.SPOKEN_VIDEO.value, ReplyMode.MUSICAL_VIDEO.value}
+                else content
+            )
         request = ReplyRequest(
             content=reply_input,
-            request_id=f"letter-reply:{letter_id}",
+            request_id=f"letter-reply:{letter_id}{request_suffix}",
             idempotency_key=(
-                f"{idempotency_key}:{letter_id}" if idempotency_key else None
+                f"{idempotency_key}:{letter_id}{request_suffix}"
+                if idempotency_key
+                else None
             ),
             max_input_chars=LLM_CONFIG.max_input_chars,
         )
@@ -2389,6 +2400,20 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
             exact_mode,
             idempotency_key=idempotency_key,
         )
+        if (
+            result.state is ReplyState.COMPLETED
+            and exact_mode
+            in {ReplyMode.SPOKEN_VIDEO.value, ReplyMode.MUSICAL_VIDEO.value}
+            and not ordinary_video_reply_length_ok(result.text)
+        ):
+            result = await _run_reply_pipeline_for_letter(
+                letter,
+                content,
+                exact_mode,
+                idempotency_key=idempotency_key,
+                reply_input_override=build_ordinary_video_repair_content(result.text),
+                request_suffix=":duration-repair",
+            )
     except asyncio.CancelledError:
         letter["letter_status"] = "FAILED"
         letter["error_code"] = "LLM_INTERRUPTED"
@@ -2417,6 +2442,16 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
         letter["error_code"] = public_code
         _persist_store_state()
         _safe_log("letter_failed", error_code=public_code)
+        return False
+    if (
+        exact_mode
+        in {ReplyMode.SPOKEN_VIDEO.value, ReplyMode.MUSICAL_VIDEO.value}
+        and not ordinary_video_reply_length_ok(result.text)
+    ):
+        letter["letter_status"] = "FAILED"
+        letter["error_code"] = "LLM_REPLY_LENGTH_INVALID"
+        _persist_store_state()
+        _safe_log("letter_failed", error_code="LLM_REPLY_LENGTH_INVALID")
         return False
 
     _prepare_private_world_delivery(letter, result.text)

--- a/local_server.py
+++ b/local_server.py
@@ -107,7 +107,6 @@ from reply_context import (
 )
 from reply_pipeline import ReplyPipeline, UnavailableRewriter
 from reply_reviewer import NullReviewer
-from tts import DIRECTED_DELIVERY_ERROR_CODES
 
 PORT = int(_os.environ.get("OLIVIA_PORT", "8899"))
 LLM_TIMEOUT_SECONDS = 30
@@ -2052,7 +2051,7 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
             OSError,
         ) as exc:
             error_code = str(exc)[:80] or "MEDIA_PROVIDER_UNAVAILABLE"
-            error_contract = DIRECTED_DELIVERY_ERROR_CODES.get(error_code)
+            error_contract = contract.letter_detail_media_error_metadata(error_code)
             letter["media_status"] = (
                 str(error_contract["status"])
                 if error_contract is not None

--- a/local_server.py
+++ b/local_server.py
@@ -2038,9 +2038,9 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
             letter["media_retryable"] = True
             _persist_media_state()
             return
-        output_dir.mkdir(parents=True, exist_ok=True)
         output_path = output_dir / f"{letter_id}.mp4"
         try:
+            output_dir.mkdir(parents=True, exist_ok=True)
             tts_config = Path(_os.environ.get("OLIVIA_TTS_CONFIG", ""))
             visual_config = Path(_os.environ.get("OLIVIA_VISUAL_CONFIG", ""))
             worker = Path(_os.environ.get("OLIVIA_LIVETALKING_WORKER", ""))

--- a/local_server.py
+++ b/local_server.py
@@ -59,6 +59,7 @@ from reply_delivery import (
 from voice_direction import (
     VoiceDirectionError,
     VoicePerformancePlan,
+    direct_music_voice_performance,
     direct_voice_performance,
 )
 from video_reply_settings import (
@@ -725,6 +726,58 @@ async def _voice_plan_for_letter(
     letter["voice_performance_plan"] = plan.to_dict()
     _persist_media_state()
     return plan
+
+
+async def _music_voice_plan_for_letter(
+    letter: dict,
+    reply_text: str,
+) -> VoicePerformancePlan:
+    """Keep the musical prelude on its pre-A director and persistence lane."""
+
+    for key in ("music_voice_performance_plan", "voice_performance_plan"):
+        stored = letter.get(key)
+        if stored is None:
+            continue
+        try:
+            if not isinstance(stored, dict):
+                raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+            plan = VoicePerformancePlan.from_music_dict(stored)
+        except VoiceDirectionError:
+            if key == "voice_performance_plan":
+                continue
+            raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_PLAN_INVALID") from None
+        if plan.reply_text != reply_text:
+            raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_PLAN_INVALID")
+        if key == "voice_performance_plan":
+            letter["music_voice_performance_plan"] = plan.to_dict()
+            _persist_media_state()
+        return plan
+
+    letter_id = str(letter.get("letter_id", "")).strip()
+    if not letter_id:
+        raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_REQUEST_INVALID")
+    request_id = f"letter-reply:{letter_id}:music-voice-direction"
+    persisted_request_id = letter.get("music_voice_direction_request_id")
+    if persisted_request_id is not None and persisted_request_id != request_id:
+        raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_REQUEST_INVALID")
+    if persisted_request_id is None:
+        letter["music_voice_direction_request_id"] = request_id
+        _persist_media_state()
+    plan = await asyncio.wait_for(
+        direct_music_voice_performance(
+            reply_text,
+            letters_adapter.gateway,
+            request_id=request_id,
+        ),
+        timeout=LLM_TIMEOUT_SECONDS,
+    )
+    if plan.reply_text != reply_text:
+        raise VoiceDirectionError("VOICE_DIRECTION_TEXT_MISMATCH")
+    letter["music_voice_performance_plan"] = plan.to_dict()
+    _persist_media_state()
+    return plan
+
+
 music_adapter = MusicAdapter()
 reply_engine = ReplyOrchestrator(
     _LetterGateway(letters_adapter),
@@ -1705,6 +1758,11 @@ async def route(method, path, body, query, *, defer_reply: bool = False):
         reply_published = l.get("reply_not_before", 0.0) <= time.time()
         reply_text = l.get("reply_text", "") if reply_published else ""
         error_code, retryable = _public_llm_error(l.get("error_code"))
+        media_detail = contract.project_letter_detail_media(
+            l.get("media_status", "NOT_REQUESTED"),
+            l.get("media_error_code"),
+            l.get("media_retryable", False),
+        )
         return ok({
             "letter_id": l["letter_id"],
             "letter_status": l.get("letter_status", 4),
@@ -1728,9 +1786,9 @@ async def route(method, path, body, query, *, defer_reply: bool = False):
                 else ReplyMode.TEXT_LETTER.value
             ),
             "triage": l.get("triage", {"status": "unavailable"}),
-            "media_status": l.get("media_status", "NOT_REQUESTED"),
-            "media_error_code": l.get("media_error_code"),
-            "media_retryable": bool(l.get("media_retryable", False)),
+            "media_status": media_detail["status"],
+            "media_error_code": media_detail["error_code"],
+            "media_retryable": media_detail["retryable"],
             "is_read": 1 if l.get("is_read") else 0,
             "replied_at": l.get("replied_at"),
             "created_at": l.get("created_at", int(time.time())),
@@ -1982,7 +2040,10 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
         data_root = Path(_os.environ.get("OLIVIA_LOCAL_DATA_ROOT", ""))
         output_dir = data_root / "media" if data_root.is_absolute() else None
         if output_dir is None:
-            letter["media_status"] = "UNAVAILABLE_DATA_ROOT_NOT_CONFIGURED"
+            letter["media_status"] = "UNAVAILABLE"
+            letter["media_error_code"] = "UNAVAILABLE_DATA_ROOT_NOT_CONFIGURED"
+            letter["media_retryable"] = True
+            _persist_media_state()
             return
         output_dir.mkdir(parents=True, exist_ok=True)
         output_path = output_dir / f"{letter_id}.mp4"
@@ -1990,8 +2051,8 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
             tts_config = Path(_os.environ.get("OLIVIA_TTS_CONFIG", ""))
             visual_config = Path(_os.environ.get("OLIVIA_VISUAL_CONFIG", ""))
             worker = Path(_os.environ.get("OLIVIA_LIVETALKING_WORKER", ""))
-            voice_plan = await _voice_plan_for_letter(letter, reply_text)
             if reply_mode == "musical_video":
+                voice_plan = await _music_voice_plan_for_letter(letter, reply_text)
                 music_duration_seconds = int(letter.get("music_duration_seconds", 60))
                 performance_scene = _current_music_performance(_os.environ)
                 if performance_scene is None or not performance_scene.is_file():
@@ -2015,6 +2076,7 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
                     voice_performance_plan=voice_plan,
                 )
             else:
+                voice_plan = await _voice_plan_for_letter(letter, reply_text)
                 from datetime import datetime
 
                 hour = datetime.now().hour
@@ -2403,7 +2465,9 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
         ReplyMode.SPOKEN_VIDEO.value,
         ReplyMode.MUSICAL_VIDEO.value,
     }:
-        letter["media_status"] = "UNAVAILABLE_THIRD_PARTY_NOT_INSTALLED"
+        letter["media_status"] = "UNAVAILABLE"
+        letter["media_error_code"] = "UNAVAILABLE_THIRD_PARTY_NOT_INSTALLED"
+        letter["media_retryable"] = True
     _schedule_text_reply_delay(letter, exact_mode)
     _persist_store_state()
 

--- a/reply_media.py
+++ b/reply_media.py
@@ -180,11 +180,15 @@ def assemble_complete_video_delivery(
         raise ReplyMediaError("COMPLETE_VIDEO_CONFIG_UNAVAILABLE") from exc
     worker = Path(worker_path)
     if (
-        not delivery_configured(tts, require_quality_gate=require_quality_gate)
+        not delivery_configured(tts)
         or not worker.is_file()
         or not media_runtime_available(env)
     ):
         raise ReplyMediaError("COMPLETE_VIDEO_CONFIG_UNAVAILABLE")
+    if require_quality_gate and not delivery_configured(
+        tts, require_quality_gate=True
+    ):
+        raise ReplyMediaError("TTS_CONTENT_GATE_UNAVAILABLE")
     return CompleteVideoDelivery(tts, visual, worker)
 
 

--- a/reply_media.py
+++ b/reply_media.py
@@ -109,6 +109,11 @@ def _tts_config(
             )
             settings["leading_trim_seconds"] = 0.0
         provider_options["voice_condition_mode"] = "cross_lingual_audio_only"
+        quality_cache_root = environment.get(
+            "OLIVIA_TTS_QUALITY_GATE_CACHE_ROOT"
+        )
+        if quality_cache_root is not None:
+            provider_options["quality_gate_cache_root"] = quality_cache_root
     reference_audio = Path(str(settings.get("reference_audio", "")))
     leading_trim = settings.get("leading_trim_seconds")
     if leading_trim is None and reference_audio.is_file():
@@ -162,6 +167,8 @@ def assemble_complete_video_delivery(
     worker_path: Path,
     temporary_root: Path,
     env: Mapping[str, str] | None = None,
+    *,
+    require_quality_gate: bool = False,
 ) -> CompleteVideoDelivery:
     """Pure configuration seam shared by availability and the real renderer."""
 
@@ -173,7 +180,7 @@ def assemble_complete_video_delivery(
         raise ReplyMediaError("COMPLETE_VIDEO_CONFIG_UNAVAILABLE") from exc
     worker = Path(worker_path)
     if (
-        not delivery_configured(tts, require_quality_gate=True)
+        not delivery_configured(tts, require_quality_gate=require_quality_gate)
         or not worker.is_file()
         or not media_runtime_available(env)
     ):
@@ -234,12 +241,17 @@ def render_reply_video(
     latentsync_root: Path | None = None,
     adaptive_delivery: bool = False,
     voice_performance_plan: VoicePerformancePlan | None = None,
+    enforce_content_gate: bool = False,
 ) -> dict[str, object]:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="olivia-reply-", dir=output_path.parent) as temporary:
         root = Path(temporary)
         delivery = assemble_complete_video_delivery(
-            tts_config_path, visual_config_path, worker_path, root
+            tts_config_path,
+            visual_config_path,
+            worker_path,
+            root,
+            require_quality_gate=enforce_content_gate,
         )
         audio_path = root / "reply.wav"
         frames = root / "frames"
@@ -253,6 +265,7 @@ def render_reply_video(
                     delivery.tts,
                     delivery_plan,
                     audio_path,
+                    enforce_content_gate=enforce_content_gate,
                 )
             except DeliveryAudioError as exc:
                 raise ReplyMediaError(str(exc)) from exc

--- a/reply_media.py
+++ b/reply_media.py
@@ -172,7 +172,11 @@ def assemble_complete_video_delivery(
     except (ReplyMediaError, ValueError, TypeError) as exc:
         raise ReplyMediaError("COMPLETE_VIDEO_CONFIG_UNAVAILABLE") from exc
     worker = Path(worker_path)
-    if not delivery_configured(tts) or not worker.is_file() or not media_runtime_available(env):
+    if (
+        not delivery_configured(tts, require_quality_gate=True)
+        or not worker.is_file()
+        or not media_runtime_available(env)
+    ):
         raise ReplyMediaError("COMPLETE_VIDEO_CONFIG_UNAVAILABLE")
     return CompleteVideoDelivery(tts, visual, worker)
 

--- a/runtime/packaging/manifests/b10b.modules.json
+++ b/runtime/packaging/manifests/b10b.modules.json
@@ -67,6 +67,28 @@
         "uninstall_path": "B10B uninstall never copies or deletes the referenced model, reference audio, or generated audio."
       },
       {
+        "id": "b06-whisper-quality-runtime",
+        "kind": "runtime",
+        "source": "https://github.com/openai/whisper",
+        "version": "openai-whisper 20250625",
+        "revision": "31243bad24cc746f07d4c8bfdd2d974872cb1803",
+        "license": "MIT",
+        "status": "composed",
+        "adapter_boundary": "The ordinary spoken-video adapter invokes the external openai-whisper runtime only after CosyVoice exits; it does not reimplement ASR.",
+        "uninstall_path": "B10B and the reply pipeline never copy or delete the external Whisper runtime or cache."
+      },
+      {
+        "id": "b06-whisper-base-model",
+        "kind": "model",
+        "source": "https://github.com/openai/whisper",
+        "version": "Whisper base.pt SHA-256 ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e",
+        "revision": "31243bad24cc746f07d4c8bfdd2d974872cb1803",
+        "license": "MIT",
+        "status": "composed",
+        "adapter_boundary": "The ordinary spoken-video quality gate reads only an explicitly configured external cache and verifies base.pt by SHA-256 before inference.",
+        "uninstall_path": "The reply pipeline never downloads, copies, overwrites, or deletes the external Whisper checkpoint."
+      },
+      {
         "id": "b07-livetalking-candidate",
         "kind": "visual-runtime",
         "source": "https://github.com/lipku/LiveTalking",

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -1064,6 +1064,7 @@ def test_mem0_mode_can_incrementally_import_archive_after_restart(
 
 def test_contract_and_fixture_artifacts_are_versioned_and_sanitized() -> None:
     import http_contract
+    from jsonschema import Draft202012Validator
 
     schema = json.loads(
         (ROOT / "contracts" / "http_contract.schema.json").read_text(encoding="utf-8")
@@ -1079,6 +1080,8 @@ def test_contract_and_fixture_artifacts_are_versioned_and_sanitized() -> None:
         (ROOT / "contracts" / "legacy_letter_import.example.json").read_text(encoding="utf-8")
     )
 
+    assert not list(Draft202012Validator(schema).iter_errors(document))
+
     assert schema["properties"]["contract_version"]["const"] == "b02.v1"
     assert legacy_schema["properties"]["mode"]["const"] == "read_only"
     assert document["contract_version"] == "b02.v1"
@@ -1086,6 +1089,35 @@ def test_contract_and_fixture_artifacts_are_versioned_and_sanitized() -> None:
     assert http_contract.error_metadata("MEMORY_UNAVAILABLE") == {
         "http_status": 503,
         "retryable": True,
+    }
+    assert http_contract.error_metadata("TTS_CONTENT_GATE_UNAVAILABLE") == {
+        "http_status": 200,
+        "retryable": True,
+    }
+    assert http_contract.error_metadata("TTS_CONTENT_GATE_REJECTED") == {
+        "http_status": 200,
+        "retryable": False,
+    }
+    assert document["letter_detail_media"] == {
+        "fields": ["media_status", "media_error_code", "media_retryable"],
+        "statuses": [
+            "NOT_REQUESTED",
+            "PENDING",
+            "PROCESSING",
+            "COMPLETED",
+            "FAILED",
+            "UNAVAILABLE",
+        ],
+        "error_codes": {
+            "TTS_CONTENT_GATE_UNAVAILABLE": {
+                "status": "UNAVAILABLE",
+                "retryable": True,
+            },
+            "TTS_CONTENT_GATE_REJECTED": {
+                "status": "FAILED",
+                "retryable": False,
+            },
+        },
     }
     assert "LEGACY_IMPORT_NOT_IMPLEMENTED" not in http_contract.ERROR_CODES
     expected_import_mode = "read-only-atomic-import"

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -1113,6 +1113,7 @@ def test_contract_and_fixture_artifacts_are_versioned_and_sanitized() -> None:
             "UNAVAILABLE",
         ],
         "error_codes": {
+            "MEDIA_PROVIDER_UNAVAILABLE": {"status": "UNAVAILABLE", "retryable": True},
             "TTS_CONTENT_GATE_UNAVAILABLE": {
                 "status": "UNAVAILABLE",
                 "retryable": True,

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -1081,6 +1081,10 @@ def test_contract_and_fixture_artifacts_are_versioned_and_sanitized() -> None:
     )
 
     assert not list(Draft202012Validator(schema).iter_errors(document))
+    assert not list(Draft202012Validator(schema).iter_errors(example))
+    missing_media_contract = dict(document)
+    missing_media_contract.pop("letter_detail_media")
+    assert list(Draft202012Validator(schema).iter_errors(missing_media_contract))
 
     assert schema["properties"]["contract_version"]["const"] == "b02.v1"
     assert legacy_schema["properties"]["mode"]["const"] == "read_only"

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -358,7 +358,7 @@ def test_complete_video_readiness_fails_closed_for_every_missing_renderer_depend
     quality_cache.mkdir()
     quality_checkpoint = quality_cache / "base.pt"
     quality_checkpoint.write_bytes(b"synthetic")
-    required.extend((tts_llm, quality_checkpoint))
+    required.append(tts_llm)
     tts_reference = write("tts/reference.wav")
     Path(env["OLIVIA_TTS_CONFIG"]).write_text(json.dumps({"settings": {
         "runtime_root": str(tts_runtime), "model_dir": str(tts_model),
@@ -395,6 +395,10 @@ def test_complete_video_readiness_fails_closed_for_every_missing_renderer_depend
     )
 
     assert routing_context_from_environment(env) == RoutingContext(True, True)
+
+    quality_checkpoint.unlink()
+    assert routing_context_from_environment(env) == RoutingContext(True, True)
+    quality_checkpoint.write_bytes(b"synthetic")
 
     for missing in required:
         missing.unlink()

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import latentsync_reply
+import tts.delivery as tts_delivery
 from letter_triage import (
     LetterReplyRouter,
     RoutingContext,
@@ -351,10 +352,18 @@ def test_complete_video_readiness_fails_closed_for_every_missing_renderer_depend
     (tts_runtime / "venv/Scripts/python.exe").write_bytes(b"synthetic")
     tts_model = tmp_path / "tts-model"
     tts_model.mkdir()
+    tts_llm = tts_model / "llm.pt"
+    tts_llm.write_bytes(b"synthetic")
+    quality_cache = tmp_path / "whisper"
+    quality_cache.mkdir()
+    quality_checkpoint = quality_cache / "base.pt"
+    quality_checkpoint.write_bytes(b"synthetic")
+    required.extend((tts_llm, quality_checkpoint))
     tts_reference = write("tts/reference.wav")
     Path(env["OLIVIA_TTS_CONFIG"]).write_text(json.dumps({"settings": {
         "runtime_root": str(tts_runtime), "model_dir": str(tts_model),
         "reference_audio": tts_reference,
+        "provider_options": {"quality_gate_cache_root": str(quality_cache)},
     }}), encoding="utf-8")
     visual_runtime = tmp_path / "visual-runtime"
     visual_runtime.mkdir()
@@ -373,6 +382,17 @@ def test_complete_video_readiness_fails_closed_for_every_missing_renderer_depend
         "upstream_revision": "a97f01ba366e55eeed94e88d6bae38ed77b3a1b9",
         "upstream_license": "Apache-2.0",
     }}), encoding="utf-8")
+
+    monkeypatch.setattr(
+        tts_delivery,
+        "_verified_file",
+        lambda path, _expected: Path(path).is_file(),
+    )
+    monkeypatch.setattr(
+        tts_delivery,
+        "_quality_runtime_available",
+        lambda *_args: True,
+    )
 
     assert routing_context_from_environment(env) == RoutingContext(True, True)
 

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -46,6 +46,23 @@ def test_exact_modes_keep_legacy_wire_compatibility():
     assert local_server._exact_reply_mode("video") == "musical_video"
 
 
+def test_media_output_directory_failure_is_normalized(tmp_path: Path, monkeypatch):
+    blocked_root = tmp_path / "blocked"
+    blocked_root.write_text("not a directory", encoding="utf-8")
+    letter = {"letter_id": "mkdir-failure", "media_status": "PENDING"}
+    local_server.store.letters[:] = [letter]
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(blocked_root))
+    monkeypatch.setattr(local_server, "_persist_media_state", lambda: None)
+
+    asyncio.run(local_server._render_media_job(
+        "mkdir-failure", "letter", "reply", ReplyMode.SPOKEN_VIDEO.value
+    ))
+
+    assert (letter["media_status"], letter["media_error_code"], letter["media_retryable"]) == (
+        "UNAVAILABLE", "MEDIA_PROVIDER_UNAVAILABLE", True
+    )
+
+
 def test_successful_media_retry_clears_the_previous_failure_code(
     tmp_path: Path,
     monkeypatch,

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -81,6 +81,8 @@ def test_successful_media_retry_clears_the_previous_failure_code(
             energy=0.5,
             breath_before_sentences=(),
             emphasize_sentences=(),
+            short_instruction="",
+            profile="legacy_music_global_direction_v1",
         )
 
     def render(_content, _reply, output, **kwargs):
@@ -89,7 +91,7 @@ def test_successful_media_retry_clears_the_previous_failure_code(
         return {}
 
     monkeypatch.setattr(local_server, "render_musical_reply", render)
-    monkeypatch.setattr(local_server, "_voice_plan_for_letter", voice_plan)
+    monkeypatch.setattr(local_server, "_music_voice_plan_for_letter", voice_plan)
 
     asyncio.run(
         local_server._render_media_job(
@@ -176,7 +178,38 @@ def test_public_detail_distinguishes_directed_tts_gate_terminal_states(
     assert detail["media_retryable"] is expected_retryable
 
 
-def test_both_product_video_renderers_receive_the_persisted_llm_voice_plan(
+@pytest.mark.parametrize(
+    ("stored_status", "expected"),
+    [
+        ("QUEUED", ("PENDING", None, False)),
+        ("UNAVAILABLE_DATA_ROOT_NOT_CONFIGURED", ("UNAVAILABLE", "UNAVAILABLE_DATA_ROOT_NOT_CONFIGURED", True)),
+        ("UNAVAILABLE_THIRD_PARTY_NOT_INSTALLED", ("UNAVAILABLE", "UNAVAILABLE_THIRD_PARTY_NOT_INSTALLED", True)),
+    ],
+)
+def test_public_detail_projects_every_legacy_internal_media_status(
+    stored_status: str,
+    expected: tuple[str, str | None, bool],
+) -> None:
+    letter_id = f"status-{stored_status.casefold()}"
+    local_server.store.letters[:] = [
+        {
+            "letter_id": letter_id,
+            "content": "synthetic",
+            "letter_status": "COMPLETED",
+            "reply_text": "synthetic",
+            "reply_mode": ReplyMode.SPOKEN_VIDEO.value,
+            "media_status": stored_status,
+            "reply_not_before": 0.0,
+        }
+    ]
+
+    detail = asyncio.run(local_server.route(
+        "GET", "/toy/letter/detail", {}, {"letter_id": letter_id}
+    ))["data"]
+    assert (detail["media_status"], detail["media_error_code"], detail["media_retryable"]) == expected
+
+
+def test_ordinary_a_direction_and_music_legacy_direction_are_isolated(
     tmp_path: Path,
     monkeypatch,
 ):
@@ -188,6 +221,16 @@ def test_both_product_video_renderers_receive_the_persisted_llm_voice_plan(
         energy=0.62,
         breath_before_sentences=(),
         emphasize_sentences=(1,),
+    )
+    music_plan = VoicePerformancePlan(
+        reply_text=reply_text,
+        overall_emotion="restrained empathy becoming steady reassurance",
+        global_speed=1.06,
+        energy=0.62,
+        breath_before_sentences=(),
+        emphasize_sentences=(1,),
+        short_instruction="",
+        profile="legacy_music_global_direction_v1",
     )
     scene = tmp_path / "scene.mp4"
     scene.write_bytes(b"scene")
@@ -221,9 +264,15 @@ def test_both_product_video_renderers_receive_the_persisted_llm_voice_plan(
     async def direct_frozen_reply(text, gateway, *, letter_content=None, request_id=None):
         assert text == reply_text
         assert gateway is local_server.letters_adapter.gateway
-        assert letter_content in {"ordinary video request", "spoken plus music request"}
+        assert letter_content == "ordinary video request"
         directed_requests.append(request_id)
         return plan
+
+    async def direct_music_reply(text, gateway, *, request_id=None):
+        assert text == reply_text
+        assert gateway is local_server.letters_adapter.gateway
+        directed_requests.append(request_id)
+        return music_plan
 
     received = {}
 
@@ -238,6 +287,11 @@ def test_both_product_video_renderers_receive_the_persisted_llm_voice_plan(
         return {}
 
     monkeypatch.setattr(local_server, "direct_voice_performance", direct_frozen_reply)
+    monkeypatch.setattr(
+        local_server,
+        "direct_music_voice_performance",
+        direct_music_reply,
+    )
     monkeypatch.setattr(local_server, "render_reply_video", render_spoken)
     monkeypatch.setattr(local_server, "render_musical_reply", render_musical)
 
@@ -251,13 +305,14 @@ def test_both_product_video_renderers_receive_the_persisted_llm_voice_plan(
 
     asyncio.run(exercise())
 
-    assert received == {"spoken_video": plan, "musical_video": plan}
+    assert received == {"spoken_video": plan, "musical_video": music_plan}
     assert directed_requests == [
         "letter-reply:spoken-entry:voice-direction",
-        "letter-reply:musical-entry:voice-direction",
+        "letter-reply:musical-entry:music-voice-direction",
     ]
     assert letters[0]["voice_performance_plan"] == plan.to_dict()
-    assert letters[1]["voice_performance_plan"] == plan.to_dict()
+    assert "voice_performance_plan" not in letters[1]
+    assert letters[1]["music_voice_performance_plan"] == music_plan.to_dict()
 
 
 def test_corrupt_persisted_voice_plan_fails_closed_without_redirection(monkeypatch):

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -148,9 +148,10 @@ def test_both_product_video_renderers_receive_the_persisted_llm_voice_plan(
 
     directed_requests = []
 
-    async def direct_frozen_reply(text, gateway, *, request_id=None):
+    async def direct_frozen_reply(text, gateway, *, letter_content=None, request_id=None):
         assert text == reply_text
         assert gateway is local_server.letters_adapter.gateway
+        assert letter_content in {"ordinary video request", "spoken plus music request"}
         directed_requests.append(request_id)
         return plan
 
@@ -196,7 +197,7 @@ def test_corrupt_persisted_voice_plan_fails_closed_without_redirection(monkeypat
     }
     provider_calls = []
 
-    async def direct(_text, _gateway, *, request_id=None):
+    async def direct(_text, _gateway, *, letter_content=None, request_id=None):
         provider_calls.append(request_id)
         raise AssertionError("corrupt state must not call the voice provider")
 
@@ -226,7 +227,7 @@ def test_voice_direction_retries_keep_a_persisted_provider_idempotency_key(monke
     def persist():
         persisted_request_ids.append(letter.get("voice_direction_request_id"))
 
-    async def direct(_text, _gateway, *, request_id=None):
+    async def direct(_text, _gateway, *, letter_content=None, request_id=None):
         provider_calls.append(request_id)
         assert letter["voice_direction_request_id"] == request_id
         if len(provider_calls) == 1:
@@ -405,7 +406,7 @@ def test_generate_reply_preserves_the_router_selected_video_route(
         return PipelineResult(
             letter_id,
             ReplyState.COMPLETED,
-            text="synthetic canonical reply",
+            text="林" * 190,
             quality_status="accepted_degraded",
         )
 
@@ -439,3 +440,47 @@ def test_generate_reply_preserves_the_router_selected_video_route(
     assert public["reply_mode"] == (
         "text" if delivery_mode == ReplyMode.TEXT_LETTER.value else "video"
     )
+
+
+def test_generate_reply_repairs_then_rechecks_video_copy_length(monkeypatch):
+    letter_id = "synthetic-duration-repair"
+    letter = {
+        "letter_id": letter_id,
+        "content": "synthetic current letter",
+        "reply_text": "",
+        "reply_mode": ReplyMode.TEXT_LETTER.value,
+        "letter_status": "PENDING",
+    }
+    local_server.store.letters[:] = [letter]
+    requests = []
+
+    async def classify(_content):
+        return TriageResult(
+            "high",
+            ReplyMode.SPOKEN_VIDEO.value,
+            "voice_adds_presence",
+            "completed",
+            True,
+            direct_response_sufficient=True,
+            voice_materially_better=True,
+        )
+
+    async def run_pipeline(request, _context):
+        requests.append(request)
+        text = "林" * 190 if request.request_id.endswith(":duration-repair") else "太短"
+        return PipelineResult(letter_id, ReplyState.COMPLETED, text=text)
+
+    monkeypatch.setattr(local_server.emotion_triage, "classify", classify)
+    monkeypatch.setattr(local_server.reply_pipeline, "run", run_pipeline)
+    monkeypatch.setattr(local_server, "_persist_store_state", lambda: None)
+    monkeypatch.setattr(local_server, "_commit_private_world_letter", lambda _letter: False)
+    monkeypatch.setattr(local_server, "_schedule_media_job", lambda *_args: None)
+    monkeypatch.setattr(local_server.letters_adapter, "remember_conversation", lambda *_args: None)
+
+    assert asyncio.run(local_server.generate_reply(letter_id, letter["content"]))
+    assert [request.request_id for request in requests] == [
+        f"letter-reply:{letter_id}",
+        f"letter-reply:{letter_id}:duration-repair",
+    ]
+    assert "180到200个汉字" in requests[1].content
+    assert letter["reply_text"] == "林" * 190

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -106,6 +106,76 @@ def test_successful_media_retry_clears_the_previous_failure_code(
     assert observed["song_video_path"].name.endswith("-song-v2-60s.mp4")
 
 
+@pytest.mark.parametrize(
+    ("error_code", "expected_status", "expected_retryable"),
+    [
+        ("TTS_CONTENT_GATE_REJECTED", "FAILED", False),
+        ("TTS_CONTENT_GATE_UNAVAILABLE", "UNAVAILABLE", True),
+    ],
+)
+def test_public_detail_distinguishes_directed_tts_gate_terminal_states(
+    tmp_path: Path,
+    monkeypatch,
+    error_code: str,
+    expected_status: str,
+    expected_retryable: bool,
+) -> None:
+    letter_id = f"media-{error_code.casefold()}"
+    letter = {
+        "letter_id": letter_id,
+        "content": "synthetic letter",
+        "reply_text": "林" * 190,
+        "reply_mode": ReplyMode.SPOKEN_VIDEO.value,
+        "letter_status": "COMPLETED",
+        "media_status": "PENDING",
+        "reply_not_before": 0.0,
+    }
+    local_server.store.letters[:] = [letter]
+    scene = tmp_path / "scene.mp4"
+    scene.write_bytes(b"synthetic scene")
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
+    for period in ("MORNING", "DAY", "DUSK", "NIGHT"):
+        monkeypatch.setenv(f"OLIVIA_SCENE_{period}", str(scene))
+    monkeypatch.setattr(local_server, "_persist_media_state", lambda: None)
+
+    async def voice_plan(_letter, text):
+        return VoicePerformancePlan(
+            reply_text=text,
+            overall_emotion="声音柔软自然地承接，再缓缓托起给到力量",
+            global_speed=1.0,
+            energy=0.55,
+            breath_before_sentences=(),
+            emphasize_sentences=(),
+        )
+
+    def fail_render(*_args, **_kwargs):
+        raise local_server.ReplyMediaError(error_code)
+
+    monkeypatch.setattr(local_server, "_voice_plan_for_letter", voice_plan)
+    monkeypatch.setattr(local_server, "render_reply_video", fail_render)
+
+    asyncio.run(
+        local_server._render_media_job(
+            letter_id,
+            letter["content"],
+            letter["reply_text"],
+            ReplyMode.SPOKEN_VIDEO.value,
+        )
+    )
+    detail = asyncio.run(
+        local_server.route(
+            "GET",
+            "/toy/letter/detail",
+            {},
+            {"letter_id": letter_id},
+        )
+    )["data"]
+
+    assert detail["media_status"] == expected_status
+    assert detail["media_error_code"] == error_code
+    assert detail["media_retryable"] is expected_retryable
+
+
 def test_both_product_video_renderers_receive_the_persisted_llm_voice_plan(
     tmp_path: Path,
     monkeypatch,

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -113,6 +113,7 @@ def test_successful_media_retry_clears_the_previous_failure_code(
     [
         ("TTS_CONTENT_GATE_REJECTED", "FAILED", False),
         ("TTS_CONTENT_GATE_UNAVAILABLE", "UNAVAILABLE", True),
+        (r"D:\private\voice.wav", "UNAVAILABLE", True),
     ],
 )
 def test_public_detail_distinguishes_directed_tts_gate_terminal_states(
@@ -174,7 +175,7 @@ def test_public_detail_distinguishes_directed_tts_gate_terminal_states(
     )["data"]
 
     assert detail["media_status"] == expected_status
-    assert detail["media_error_code"] == error_code
+    assert detail["media_error_code"] == (error_code if error_code.startswith("TTS_") else "MEDIA_PROVIDER_UNAVAILABLE")
     assert detail["media_retryable"] is expected_retryable
 
 
@@ -182,8 +183,9 @@ def test_public_detail_distinguishes_directed_tts_gate_terminal_states(
     ("stored_status", "expected"),
     [
         ("QUEUED", ("PENDING", None, False)),
-        ("UNAVAILABLE_DATA_ROOT_NOT_CONFIGURED", ("UNAVAILABLE", "UNAVAILABLE_DATA_ROOT_NOT_CONFIGURED", True)),
-        ("UNAVAILABLE_THIRD_PARTY_NOT_INSTALLED", ("UNAVAILABLE", "UNAVAILABLE_THIRD_PARTY_NOT_INSTALLED", True)),
+        ("UNAVAILABLE_DATA_ROOT_NOT_CONFIGURED", ("UNAVAILABLE", "MEDIA_PROVIDER_UNAVAILABLE", True)),
+        ("UNAVAILABLE_THIRD_PARTY_NOT_INSTALLED", ("UNAVAILABLE", "MEDIA_PROVIDER_UNAVAILABLE", True)),
+        ("INTERNAL_CRASH", ("UNAVAILABLE", "MEDIA_PROVIDER_UNAVAILABLE", True)),
     ],
 )
 def test_public_detail_projects_every_legacy_internal_media_status(
@@ -199,6 +201,7 @@ def test_public_detail_projects_every_legacy_internal_media_status(
             "reply_text": "synthetic",
             "reply_mode": ReplyMode.SPOKEN_VIDEO.value,
             "media_status": stored_status,
+            "media_error_code": r"D:\private\voice.wav" if stored_status == "INTERNAL_CRASH" else None,
             "reply_not_before": 0.0,
         }
     ]
@@ -308,11 +311,10 @@ def test_ordinary_a_direction_and_music_legacy_direction_are_isolated(
     assert received == {"spoken_video": plan, "musical_video": music_plan}
     assert directed_requests == [
         "letter-reply:spoken-entry:voice-direction",
-        "letter-reply:musical-entry:music-voice-direction",
+        "letter-reply:musical-entry:voice-direction",
     ]
     assert letters[0]["voice_performance_plan"] == plan.to_dict()
-    assert "voice_performance_plan" not in letters[1]
-    assert letters[1]["music_voice_performance_plan"] == music_plan.to_dict()
+    assert letters[1]["voice_performance_plan"] == music_plan.to_dict()
 
 
 def test_corrupt_persisted_voice_plan_fails_closed_without_redirection(monkeypatch):

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -75,6 +75,73 @@ def test_media_workers_fail_closed_without_external_provider(tmp_path):
         )
 
 
+def test_ordinary_quality_preflight_preserves_retryable_gate_error(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    worker = tmp_path / "worker.py"
+    worker.write_text("# synthetic", encoding="utf-8")
+    calls: list[bool] = []
+
+    monkeypatch.setattr(reply_media, "_tts_config", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(
+        reply_media,
+        "_visual_config",
+        lambda *_args, **_kwargs: SimpleNamespace(validate=lambda: None),
+    )
+    monkeypatch.setattr(reply_media, "media_runtime_available", lambda *_args: True)
+
+    def configured(_config, *, require_quality_gate=False):
+        calls.append(require_quality_gate)
+        return not require_quality_gate
+
+    monkeypatch.setattr(reply_media, "delivery_configured", configured)
+
+    with pytest.raises(ReplyMediaError, match="TTS_CONTENT_GATE_UNAVAILABLE"):
+        reply_media.assemble_complete_video_delivery(
+            tmp_path / "tts.json",
+            tmp_path / "visual.json",
+            worker,
+            tmp_path,
+            require_quality_gate=True,
+        )
+
+    assert calls == [False, True]
+
+
+def test_shared_music_preflight_never_checks_ordinary_quality_gate(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    worker = tmp_path / "worker.py"
+    worker.write_text("# synthetic", encoding="utf-8")
+    calls: list[bool] = []
+
+    monkeypatch.setattr(reply_media, "_tts_config", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(
+        reply_media,
+        "_visual_config",
+        lambda *_args, **_kwargs: SimpleNamespace(validate=lambda: None),
+    )
+    monkeypatch.setattr(reply_media, "media_runtime_available", lambda *_args: True)
+
+    def configured(_config, *, require_quality_gate=False):
+        calls.append(require_quality_gate)
+        return True
+
+    monkeypatch.setattr(reply_media, "delivery_configured", configured)
+
+    reply_media.assemble_complete_video_delivery(
+        tmp_path / "tts.json",
+        tmp_path / "visual.json",
+        worker,
+        tmp_path,
+        require_quality_gate=False,
+    )
+
+    assert calls == [False]
+
+
 def test_roformer_uses_explicit_f_drive_assets_and_utf8(tmp_path, monkeypatch):
     executable = tmp_path / "roformer.exe"
     model = tmp_path / "models" / "MelBandRoformer.ckpt"

--- a/tests/persona/test_reply_pipeline.py
+++ b/tests/persona/test_reply_pipeline.py
@@ -299,6 +299,20 @@ class FakeTriageService:
         return FakeTriage()
 
 
+def test_reply_length_error_is_terminal_and_not_provider_unavailable() -> None:
+    import http_contract
+    import local_server
+
+    assert local_server._public_llm_error("LLM_REPLY_LENGTH_INVALID") == (
+        "LLM_REPLY_LENGTH_INVALID",
+        False,
+    )
+    assert http_contract.ERROR_CODES["LLM_REPLY_LENGTH_INVALID"] == {
+        "http_status": 503,
+        "retryable": False,
+    }
+
+
 class FakePipeline:
     def __init__(self, result: PipelineResult) -> None:
         self.result = result

--- a/tests/private_world/test_private_world_runtime_wiring.py
+++ b/tests/private_world/test_private_world_runtime_wiring.py
@@ -397,7 +397,7 @@ def test_fresh_generate_reply_commits_once_and_media_retry_never_recommits(
         "recovery_count": 0,
         "event_count_after_canonical": 1,
         "event_count_after_media_retry": 1,
-        "media_status": "UNAVAILABLE",
+        "media_status": "COMPLETED",
     }
 
 
@@ -418,7 +418,7 @@ def test_fresh_generate_reply_keeps_canonical_reply_pending_when_sqlite_fails(
         "recovery_count": 0,
         "event_count_after_canonical": 0,
         "event_count_after_media_retry": 0,
-        "media_status": "UNAVAILABLE",
+        "media_status": "COMPLETED",
     }
 
 
@@ -439,7 +439,7 @@ def test_fresh_generate_reply_keeps_canonical_reply_pending_when_snapshot_is_cor
         "recovery_count": 0,
         "event_count_after_canonical": 0,
         "event_count_after_media_retry": 0,
-        "media_status": "UNAVAILABLE",
+        "media_status": "COMPLETED",
     }
 
 

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -30,11 +30,14 @@ from tts.delivery import (
 )
 from voice_direction import VoicePerformancePlan
 
+_QUALITY_EXPECTED = "这是完整的冻结语音内容，必须原样说完。"
+_QUALITY_FORBIDDEN = "声音柔软自然地承接"
 
-def _quality_report(*, passed: bool = False) -> dict[str, object]:
-    expected = "这是完整的冻结语音内容，必须原样说完。"
+
+def _quality_report(*, passed: bool = False, expected: str = _QUALITY_EXPECTED,
+                    forbidden: str = _QUALITY_FORBIDDEN) -> dict[str, object]:
     transcript = expected if passed else "这是完全不同的内容。"
-    return assess_transcript(expected, transcript, "声音柔软自然地承接")
+    return assess_transcript(expected, transcript, forbidden)
 
 
 def test_ordinary_video_copy_contract_targets_cross_lingual_delivery_length() -> None:
@@ -507,7 +510,9 @@ def test_content_gate_accepts_small_asr_substitutions_but_rejects_control_or_omi
 def test_empty_asr_report_keeps_the_complete_rejection_schema() -> None:
     report = assess_transcript("完整冻结正文", "", "声音柔软自然地承接")
 
-    assert _validated_quality_report(report)["error_code"] == "TTS_CONTENT_EMPTY"
+    assert _validated_quality_report(
+        report, expected_text="完整冻结正文", forbidden_text="声音柔软自然地承接"
+    )["error_code"] == "TTS_CONTENT_EMPTY"
 
 
 @pytest.mark.parametrize(
@@ -519,13 +524,16 @@ def test_empty_asr_report_keeps_the_complete_rejection_schema() -> None:
         {**_quality_report(), "error_code": "UNKNOWN_REJECTION"},
         {**_quality_report(passed=True), "checks": {"cer": True}},
         {**_quality_report(), "cer": 0.0},
+        {**_quality_report(), "transcript": _QUALITY_EXPECTED},
     ],
 )
 def test_quality_gate_rejects_incomplete_or_unknown_reports(
     report: dict[str, object],
 ) -> None:
     with pytest.raises(DeliveryAudioError, match="TTS_CONTENT_GATE_UNAVAILABLE"):
-        _validated_quality_report(report)
+        _validated_quality_report(
+            report, expected_text=_QUALITY_EXPECTED, forbidden_text=_QUALITY_FORBIDDEN
+        )
 
 
 def test_external_worker_rejects_unpinned_base_llm_before_model_load(
@@ -686,7 +694,7 @@ def test_three_rejected_candidates_never_replace_existing_output(
         else:
             calls["quality"] += 1
             target.write_text(
-                json.dumps(_quality_report()),
+                    json.dumps(_quality_report(expected=plan.spoken_text, forbidden=plan.short_instruction)),
                 encoding="utf-8",
             )
         return SimpleNamespace(returncode=0)
@@ -738,7 +746,7 @@ def test_mixed_duration_failures_do_not_fabricate_three_quality_rejections(
         else:
             calls["quality"] += 1
             target.write_text(
-                json.dumps(_quality_report()),
+                    json.dumps(_quality_report(expected=plan.spoken_text, forbidden=plan.short_instruction)),
                 encoding="utf-8",
             )
         return SimpleNamespace(returncode=0)

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -22,12 +22,19 @@ from tts.external_audio_quality_worker import assess_transcript, normalize_trans
 from tts.delivery import (
     DeliveryAudioError,
     _fit_overlong_wav,
+    _validated_quality_report,
     build_external_delivery_request,
     delivery_configured,
     delivery_tempo_factor,
     render_delivery_wav,
 )
 from voice_direction import VoicePerformancePlan
+
+
+def _quality_report(*, passed: bool = False) -> dict[str, object]:
+    expected = "这是完整的冻结语音内容，必须原样说完。"
+    transcript = expected if passed else "这是完全不同的内容。"
+    return assess_transcript(expected, transcript, "声音柔软自然地承接")
 
 
 def test_ordinary_video_copy_contract_targets_cross_lingual_delivery_length() -> None:
@@ -496,6 +503,29 @@ def test_content_gate_accepts_small_asr_substitutions_but_rejects_control_or_omi
     assert repeated["checks"]["repetition"] is False
 
 
+def test_empty_asr_report_keeps_the_complete_rejection_schema() -> None:
+    report = assess_transcript("完整冻结正文", "", "声音柔软自然地承接")
+
+    assert _validated_quality_report(report)["error_code"] == "TTS_CONTENT_EMPTY"
+
+
+@pytest.mark.parametrize(
+    "report",
+    [
+        {"passed": True},
+        {"passed": False},
+        {**_quality_report(), "error_code": {}},
+        {**_quality_report(), "error_code": "UNKNOWN_REJECTION"},
+        {**_quality_report(passed=True), "checks": {"cer": True}},
+    ],
+)
+def test_quality_gate_rejects_incomplete_or_unknown_reports(
+    report: dict[str, object],
+) -> None:
+    with pytest.raises(DeliveryAudioError, match="TTS_CONTENT_GATE_UNAVAILABLE"):
+        _validated_quality_report(report)
+
+
 def test_external_worker_rejects_unpinned_base_llm_before_model_load(
     tmp_path,
 ) -> None:
@@ -654,7 +684,7 @@ def test_three_rejected_candidates_never_replace_existing_output(
         else:
             calls["quality"] += 1
             target.write_text(
-                json.dumps({"passed": False, "error_code": "TTS_CONTENT_MISMATCH"}),
+                json.dumps(_quality_report()),
                 encoding="utf-8",
             )
         return SimpleNamespace(returncode=0)
@@ -706,7 +736,7 @@ def test_mixed_duration_failures_do_not_fabricate_three_quality_rejections(
         else:
             calls["quality"] += 1
             target.write_text(
-                json.dumps({"passed": False, "error_code": "TTS_CONTENT_MISMATCH"}),
+                json.dumps(_quality_report()),
                 encoding="utf-8",
             )
         return SimpleNamespace(returncode=0)

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -17,6 +17,7 @@ from reply_delivery import (
     plan_reply_delivery,
 )
 from tts import external_cosyvoice_worker
+from tts.external_audio_quality_worker import assess_transcript
 from tts.delivery import (
     DeliveryAudioError,
     _fit_overlong_wav,
@@ -66,10 +67,11 @@ def test_llm_voice_plan_builds_one_non_spoken_instruct2_request() -> None:
     plan = VoicePerformancePlan(
         reply_text=reply_text,
         overall_emotion="restrained empathy becoming steady reassurance",
-        global_speed=1.06,
+        global_speed=1.0,
         energy=0.62,
-        breath_before_sentences=(2,),
-        emphasize_sentences=(1,),
+        breath_before_sentences=(),
+        emphasize_sentences=(),
+        short_instruction="声音柔软自然地承接，再缓缓托起给到力量",
     )
     config = SimpleNamespace(
         runtime_root="runtime",
@@ -85,10 +87,14 @@ def test_llm_voice_plan_builds_one_non_spoken_instruct2_request() -> None:
     assert request["text"] == reply_text
     assert "[breath]" not in str(request["text"])
     assert "<strong>" not in str(request["text"])
+    assert request["llm_variant"] == "base"
+    assert request["speed"] == 1.0
     assert request["instruct_text"].count("<|endofprompt|>") == 1
-    assert "natural silent breath before sentence 2" in str(request["instruct_text"])
-    assert "Gently emphasize sentence 1" in str(request["instruct_text"])
-    assert request["performance_control_mode"] == "single_pass_llm_instruct"
+    assert request["instruct_text"] == (
+        "You are a helpful assistant. "
+        "声音柔软自然地承接，再缓缓托起给到力量。<|endofprompt|>"
+    )
+    assert request["performance_control_mode"] == "single_pass_llm_short_instruct"
     assert request["duration_target_seconds"] == [40.0, 50.0]
     assert request["max_attempts"] == 3
     assert "blocks" not in request
@@ -398,3 +404,24 @@ def test_directed_tts_provenance_and_human_acceptance_are_publicly_recorded() ->
     assert "24 kHz mono" in acceptance
     assert "863ef5185c448f189c46524fd8e87010bf353bc2bf8e3df9f59bdc0948ec14ce" in acceptance
     assert "Candidate 1" in acceptance
+
+
+def test_content_gate_accepts_small_asr_substitutions_but_rejects_control_or_omission() -> None:
+    expected = (
+        "这是完全合成的语音验收样例。"
+        "虚构的月面温室响起提示音，巡检员关闭报警器，再核对三组传感器。"
+        "设备稳定后，她把结果写入公开测试日志。"
+    )
+    instruction = "保持清楚自然，结尾平稳收住"
+
+    accepted = assess_transcript(
+        expected,
+        expected.replace("，", "。").replace("。", " "),
+        instruction,
+    )
+    contaminated = assess_transcript(expected, instruction + expected, instruction)
+    omitted = assess_transcript(expected, "这是完全合成的语音验收样例。", instruction)
+
+    assert accepted["passed"] is True
+    assert contaminated["checks"]["instruction_overlap"] is False
+    assert omitted["checks"]["length_ratio"] is False

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -52,6 +52,7 @@ def test_ordinary_video_copy_contract_targets_cross_lingual_delivery_length() ->
 
 def test_directed_delivery_error_schema_is_stable() -> None:
     assert http_contract.LETTER_DETAIL_MEDIA_ERROR_CODES == {
+        "MEDIA_PROVIDER_UNAVAILABLE": {"status": "UNAVAILABLE", "retryable": True},
         "TTS_CONTENT_GATE_UNAVAILABLE": {
             "status": "UNAVAILABLE",
             "retryable": True,
@@ -517,6 +518,7 @@ def test_empty_asr_report_keeps_the_complete_rejection_schema() -> None:
         {**_quality_report(), "error_code": {}},
         {**_quality_report(), "error_code": "UNKNOWN_REJECTION"},
         {**_quality_report(passed=True), "checks": {"cer": True}},
+        {**_quality_report(), "cer": 0.0},
     ],
 )
 def test_quality_gate_rejects_incomplete_or_unknown_reports(

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -17,7 +17,7 @@ from reply_delivery import (
     plan_reply_delivery,
 )
 from tts import DIRECTED_DELIVERY_ERROR_CODES, TTSConfig, external_cosyvoice_worker
-from tts.external_audio_quality_worker import assess_transcript
+from tts.external_audio_quality_worker import assess_transcript, normalize_transcript
 from tts.delivery import (
     DeliveryAudioError,
     _fit_overlong_wav,
@@ -108,6 +108,10 @@ def test_llm_voice_plan_builds_one_non_spoken_instruct2_request() -> None:
     assert request["instruct_text"] == (
         "You are a helpful assistant. "
         "声音柔软自然地承接，再缓缓托起给到力量。<|endofprompt|>"
+    )
+    assert request["quality_forbidden_text"] == (
+        "You are a helpful assistant. "
+        "声音柔软自然地承接，再缓缓托起给到力量"
     )
     assert request["performance_control_mode"] == "single_pass_llm_short_instruct"
     assert request["duration_target_seconds"] == [40.0, 50.0]
@@ -358,7 +362,14 @@ def test_external_worker_rejects_runtime_without_pinned_instruct2_api(
         )
 
 
-def test_external_worker_rejects_frozen_text_with_model_control_token(tmp_path) -> None:
+@pytest.mark.parametrize(
+    "control_text",
+    ["<|endofprompt|>", "[breath]", "<strong>强调</strong>", "**强调**"],
+)
+def test_external_worker_rejects_frozen_text_with_model_control_token(
+    tmp_path,
+    control_text: str,
+) -> None:
     calls: list[object] = []
 
     class Model:
@@ -373,7 +384,7 @@ def test_external_worker_rejects_frozen_text_with_model_control_token(tmp_path) 
             Model(),
             {
                 "reference_audio": str(tmp_path / "reference.wav"),
-                "text": "frozen reply <|endofprompt|>",
+                "text": f"frozen reply {control_text}",
                 "instruct_text": "steady reassurance<|endofprompt|>",
             },
             tmp_path / "directed.wav",
@@ -382,9 +393,15 @@ def test_external_worker_rejects_frozen_text_with_model_control_token(tmp_path) 
     assert calls == []
 
 
-def test_directed_request_rejects_frozen_text_with_model_control_token() -> None:
+@pytest.mark.parametrize(
+    "control_text",
+    ["<|endofprompt|>", "[breath]", "<strong>强调</strong>", "**强调**"],
+)
+def test_directed_request_rejects_frozen_text_with_model_control_token(
+    control_text: str,
+) -> None:
     plan = VoicePerformancePlan(
-        reply_text="frozen reply <|endofprompt|>",
+        reply_text=f"frozen reply {control_text}",
         overall_emotion="steady reassurance",
         global_speed=1.06,
         energy=0.62,
@@ -414,6 +431,8 @@ def test_directed_tts_provenance_and_human_acceptance_are_publicly_recorded() ->
     }
     runtime = upstreams["b06-cosyvoice-runtime"]
     model = upstreams["b06-cosyvoice-model"]
+    quality_runtime = upstreams["b06-whisper-quality-runtime"]
+    quality_model = upstreams["b06-whisper-base-model"]
     acceptance = (root / "docs/B06_LOCAL_TTS_ACCEPTANCE.md").read_text(
         encoding="utf-8"
     )
@@ -424,6 +443,14 @@ def test_directed_tts_provenance_and_human_acceptance_are_publicly_recorded() ->
     assert runtime["adapter_boundary"] in normalized_acceptance
     assert runtime["uninstall_path"] in normalized_acceptance
     assert model["revision"] == "29e01c4e8d000f4bcd70751be16fa94bf3d85a18"
+    assert quality_runtime["revision"] == "31243bad24cc746f07d4c8bfdd2d974872cb1803"
+    assert quality_runtime["license"] == "MIT"
+    assert quality_model["revision"] == "31243bad24cc746f07d4c8bfdd2d974872cb1803"
+    assert (
+        "ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e"
+        in quality_model["version"]
+    )
+    assert quality_model["license"] == "MIT"
     assert "inference_instruct2" in acceptance
     assert "41.28 seconds" in acceptance
     assert "24 kHz mono" in acceptance
@@ -445,6 +472,15 @@ def test_content_gate_accepts_small_asr_substitutions_but_rejects_control_or_omi
         instruction,
     )
     contaminated = assess_transcript(expected, instruction + expected, instruction)
+    fixed_prefix = "You are a helpful assistant"
+    normalized_expected = normalize_transcript(expected)
+    normalized_prefix = normalize_transcript(fixed_prefix)
+    equal_length_prefix = normalized_prefix + normalized_expected[len(normalized_prefix) :]
+    prefix_contaminated = assess_transcript(
+        normalized_expected,
+        equal_length_prefix,
+        fixed_prefix + instruction,
+    )
     omitted = assess_transcript(expected, "这是完全合成的语音验收样例。", instruction)
     one_missing = assess_transcript(expected, expected.replace("月", "", 1), instruction)
     one_extra = assess_transcript(expected, expected + "啊", instruction)
@@ -452,6 +488,7 @@ def test_content_gate_accepts_small_asr_substitutions_but_rejects_control_or_omi
 
     assert accepted["passed"] is True
     assert contaminated["checks"]["instruction_overlap"] is False
+    assert prefix_contaminated["checks"]["instruction_overlap"] is False
     assert omitted["checks"]["length_ratio"] is False
     assert one_missing["checks"]["contiguous_omission"] is False
     assert one_extra["checks"]["extra_speech"] is False
@@ -523,6 +560,30 @@ def test_directed_delivery_preflight_requires_pinned_model_and_asr_runtime(
     assert all(len(expected) == 64 for _name, expected in verified)
 
 
+def test_directed_delivery_preflight_rejects_implicit_whisper_cache(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    runtime = tmp_path / "runtime"
+    model = tmp_path / "model"
+    runtime.mkdir()
+    model.mkdir()
+    executable = tmp_path / "python.exe"
+    reference = tmp_path / "reference.wav"
+    executable.write_bytes(b"synthetic executable")
+    reference.write_bytes(b"synthetic reference")
+    (model / "llm.pt").write_bytes(b"synthetic model")
+    monkeypatch.setattr(delivery, "_verified_file", lambda *_args: True)
+    config = TTSConfig(
+        runtime_root=str(runtime),
+        model_dir=str(model),
+        reference_audio=str(reference),
+        provider_options={"external_python": str(executable)},
+    )
+
+    assert delivery_configured(config, require_quality_gate=True) is False
+
+
 def test_three_rejected_candidates_never_replace_existing_output(
     tmp_path,
     monkeypatch,
@@ -571,4 +632,54 @@ def test_three_rejected_candidates_never_replace_existing_output(
         render_delivery_wav(config, plan, output)
 
     assert calls == {"tts": 3, "quality": 3}
+    assert output.read_bytes() == b"existing-output"
+
+
+def test_quality_request_write_failure_is_sanitized_and_atomic(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    output = tmp_path / "reply.wav"
+    output.write_bytes(b"existing-output")
+    original_write_text = Path.write_text
+
+    def guarded_write_text(path: Path, *args, **kwargs):
+        if path.name == "quality-request.json":
+            raise OSError("private-path-must-not-escape")
+        return original_write_text(path, *args, **kwargs)
+
+    def fake_run(command, **_kwargs):
+        command = [str(item) for item in command]
+        target = Path(command[command.index("--output") + 1])
+        with wave.open(str(target), "wb") as rendered:
+            rendered.setnchannels(1)
+            rendered.setsampwidth(2)
+            rendered.setframerate(100)
+            rendered.writeframes(array("h", [1] * 4_500).tobytes())
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(delivery, "delivery_configured", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(delivery.subprocess, "run", fake_run)
+    monkeypatch.setattr(Path, "write_text", guarded_write_text)
+    config = TTSConfig(
+        runtime_root=str(tmp_path),
+        model_dir=str(tmp_path),
+        reference_audio=str(tmp_path / "reference.wav"),
+        provider_options={"external_python": sys.executable},
+    )
+    plan = VoicePerformancePlan(
+        reply_text="林" * 190,
+        overall_emotion="声音柔软自然地承接，再缓缓托起给到力量",
+        global_speed=1.0,
+        energy=0.55,
+        breath_before_sentences=(),
+        emphasize_sentences=(),
+        short_instruction="声音柔软自然地承接，再缓缓托起给到力量",
+    )
+
+    with pytest.raises(DeliveryAudioError) as exc_info:
+        render_delivery_wav(config, plan, output)
+
+    assert str(exc_info.value) == "TTS_CONTENT_GATE_UNAVAILABLE"
+    assert "private-path" not in str(exc_info.value)
     assert output.read_bytes() == b"existing-output"

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -16,13 +16,15 @@ from reply_delivery import (
     ordinary_video_reply_length_ok,
     plan_reply_delivery,
 )
-from tts import external_cosyvoice_worker
+from tts import DIRECTED_DELIVERY_ERROR_CODES, TTSConfig, external_cosyvoice_worker
 from tts.external_audio_quality_worker import assess_transcript
 from tts.delivery import (
     DeliveryAudioError,
     _fit_overlong_wav,
     build_external_delivery_request,
+    delivery_configured,
     delivery_tempo_factor,
+    render_delivery_wav,
 )
 from voice_direction import VoicePerformancePlan
 
@@ -38,6 +40,19 @@ def test_ordinary_video_copy_contract_targets_cross_lingual_delivery_length() ->
     assert ordinary_video_reply_length_ok("林" * 180) is True
     assert ordinary_video_reply_length_ok("林" * 200) is True
     assert ordinary_video_reply_length_ok("林" * 201) is False
+
+
+def test_directed_delivery_error_schema_is_stable() -> None:
+    assert DIRECTED_DELIVERY_ERROR_CODES == {
+        "TTS_CONTENT_GATE_UNAVAILABLE": {
+            "status": "UNAVAILABLE",
+            "retryable": True,
+        },
+        "TTS_CONTENT_GATE_REJECTED": {
+            "status": "FAILED",
+            "retryable": False,
+        },
+    }
 
 
 def test_delivery_request_uses_one_contextual_long_form_payload() -> None:
@@ -265,6 +280,11 @@ def test_external_worker_runs_one_whole_reply_instruct2_inference(
     monkeypatch.setitem(sys.modules, "cosyvoice.cli.cosyvoice", module)
     monkeypatch.setitem(sys.modules, "torch", torch)
     monkeypatch.setitem(sys.modules, "numpy", numpy)
+    monkeypatch.setattr(
+        external_cosyvoice_worker,
+        "_validate_base_model",
+        lambda _model_dir: None,
+    )
     output = tmp_path / "directed.wav"
 
     external_cosyvoice_worker._synthesize(
@@ -318,6 +338,11 @@ def test_external_worker_rejects_runtime_without_pinned_instruct2_api(
     monkeypatch.setitem(sys.modules, "cosyvoice", cosyvoice)
     monkeypatch.setitem(sys.modules, "cosyvoice.cli", cli)
     monkeypatch.setitem(sys.modules, "cosyvoice.cli.cosyvoice", module)
+    monkeypatch.setattr(
+        external_cosyvoice_worker,
+        "_validate_base_model",
+        lambda _model_dir: None,
+    )
 
     with pytest.raises(RuntimeError, match="COSYVOICE_INSTRUCT2_UNSUPPORTED"):
         external_cosyvoice_worker._synthesize(
@@ -421,7 +446,129 @@ def test_content_gate_accepts_small_asr_substitutions_but_rejects_control_or_omi
     )
     contaminated = assess_transcript(expected, instruction + expected, instruction)
     omitted = assess_transcript(expected, "这是完全合成的语音验收样例。", instruction)
+    one_missing = assess_transcript(expected, expected.replace("月", "", 1), instruction)
+    one_extra = assess_transcript(expected, expected + "啊", instruction)
+    repeated = assess_transcript(expected, expected + expected[-4:], instruction)
 
     assert accepted["passed"] is True
     assert contaminated["checks"]["instruction_overlap"] is False
     assert omitted["checks"]["length_ratio"] is False
+    assert one_missing["checks"]["contiguous_omission"] is False
+    assert one_extra["checks"]["extra_speech"] is False
+    assert repeated["checks"]["repetition"] is False
+
+
+def test_external_worker_rejects_unpinned_base_llm_before_model_load(
+    tmp_path,
+) -> None:
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "llm.pt").write_bytes(b"not-the-pinned-base-model")
+
+    with pytest.raises(RuntimeError, match="COSYVOICE_BASE_MODEL_HASH_MISMATCH"):
+        external_cosyvoice_worker._synthesize(
+            {
+                "runtime_root": str(tmp_path),
+                "model_dir": str(model),
+                "reference_audio": str(tmp_path / "reference.wav"),
+                "voice_condition_mode": "instruct2_single_pass",
+                "llm_variant": "base",
+                "text": "完整冻结回信",
+                "instruct_text": "声音柔软自然地承接，再缓缓托起给到力量",
+            },
+            tmp_path / "directed.wav",
+        )
+
+
+def test_directed_delivery_preflight_requires_pinned_model_and_asr_runtime(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    runtime = tmp_path / "runtime"
+    model = tmp_path / "model"
+    cache = tmp_path / "whisper"
+    runtime.mkdir()
+    model.mkdir()
+    cache.mkdir()
+    executable = tmp_path / "python.exe"
+    reference = tmp_path / "reference.wav"
+    executable.write_bytes(b"synthetic executable")
+    reference.write_bytes(b"synthetic reference")
+    (model / "llm.pt").write_bytes(b"synthetic model")
+    (cache / "base.pt").write_bytes(b"synthetic asr")
+    verified: list[tuple[str, str]] = []
+
+    def fake_verified(path: Path, expected: str) -> bool:
+        verified.append((path.name, expected))
+        return True
+
+    monkeypatch.setattr(delivery, "_verified_file", fake_verified)
+    monkeypatch.setattr(
+        delivery,
+        "_quality_runtime_available",
+        lambda *_args: True,
+    )
+    config = TTSConfig(
+        runtime_root=str(runtime),
+        model_dir=str(model),
+        reference_audio=str(reference),
+        provider_options={
+            "external_python": str(executable),
+            "quality_gate_cache_root": str(cache),
+        },
+    )
+
+    assert delivery_configured(config, require_quality_gate=True) is True
+    assert [name for name, _expected in verified] == ["llm.pt", "base.pt"]
+    assert all(len(expected) == 64 for _name, expected in verified)
+
+
+def test_three_rejected_candidates_never_replace_existing_output(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    output = tmp_path / "reply.wav"
+    output.write_bytes(b"existing-output")
+    calls = {"tts": 0, "quality": 0}
+
+    def fake_run(command, **_kwargs):
+        command = [str(item) for item in command]
+        target = Path(command[command.index("--output") + 1])
+        if command[1].endswith("external_cosyvoice_worker.py"):
+            calls["tts"] += 1
+            with wave.open(str(target), "wb") as rendered:
+                rendered.setnchannels(1)
+                rendered.setsampwidth(2)
+                rendered.setframerate(100)
+                rendered.writeframes(array("h", [1] * 4_500).tobytes())
+        else:
+            calls["quality"] += 1
+            target.write_text(
+                json.dumps({"passed": False, "error_code": "TTS_CONTENT_MISMATCH"}),
+                encoding="utf-8",
+            )
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(delivery, "delivery_configured", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(delivery.subprocess, "run", fake_run)
+    config = TTSConfig(
+        runtime_root=str(tmp_path),
+        model_dir=str(tmp_path),
+        reference_audio=str(tmp_path / "reference.wav"),
+        provider_options={"external_python": sys.executable},
+    )
+    plan = VoicePerformancePlan(
+        reply_text="林" * 190,
+        overall_emotion="声音柔软自然地承接，再缓缓托起给到力量",
+        global_speed=1.0,
+        energy=0.55,
+        breath_before_sentences=(),
+        emphasize_sentences=(),
+        short_instruction="声音柔软自然地承接，再缓缓托起给到力量",
+    )
+
+    with pytest.raises(DeliveryAudioError, match="TTS_CONTENT_GATE_REJECTED"):
+        render_delivery_wav(config, plan, output)
+
+    assert calls == {"tts": 3, "quality": 3}
+    assert output.read_bytes() == b"existing-output"

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -9,6 +9,7 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 import tts.delivery as delivery
+import http_contract
 
 from reply_delivery import (
     build_ordinary_video_llm_content,
@@ -16,7 +17,7 @@ from reply_delivery import (
     ordinary_video_reply_length_ok,
     plan_reply_delivery,
 )
-from tts import DIRECTED_DELIVERY_ERROR_CODES, TTSConfig, external_cosyvoice_worker
+from tts import TTSConfig, external_cosyvoice_worker
 from tts.external_audio_quality_worker import assess_transcript, normalize_transcript
 from tts.delivery import (
     DeliveryAudioError,
@@ -43,7 +44,7 @@ def test_ordinary_video_copy_contract_targets_cross_lingual_delivery_length() ->
 
 
 def test_directed_delivery_error_schema_is_stable() -> None:
-    assert DIRECTED_DELIVERY_ERROR_CODES == {
+    assert http_contract.LETTER_DETAIL_MEDIA_ERROR_CODES == {
         "TTS_CONTENT_GATE_UNAVAILABLE": {
             "status": "UNAVAILABLE",
             "retryable": True,
@@ -510,6 +511,7 @@ def test_external_worker_rejects_unpinned_base_llm_before_model_load(
                 "reference_audio": str(tmp_path / "reference.wav"),
                 "voice_condition_mode": "instruct2_single_pass",
                 "llm_variant": "base",
+                "verify_accepted_base_model": True,
                 "text": "完整冻结回信",
                 "instruct_text": "声音柔软自然地承接，再缓缓托起给到力量",
             },
@@ -584,6 +586,53 @@ def test_directed_delivery_preflight_rejects_implicit_whisper_cache(
     assert delivery_configured(config, require_quality_gate=True) is False
 
 
+def test_non_quality_delivery_does_not_require_quality_worker_or_pinned_base(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    runtime = tmp_path / "runtime"
+    model = tmp_path / "model"
+    runtime.mkdir()
+    model.mkdir()
+    executable = tmp_path / "python.exe"
+    reference = tmp_path / "reference.wav"
+    executable.write_bytes(b"synthetic executable")
+    reference.write_bytes(b"synthetic reference")
+    (model / "llm.pt").write_bytes(b"unpinned model")
+    verified: list[str] = []
+    monkeypatch.setattr(
+        delivery,
+        "_verified_file",
+        lambda path, _expected: verified.append(path.name) or False,
+    )
+    config = TTSConfig(
+        runtime_root=str(runtime),
+        model_dir=str(model),
+        reference_audio=str(reference),
+        provider_options={"external_python": str(executable)},
+    )
+
+    assert delivery_configured(config) is True
+    assert verified == []
+
+
+def test_quality_runtime_preflight_enforces_pinned_distribution_version(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    observed: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        observed.append([str(item) for item in command])
+        return SimpleNamespace(returncode=3)
+
+    monkeypatch.setattr(delivery.subprocess, "run", fake_run)
+
+    assert delivery._quality_runtime_available(str(tmp_path / "python.exe"), 1, 1) is False
+    assert "m.version('openai-whisper')" in observed[0][-1]
+    assert "20250625" in observed[0][-1]
+
+
 def test_three_rejected_candidates_never_replace_existing_output(
     tmp_path,
     monkeypatch,
@@ -632,6 +681,58 @@ def test_three_rejected_candidates_never_replace_existing_output(
         render_delivery_wav(config, plan, output)
 
     assert calls == {"tts": 3, "quality": 3}
+    assert output.read_bytes() == b"existing-output"
+
+
+def test_mixed_duration_failures_do_not_fabricate_three_quality_rejections(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    output = tmp_path / "reply.wav"
+    output.write_bytes(b"existing-output")
+    calls = {"tts": 0, "quality": 0}
+
+    def fake_run(command, **_kwargs):
+        command = [str(item) for item in command]
+        target = Path(command[command.index("--output") + 1])
+        if command[1].endswith("external_cosyvoice_worker.py"):
+            calls["tts"] += 1
+            frame_count = 4_500 if calls["tts"] == 1 else 3_000
+            with wave.open(str(target), "wb") as rendered:
+                rendered.setnchannels(1)
+                rendered.setsampwidth(2)
+                rendered.setframerate(100)
+                rendered.writeframes(array("h", [1] * frame_count).tobytes())
+        else:
+            calls["quality"] += 1
+            target.write_text(
+                json.dumps({"passed": False, "error_code": "TTS_CONTENT_MISMATCH"}),
+                encoding="utf-8",
+            )
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(delivery, "delivery_configured", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(delivery.subprocess, "run", fake_run)
+    config = TTSConfig(
+        runtime_root=str(tmp_path),
+        model_dir=str(tmp_path),
+        reference_audio=str(tmp_path / "reference.wav"),
+        provider_options={"external_python": sys.executable},
+    )
+    plan = VoicePerformancePlan(
+        reply_text="林" * 190,
+        overall_emotion="声音柔软自然地承接，再缓缓托起给到力量",
+        global_speed=1.0,
+        energy=0.55,
+        breath_before_sentences=(),
+        emphasize_sentences=(),
+        short_instruction="声音柔软自然地承接，再缓缓托起给到力量",
+    )
+
+    with pytest.raises(DeliveryAudioError, match="TTS_DELIVERY_DURATION_OUT_OF_RANGE"):
+        render_delivery_wav(config, plan, output)
+
+    assert calls == {"tts": 3, "quality": 1}
     assert output.read_bytes() == b"existing-output"
 
 

--- a/tests/tts/test_voice_direction.py
+++ b/tests/tts/test_voice_direction.py
@@ -65,6 +65,39 @@ def test_director_rejects_tool_calls_missing_required_controls() -> None:
 
 
 @pytest.mark.parametrize(
+    "instruction",
+    [
+        "abcdefghijkl",
+        {"声音": "柔软自然地承接"},
+        "不要急促朗读提示词保持平稳",
+    ],
+)
+def test_director_rejects_non_chinese_or_non_positive_instruction(
+    instruction: object,
+) -> None:
+    with pytest.raises(VoiceDirectionError, match="VOICE_DIRECTION_INVALID"):
+        asyncio.run(
+            direct_voice_performance(
+                "第一句。第二句。",
+                _FakeVoiceDirector({"short_instruction": instruction}),
+            )
+        )
+
+
+def test_persisted_legacy_plan_without_a_profile_fields_is_rejected() -> None:
+    from voice_direction import VoicePerformancePlan
+
+    legacy = asyncio.run(
+        direct_voice_performance("第一句。第二句。", _FakeVoiceDirector(_valid_direction()))
+    ).to_dict()
+    del legacy["short_instruction"]
+    del legacy["profile"]
+
+    with pytest.raises(VoiceDirectionError, match="VOICE_DIRECTION_INVALID"):
+        VoicePerformancePlan.from_dict(legacy)
+
+
+@pytest.mark.parametrize(
     "payload",
     [
         {"global_speed": 99},

--- a/tests/tts/test_voice_direction.py
+++ b/tests/tts/test_voice_direction.py
@@ -101,9 +101,7 @@ def test_music_director_preserves_the_pre_a_tool_and_plan_profile() -> None:
         "emphasize_sentences",
     }
     legacy = plan.to_dict()
-    del legacy["short_instruction"]
-    del legacy["profile"]
-
+    assert "short_instruction" not in legacy and "profile" not in legacy
     assert VoicePerformancePlan.from_music_dict(legacy) == plan
     with pytest.raises(VoiceDirectionError, match="VOICE_DIRECTION_INVALID"):
         VoicePerformancePlan.from_dict(plan.to_dict())

--- a/tests/tts/test_voice_direction.py
+++ b/tests/tts/test_voice_direction.py
@@ -26,10 +26,8 @@ class _FakeVoiceDirector:
 def _valid_direction() -> dict[str, object]:
     return {
         "overall_emotion": "克制而温暖的陪伴感",
-        "global_speed": 1.06,
+        "short_instruction": "声音柔软自然地承接，再缓缓托起给到力量",
         "energy": 0.55,
-        "breath_before_sentences": [2],
-        "emphasize_sentences": [1],
     }
 
 
@@ -37,7 +35,9 @@ def test_director_preserves_frozen_reply_and_requests_only_global_controls() -> 
     reply = "你不是不够好。你只是被一次突然的离开伤到了。先别急着逼自己相信谁。"
     director = _FakeVoiceDirector(_valid_direction())
 
-    plan = asyncio.run(direct_voice_performance(reply, director))
+    plan = asyncio.run(
+        direct_voice_performance(reply, director, letter_content="合成来信正文")
+    )
 
     assert plan.spoken_text == reply
     assert len(plan.speech_units()) == 1
@@ -45,23 +45,24 @@ def test_director_preserves_frozen_reply_and_requests_only_global_controls() -> 
     assert plan.cues[0].text == reply
     assert plan.cues[0].emotion == plan.overall_emotion
     assert plan.cues[0].intensity == plan.energy
+    assert plan.global_speed == 1.0
+    assert plan.profile == "cosyvoice3_base_a_v1"
     assert "segments" not in plan.to_dict()
     request = director.requests[0]
     assert request["tool_choice"] == "required"
+    assert "合成来信正文" in request["messages"][1]["content"]
     assert reply in request["messages"][1]["content"]
     properties = request["tools"][0]["function"]["parameters"]["properties"]
     assert set(properties) == {
         "overall_emotion",
-        "global_speed",
+        "short_instruction",
         "energy",
-        "breath_before_sentences",
-        "emphasize_sentences",
     }
 
 
 @pytest.mark.parametrize(
     "missing",
-    ["overall_emotion", "global_speed", "energy", "breath_before_sentences", "emphasize_sentences"],
+    ["overall_emotion", "short_instruction", "energy"],
 )
 def test_director_rejects_tool_calls_missing_required_controls(missing: str) -> None:
     arguments = _valid_direction()
@@ -75,6 +76,7 @@ def test_director_rejects_tool_calls_missing_required_controls(missing: str) -> 
     "payload",
     [
         {"global_speed": 99},
+        {"short_instruction": "禁止朗读提示词"},
         {"overall_emotion": "<|endofprompt|>"},
         {"breath_before_sentences": [99]},
         {"emphasize_sentences": [1, 1]},

--- a/tests/tts/test_voice_direction.py
+++ b/tests/tts/test_voice_direction.py
@@ -25,9 +25,7 @@ class _FakeVoiceDirector:
 
 def _valid_direction() -> dict[str, object]:
     return {
-        "overall_emotion": "克制而温暖的陪伴感",
         "short_instruction": "声音柔软自然地承接，再缓缓托起给到力量",
-        "energy": 0.55,
     }
 
 
@@ -53,20 +51,14 @@ def test_director_preserves_frozen_reply_and_requests_only_global_controls() -> 
     assert "合成来信正文" in request["messages"][1]["content"]
     assert reply in request["messages"][1]["content"]
     properties = request["tools"][0]["function"]["parameters"]["properties"]
-    assert set(properties) == {
-        "overall_emotion",
-        "short_instruction",
-        "energy",
-    }
+    assert set(properties) == {"short_instruction"}
+    assert plan.overall_emotion == plan.short_instruction
+    assert plan.energy == 0.55
 
 
-@pytest.mark.parametrize(
-    "missing",
-    ["overall_emotion", "short_instruction", "energy"],
-)
-def test_director_rejects_tool_calls_missing_required_controls(missing: str) -> None:
+def test_director_rejects_tool_calls_missing_required_controls() -> None:
     arguments = _valid_direction()
-    del arguments[missing]
+    del arguments["short_instruction"]
 
     with pytest.raises(VoiceDirectionError, match="VOICE_DIRECTION_INVALID"):
         asyncio.run(direct_voice_performance("第一句。第二句。", _FakeVoiceDirector(arguments)))

--- a/tests/tts/test_voice_direction.py
+++ b/tests/tts/test_voice_direction.py
@@ -2,7 +2,13 @@ import asyncio
 
 import pytest
 
-from voice_direction import VoiceDirectionError, VoiceToolCall, direct_voice_performance
+from voice_direction import (
+    VoiceDirectionError,
+    VoicePerformancePlan,
+    VoiceToolCall,
+    direct_music_voice_performance,
+    direct_voice_performance,
+)
 
 
 class _FakeVoiceDirector:
@@ -26,6 +32,16 @@ class _FakeVoiceDirector:
 def _valid_direction() -> dict[str, object]:
     return {
         "short_instruction": "声音柔软自然地承接，再缓缓托起给到力量",
+    }
+
+
+def _valid_music_direction() -> dict[str, object]:
+    return {
+        "overall_emotion": "restrained empathy becoming reassurance",
+        "global_speed": 1.06,
+        "energy": 0.55,
+        "breath_before_sentences": [2],
+        "emphasize_sentences": [1],
     }
 
 
@@ -62,6 +78,35 @@ def test_director_rejects_tool_calls_missing_required_controls() -> None:
 
     with pytest.raises(VoiceDirectionError, match="VOICE_DIRECTION_INVALID"):
         asyncio.run(direct_voice_performance("第一句。第二句。", _FakeVoiceDirector(arguments)))
+
+
+def test_music_director_preserves_the_pre_a_tool_and_plan_profile() -> None:
+    reply = "第一句。第二句。"
+    director = _FakeVoiceDirector(_valid_music_direction())
+
+    plan = asyncio.run(direct_music_voice_performance(reply, director))
+
+    assert plan.spoken_text == reply
+    assert plan.profile == "legacy_music_global_direction_v1"
+    assert plan.short_instruction == ""
+    assert plan.global_speed == 1.06
+    properties = director.requests[0]["tools"][0]["function"]["parameters"][
+        "properties"
+    ]
+    assert set(properties) == {
+        "overall_emotion",
+        "global_speed",
+        "energy",
+        "breath_before_sentences",
+        "emphasize_sentences",
+    }
+    legacy = plan.to_dict()
+    del legacy["short_instruction"]
+    del legacy["profile"]
+
+    assert VoicePerformancePlan.from_music_dict(legacy) == plan
+    with pytest.raises(VoiceDirectionError, match="VOICE_DIRECTION_INVALID"):
+        VoicePerformancePlan.from_dict(plan.to_dict())
 
 
 @pytest.mark.parametrize(

--- a/tts/__init__.py
+++ b/tts/__init__.py
@@ -7,6 +7,7 @@ the native HTTP capability claim that B02 deliberately keeps unavailable.
 
 from .contracts import (
     AudioChunk,
+    DIRECTED_DELIVERY_ERROR_CODES,
     TTSConfig,
     TTSResult,
     TTSRun,
@@ -21,6 +22,7 @@ from .service import TTSService
 
 __all__ = [
     "AudioChunk",
+    "DIRECTED_DELIVERY_ERROR_CODES",
     "TTSConfig",
     "TTSProfileManager",
     "TTSProviderRegistry",

--- a/tts/__init__.py
+++ b/tts/__init__.py
@@ -7,7 +7,6 @@ the native HTTP capability claim that B02 deliberately keeps unavailable.
 
 from .contracts import (
     AudioChunk,
-    DIRECTED_DELIVERY_ERROR_CODES,
     TTSConfig,
     TTSResult,
     TTSRun,
@@ -22,7 +21,6 @@ from .service import TTSService
 
 __all__ = [
     "AudioChunk",
-    "DIRECTED_DELIVERY_ERROR_CODES",
     "TTSConfig",
     "TTSProfileManager",
     "TTSProviderRegistry",

--- a/tts/contracts.py
+++ b/tts/contracts.py
@@ -11,6 +11,18 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 
+DIRECTED_DELIVERY_ERROR_CODES: Mapping[str, Mapping[str, object]] = {
+    "TTS_CONTENT_GATE_UNAVAILABLE": {
+        "status": "UNAVAILABLE",
+        "retryable": True,
+    },
+    "TTS_CONTENT_GATE_REJECTED": {
+        "status": "FAILED",
+        "retryable": False,
+    },
+}
+
+
 class TTSError(RuntimeError):
     """Sanitized, machine-readable TTS failure."""
 

--- a/tts/contracts.py
+++ b/tts/contracts.py
@@ -76,6 +76,7 @@ def _public_provider_options(options: Mapping[str, Any]) -> dict[str, Any]:
 
     path_keys = {
         "numba_cache_dir",
+        "quality_gate_cache_root",
         "temp_root",
         "wetext_fst_root",
     }

--- a/tts/contracts.py
+++ b/tts/contracts.py
@@ -11,18 +11,6 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 
-DIRECTED_DELIVERY_ERROR_CODES: Mapping[str, Mapping[str, object]] = {
-    "TTS_CONTENT_GATE_UNAVAILABLE": {
-        "status": "UNAVAILABLE",
-        "retryable": True,
-    },
-    "TTS_CONTENT_GATE_REJECTED": {
-        "status": "FAILED",
-        "retryable": False,
-    },
-}
-
-
 class TTSError(RuntimeError):
     """Sanitized, machine-readable TTS failure."""
 

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -29,6 +29,7 @@ class DeliveryAudioResult:
     duration_seconds: float
     sample_rate: int
     segment_count: int
+    quality_report: dict[str, object] | None = None
 
 
 def delivery_tempo_factor(duration_seconds: float) -> float | None:
@@ -47,29 +48,6 @@ def validate_delivery_duration(duration_seconds: float) -> None:
 
     if not 40.0 <= float(duration_seconds) <= 50.0:
         raise DeliveryAudioError("TTS_DELIVERY_DURATION_OUT_OF_RANGE")
-
-
-def _normalized_instruct_text(value: str) -> str:
-    """Leave the model control token exclusively at the instruction tail."""
-
-    return value.replace(_END_OF_PROMPT_TOKEN, "").rstrip() + _END_OF_PROMPT_TOKEN
-
-
-def _directed_instruct_text(plan: object, *, emotion: str, speed: float, energy: float) -> str:
-    """Express optional sparse direction in CosyVoice's non-spoken channel."""
-
-    parts = [
-        "You are a helpful assistant.",
-        f"Deliver this complete reply with {emotion}.",
-        f"Keep one continuous performance at energy {energy:.2f} and pace {speed:.2f}.",
-    ]
-    breaths = tuple(getattr(plan, "breath_before_sentences", ()) or ())
-    emphasis = tuple(getattr(plan, "emphasize_sentences", ()) or ())
-    if breaths:
-        parts.append("Take a natural silent breath before sentence " + ", ".join(map(str, breaths)) + ".")
-    if emphasis:
-        parts.append("Gently emphasize sentence " + ", ".join(map(str, emphasis)) + ".")
-    return _normalized_instruct_text(" ".join(parts))
 
 
 def build_external_delivery_request(
@@ -99,22 +77,35 @@ def build_external_delivery_request(
     }
     overall_emotion = str(getattr(plan, "overall_emotion", "") or "").strip()
     if overall_emotion:
+        short_instruction = str(
+            getattr(plan, "short_instruction", "") or overall_emotion
+        ).strip().rstrip("。")
+        forbidden = ("<|", "|>", "[", "]", "<", ">", "不要", "禁止", "朗读", "提示词")
+        if not 12 <= len(short_instruction) <= 24 or any(
+            token in short_instruction for token in forbidden
+        ):
+            raise DeliveryAudioError("TTS_INSTRUCTION_INVALID")
+        options = getattr(config, "provider_options", {}) or {}
         return {
             **common,
             "voice_condition_mode": "instruct2_single_pass",
+            "llm_variant": "base",
             "text": spoken_text,
-            "instruct_text": _directed_instruct_text(
-                plan,
-                emotion=overall_emotion,
-                speed=max(1.02, min(1.08, speed)),
-                energy=float(getattr(plan, "energy", 0.0)),
+            "instruct_text": (
+                "You are a helpful assistant. "
+                + short_instruction
+                + "。<|endofprompt|>"
             ),
-            "speed": max(1.02, min(1.08, speed)),
+            "quality_forbidden_text": short_instruction,
+            "quality_gate_model": str(options.get("quality_gate_model", "base") or "base"),
+            "quality_gate_cache_root": str(options.get("quality_gate_cache_root", "") or ""),
+            "quality_max_cer": 0.18,
+            "speed": 1.0,
             "gain_db": max(-0.75, min(0.75, gain_db)),
             "duration_target_seconds": [40.0, 50.0],
             "max_attempts": 3,
             "seed": 200717,
-            "performance_control_mode": "single_pass_llm_instruct",
+            "performance_control_mode": "single_pass_llm_short_instruct",
             "director_segment_count": len(getattr(plan, "cues", units)),
         }
     return {
@@ -203,6 +194,7 @@ def delivery_configured(config: TTSConfig) -> bool:
     return all((
         Path(str(config.provider_options.get("external_python", "") or "")).is_file(),
         Path(__file__).with_name("external_cosyvoice_worker.py").is_file(),
+        Path(__file__).with_name("external_audio_quality_worker.py").is_file(),
         Path(config.runtime_root).is_dir(),
         Path(config.model_dir).is_dir(),
         Path(config.reference_audio).is_file(),
@@ -230,12 +222,11 @@ def render_delivery_wav(
     except OSError as exc:
         raise DeliveryAudioError("TTS_TEMP_CONFIG_INVALID") from exc
     request_path = work / "request.json"
+    quality_request_path = work / "quality-request.json"
+    quality_output_path = work / "quality-result.json"
     temporary_output = work / "speech.wav"
     try:
-        request_path.write_text(
-            json.dumps(build_external_delivery_request(config, plan), ensure_ascii=False),
-            encoding="utf-8",
-        )
+        request = build_external_delivery_request(config, plan)
         environment = dict(os.environ)
         environment.update(
             {
@@ -244,33 +235,107 @@ def render_delivery_wav(
                 "MODELSCOPE_OFFLINE": "1",
             }
         )
-        try:
-            completed = subprocess.run(
-                [str(executable), str(worker), "--request", str(request_path), "--output", str(temporary_output)],
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                env=environment,
-                check=False,
-                timeout=timeout_seconds,
+        def run_worker(payload: dict[str, object]) -> None:
+            temporary_output.unlink(missing_ok=True)
+            request_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+            try:
+                completed = subprocess.run(
+                    [str(executable), str(worker), "--request", str(request_path), "--output", str(temporary_output)],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    env=environment,
+                    check=False,
+                    timeout=timeout_seconds,
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                raise DeliveryAudioError("TTS_EXTERNAL_PROCESS_UNAVAILABLE") from exc
+            if completed.returncode != 0 or not temporary_output.is_file():
+                raise DeliveryAudioError("TTS_EXTERNAL_PROCESS_FAILED")
+
+        def run_quality_gate(payload: dict[str, object]) -> dict[str, object]:
+            quality_worker = Path(__file__).with_name("external_audio_quality_worker.py")
+            if not quality_worker.is_file():
+                raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
+            quality_request_path.write_text(
+                json.dumps(
+                    {
+                        "audio_path": str(temporary_output),
+                        "expected_text": str(payload.get("text", "")),
+                        "forbidden_text": str(payload.get("quality_forbidden_text", "")),
+                        "model": str(payload.get("quality_gate_model", "base")),
+                        "cache_root": str(payload.get("quality_gate_cache_root", "")),
+                        "max_cer": float(payload.get("quality_max_cer", 0.18)),
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
             )
-        except (OSError, subprocess.TimeoutExpired) as exc:
-            raise DeliveryAudioError("TTS_EXTERNAL_PROCESS_UNAVAILABLE") from exc
-        if completed.returncode != 0 or not temporary_output.is_file():
-            raise DeliveryAudioError("TTS_EXTERNAL_PROCESS_FAILED")
-        sample_rate, frame_count = _validate_wav(temporary_output)
-        if frame_count <= 0 or sample_rate <= 0:
-            raise DeliveryAudioError("TTS_EMPTY_AUDIO")
-        sample_rate, frame_count = _fit_overlong_wav(
-            temporary_output,
-            frame_count / sample_rate,
-        )
-        validate_delivery_duration(frame_count / sample_rate)
+            quality_output_path.unlink(missing_ok=True)
+            try:
+                completed = subprocess.run(
+                    [str(executable), str(quality_worker), "--request", str(quality_request_path), "--output", str(quality_output_path)],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    env=environment,
+                    check=False,
+                    timeout=min(timeout_seconds, 600.0),
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE") from exc
+            if completed.returncode != 0 or not quality_output_path.is_file():
+                raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
+            try:
+                report = json.loads(quality_output_path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE") from exc
+            if not isinstance(report, dict) or not isinstance(report.get("passed"), bool):
+                raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
+            return report
+
+        quality_report: dict[str, object] | None = None
+        if request.get("voice_condition_mode") == "instruct2_single_pass":
+            duration_candidate_seen = False
+            for attempt in range(max(1, min(3, int(request.get("max_attempts", 1))))):
+                candidate = dict(request)
+                candidate["seed"] = int(request.get("seed", 200717)) + attempt
+                candidate["max_attempts"] = 1
+                run_worker(candidate)
+                sample_rate, frame_count = _validate_wav(temporary_output)
+                try:
+                    sample_rate, frame_count = _fit_overlong_wav(
+                        temporary_output, frame_count / sample_rate
+                    )
+                    validate_delivery_duration(frame_count / sample_rate)
+                except DeliveryAudioError:
+                    continue
+                duration_candidate_seen = True
+                quality_report = run_quality_gate(candidate)
+                quality_report.update(
+                    attempt=attempt + 1,
+                    seed=candidate["seed"],
+                    duration_seconds=round(frame_count / sample_rate, 3),
+                )
+                if quality_report["passed"] is True:
+                    break
+            else:
+                if duration_candidate_seen:
+                    raise DeliveryAudioError("TTS_CONTENT_GATE_REJECTED")
+                raise DeliveryAudioError("TTS_DELIVERY_DURATION_OUT_OF_RANGE")
+        else:
+            run_worker(request)
+            sample_rate, frame_count = _validate_wav(temporary_output)
+            sample_rate, frame_count = _fit_overlong_wav(
+                temporary_output, frame_count / sample_rate
+            )
+            validate_delivery_duration(frame_count / sample_rate)
         temporary_output.replace(output_path)
         return DeliveryAudioResult(
             duration_seconds=frame_count / sample_rate,
             sample_rate=sample_rate,
             segment_count=len(plan.speech_units()),
+            quality_report=quality_report,
         )
     finally:
         shutil.rmtree(work, ignore_errors=True)

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -12,7 +12,6 @@ import tempfile
 import wave
 from dataclasses import dataclass
 from functools import lru_cache
-from math import isfinite
 from pathlib import Path
 
 from latentsync_reply import LatentSyncReplyError, resolve_ffmpeg_executable
@@ -20,6 +19,7 @@ from reply_delivery import ReplyDeliveryPlan
 from voice_direction import VoiceDirectionError, validate_short_instruction
 
 from .contracts import TTSConfig
+from .external_audio_quality_worker import assess_transcript
 
 
 class DeliveryAudioError(RuntimeError):
@@ -35,15 +35,6 @@ _COSYVOICE_BASE_LLM_SHA256 = "69f43bd545131c30e98947fb360ea8b4dc9916d8e83dded775
 _WHISPER_BASE_SHA256 = "ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e"
 _WHISPER_DISTRIBUTION = "openai-whisper"
 _WHISPER_VERSION = "20250625"
-_QUALITY_CHECKS = frozenset(
-    "cer length_ratio instruction_overlap extra_speech contiguous_omission repetition".split()
-)
-_QUALITY_REPORT_FIELDS = frozenset(
-    "passed error_code transcript cer length_ratio instruction_overlap_chars "
-    "longest_extra_insertion_chars longest_contiguous_omission_chars added_repetition checks".split()
-)
-
-
 @dataclass(frozen=True)
 class DeliveryAudioResult:
     duration_seconds: float
@@ -52,38 +43,21 @@ class DeliveryAudioResult:
     quality_report: dict[str, object] | None = None
 
 
-def _validated_quality_report(value: object, *, max_cer: float = 0.18) -> dict[str, object]:
-    if not isinstance(value, dict) or set(value) != _QUALITY_REPORT_FIELDS:
+def _validated_quality_report(
+    value: object, *, expected_text: str, forbidden_text: str, max_cer: float = 0.18
+) -> dict[str, object]:
+    if not isinstance(value, dict) or not isinstance(value.get("transcript"), str):
         raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
-    checks = value["checks"]
-    if (
-        not isinstance(checks, dict)
-        or set(checks) != _QUALITY_CHECKS
-        or any(not isinstance(item, bool) for item in checks.values())
-        or not isinstance(value["passed"], bool)
-        or not isinstance(value["transcript"], str)
-        or not isinstance(value["added_repetition"], bool)
-    ):
-        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
-    metrics = (value["cer"], value["length_ratio"])
-    counts = tuple(value[field] for field in (
-        "instruction_overlap_chars", "longest_extra_insertion_chars", "longest_contiguous_omission_chars"
-    ))
-    if any(isinstance(item, bool) or not isinstance(item, (int, float)) or not isfinite(item) or item < 0 for item in metrics):
-        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
-    if any(isinstance(item, bool) or not isinstance(item, int) or item < 0 for item in counts):
-        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
-    expected_checks = dict(cer=value["cer"] <= max_cer, length_ratio=value["length_ratio"] == 1.0,
-                           instruction_overlap=value["instruction_overlap_chars"] < 4, extra_speech=value["longest_extra_insertion_chars"] == 0,
-                           contiguous_omission=value["longest_contiguous_omission_chars"] == 0, repetition=not value["added_repetition"])
-    if checks != expected_checks:
-        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
-    passed = value["passed"]
-    error_code = value["error_code"]
-    if passed is not all(checks.values()):
-        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
-    expected_error = None if passed else ("TTS_CONTENT_EMPTY" if not value["transcript"].strip() else "TTS_CONTENT_MISMATCH")
-    if error_code != expected_error:
+    expected = assess_transcript(
+        expected_text, value["transcript"], forbidden_text, max_cer=max_cer
+    )
+    try:
+        matches = json.dumps(value, ensure_ascii=False, sort_keys=True) == json.dumps(
+            expected, ensure_ascii=False, sort_keys=True
+        )
+    except (TypeError, ValueError):
+        matches = False
+    if not matches:
         raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
     return dict(value)
 
@@ -485,7 +459,10 @@ def render_delivery_wav(
             except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
                 raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE") from exc
             return _validated_quality_report(
-                report, max_cer=float(payload.get("quality_max_cer", 0.18))
+                report,
+                expected_text=str(payload.get("text", "")),
+                forbidden_text=str(payload.get("quality_forbidden_text", "")),
+                max_cer=float(payload.get("quality_max_cer", 0.18)),
             )
 
         quality_report: dict[str, object] | None = None

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -12,6 +12,7 @@ import tempfile
 import wave
 from dataclasses import dataclass
 from functools import lru_cache
+from math import isfinite
 from pathlib import Path
 
 from latentsync_reply import LatentSyncReplyError, resolve_ffmpeg_executable
@@ -34,6 +35,14 @@ _COSYVOICE_BASE_LLM_SHA256 = "69f43bd545131c30e98947fb360ea8b4dc9916d8e83dded775
 _WHISPER_BASE_SHA256 = "ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e"
 _WHISPER_DISTRIBUTION = "openai-whisper"
 _WHISPER_VERSION = "20250625"
+_QUALITY_CHECKS = frozenset(
+    "cer length_ratio instruction_overlap extra_speech contiguous_omission repetition".split()
+)
+_QUALITY_REPORT_FIELDS = frozenset(
+    "passed error_code transcript cer length_ratio instruction_overlap_chars "
+    "longest_extra_insertion_chars longest_contiguous_omission_chars added_repetition checks".split()
+)
+_QUALITY_REJECTION_CODES = {"TTS_CONTENT_EMPTY", "TTS_CONTENT_MISMATCH"}
 
 
 @dataclass(frozen=True)
@@ -42,6 +51,40 @@ class DeliveryAudioResult:
     sample_rate: int
     segment_count: int
     quality_report: dict[str, object] | None = None
+
+
+def _validated_quality_report(value: object) -> dict[str, object]:
+    if not isinstance(value, dict) or set(value) != _QUALITY_REPORT_FIELDS:
+        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
+    checks = value["checks"]
+    if (
+        not isinstance(checks, dict)
+        or set(checks) != _QUALITY_CHECKS
+        or any(not isinstance(item, bool) for item in checks.values())
+        or not isinstance(value["passed"], bool)
+        or not isinstance(value["transcript"], str)
+        or not isinstance(value["added_repetition"], bool)
+    ):
+        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
+    metrics = (value["cer"], value["length_ratio"])
+    counts = tuple(value[field] for field in (
+        "instruction_overlap_chars", "longest_extra_insertion_chars", "longest_contiguous_omission_chars"
+    ))
+    if any(isinstance(item, bool) or not isinstance(item, (int, float)) or not isfinite(item) or item < 0 for item in metrics):
+        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
+    if any(isinstance(item, bool) or not isinstance(item, int) or item < 0 for item in counts):
+        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
+    passed = value["passed"]
+    error_code = value["error_code"]
+    if error_code is not None and not isinstance(error_code, str):
+        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
+    if passed is not all(checks.values()):
+        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
+    if (passed and error_code is not None) or (
+        not passed and error_code not in _QUALITY_REJECTION_CODES
+    ):
+        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
+    return dict(value)
 
 
 def delivery_tempo_factor(duration_seconds: float) -> float | None:
@@ -60,6 +103,29 @@ def validate_delivery_duration(duration_seconds: float) -> None:
 
     if not 40.0 <= float(duration_seconds) <= 50.0:
         raise DeliveryAudioError("TTS_DELIVERY_DURATION_OUT_OF_RANGE")
+
+
+def _normalized_instruct_text(value: str) -> str:
+    """Leave the model control token exclusively at the instruction tail."""
+
+    return value.replace("<|endofprompt|>", "").rstrip() + "<|endofprompt|>"
+
+
+def _directed_instruct_text(plan: object, *, emotion: str, speed: float, energy: float) -> str:
+    """Express optional sparse direction in CosyVoice's non-spoken channel."""
+
+    parts = [
+        "You are a helpful assistant.",
+        f"Deliver this complete reply with {emotion}.",
+        f"Keep one continuous performance at energy {energy:.2f} and pace {speed:.2f}.",
+    ]
+    breaths = tuple(getattr(plan, "breath_before_sentences", ()) or ())
+    emphasis = tuple(getattr(plan, "emphasize_sentences", ()) or ())
+    if breaths:
+        parts.append("Take a natural silent breath before sentence " + ", ".join(map(str, breaths)) + ".")
+    if emphasis:
+        parts.append("Gently emphasize sentence " + ", ".join(map(str, emphasis)) + ".")
+    return _normalized_instruct_text(" ".join(parts))
 
 
 def build_external_delivery_request(
@@ -88,7 +154,7 @@ def build_external_delivery_request(
         "fp16": bool(config.fp16),
     }
     overall_emotion = str(getattr(plan, "overall_emotion", "") or "").strip()
-    if overall_emotion:
+    if overall_emotion and getattr(plan, "profile", "") == "cosyvoice3_base_a_v1":
         try:
             short_instruction = validate_short_instruction(
                 getattr(plan, "short_instruction", "") or overall_emotion
@@ -116,6 +182,25 @@ def build_external_delivery_request(
             "max_attempts": 3,
             "seed": 200717,
             "performance_control_mode": "single_pass_llm_short_instruct",
+            "director_segment_count": len(getattr(plan, "cues", units)),
+        }
+    if overall_emotion:
+        return {
+            **common,
+            "voice_condition_mode": "instruct2_single_pass",
+            "text": spoken_text,
+            "instruct_text": _directed_instruct_text(
+                plan,
+                emotion=overall_emotion,
+                speed=max(1.02, min(1.08, speed)),
+                energy=float(getattr(plan, "energy", 0.0)),
+            ),
+            "speed": max(1.02, min(1.08, speed)),
+            "gain_db": max(-0.75, min(0.75, gain_db)),
+            "duration_target_seconds": [40.0, 50.0],
+            "max_attempts": 3,
+            "seed": 200717,
+            "performance_control_mode": "single_pass_llm_instruct",
             "director_segment_count": len(getattr(plan, "cues", units)),
         }
     return {
@@ -398,9 +483,7 @@ def render_delivery_wav(
                 report = json.loads(quality_output_path.read_text(encoding="utf-8"))
             except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
                 raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE") from exc
-            if not isinstance(report, dict) or not isinstance(report.get("passed"), bool):
-                raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
-            return report
+            return _validated_quality_report(report)
 
         quality_report: dict[str, object] | None = None
         if require_quality_gate:

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -32,6 +32,8 @@ _SPOKEN_CONTROL_RE = re.compile(
 )
 _COSYVOICE_BASE_LLM_SHA256 = "69f43bd545131c30e98947fb360ea8b4dc9916d8e83dded7757c7ea4f5a24970"
 _WHISPER_BASE_SHA256 = "ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e"
+_WHISPER_DISTRIBUTION = "openai-whisper"
+_WHISPER_VERSION = "20250625"
 
 
 @dataclass(frozen=True)
@@ -227,16 +229,20 @@ def _verified_file(path: Path, expected_sha256: str) -> bool:
     )
 
 
-@lru_cache(maxsize=8)
 def _quality_runtime_available(
     executable_text: str,
     size: int,
     modified_ns: int,
 ) -> bool:
     del size, modified_ns
+    probe = (
+        "import importlib.metadata as m; import torch, whisper; "
+        f"raise SystemExit(0 if m.version('{_WHISPER_DISTRIBUTION}') == "
+        f"'{_WHISPER_VERSION}' else 3)"
+    )
     try:
         completed = subprocess.run(
-            [executable_text, "-I", "-c", "import torch, whisper"],
+            [executable_text, "-I", "-c", probe],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -261,11 +267,9 @@ def delivery_configured(
     base_checks = all((
         executable.is_file(),
         Path(__file__).with_name("external_cosyvoice_worker.py").is_file(),
-        Path(__file__).with_name("external_audio_quality_worker.py").is_file(),
         Path(config.runtime_root).is_dir(),
         Path(config.model_dir).is_dir(),
         Path(config.reference_audio).is_file(),
-        _verified_file(model_checkpoint, _COSYVOICE_BASE_LLM_SHA256),
     ))
     if not base_checks or not require_quality_gate:
         return base_checks
@@ -279,6 +283,8 @@ def delivery_configured(
     except OSError:
         return False
     return all((
+        Path(__file__).with_name("external_audio_quality_worker.py").is_file(),
+        _verified_file(model_checkpoint, _COSYVOICE_BASE_LLM_SHA256),
         _verified_file(checkpoint, _WHISPER_BASE_SHA256),
         _quality_runtime_available(
             str(executable.resolve()),
@@ -305,8 +311,13 @@ def render_delivery_wav(
         enforce_content_gate
         and request.get("voice_condition_mode") == "instruct2_single_pass"
     )
-    if not delivery_configured(config, require_quality_gate=require_quality_gate):
+    if not delivery_configured(config):
         raise DeliveryAudioError("TTS_DELIVERY_UNAVAILABLE")
+    if require_quality_gate and not delivery_configured(
+        config, require_quality_gate=True
+    ):
+        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
+    request["verify_accepted_base_model"] = require_quality_gate
     executable = Path(str(config.provider_options.get("external_python", "") or ""))
     worker = Path(__file__).with_name("external_cosyvoice_worker.py")
 
@@ -393,8 +404,11 @@ def render_delivery_wav(
 
         quality_report: dict[str, object] | None = None
         if require_quality_gate:
-            duration_candidate_seen = False
-            for attempt in range(max(1, min(3, int(request.get("max_attempts", 1))))):
+            quality_rejection_count = 0
+            synthesis_attempts = max(
+                1, min(3, int(request.get("max_attempts", 1)))
+            )
+            for attempt in range(synthesis_attempts):
                 candidate = dict(request)
                 candidate["seed"] = int(request.get("seed", 200717)) + attempt
                 candidate["max_attempts"] = 1
@@ -407,7 +421,6 @@ def render_delivery_wav(
                     validate_delivery_duration(frame_count / sample_rate)
                 except DeliveryAudioError:
                     continue
-                duration_candidate_seen = True
                 quality_report = run_quality_gate(candidate)
                 quality_report.update(
                     attempt=attempt + 1,
@@ -416,8 +429,9 @@ def render_delivery_wav(
                 )
                 if quality_report["passed"] is True:
                     break
+                quality_rejection_count += 1
             else:
-                if duration_candidate_seen:
+                if quality_rejection_count == synthesis_attempts:
                     raise DeliveryAudioError("TTS_CONTENT_GATE_REJECTED")
                 raise DeliveryAudioError("TTS_DELIVERY_DURATION_OUT_OF_RANGE")
         else:

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import shutil
 import subprocess
 import tempfile
 import wave
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 
 from latentsync_reply import LatentSyncReplyError, resolve_ffmpeg_executable
@@ -22,6 +24,8 @@ class DeliveryAudioError(RuntimeError):
 
 
 _END_OF_PROMPT_TOKEN = "<|endofprompt|>"
+_COSYVOICE_BASE_LLM_SHA256 = "69f43bd545131c30e98947fb360ea8b4dc9916d8e83dded7757c7ea4f5a24970"
+_WHISPER_BASE_SHA256 = "ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e"
 
 
 @dataclass(frozen=True)
@@ -188,16 +192,93 @@ def _fit_overlong_wav(path: Path, duration_seconds: float) -> tuple[int, int]:
     return sample_rate, frame_count
 
 
-def delivery_configured(config: TTSConfig) -> bool:
+@lru_cache(maxsize=16)
+def _pinned_file_matches(
+    path_text: str,
+    size: int,
+    modified_ns: int,
+    expected_sha256: str,
+) -> bool:
+    del size, modified_ns
+    digest = hashlib.sha256()
+    try:
+        with Path(path_text).open("rb") as source:
+            for block in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError:
+        return False
+    return digest.hexdigest() == expected_sha256
+
+
+def _verified_file(path: Path, expected_sha256: str) -> bool:
+    try:
+        stat = path.stat()
+    except OSError:
+        return False
+    return _pinned_file_matches(
+        str(path.resolve()),
+        stat.st_size,
+        stat.st_mtime_ns,
+        expected_sha256,
+    )
+
+
+@lru_cache(maxsize=8)
+def _quality_runtime_available(
+    executable_text: str,
+    size: int,
+    modified_ns: int,
+) -> bool:
+    del size, modified_ns
+    try:
+        completed = subprocess.run(
+            [executable_text, "-I", "-c", "import torch, whisper"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=30.0,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
+
+
+def delivery_configured(
+    config: TTSConfig,
+    *,
+    require_quality_gate: bool = False,
+) -> bool:
     """Read-only closure check shared by delivery preflight and rendering."""
 
-    return all((
-        Path(str(config.provider_options.get("external_python", "") or "")).is_file(),
+    options = config.provider_options or {}
+    executable = Path(str(options.get("external_python", "") or ""))
+    model_checkpoint = Path(config.model_dir) / "llm.pt"
+    base_checks = all((
+        executable.is_file(),
         Path(__file__).with_name("external_cosyvoice_worker.py").is_file(),
         Path(__file__).with_name("external_audio_quality_worker.py").is_file(),
         Path(config.runtime_root).is_dir(),
         Path(config.model_dir).is_dir(),
         Path(config.reference_audio).is_file(),
+        _verified_file(model_checkpoint, _COSYVOICE_BASE_LLM_SHA256),
+    ))
+    if not base_checks or not require_quality_gate:
+        return base_checks
+    cache_value = str(options.get("quality_gate_cache_root", "") or "").strip()
+    cache_root = Path(cache_value) if cache_value else Path.home() / ".cache" / "whisper"
+    checkpoint = cache_root / "base.pt"
+    try:
+        executable_stat = executable.stat()
+    except OSError:
+        return False
+    return all((
+        _verified_file(checkpoint, _WHISPER_BASE_SHA256),
+        _quality_runtime_available(
+            str(executable.resolve()),
+            executable_stat.st_size,
+            executable_stat.st_mtime_ns,
+        ),
     ))
 
 
@@ -210,7 +291,11 @@ def render_delivery_wav(
 ) -> DeliveryAudioResult:
     """Render all delivery segments while loading the maintained model once."""
 
-    if not delivery_configured(config) or not plan.cues:
+    if not plan.cues:
+        raise DeliveryAudioError("TTS_DELIVERY_UNAVAILABLE")
+    request = build_external_delivery_request(config, plan)
+    require_quality_gate = request.get("voice_condition_mode") == "instruct2_single_pass"
+    if not delivery_configured(config, require_quality_gate=require_quality_gate):
         raise DeliveryAudioError("TTS_DELIVERY_UNAVAILABLE")
     executable = Path(str(config.provider_options.get("external_python", "") or ""))
     worker = Path(__file__).with_name("external_cosyvoice_worker.py")
@@ -226,7 +311,6 @@ def render_delivery_wav(
     quality_output_path = work / "quality-result.json"
     temporary_output = work / "speech.wav"
     try:
-        request = build_external_delivery_request(config, plan)
         environment = dict(os.environ)
         environment.update(
             {

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import hashlib
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -15,6 +16,7 @@ from pathlib import Path
 
 from latentsync_reply import LatentSyncReplyError, resolve_ffmpeg_executable
 from reply_delivery import ReplyDeliveryPlan
+from voice_direction import VoiceDirectionError, validate_short_instruction
 
 from .contracts import TTSConfig
 
@@ -23,7 +25,11 @@ class DeliveryAudioError(RuntimeError):
     """Stable ordinary-reply audio rendering failure."""
 
 
-_END_OF_PROMPT_TOKEN = "<|endofprompt|>"
+_INSTRUCT_PREFIX = "You are a helpful assistant. "
+_SPOKEN_CONTROL_RE = re.compile(
+    r"<\|[^\r\n]{1,120}?\|>|</?[A-Za-z][^>\r\n]{0,120}>|\[[^\]\r\n]{1,80}\]|\*\*[^*\r\n]{1,120}\*\*",
+    re.IGNORECASE,
+)
 _COSYVOICE_BASE_LLM_SHA256 = "69f43bd545131c30e98947fb360ea8b4dc9916d8e83dded7757c7ea4f5a24970"
 _WHISPER_BASE_SHA256 = "ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e"
 
@@ -62,7 +68,7 @@ def build_external_delivery_request(
 
     units = tuple(plan.speech_units())
     spoken_text = str(getattr(plan, "spoken_text", "") or "".join(unit.text for unit in units))
-    if _END_OF_PROMPT_TOKEN in spoken_text:
+    if _SPOKEN_CONTROL_RE.search(spoken_text):
         raise DeliveryAudioError("TTS_DIRECTED_TEXT_CONTAINS_CONTROL_TOKEN")
     if len(units) == 1:
         speed = float(units[0].speed)
@@ -81,13 +87,11 @@ def build_external_delivery_request(
     }
     overall_emotion = str(getattr(plan, "overall_emotion", "") or "").strip()
     if overall_emotion:
-        short_instruction = str(
-            getattr(plan, "short_instruction", "") or overall_emotion
-        ).strip().rstrip("。")
-        forbidden = ("<|", "|>", "[", "]", "<", ">", "不要", "禁止", "朗读", "提示词")
-        if not 12 <= len(short_instruction) <= 24 or any(
-            token in short_instruction for token in forbidden
-        ):
+        try:
+            short_instruction = validate_short_instruction(
+                getattr(plan, "short_instruction", "") or overall_emotion
+            )
+        except VoiceDirectionError:
             raise DeliveryAudioError("TTS_INSTRUCTION_INVALID")
         options = getattr(config, "provider_options", {}) or {}
         return {
@@ -96,11 +100,11 @@ def build_external_delivery_request(
             "llm_variant": "base",
             "text": spoken_text,
             "instruct_text": (
-                "You are a helpful assistant. "
+                _INSTRUCT_PREFIX
                 + short_instruction
                 + "。<|endofprompt|>"
             ),
-            "quality_forbidden_text": short_instruction,
+            "quality_forbidden_text": _INSTRUCT_PREFIX + short_instruction,
             "quality_gate_model": str(options.get("quality_gate_model", "base") or "base"),
             "quality_gate_cache_root": str(options.get("quality_gate_cache_root", "") or ""),
             "quality_max_cer": 0.18,
@@ -266,7 +270,9 @@ def delivery_configured(
     if not base_checks or not require_quality_gate:
         return base_checks
     cache_value = str(options.get("quality_gate_cache_root", "") or "").strip()
-    cache_root = Path(cache_value) if cache_value else Path.home() / ".cache" / "whisper"
+    if not cache_value:
+        return False
+    cache_root = Path(cache_value)
     checkpoint = cache_root / "base.pt"
     try:
         executable_stat = executable.stat()
@@ -288,13 +294,17 @@ def render_delivery_wav(
     output_path: Path,
     *,
     timeout_seconds: float = 3600.0,
+    enforce_content_gate: bool = True,
 ) -> DeliveryAudioResult:
     """Render all delivery segments while loading the maintained model once."""
 
     if not plan.cues:
         raise DeliveryAudioError("TTS_DELIVERY_UNAVAILABLE")
     request = build_external_delivery_request(config, plan)
-    require_quality_gate = request.get("voice_condition_mode") == "instruct2_single_pass"
+    require_quality_gate = bool(
+        enforce_content_gate
+        and request.get("voice_condition_mode") == "instruct2_single_pass"
+    )
     if not delivery_configured(config, require_quality_gate=require_quality_gate):
         raise DeliveryAudioError("TTS_DELIVERY_UNAVAILABLE")
     executable = Path(str(config.provider_options.get("external_python", "") or ""))
@@ -341,21 +351,24 @@ def render_delivery_wav(
             quality_worker = Path(__file__).with_name("external_audio_quality_worker.py")
             if not quality_worker.is_file():
                 raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
-            quality_request_path.write_text(
-                json.dumps(
-                    {
-                        "audio_path": str(temporary_output),
-                        "expected_text": str(payload.get("text", "")),
-                        "forbidden_text": str(payload.get("quality_forbidden_text", "")),
-                        "model": str(payload.get("quality_gate_model", "base")),
-                        "cache_root": str(payload.get("quality_gate_cache_root", "")),
-                        "max_cer": float(payload.get("quality_max_cer", 0.18)),
-                    },
-                    ensure_ascii=False,
-                ),
-                encoding="utf-8",
-            )
-            quality_output_path.unlink(missing_ok=True)
+            try:
+                quality_request_path.write_text(
+                    json.dumps(
+                        {
+                            "audio_path": str(temporary_output),
+                            "expected_text": str(payload.get("text", "")),
+                            "forbidden_text": str(payload.get("quality_forbidden_text", "")),
+                            "model": str(payload.get("quality_gate_model", "base")),
+                            "cache_root": str(payload.get("quality_gate_cache_root", "")),
+                            "max_cer": float(payload.get("quality_max_cer", 0.18)),
+                        },
+                        ensure_ascii=False,
+                    ),
+                    encoding="utf-8",
+                )
+                quality_output_path.unlink(missing_ok=True)
+            except OSError as exc:
+                raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE") from exc
             try:
                 completed = subprocess.run(
                     [str(executable), str(quality_worker), "--request", str(quality_request_path), "--output", str(quality_output_path)],
@@ -379,7 +392,7 @@ def render_delivery_wav(
             return report
 
         quality_report: dict[str, object] | None = None
-        if request.get("voice_condition_mode") == "instruct2_single_pass":
+        if require_quality_gate:
             duration_candidate_seen = False
             for attempt in range(max(1, min(3, int(request.get("max_attempts", 1))))):
                 candidate = dict(request)

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -42,7 +42,6 @@ _QUALITY_REPORT_FIELDS = frozenset(
     "passed error_code transcript cer length_ratio instruction_overlap_chars "
     "longest_extra_insertion_chars longest_contiguous_omission_chars added_repetition checks".split()
 )
-_QUALITY_REJECTION_CODES = {"TTS_CONTENT_EMPTY", "TTS_CONTENT_MISMATCH"}
 
 
 @dataclass(frozen=True)
@@ -53,7 +52,7 @@ class DeliveryAudioResult:
     quality_report: dict[str, object] | None = None
 
 
-def _validated_quality_report(value: object) -> dict[str, object]:
+def _validated_quality_report(value: object, *, max_cer: float = 0.18) -> dict[str, object]:
     if not isinstance(value, dict) or set(value) != _QUALITY_REPORT_FIELDS:
         raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
     checks = value["checks"]
@@ -74,15 +73,17 @@ def _validated_quality_report(value: object) -> dict[str, object]:
         raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
     if any(isinstance(item, bool) or not isinstance(item, int) or item < 0 for item in counts):
         raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
+    expected_checks = dict(cer=value["cer"] <= max_cer, length_ratio=value["length_ratio"] == 1.0,
+                           instruction_overlap=value["instruction_overlap_chars"] < 4, extra_speech=value["longest_extra_insertion_chars"] == 0,
+                           contiguous_omission=value["longest_contiguous_omission_chars"] == 0, repetition=not value["added_repetition"])
+    if checks != expected_checks:
+        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
     passed = value["passed"]
     error_code = value["error_code"]
-    if error_code is not None and not isinstance(error_code, str):
-        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
     if passed is not all(checks.values()):
         raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
-    if (passed and error_code is not None) or (
-        not passed and error_code not in _QUALITY_REJECTION_CODES
-    ):
+    expected_error = None if passed else ("TTS_CONTENT_EMPTY" if not value["transcript"].strip() else "TTS_CONTENT_MISMATCH")
+    if error_code != expected_error:
         raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
     return dict(value)
 
@@ -483,7 +484,9 @@ def render_delivery_wav(
                 report = json.loads(quality_output_path.read_text(encoding="utf-8"))
             except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
                 raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE") from exc
-            return _validated_quality_report(report)
+            return _validated_quality_report(
+                report, max_cer=float(payload.get("quality_max_cer", 0.18))
+            )
 
         quality_report: dict[str, object] | None = None
         if require_quality_gate:

--- a/tts/external_audio_quality_worker.py
+++ b/tts/external_audio_quality_worker.py
@@ -1,0 +1,193 @@
+"""Offline ASR content gate for an ordinary-reply TTS candidate.
+
+This worker runs after the CosyVoice process exits, so the two models never
+compete for GPU memory.  It deliberately has no product-package imports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import wave
+from pathlib import Path
+
+
+def normalize_transcript(text: str) -> str:
+    return re.sub(r"[^\u3400-\u9fffA-Za-z0-9]+", "", str(text)).casefold()
+
+
+def _edit_distance(left: str, right: str) -> int:
+    if len(left) < len(right):
+        left, right = right, left
+    previous = list(range(len(right) + 1))
+    for row, left_char in enumerate(left, 1):
+        current = [row]
+        for column, right_char in enumerate(right, 1):
+            current.append(
+                min(
+                    current[-1] + 1,
+                    previous[column] + 1,
+                    previous[column - 1] + (left_char != right_char),
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+def _longest_extra_insertion(expected: str, actual: str) -> int:
+    matcher = difflib.SequenceMatcher(a=expected, b=actual, autojunk=False)
+    return max(
+        (
+            actual_end - actual_start
+            for tag, _expected_start, _expected_end, actual_start, actual_end in matcher.get_opcodes()
+            if tag in {"insert", "replace"}
+        ),
+        default=0,
+    )
+
+
+def _longest_contiguous_omission(expected: str, actual: str) -> int:
+    matcher = difflib.SequenceMatcher(a=expected, b=actual, autojunk=False)
+    return max(
+        (
+            expected_end - expected_start
+            for tag, expected_start, expected_end, actual_start, actual_end in matcher.get_opcodes()
+            if tag in {"delete", "replace"}
+        ),
+        default=0,
+    )
+
+
+def _has_added_repetition(expected: str, actual: str, width: int = 8) -> bool:
+    if len(actual) < width * 2:
+        return False
+    for start in range(len(actual) - width + 1):
+        phrase = actual[start : start + width]
+        if actual.count(phrase) > max(1, expected.count(phrase)):
+            return True
+    return False
+
+
+def _read_pcm16_for_whisper(path: Path):
+    """Decode the product WAV directly so ASR never depends on an ffmpeg alias."""
+
+    import numpy as np
+
+    with wave.open(str(path), "rb") as source:
+        channels = source.getnchannels()
+        sample_width = source.getsampwidth()
+        sample_rate = source.getframerate()
+        samples = np.frombuffer(
+            source.readframes(source.getnframes()), dtype="<i2"
+        ).astype("float32")
+    if sample_width != 2 or channels < 1:
+        raise RuntimeError("TTS_CONTENT_AUDIO_INVALID")
+    if channels > 1:
+        samples = samples.reshape(-1, channels).mean(axis=1)
+    samples /= 32768.0
+    if sample_rate == 16000:
+        return samples
+    target_count = max(1, round(len(samples) * 16000 / sample_rate))
+    source_x = np.linspace(0.0, 1.0, num=len(samples), endpoint=False)
+    target_x = np.linspace(0.0, 1.0, num=target_count, endpoint=False)
+    return np.interp(target_x, source_x, samples).astype("float32")
+
+
+def assess_transcript(
+    expected_text: str,
+    transcript: str,
+    forbidden_text: str,
+    *,
+    max_cer: float = 0.18,
+) -> dict[str, object]:
+    expected = normalize_transcript(expected_text)
+    actual = normalize_transcript(transcript)
+    forbidden = normalize_transcript(forbidden_text)
+    if not expected or not actual:
+        return {
+            "passed": False,
+            "error_code": "TTS_CONTENT_EMPTY",
+            "transcript": str(transcript).strip(),
+        }
+
+    cer = _edit_distance(expected, actual) / len(expected)
+    length_ratio = len(actual) / len(expected)
+    instruction_overlap = max(
+        (
+            block.size
+            for block in difflib.SequenceMatcher(
+                a=forbidden,
+                b=actual,
+                autojunk=False,
+            ).get_matching_blocks()
+        ),
+        default=0,
+    )
+    longest_extra = _longest_extra_insertion(expected, actual)
+    longest_omission = _longest_contiguous_omission(expected, actual)
+    repeated = _has_added_repetition(expected, actual)
+    checks = {
+        "cer": cer <= max_cer,
+        "length_ratio": 0.80 <= length_ratio <= 1.18,
+        "instruction_overlap": instruction_overlap < 6,
+        "extra_speech": longest_extra < 8,
+        "contiguous_omission": longest_omission < 12,
+        "repetition": not repeated,
+    }
+    return {
+        "passed": all(checks.values()),
+        "error_code": None if all(checks.values()) else "TTS_CONTENT_MISMATCH",
+        "transcript": str(transcript).strip(),
+        "cer": round(cer, 4),
+        "length_ratio": round(length_ratio, 4),
+        "instruction_overlap_chars": instruction_overlap,
+        "longest_extra_insertion_chars": longest_extra,
+        "longest_contiguous_omission_chars": longest_omission,
+        "added_repetition": repeated,
+        "checks": checks,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--request", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args(argv)
+    request = json.loads(Path(args.request).read_text(encoding="utf-8"))
+
+    model_name = str(request.get("model", "base") or "base").strip()
+    if model_name != "base":
+        raise RuntimeError("only the pinned Whisper base gate is supported")
+    cache_value = str(request.get("cache_root", "") or "").strip()
+    cache_root = Path(cache_value) if cache_value else Path.home() / ".cache" / "whisper"
+    if not (cache_root / "base.pt").is_file():
+        raise RuntimeError("offline Whisper base checkpoint unavailable")
+
+    import torch
+    import whisper
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = whisper.load_model("base", device=device, download_root=str(cache_root))
+    result = model.transcribe(
+        _read_pcm16_for_whisper(Path(str(request["audio_path"]))),
+        language="zh",
+        fp16=device == "cuda",
+        temperature=0,
+    )
+    report = assess_transcript(
+        str(request["expected_text"]),
+        str(result.get("text", "")),
+        str(request.get("forbidden_text", "")),
+        max_cer=float(request.get("max_cer", 0.18)),
+    )
+    Path(args.output).write_text(
+        json.dumps(report, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tts/external_audio_quality_worker.py
+++ b/tts/external_audio_quality_worker.py
@@ -1,8 +1,4 @@
-"""Offline ASR content gate for an ordinary-reply TTS candidate.
-
-This worker runs after the CosyVoice process exits, so the two models never
-compete for GPU memory.  It deliberately has no product-package imports.
-"""
+"""Offline ASR gate run after CosyVoice exits, without product imports."""
 
 from __future__ import annotations
 
@@ -40,25 +36,13 @@ def _edit_distance(left: str, right: str) -> int:
     return previous[-1]
 
 
-def _longest_extra_insertion(expected: str, actual: str) -> int:
+def _longest_change(expected: str, actual: str, tag: str) -> int:
     matcher = difflib.SequenceMatcher(a=expected, b=actual, autojunk=False)
     return max(
         (
-            actual_end - actual_start
-            for tag, _expected_start, _expected_end, actual_start, actual_end in matcher.get_opcodes()
-            if tag == "insert"
-        ),
-        default=0,
-    )
-
-
-def _longest_contiguous_omission(expected: str, actual: str) -> int:
-    matcher = difflib.SequenceMatcher(a=expected, b=actual, autojunk=False)
-    return max(
-        (
-            expected_end - expected_start
-            for tag, expected_start, expected_end, actual_start, actual_end in matcher.get_opcodes()
-            if tag == "delete"
+            (actual_end - actual_start) if tag == "insert" else (expected_end - expected_start)
+            for operation, expected_start, expected_end, actual_start, actual_end in matcher.get_opcodes()
+            if operation == tag
         ),
         default=0,
     )
@@ -118,44 +102,32 @@ def assess_transcript(
     actual = normalize_transcript(transcript)
     forbidden = normalize_transcript(forbidden_text)
     if not expected or not actual:
-        return {
-            "passed": False,
-            "error_code": "TTS_CONTENT_EMPTY",
-            "transcript": str(transcript).strip(),
-        }
-
-    cer = _edit_distance(expected, actual) / len(expected)
-    length_ratio = len(actual) / len(expected)
-    instruction_overlap = max(
-        (
-            block.size
-            for block in difflib.SequenceMatcher(
-                a=forbidden,
-                b=actual,
-                autojunk=False,
-            ).get_matching_blocks()
-        ),
-        default=0,
-    )
-    longest_extra = _longest_extra_insertion(expected, actual)
-    longest_omission = _longest_contiguous_omission(expected, actual)
-    repeated = _has_added_repetition(expected, actual)
-    checks = {
-        "cer": cer <= max_cer,
-        "length_ratio": len(actual) == len(expected),
-        "instruction_overlap": instruction_overlap < 4,
-        "extra_speech": longest_extra == 0,
-        "contiguous_omission": longest_omission == 0,
-        "repetition": not repeated,
-    }
+        cer, length_ratio = 1.0, 0.0
+        instruction_overlap = longest_extra = 0
+        longest_omission, repeated = len(expected), False
+        checks = dict(cer=False, length_ratio=False, instruction_overlap=True,
+                      extra_speech=True, contiguous_omission=False, repetition=True)
+        error_code = "TTS_CONTENT_EMPTY"
+    else:
+        cer = _edit_distance(expected, actual) / len(expected)
+        length_ratio = len(actual) / len(expected)
+        instruction_overlap = max((block.size for block in difflib.SequenceMatcher(
+            a=forbidden, b=actual, autojunk=False
+        ).get_matching_blocks()), default=0)
+        longest_extra = _longest_change(expected, actual, "insert")
+        longest_omission = _longest_change(expected, actual, "delete")
+        repeated = _has_added_repetition(expected, actual)
+        checks = dict(cer=cer <= max_cer, length_ratio=len(actual) == len(expected),
+                      instruction_overlap=instruction_overlap < 4, extra_speech=longest_extra == 0,
+                      contiguous_omission=longest_omission == 0, repetition=not repeated)
+        error_code = None if all(checks.values()) else "TTS_CONTENT_MISMATCH"
     return {
         "passed": all(checks.values()),
-        "error_code": None if all(checks.values()) else "TTS_CONTENT_MISMATCH",
+        "error_code": error_code,
         "transcript": str(transcript).strip(),
         "cer": round(cer, 4),
         "length_ratio": round(length_ratio, 4),
-        "instruction_overlap_chars": instruction_overlap,
-        "longest_extra_insertion_chars": longest_extra,
+        "instruction_overlap_chars": instruction_overlap, "longest_extra_insertion_chars": longest_extra,
         "longest_contiguous_omission_chars": longest_omission,
         "added_repetition": repeated,
         "checks": checks,
@@ -164,8 +136,8 @@ def assess_transcript(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--request", required=True)
-    parser.add_argument("--output", required=True)
+    for option in ("--request", "--output"):
+        parser.add_argument(option, required=True)
     args = parser.parse_args(argv)
     request = json.loads(Path(args.request).read_text(encoding="utf-8"))
 
@@ -199,10 +171,7 @@ def main(argv: list[str] | None = None) -> int:
         str(request.get("forbidden_text", "")),
         max_cer=float(request.get("max_cer", 0.18)),
     )
-    Path(args.output).write_text(
-        json.dumps(report, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
+    Path(args.output).write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
     return 0
 
 

--- a/tts/external_audio_quality_worker.py
+++ b/tts/external_audio_quality_worker.py
@@ -173,7 +173,9 @@ def main(argv: list[str] | None = None) -> int:
     if model_name != "base":
         raise RuntimeError("only the pinned Whisper base gate is supported")
     cache_value = str(request.get("cache_root", "") or "").strip()
-    cache_root = Path(cache_value) if cache_value else Path.home() / ".cache" / "whisper"
+    if not cache_value:
+        raise RuntimeError("offline Whisper base checkpoint path must be explicit")
+    cache_root = Path(cache_value)
     checkpoint = cache_root / "base.pt"
     if not checkpoint.is_file():
         raise RuntimeError("offline Whisper base checkpoint unavailable")

--- a/tts/external_audio_quality_worker.py
+++ b/tts/external_audio_quality_worker.py
@@ -13,10 +13,8 @@ from pathlib import Path
 
 _WHISPER_BASE_SHA256 = "ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e"
 
-
 def normalize_transcript(text: str) -> str:
     return re.sub(r"[^\u3400-\u9fffA-Za-z0-9]+", "", str(text)).casefold()
-
 
 def _edit_distance(left: str, right: str) -> int:
     if len(left) < len(right):
@@ -35,7 +33,6 @@ def _edit_distance(left: str, right: str) -> int:
         previous = current
     return previous[-1]
 
-
 def _longest_change(expected: str, actual: str, tag: str) -> int:
     matcher = difflib.SequenceMatcher(a=expected, b=actual, autojunk=False)
     return max(
@@ -46,7 +43,6 @@ def _longest_change(expected: str, actual: str, tag: str) -> int:
         ),
         default=0,
     )
-
 
 def _has_added_repetition(expected: str, actual: str, width: int = 2) -> bool:
     if len(actual) < width * 2:

--- a/tts/external_audio_quality_worker.py
+++ b/tts/external_audio_quality_worker.py
@@ -8,10 +8,14 @@ from __future__ import annotations
 
 import argparse
 import difflib
+import hashlib
 import json
 import re
 import wave
 from pathlib import Path
+
+
+_WHISPER_BASE_SHA256 = "ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e"
 
 
 def normalize_transcript(text: str) -> str:
@@ -42,7 +46,7 @@ def _longest_extra_insertion(expected: str, actual: str) -> int:
         (
             actual_end - actual_start
             for tag, _expected_start, _expected_end, actual_start, actual_end in matcher.get_opcodes()
-            if tag in {"insert", "replace"}
+            if tag == "insert"
         ),
         default=0,
     )
@@ -54,13 +58,13 @@ def _longest_contiguous_omission(expected: str, actual: str) -> int:
         (
             expected_end - expected_start
             for tag, expected_start, expected_end, actual_start, actual_end in matcher.get_opcodes()
-            if tag in {"delete", "replace"}
+            if tag == "delete"
         ),
         default=0,
     )
 
 
-def _has_added_repetition(expected: str, actual: str, width: int = 8) -> bool:
+def _has_added_repetition(expected: str, actual: str, width: int = 2) -> bool:
     if len(actual) < width * 2:
         return False
     for start in range(len(actual) - width + 1):
@@ -68,6 +72,14 @@ def _has_added_repetition(expected: str, actual: str, width: int = 8) -> bool:
         if actual.count(phrase) > max(1, expected.count(phrase)):
             return True
     return False
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
 
 
 def _read_pcm16_for_whisper(path: Path):
@@ -130,10 +142,10 @@ def assess_transcript(
     repeated = _has_added_repetition(expected, actual)
     checks = {
         "cer": cer <= max_cer,
-        "length_ratio": 0.80 <= length_ratio <= 1.18,
-        "instruction_overlap": instruction_overlap < 6,
-        "extra_speech": longest_extra < 8,
-        "contiguous_omission": longest_omission < 12,
+        "length_ratio": len(actual) == len(expected),
+        "instruction_overlap": instruction_overlap < 4,
+        "extra_speech": longest_extra == 0,
+        "contiguous_omission": longest_omission == 0,
         "repetition": not repeated,
     }
     return {
@@ -162,8 +174,11 @@ def main(argv: list[str] | None = None) -> int:
         raise RuntimeError("only the pinned Whisper base gate is supported")
     cache_value = str(request.get("cache_root", "") or "").strip()
     cache_root = Path(cache_value) if cache_value else Path.home() / ".cache" / "whisper"
-    if not (cache_root / "base.pt").is_file():
+    checkpoint = cache_root / "base.pt"
+    if not checkpoint.is_file():
         raise RuntimeError("offline Whisper base checkpoint unavailable")
+    if _sha256(checkpoint) != _WHISPER_BASE_SHA256:
+        raise RuntimeError("offline Whisper base checkpoint hash mismatch")
 
     import torch
     import whisper

--- a/tts/external_cosyvoice_worker.py
+++ b/tts/external_cosyvoice_worker.py
@@ -57,7 +57,8 @@ def _synthesize(request: dict[str, object], output: Path) -> None:
     if request.get("voice_condition_mode") == "instruct2_single_pass":
         if str(request.get("llm_variant", "base")) != "base":
             raise RuntimeError("only the accepted base llm.pt variant is supported")
-        _validate_base_model(Path(str(request["model_dir"])))
+        if bool(request.get("verify_accepted_base_model", False)):
+            _validate_base_model(Path(str(request["model_dir"])))
     sys.path.insert(0, str(runtime_root))
     for key in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "MODELSCOPE_OFFLINE"):
         os.environ[key] = "1"

--- a/tts/external_cosyvoice_worker.py
+++ b/tts/external_cosyvoice_worker.py
@@ -65,6 +65,8 @@ def _synthesize(request: dict[str, object], output: Path) -> None:
 def _synthesize_instruct2_single_pass(model, request: dict[str, object], output: Path) -> None:
     """Apply one LLM-chosen global style without placing it in spoken text."""
 
+    if str(request.get("llm_variant", "base")) != "base":
+        raise RuntimeError("only the accepted base llm.pt variant is supported")
     if not callable(getattr(model, "inference_instruct2", None)):
         raise RuntimeError("COSYVOICE_INSTRUCT2_UNSUPPORTED")
     text = str(request.get("text", ""))

--- a/tts/external_cosyvoice_worker.py
+++ b/tts/external_cosyvoice_worker.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import os
 import random
+import re
 import sys
 import wave
 from array import array
@@ -19,6 +20,10 @@ from pathlib import Path
 
 
 _END_OF_PROMPT_TOKEN = "<|endofprompt|>"
+_SPOKEN_CONTROL_RE = re.compile(
+    r"<\|[^\r\n]{1,120}?\|>|</?[A-Za-z][^>\r\n]{0,120}>|\[[^\]\r\n]{1,80}\]|\*\*[^*\r\n]{1,120}\*\*",
+    re.IGNORECASE,
+)
 _COSYVOICE_BASE_LLM_SHA256 = "69f43bd545131c30e98947fb360ea8b4dc9916d8e83dded7757c7ea4f5a24970"
 
 
@@ -93,7 +98,7 @@ def _synthesize_instruct2_single_pass(model, request: dict[str, object], output:
     instruction = str(request.get("instruct_text", "")).strip()
     if not text.strip() or not instruction:
         raise RuntimeError("single-pass text or instruction missing")
-    if _END_OF_PROMPT_TOKEN in text:
+    if _SPOKEN_CONTROL_RE.search(text):
         raise RuntimeError("TTS_DIRECTED_TEXT_CONTAINS_CONTROL_TOKEN")
     instruction = instruction.replace(_END_OF_PROMPT_TOKEN, "").rstrip()
     instruction += _END_OF_PROMPT_TOKEN

--- a/tts/external_cosyvoice_worker.py
+++ b/tts/external_cosyvoice_worker.py
@@ -8,6 +8,7 @@ references supplied in a private temporary request file.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import random
@@ -18,6 +19,21 @@ from pathlib import Path
 
 
 _END_OF_PROMPT_TOKEN = "<|endofprompt|>"
+_COSYVOICE_BASE_LLM_SHA256 = "69f43bd545131c30e98947fb360ea8b4dc9916d8e83dded7757c7ea4f5a24970"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _validate_base_model(model_dir: Path) -> None:
+    checkpoint = model_dir / "llm.pt"
+    if not checkpoint.is_file() or _sha256(checkpoint) != _COSYVOICE_BASE_LLM_SHA256:
+        raise RuntimeError("COSYVOICE_BASE_MODEL_HASH_MISMATCH")
 
 
 def _write_wav(path: Path, sample_rate: int, samples: list[float]) -> None:
@@ -33,6 +49,10 @@ def _write_wav(path: Path, sample_rate: int, samples: list[float]) -> None:
 
 def _synthesize(request: dict[str, object], output: Path) -> None:
     runtime_root = Path(str(request["runtime_root"]))
+    if request.get("voice_condition_mode") == "instruct2_single_pass":
+        if str(request.get("llm_variant", "base")) != "base":
+            raise RuntimeError("only the accepted base llm.pt variant is supported")
+        _validate_base_model(Path(str(request["model_dir"])))
     sys.path.insert(0, str(runtime_root))
     for key in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "MODELSCOPE_OFFLINE"):
         os.environ[key] = "1"

--- a/voice_direction.py
+++ b/voice_direction.py
@@ -53,22 +53,26 @@ class VoicePerformanceSegment:
 
 _SOURCE = "llm_tool_call"
 _CONTROL_CHANNEL = "non_spoken"
+_PROFILE = "cosyvoice3_base_a_v1"
 _DURATION_TARGET = (40.0, 50.0)
 _TOOL_FIELDS = frozenset(
     {
         "overall_emotion",
-        "global_speed",
+        "short_instruction",
         "energy",
-        "breath_before_sentences",
-        "emphasize_sentences",
     }
 )
 _PERSISTED_FIELDS = _TOOL_FIELDS | {
     "reply_text",
+    "global_speed",
+    "breath_before_sentences",
+    "emphasize_sentences",
     "source",
     "control_channel",
+    "profile",
     "duration_target_seconds",
 }
+_LEGACY_PERSISTED_FIELDS = _PERSISTED_FIELDS - {"short_instruction", "profile"}
 
 
 @dataclass(frozen=True)
@@ -81,8 +85,10 @@ class VoicePerformancePlan:
     energy: float
     breath_before_sentences: tuple[int, ...]
     emphasize_sentences: tuple[int, ...]
+    short_instruction: str = "声音柔软自然地承接，再缓缓托起给到力量"
     source: str = _SOURCE
     control_channel: str = _CONTROL_CHANNEL
+    profile: str = _PROFILE
     duration_target_seconds: tuple[float, float] = _DURATION_TARGET
 
     def __post_init__(self) -> None:
@@ -135,14 +141,17 @@ class VoicePerformancePlan:
             "energy": self.energy,
             "breath_before_sentences": list(self.breath_before_sentences),
             "emphasize_sentences": list(self.emphasize_sentences),
+            "short_instruction": self.short_instruction,
             "source": self.source,
             "control_channel": self.control_channel,
+            "profile": self.profile,
             "duration_target_seconds": list(self.duration_target_seconds),
         }
 
     @classmethod
     def from_dict(cls, value: Mapping[str, object]) -> "VoicePerformancePlan":
-        if set(value) != _PERSISTED_FIELDS:
+        fields = set(value)
+        if fields not in {_PERSISTED_FIELDS, _LEGACY_PERSISTED_FIELDS}:
             raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
         reply_text = value["reply_text"]
         overall_emotion = value["overall_emotion"]
@@ -153,7 +162,7 @@ class VoicePerformancePlan:
         return cls(
             reply_text=reply_text,
             overall_emotion=overall_emotion,
-            global_speed=_number(value["global_speed"], minimum=1.02, maximum=1.08),
+            global_speed=_number(value["global_speed"], minimum=1.0, maximum=1.08),
             energy=_number(value["energy"], minimum=0.35, maximum=0.8),
             breath_before_sentences=_sentence_marks(
                 value["breath_before_sentences"], sentence_count=len(_sentences(reply_text)), minimum=2, maximum_items=2
@@ -161,8 +170,15 @@ class VoicePerformancePlan:
             emphasize_sentences=_sentence_marks(
                 value["emphasize_sentences"], sentence_count=len(_sentences(reply_text)), minimum=1, maximum_items=1
             ),
+            short_instruction=str(
+                value.get(
+                    "short_instruction",
+                    "声音柔软自然地承接，再缓缓托起给到力量",
+                )
+            ),
             source=source,
             control_channel=channel,
+            profile=str(value.get("profile", "legacy_global_direction_v1")),
             duration_target_seconds=_duration_target(value["duration_target_seconds"]),
         )
 
@@ -171,23 +187,20 @@ _TOOL = {
     "type": "function",
     "function": {
         "name": "apply_voice_performance",
-        "description": "Direct one frozen utterance with global, non-spoken controls only.",
+        "description": "Choose one short, non-spoken direction for a frozen utterance.",
         "parameters": {
             "type": "object",
             "additionalProperties": False,
             "required": sorted(_TOOL_FIELDS),
             "properties": {
                 "overall_emotion": {"type": "string", "description": "One concise whole-utterance acting intention."},
-                "global_speed": {"type": "number", "minimum": 1.02, "maximum": 1.08},
+                "short_instruction": {
+                    "type": "string",
+                    "minLength": 12,
+                    "maxLength": 24,
+                    "description": "一条正向具体的中文表演指令，不复述正文。",
+                },
                 "energy": {"type": "number", "minimum": 0.35, "maximum": 0.8},
-                "breath_before_sentences": {
-                    "type": "array", "maxItems": 2, "uniqueItems": True,
-                    "items": {"type": "integer", "minimum": 2},
-                },
-                "emphasize_sentences": {
-                    "type": "array", "maxItems": 1, "uniqueItems": True,
-                    "items": {"type": "integer", "minimum": 1},
-                },
             },
         },
     },
@@ -254,9 +267,15 @@ def _validate_plan(plan: VoicePerformancePlan) -> None:
         or any(token in plan.overall_emotion for token in ("<|", "|>", "[", "]", "<", ">"))
         or plan.source != _SOURCE
         or plan.control_channel != _CONTROL_CHANNEL
+        or plan.profile not in {_PROFILE, "legacy_global_direction_v1"}
     ):
         raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
-    _number(plan.global_speed, minimum=1.02, maximum=1.08)
+    forbidden = ("<|", "|>", "[", "]", "<", ">", "不要", "禁止", "朗读", "提示词")
+    if not 12 <= len(plan.short_instruction.strip().rstrip("。")) <= 24 or any(
+        token in plan.short_instruction for token in forbidden
+    ):
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    _number(plan.global_speed, minimum=1.0, maximum=1.08)
     _number(plan.energy, minimum=0.35, maximum=0.8)
     sentence_count = len(_sentences(plan.reply_text))
     if _sentence_marks(list(plan.breath_before_sentences), sentence_count=sentence_count, minimum=2, maximum_items=2) != plan.breath_before_sentences:
@@ -275,6 +294,7 @@ async def direct_voice_performance(
     reply_text: str,
     gateway: VoiceToolGateway,
     *,
+    letter_content: str | None = None,
     request_id: str | None = None,
 ) -> VoicePerformancePlan:
     """Ask a second LLM call for global controls without changing frozen text."""
@@ -286,13 +306,21 @@ async def direct_voice_performance(
             "role": "system",
             "content": (
                 "你是 Olivia 普通视频回信的声音导演。正文已定稿，禁止改字、补字或复述台词。"
-                "必须调用 apply_voice_performance。只提供整篇 overall_emotion、global_speed、energy，"
-                "以及极少的句前呼吸和一句重音标记；不得输出逐段情绪、强度、速度、停顿或响度。"
+                "必须调用 apply_voice_performance，并结合原始来信与完整回信判断声音情绪。"
+                "short_instruction 只写一条正向、具体、12至24个汉字的表演指令，最多一次平滑转折；"
+                "语速固定为自然对话 1.0，停顿只由正文标点决定。"
             ),
         },
         {
             "role": "user",
-            "content": "以下冻结正文仅供表演理解。不要复述正文。\n\n【完整冻结正文】\n" + reply_text + "\n\n【句子编号】\n" + indexed,
+            "content": (
+                "以下内容仅供表演理解，不要复述。\n\n【原始来信】\n"
+                + str(letter_content or "未提供；仅依据回信判断")
+                + "\n\n【完整冻结回信】\n"
+                + reply_text
+                + "\n\n【句子编号】\n"
+                + indexed
+            ),
         },
     ]
     try:
@@ -309,11 +337,13 @@ async def direct_voice_performance(
     overall_emotion = arguments["overall_emotion"]
     if not isinstance(overall_emotion, str):
         raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    short_instruction = str(arguments["short_instruction"]).strip().rstrip("。")
     return VoicePerformancePlan(
         reply_text=reply_text,
         overall_emotion=overall_emotion,
-        global_speed=_number(arguments["global_speed"], minimum=1.02, maximum=1.08),
+        global_speed=1.0,
         energy=_number(arguments["energy"], minimum=0.35, maximum=0.8),
-        breath_before_sentences=_sentence_marks(arguments["breath_before_sentences"], sentence_count=len(sentences), minimum=2, maximum_items=2),
-        emphasize_sentences=_sentence_marks(arguments["emphasize_sentences"], sentence_count=len(sentences), minimum=1, maximum_items=1),
+        breath_before_sentences=(),
+        emphasize_sentences=(),
+        short_instruction=short_instruction,
     )

--- a/voice_direction.py
+++ b/voice_direction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from math import isfinite
+import re
 from typing import Any, Mapping, Protocol, Sequence
 
 
@@ -69,7 +70,7 @@ _PERSISTED_FIELDS = frozenset({
     "profile",
     "duration_target_seconds",
 })
-_LEGACY_PERSISTED_FIELDS = _PERSISTED_FIELDS - {"short_instruction", "profile"}
+_ALLOWED_INSTRUCTION_RE = re.compile(r"[\u3400-\u9fff，。！？、；：…—]+")
 
 
 @dataclass(frozen=True)
@@ -148,7 +149,7 @@ class VoicePerformancePlan:
     @classmethod
     def from_dict(cls, value: Mapping[str, object]) -> "VoicePerformancePlan":
         fields = set(value)
-        if fields not in {_PERSISTED_FIELDS, _LEGACY_PERSISTED_FIELDS}:
+        if fields != _PERSISTED_FIELDS:
             raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
         reply_text = value["reply_text"]
         overall_emotion = value["overall_emotion"]
@@ -167,15 +168,10 @@ class VoicePerformancePlan:
             emphasize_sentences=_sentence_marks(
                 value["emphasize_sentences"], sentence_count=len(_sentences(reply_text)), minimum=1, maximum_items=1
             ),
-            short_instruction=str(
-                value.get(
-                    "short_instruction",
-                    "声音柔软自然地承接，再缓缓托起给到力量",
-                )
-            ),
+            short_instruction=validate_short_instruction(value["short_instruction"]),
             source=source,
             control_channel=channel,
-            profile=str(value.get("profile", "legacy_global_direction_v1")),
+            profile=str(value["profile"]),
             duration_target_seconds=_duration_target(value["duration_target_seconds"]),
         )
 
@@ -194,6 +190,7 @@ _TOOL = {
                     "type": "string",
                     "minLength": 12,
                     "maxLength": 24,
+                    "pattern": "^[\\u3400-\\u9fff，。！？、；：…—]+$",
                     "description": "一条正向具体的中文表演指令，不复述正文。",
                 },
             },
@@ -254,6 +251,33 @@ def _duration_target(value: object) -> tuple[float, float]:
     return parsed
 
 
+def validate_short_instruction(value: object) -> str:
+    if not isinstance(value, str):
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    instruction = value.strip().rstrip("。")
+    han_count = len(re.findall(r"[\u3400-\u9fff]", instruction))
+    forbidden = (
+        "不要",
+        "禁止",
+        "避免",
+        "不能",
+        "不可",
+        "别",
+        "勿",
+        "不",
+        "无",
+        "朗读",
+        "提示词",
+    )
+    if (
+        not 12 <= han_count <= 24
+        or _ALLOWED_INSTRUCTION_RE.fullmatch(instruction) is None
+        or any(token in instruction for token in forbidden)
+    ):
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    return instruction
+
+
 def _validate_plan(plan: VoicePerformancePlan) -> None:
     _sentences(plan.reply_text)
     if (
@@ -262,14 +286,10 @@ def _validate_plan(plan: VoicePerformancePlan) -> None:
         or any(token in plan.overall_emotion for token in ("<|", "|>", "[", "]", "<", ">"))
         or plan.source != _SOURCE
         or plan.control_channel != _CONTROL_CHANNEL
-        or plan.profile not in {_PROFILE, "legacy_global_direction_v1"}
+        or plan.profile != _PROFILE
     ):
         raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
-    forbidden = ("<|", "|>", "[", "]", "<", ">", "不要", "禁止", "朗读", "提示词")
-    if not 12 <= len(plan.short_instruction.strip().rstrip("。")) <= 24 or any(
-        token in plan.short_instruction for token in forbidden
-    ):
-        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    validate_short_instruction(plan.short_instruction)
     _number(plan.global_speed, minimum=1.0, maximum=1.08)
     _number(plan.energy, minimum=0.35, maximum=0.8)
     sentence_count = len(_sentences(plan.reply_text))
@@ -329,7 +349,7 @@ async def direct_voice_performance(
     arguments = calls[0].arguments
     if not isinstance(arguments, Mapping) or set(arguments) != _TOOL_FIELDS:
         raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
-    short_instruction = str(arguments["short_instruction"]).strip().rstrip("。")
+    short_instruction = validate_short_instruction(arguments["short_instruction"])
     return VoicePerformancePlan(
         reply_text=reply_text,
         overall_emotion=short_instruction,

--- a/voice_direction.py
+++ b/voice_direction.py
@@ -142,19 +142,20 @@ class VoicePerformancePlan:
         )
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        value = {
             "reply_text": self.reply_text,
             "overall_emotion": self.overall_emotion,
             "global_speed": self.global_speed,
             "energy": self.energy,
             "breath_before_sentences": list(self.breath_before_sentences),
             "emphasize_sentences": list(self.emphasize_sentences),
-            "short_instruction": self.short_instruction,
             "source": self.source,
             "control_channel": self.control_channel,
-            "profile": self.profile,
             "duration_target_seconds": list(self.duration_target_seconds),
         }
+        if self.profile != _MUSIC_PROFILE:
+            value.update(short_instruction=self.short_instruction, profile=self.profile)
+        return value
 
     @classmethod
     def from_dict(cls, value: Mapping[str, object]) -> "VoicePerformancePlan":

--- a/voice_direction.py
+++ b/voice_direction.py
@@ -55,23 +55,20 @@ _SOURCE = "llm_tool_call"
 _CONTROL_CHANNEL = "non_spoken"
 _PROFILE = "cosyvoice3_base_a_v1"
 _DURATION_TARGET = (40.0, 50.0)
-_TOOL_FIELDS = frozenset(
-    {
-        "overall_emotion",
-        "short_instruction",
-        "energy",
-    }
-)
-_PERSISTED_FIELDS = _TOOL_FIELDS | {
+_TOOL_FIELDS = frozenset({"short_instruction"})
+_PERSISTED_FIELDS = frozenset({
     "reply_text",
+    "overall_emotion",
     "global_speed",
+    "energy",
     "breath_before_sentences",
     "emphasize_sentences",
+    "short_instruction",
     "source",
     "control_channel",
     "profile",
     "duration_target_seconds",
-}
+})
 _LEGACY_PERSISTED_FIELDS = _PERSISTED_FIELDS - {"short_instruction", "profile"}
 
 
@@ -193,14 +190,12 @@ _TOOL = {
             "additionalProperties": False,
             "required": sorted(_TOOL_FIELDS),
             "properties": {
-                "overall_emotion": {"type": "string", "description": "One concise whole-utterance acting intention."},
                 "short_instruction": {
                     "type": "string",
                     "minLength": 12,
                     "maxLength": 24,
                     "description": "一条正向具体的中文表演指令，不复述正文。",
                 },
-                "energy": {"type": "number", "minimum": 0.35, "maximum": 0.8},
             },
         },
     },
@@ -334,15 +329,12 @@ async def direct_voice_performance(
     arguments = calls[0].arguments
     if not isinstance(arguments, Mapping) or set(arguments) != _TOOL_FIELDS:
         raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
-    overall_emotion = arguments["overall_emotion"]
-    if not isinstance(overall_emotion, str):
-        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
     short_instruction = str(arguments["short_instruction"]).strip().rstrip("。")
     return VoicePerformancePlan(
         reply_text=reply_text,
-        overall_emotion=overall_emotion,
+        overall_emotion=short_instruction,
         global_speed=1.0,
-        energy=_number(arguments["energy"], minimum=0.35, maximum=0.8),
+        energy=0.55,
         breath_before_sentences=(),
         emphasize_sentences=(),
         short_instruction=short_instruction,

--- a/voice_direction.py
+++ b/voice_direction.py
@@ -55,8 +55,12 @@ class VoicePerformanceSegment:
 _SOURCE = "llm_tool_call"
 _CONTROL_CHANNEL = "non_spoken"
 _PROFILE = "cosyvoice3_base_a_v1"
+_MUSIC_PROFILE = "legacy_music_global_direction_v1"
 _DURATION_TARGET = (40.0, 50.0)
 _TOOL_FIELDS = frozenset({"short_instruction"})
+_MUSIC_TOOL_FIELDS = frozenset(
+    {"overall_emotion", "global_speed", "energy", "breath_before_sentences", "emphasize_sentences"}
+)
 _PERSISTED_FIELDS = frozenset({
     "reply_text",
     "overall_emotion",
@@ -70,6 +74,12 @@ _PERSISTED_FIELDS = frozenset({
     "profile",
     "duration_target_seconds",
 })
+_LEGACY_MUSIC_PERSISTED_FIELDS = _MUSIC_TOOL_FIELDS | {
+    "reply_text",
+    "source",
+    "control_channel",
+    "duration_target_seconds",
+}
 _ALLOWED_INSTRUCTION_RE = re.compile(r"[\u3400-\u9fff，。！？、；：…—]+")
 
 
@@ -148,32 +158,57 @@ class VoicePerformancePlan:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, object]) -> "VoicePerformancePlan":
-        fields = set(value)
-        if fields != _PERSISTED_FIELDS:
-            raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
-        reply_text = value["reply_text"]
-        overall_emotion = value["overall_emotion"]
-        source = value["source"]
-        channel = value["control_channel"]
-        if not all(isinstance(item, str) for item in (reply_text, overall_emotion, source, channel)):
-            raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
-        return cls(
-            reply_text=reply_text,
-            overall_emotion=overall_emotion,
-            global_speed=_number(value["global_speed"], minimum=1.0, maximum=1.08),
-            energy=_number(value["energy"], minimum=0.35, maximum=0.8),
-            breath_before_sentences=_sentence_marks(
-                value["breath_before_sentences"], sentence_count=len(_sentences(reply_text)), minimum=2, maximum_items=2
-            ),
-            emphasize_sentences=_sentence_marks(
-                value["emphasize_sentences"], sentence_count=len(_sentences(reply_text)), minimum=1, maximum_items=1
-            ),
-            short_instruction=validate_short_instruction(value["short_instruction"]),
-            source=source,
-            control_channel=channel,
-            profile=str(value["profile"]),
-            duration_target_seconds=_duration_target(value["duration_target_seconds"]),
+        return _persisted_plan(cls, value, profile=_PROFILE, minimum_speed=1.0)
+
+    @classmethod
+    def from_music_dict(cls, value: Mapping[str, object]) -> "VoicePerformancePlan":
+        if set(value) == _LEGACY_MUSIC_PERSISTED_FIELDS:
+            value = {**value, "short_instruction": "", "profile": _MUSIC_PROFILE}
+        return _persisted_plan(
+            cls, value, profile=_MUSIC_PROFILE, minimum_speed=1.02
         )
+
+
+def _persisted_plan(
+    cls: type[VoicePerformancePlan],
+    value: Mapping[str, object],
+    *,
+    profile: str,
+    minimum_speed: float,
+) -> VoicePerformancePlan:
+    if set(value) != _PERSISTED_FIELDS:
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    reply_text, emotion = value["reply_text"], value["overall_emotion"]
+    source, channel = value["source"], value["control_channel"]
+    if not all(isinstance(item, str) for item in (reply_text, emotion, source, channel)):
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    if profile != _PROFILE and value["short_instruction"] != "":
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    sentence_count = len(_sentences(reply_text))
+    plan = cls(
+        reply_text=reply_text,
+        overall_emotion=emotion,
+        global_speed=_number(value["global_speed"], minimum=minimum_speed, maximum=1.08),
+        energy=_number(value["energy"], minimum=0.35, maximum=0.8),
+        breath_before_sentences=_sentence_marks(
+            value["breath_before_sentences"], sentence_count=sentence_count, minimum=2, maximum_items=2
+        ),
+        emphasize_sentences=_sentence_marks(
+            value["emphasize_sentences"], sentence_count=sentence_count, minimum=1, maximum_items=1
+        ),
+        short_instruction=(
+            validate_short_instruction(value["short_instruction"])
+            if profile == _PROFILE
+            else ""
+        ),
+        source=source,
+        control_channel=channel,
+        profile=str(value["profile"]),
+        duration_target_seconds=_duration_target(value["duration_target_seconds"]),
+    )
+    if plan.profile != profile:
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    return plan
 
 
 _TOOL = {
@@ -192,6 +227,32 @@ _TOOL = {
                     "maxLength": 24,
                     "pattern": "^[\\u3400-\\u9fff，。！？、；：…—]+$",
                     "description": "一条正向具体的中文表演指令，不复述正文。",
+                },
+            },
+        },
+    },
+}
+
+_MUSIC_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "apply_voice_performance",
+        "description": "Direct one frozen utterance with global, non-spoken controls only.",
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": sorted(_MUSIC_TOOL_FIELDS),
+            "properties": {
+                "overall_emotion": {"type": "string", "description": "One concise whole-utterance acting intention."},
+                "global_speed": {"type": "number", "minimum": 1.02, "maximum": 1.08},
+                "energy": {"type": "number", "minimum": 0.35, "maximum": 0.8},
+                "breath_before_sentences": {
+                    "type": "array", "maxItems": 2, "uniqueItems": True,
+                    "items": {"type": "integer", "minimum": 2},
+                },
+                "emphasize_sentences": {
+                    "type": "array", "maxItems": 1, "uniqueItems": True,
+                    "items": {"type": "integer", "minimum": 1},
                 },
             },
         },
@@ -286,11 +347,16 @@ def _validate_plan(plan: VoicePerformancePlan) -> None:
         or any(token in plan.overall_emotion for token in ("<|", "|>", "[", "]", "<", ">"))
         or plan.source != _SOURCE
         or plan.control_channel != _CONTROL_CHANNEL
-        or plan.profile != _PROFILE
+        or plan.profile not in {_PROFILE, _MUSIC_PROFILE}
     ):
         raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
-    validate_short_instruction(plan.short_instruction)
-    _number(plan.global_speed, minimum=1.0, maximum=1.08)
+    if plan.profile == _PROFILE:
+        validate_short_instruction(plan.short_instruction)
+        _number(plan.global_speed, minimum=1.0, maximum=1.08)
+    else:
+        if plan.short_instruction:
+            raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+        _number(plan.global_speed, minimum=1.02, maximum=1.08)
     _number(plan.energy, minimum=0.35, maximum=0.8)
     sentence_count = len(_sentences(plan.reply_text))
     if _sentence_marks(list(plan.breath_before_sentences), sentence_count=sentence_count, minimum=2, maximum_items=2) != plan.breath_before_sentences:
@@ -303,6 +369,28 @@ def _validate_plan(plan: VoicePerformancePlan) -> None:
 
 def _gain_db(energy: float) -> float:
     return max(-0.75, min(0.75, (energy - 0.5) * 1.5))
+
+
+async def _tool_arguments(
+    gateway: VoiceToolGateway,
+    messages: list[dict[str, str]],
+    tool: Mapping[str, object],
+    fields: frozenset[str],
+    request_id: str | None,
+) -> Mapping[str, Any]:
+    kwargs = {"messages": messages, "tools": [tool], "tool_choice": "required"}
+    try:
+        calls = await gateway.complete_with_tools(**kwargs, request_id=request_id)
+    except TypeError as exc:
+        if request_id is not None:
+            raise VoiceDirectionError("VOICE_DIRECTION_GATEWAY_INVALID") from exc
+        calls = await gateway.complete_with_tools(**kwargs)
+    if len(calls) != 1 or calls[0].name != "apply_voice_performance":
+        raise VoiceDirectionError("VOICE_DIRECTION_TOOL_INVALID")
+    arguments = calls[0].arguments
+    if not isinstance(arguments, Mapping) or set(arguments) != fields:
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    return arguments
 
 
 async def direct_voice_performance(
@@ -338,17 +426,9 @@ async def direct_voice_performance(
             ),
         },
     ]
-    try:
-        calls = await gateway.complete_with_tools(messages=messages, tools=[_TOOL], tool_choice="required", request_id=request_id)
-    except TypeError as exc:
-        if request_id is not None:
-            raise VoiceDirectionError("VOICE_DIRECTION_GATEWAY_INVALID") from exc
-        calls = await gateway.complete_with_tools(messages=messages, tools=[_TOOL], tool_choice="required")
-    if len(calls) != 1 or calls[0].name != "apply_voice_performance":
-        raise VoiceDirectionError("VOICE_DIRECTION_TOOL_INVALID")
-    arguments = calls[0].arguments
-    if not isinstance(arguments, Mapping) or set(arguments) != _TOOL_FIELDS:
-        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    arguments = await _tool_arguments(
+        gateway, messages, _TOOL, _TOOL_FIELDS, request_id
+    )
     short_instruction = validate_short_instruction(arguments["short_instruction"])
     return VoicePerformancePlan(
         reply_text=reply_text,
@@ -358,4 +438,56 @@ async def direct_voice_performance(
         breath_before_sentences=(),
         emphasize_sentences=(),
         short_instruction=short_instruction,
+    )
+
+
+async def direct_music_voice_performance(
+    reply_text: str,
+    gateway: VoiceToolGateway,
+    *,
+    request_id: str | None = None,
+) -> VoicePerformancePlan:
+    """Preserve the pre-A global director contract for the musical prelude."""
+
+    sentences = _sentences(reply_text)
+    indexed = "\n".join(f"S{index}: {text}" for index, text in enumerate(sentences, 1))
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "你是 Olivia 普通视频回信的声音导演。正文已定稿，禁止改字、补字或复述台词。"
+                "必须调用 apply_voice_performance。只提供整篇 overall_emotion、global_speed、energy，"
+                "以及极少的句前呼吸和一句重音标记；不得输出逐段情绪、强度、速度、停顿或响度。"
+            ),
+        },
+        {
+            "role": "user",
+            "content": "以下冻结正文仅供表演理解。不要复述正文。\n\n【完整冻结正文】\n" + reply_text + "\n\n【句子编号】\n" + indexed,
+        },
+    ]
+    arguments = await _tool_arguments(
+        gateway, messages, _MUSIC_TOOL, _MUSIC_TOOL_FIELDS, request_id
+    )
+    overall_emotion = arguments["overall_emotion"]
+    if not isinstance(overall_emotion, str):
+        raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+    return VoicePerformancePlan(
+        reply_text=reply_text,
+        overall_emotion=overall_emotion,
+        global_speed=_number(arguments["global_speed"], minimum=1.02, maximum=1.08),
+        energy=_number(arguments["energy"], minimum=0.35, maximum=0.8),
+        breath_before_sentences=_sentence_marks(
+            arguments["breath_before_sentences"],
+            sentence_count=len(sentences),
+            minimum=2,
+            maximum_items=2,
+        ),
+        emphasize_sentences=_sentence_marks(
+            arguments["emphasize_sentences"],
+            sentence_count=len(sentences),
+            minimum=1,
+            maximum_items=1,
+        ),
+        short_instruction="",
+        profile=_MUSIC_PROFILE,
     )


### PR DESCRIPTION
## Scope
- Direct one frozen ordinary spoken-video reply with one positive Chinese non-spoken instruction selected from full letter and reply context.
- Use one continuous accepted CosyVoice base inference at speed 1.0, with strict pinned offline ASR acceptance.
- Recompute the complete ASR report from expected text, forbidden instruction, and transcript before publishing or counting rejection.
- Preserve exact pre-PR music direction, serialization, persistence, request ID, manifest identity, and rendering.
- Normalize every media failure into a registered sanitized public detail tuple.

## Validation
- Full pytest after final rebase: 950 passed, 1 deselected.
- Focused voice/delivery/HTTP/media: 118 passed, 1 deselected.
- Hardening, py_compile, and diff check: PASS.
- Pinned provider preflight: base=true, quality=true.
- Real accepted A-01 report recomputation: PASS, CER 0.0909, all six checks true.

## Boundary
- No video/music/TTS synthesis model was run in the repair; accepted A-01 evidence was reused.
- Private assets, model/cache paths, and provider artifacts remain local-only.

## Size and atomicity
Exact base eb3ea7c2fb061c94f6b49f4b1f33444cafdcb749 to head b32e685c62faa2e52cc738135a955bb0435c64fa changes 23 files, 1866 insertions, 133 deletions: 1999 changed lines, below the 2000-line hard limit. The direction, acceptance, music-compatibility, and public-contract changes must land atomically.

## Rollback
Revert PR 134's merge commit as one unit.