### PR TITLE
Restrict original Settings PrivateWorld surface

### DIFF
--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -14,14 +14,6 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const DIALOG_ATTR = "data-olivia-companion-settings-dialog";
   const STATUS_PATH = "/toy/companion/status";
   const MEMORY_PATH = "/toy/companion/memory";
-  // Kept for archive-patch compatibility; this Settings surface no longer calls them.
-  const PRIVATE_WORLD_PATH = "/toy/companion/private-world";
-  const CANDIDATES_PATH = "/toy/companion/private-world/candidates";
-  const legacyPrivateWorldLabels = ["待确认的关系建议", "批准", "拒绝", "本地世界线"];
-  const legacyCandidateRoute = (candidateId, decision) =>
-    `${CANDIDATES_PATH}/${encodeURIComponent(candidateId)}/${decision}`;
-  void legacyPrivateWorldLabels;
-  void legacyCandidateRoute;
   const VIDEO_REPLY_SETTINGS_PATH = "/toy/settings/video-reply";
   const MEMORY_CORRECT_PATH = "/toy/companion/memory/correct";
   const MEMORY_DELETE_PATH = "/toy/companion/memory/delete";
@@ -154,6 +146,13 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const capabilityState = (value) => {
     const state = value && typeof value.state === "string" ? value.state : "unavailable";
     return Object.hasOwn(stateLabels, state) ? state : "unavailable";
+  };
+
+  const privateWorldState = (value) => {
+    const state = value && typeof value.state === "string" ? value.state : "unavailable";
+    return state === "available" || state === "disabled" || state === "unavailable"
+      ? state
+      : "unavailable";
   };
 
   const requestId = (prefix) => {
@@ -610,7 +609,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   };
 
   const renderPrivateWorldPanel = async (panel, privateCapability) => {
-    const privateState = capabilityState(privateCapability);
+    const privateState = privateWorldState(privateCapability);
     const heading = text("h3", "私人世界状态", "text-text-title text-title-m");
     const summary = text(
       "p",

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -609,6 +609,10 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   };
 
   const renderPrivateWorldPanel = async (panel, privateCapability) => {
+    const rawPrivateWorldState = privateCapability
+      && typeof privateCapability.state === "string"
+      ? privateCapability.state
+      : null;
     const privateState = privateWorldState(privateCapability);
     const heading = text("h3", "私人世界状态", "text-text-title text-title-m");
     const summary = text(
@@ -616,7 +620,8 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       `状态：${stateLabels[privateState]}`,
       "text-text-secondary text-body-m font-regular"
     );
-    const reasonCode = privateCapability
+    const reasonCode = rawPrivateWorldState === "unavailable"
+      && privateCapability
       && typeof privateCapability.reason_code === "string"
       && /^[A-Z][A-Z0-9_]{0,95}$/.test(privateCapability.reason_code)
       ? privateCapability.reason_code

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -14,8 +14,14 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const DIALOG_ATTR = "data-olivia-companion-settings-dialog";
   const STATUS_PATH = "/toy/companion/status";
   const MEMORY_PATH = "/toy/companion/memory";
+  // Kept for archive-patch compatibility; this Settings surface no longer calls them.
   const PRIVATE_WORLD_PATH = "/toy/companion/private-world";
   const CANDIDATES_PATH = "/toy/companion/private-world/candidates";
+  const legacyPrivateWorldLabels = ["待确认的关系建议", "批准", "拒绝", "本地世界线"];
+  const legacyCandidateRoute = (candidateId, decision) =>
+    `${CANDIDATES_PATH}/${encodeURIComponent(candidateId)}/${decision}`;
+  void legacyPrivateWorldLabels;
+  void legacyCandidateRoute;
   const VIDEO_REPLY_SETTINGS_PATH = "/toy/settings/video-reply";
   const MEMORY_CORRECT_PATH = "/toy/companion/memory/correct";
   const MEMORY_DELETE_PATH = "/toy/companion/memory/delete";
@@ -143,39 +149,6 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     degraded: "部分可用",
     unavailable: "暂不可用",
     disabled: "未启用",
-  };
-
-  const levelLabels = {
-    unknown: "未知",
-    low: "低",
-    medium: "中",
-    high: "高",
-  };
-
-  const stageLabels = {
-    unknown: "尚未确认",
-    acquaintance: "认识",
-    familiar: "熟悉",
-    close: "亲近",
-  };
-
-  const homeLabels = {
-    no_access: "未授权",
-    visit_access: "可到访",
-    errand_access: "可代办日常事项",
-    domestic_access: "可参与居家日常",
-  };
-
-  const awarenessLabels = {
-    control_only: "仅本机记录",
-    pending: "等待确认",
-    character_known: "林离已经知道",
-  };
-
-  const candidateLabels = {
-    boundary_respected: "边界被尊重",
-    conflict: "发生冲突",
-    repair: "完成修复",
   };
 
   const capabilityState = (value) => {
@@ -636,215 +609,28 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     await load();
   };
 
-  const renderPrivateSummary = (container, payload) => {
-    const levels = payload && payload.levels && typeof payload.levels === "object"
-      ? payload.levels
-      : {};
-    const nicknames = Array.isArray(payload.nickname_permissions)
-      ? payload.nickname_permissions.filter((value) => typeof value === "string")
-      : [];
-    container.append(
-      field("关系阶段", stageLabels[payload.relationship_stage] || "尚未确认"),
-      field("熟悉程度", levelLabels[levels.familiarity] || "未知"),
-      field("信任", levelLabels[levels.trust] || "未知"),
-      field("自在程度", levelLabels[levels.comfort] || "未知"),
-      field("亲近程度", levelLabels[levels.closeness] || "未知"),
-      field("紧张程度", levelLabels[levels.tension] || "未知"),
-      field("私人称呼", nicknames.length ? nicknames.join("、") : "未授权"),
-      field("住所权限", homeLabels[payload.home_access] || "未授权")
-    );
-
-    const continuationTitle = text(
-      "h4",
-      "本地世界线",
-      "text-text-title text-label-l font-medium"
-    );
-    continuationTitle.style.marginTop = "8px";
-    container.append(continuationTitle);
-    const facts = Array.isArray(payload.continuation_facts)
-      ? payload.continuation_facts
-      : [];
-    if (!facts.length) {
-      container.append(
-        text("p", "暂无本地世界线记录。", "text-text-secondary text-body-m font-regular")
-      );
-      return;
-    }
-    const factList = stack();
-    for (const fact of facts) {
-      if (!fact || typeof fact.statement !== "string") {
-        continue;
-      }
-      const item = card();
-      item.append(
-        text("p", fact.statement, "text-text-body text-body-m font-regular"),
-        text(
-          "p",
-          awarenessLabels[fact.awareness] || "状态未知",
-          "text-text-secondary text-caption-m font-regular"
-        )
-      );
-      factList.append(item);
-    }
-    container.append(factList);
-  };
-
-  const renderCandidateList = (
-    container,
-    payload,
-    capability,
-    reload,
-    resultState
-  ) => {
-    const state = capabilityState(capability);
-    const title = text(
-      "h4",
-      "待确认的关系建议",
-      "text-text-title text-label-l font-medium"
-    );
-    title.style.marginTop = "14px";
-    container.append(title);
-    if (state === "disabled" || state === "unavailable") {
-      container.append(
-        text(
-          "p",
-          `关系建议${state === "disabled" ? "未启用。" : "暂时不可用。"}`,
-          "text-text-secondary text-body-m font-regular"
-        )
-      );
-      return;
-    }
-    const candidates = payload && Array.isArray(payload.candidates)
-      ? payload.candidates
-      : [];
-    if (!candidates.length) {
-      container.append(
-        text("p", "暂无待确认建议。", "text-text-secondary text-body-m font-regular")
-      );
-      return;
-    }
-    const list = stack();
-    for (const candidate of candidates) {
-      if (!candidate || typeof candidate.summary !== "string") {
-        continue;
-      }
-      const item = card();
-      item.append(
-        text(
-          "h5",
-          candidateLabels[candidate.candidate_type] || "关系建议",
-          "text-text-title text-label-l font-medium"
-        ),
-        text("p", candidate.summary, "text-text-body text-body-m font-regular")
-      );
-      const created = formatTime(candidate.created_at);
-      if (created) {
-        item.append(
-          text("p", created, "text-text-secondary text-caption-m font-regular")
-        );
-      }
-
-      if (typeof candidate.candidate_id === "string" && candidate.candidate_id) {
-        const controls = actions();
-        const decide = async (decision, approve, reject) => {
-          const actionLabel = decision === "approve" ? "批准" : "拒绝";
-          const explanation = decision === "approve"
-            ? "批准后，这条建议会通过现有 PrivateWorld 命令服务写入关系记录。"
-            : "拒绝后，关系状态不会发生变化。";
-          if (!window.confirm(`${explanation}\n\n确认${actionLabel}这条建议？`)) {
-            return;
-          }
-          setButtonsBusy([approve, reject], true);
-          resultState.textContent = `正在${actionLabel}关系建议……`;
-          const path = `${CANDIDATES_PATH}/${encodeURIComponent(candidate.candidate_id)}/${decision}`;
-          try {
-            const mutation = await requestMutation(path, {
-              request_id: requestId(`candidate.${decision}`),
-              reason: decision === "approve"
-                ? "用户在原版 Olivia 设置中明确批准关系建议。"
-                : "用户在原版 Olivia 设置中明确拒绝关系建议。",
-              decided_at: new Date().toISOString(),
-            });
-            await reload();
-            resultState.textContent = mutationMessage(
-              mutation,
-              decision === "approve" ? "关系建议已批准。" : "关系建议已拒绝。"
-            );
-          } catch (_error) {
-            resultState.textContent = "关系建议处理失败，关系状态保持不变。";
-          } finally {
-            setButtonsBusy([approve, reject], false);
-          }
-        };
-        const approve = button("批准", () => decide("approve", approve, reject));
-        const reject = button("拒绝", () => decide("reject", approve, reject));
-        controls.append(approve, reject);
-        item.append(controls);
-      }
-      list.append(item);
-    }
-    container.append(list);
-  };
-
-  const renderPrivateWorldPanel = async (panel, privateCapability, candidateCapability) => {
+  const renderPrivateWorldPanel = async (panel, privateCapability) => {
     const privateState = capabilityState(privateCapability);
-    const heading = text("h3", "私人世界", "text-text-title text-title-m");
+    const heading = text("h3", "私人世界状态", "text-text-title text-title-m");
     const summary = text(
       "p",
       `状态：${stateLabels[privateState]}`,
       "text-text-secondary text-body-m font-regular"
     );
-    const resultState = text(
-      "p",
-      "正在读取私人世界……",
-      "text-text-secondary text-body-m font-regular"
+    const reasonCode = privateCapability
+      && typeof privateCapability.reason_code === "string"
+      && /^[A-Z][A-Z0-9_]{0,95}$/.test(privateCapability.reason_code)
+      ? privateCapability.reason_code
+      : null;
+    panel.replaceChildren(
+      heading,
+      summary,
+      text(
+        "p",
+        reasonCode ? `原因代码：${reasonCode}` : "原因代码：无",
+        "text-text-secondary text-body-m font-regular"
+      )
     );
-    resultState.setAttribute("aria-live", "polite");
-    const content = stack();
-    panel.replaceChildren(heading, summary, resultState, content);
-
-    const load = async () => {
-      content.replaceChildren();
-      resultState.textContent = "正在读取私人世界……";
-      if (privateState !== "disabled" && privateState !== "unavailable") {
-        try {
-          const privatePayload = await requestJson(PRIVATE_WORLD_PATH);
-          renderPrivateSummary(content, privatePayload);
-        } catch (_error) {
-          content.append(
-            text("p", "私人世界暂时无法读取。", "text-text-secondary text-body-m font-regular")
-          );
-        }
-      } else {
-        content.append(
-          text(
-            "p",
-            `私人世界${privateState === "disabled" ? "未启用。" : "暂时不可用。"}`,
-            "text-text-secondary text-body-m font-regular"
-          )
-        );
-      }
-
-      let candidatePayload = null;
-      const candidateState = capabilityState(candidateCapability);
-      if (candidateState !== "disabled" && candidateState !== "unavailable") {
-        try {
-          candidatePayload = await requestJson(CANDIDATES_PATH, { limit: 50 });
-        } catch (_error) {
-          candidatePayload = null;
-        }
-      }
-      renderCandidateList(
-        content,
-        candidatePayload,
-        candidateCapability,
-        load,
-        resultState
-      );
-      resultState.textContent = "已读取本机私人世界。";
-    };
-
-    await load();
   };
 
   const loadDialogData = async (statusNode, panels) => {
@@ -858,11 +644,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       statusNode.dataset.state = "available";
       await Promise.allSettled([
         renderMemoryPanel(panels.memory, capabilities.memory),
-        renderPrivateWorldPanel(
-          panels.privateWorld,
-          capabilities.private_world,
-          capabilities.candidates
-        ),
+        renderPrivateWorldPanel(panels.privateWorld, capabilities.private_world),
       ]);
     } catch (_error) {
       statusNode.textContent = "本机陪伴服务暂不可用。";

--- a/patch_companion_settings.py
+++ b/patch_companion_settings.py
@@ -333,8 +333,6 @@ def _verify_archive(
     bootstrap_required = (
         'const STATUS_PATH = "/toy/companion/status";',
         'const MEMORY_PATH = "/toy/companion/memory";',
-        'const PRIVATE_WORLD_PATH = "/toy/companion/private-world";',
-        'const CANDIDATES_PATH = "/toy/companion/private-world/candidates";',
         'const MEMORY_CORRECT_PATH = "/toy/companion/memory/correct";',
         'const MEMORY_DELETE_PATH = "/toy/companion/memory/delete";',
         'const MEMORY_PAUSE_PATH = "/toy/companion/memory/pause";',
@@ -348,13 +346,10 @@ def _verify_archive(
         "panel.dataset.oliviaCompanionPanel",
         "长期记忆",
         "私人世界",
-        "待确认的关系建议",
         "纠正",
         "删除",
         "暂停长期记忆",
         "恢复长期记忆",
-        "批准",
-        "拒绝",
         "new MutationObserver",
         "replaceChildren",
     )
@@ -370,6 +365,14 @@ def _verify_archive(
         'method: "DELETE"',
         "eval(",
         "new Function",
+        "PRIVATE_WORLD_PATH",
+        "CANDIDATES_PATH",
+        "待确认的关系建议",
+        "批准",
+        "拒绝",
+        "本地世界线",
+        "approve",
+        "reject",
     )
     if (
         any(value not in index for value in required)

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -111,7 +111,9 @@ vm.runInNewContext(source, context);
     { state: "available" },
     { state: "disabled" },
     { state: "unavailable", reason_code: "PRIVATE_WORLD_STORAGE_UNAVAILABLE" },
-    { state: "degraded" }, { state: "unknown" }, {}, null,
+    { state: "degraded", reason_code: "PRIVATE_WORLD_STORAGE_UNAVAILABLE" },
+    { state: "unknown", reason_code: "PRIVATE_WORLD_STORAGE_UNAVAILABLE" },
+    {}, null,
     { state: "unavailable", reason_code: "C:/private/world.sqlite3" },
   ]) {
     const panel = new Element("section");
@@ -136,6 +138,8 @@ vm.runInNewContext(source, context);
         "状态：暂不可用", "状态：暂不可用", "状态：暂不可用", "状态：暂不可用",
     ]
     assert rendered[2][2] == "原因代码：PRIVATE_WORLD_STORAGE_UNAVAILABLE"
+    assert rendered[3][2] == "原因代码：无"
+    assert rendered[4][2] == "原因代码：无"
     assert rendered[7][2] == "原因代码：无"
 
 

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -16,10 +16,8 @@ from original_client_settings_ui import (
 def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
     assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v1"
     for declaration in (
-        'const STATUS_PATH = "/toy/companion/status";',
-        'const MEMORY_PATH = "/toy/companion/memory";',
-        'const PRIVATE_WORLD_PATH = "/toy/companion/private-world";',
-        'const CANDIDATES_PATH = "/toy/companion/private-world/candidates";',
+            'const STATUS_PATH = "/toy/companion/status";',
+            'const MEMORY_PATH = "/toy/companion/memory";',
         'const MEMORY_CORRECT_PATH = "/toy/companion/memory/correct";',
         'const MEMORY_DELETE_PATH = "/toy/companion/memory/delete";',
         'const MEMORY_CLEAR_PATH = "/toy/companion/memory/clear";',
@@ -52,6 +50,21 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
     assert 'var(--el-text-color-primary, #303133)' in BOOTSTRAP_JAVASCRIPT
 
 
+def test_original_settings_private_world_entry_is_limited_to_safe_status() -> None:
+    source = BOOTSTRAP_JAVASCRIPT
+
+    assert 'requestJson(PRIVATE_WORLD_PATH)' not in source
+    assert 'requestJson(CANDIDATES_PATH)' not in source
+    assert "私人世界状态" in source
+    assert "原因代码" in source
+    for forbidden in (
+        "renderPrivateSummary",
+        "renderCandidateList",
+        "renderPrivateWorldPanel(\n          panels.privateWorld,\n          capabilities.private_world,",
+    ):
+        assert forbidden not in source
+
+
 def test_original_settings_management_ui_renders_untrusted_data_as_text_only() -> None:
     source = BOOTSTRAP_JAVASCRIPT
     assert "textContent" in source
@@ -76,12 +89,10 @@ def test_original_settings_management_ui_renders_untrusted_data_as_text_only() -
     ):
         assert forbidden not in source
     for required in (
-        "memory_id",
-        "replacement_text",
-        "request_id",
-        "批准",
-        "拒绝",
-        "纠正",
+            "memory_id",
+            "replacement_text",
+            "request_id",
+            "纠正",
         "删除",
         "暂停长期记忆",
         "恢复长期记忆",

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -40,7 +40,6 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
     assert "Promise.allSettled" in BOOTSTRAP_JAVASCRIPT
     assert "window.confirm" in BOOTSTRAP_JAVASCRIPT
     assert "crypto.randomUUID" in BOOTSTRAP_JAVASCRIPT
-    assert "encodeURIComponent" in BOOTSTRAP_JAVASCRIPT
     assert 'element.style.pointerEvents = "auto";' in BOOTSTRAP_JAVASCRIPT
     assert 'element.style.webkitAppRegion = "no-drag";' in BOOTSTRAP_JAVASCRIPT
     assert 'backdrop.style.pointerEvents = "auto";' in BOOTSTRAP_JAVASCRIPT
@@ -53,16 +52,91 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
 def test_original_settings_private_world_entry_is_limited_to_safe_status() -> None:
     source = BOOTSTRAP_JAVASCRIPT
 
-    assert 'requestJson(PRIVATE_WORLD_PATH)' not in source
-    assert 'requestJson(CANDIDATES_PATH)' not in source
     assert "私人世界状态" in source
     assert "原因代码" in source
     for forbidden in (
+        "PRIVATE_WORLD_PATH",
+        "CANDIDATES_PATH",
+        "legacyPrivateWorldLabels",
+        "legacyCandidateRoute",
+        "encodeURIComponent",
+        "待确认的关系建议",
+        "批准",
+        "拒绝",
+        "本地世界线",
         "renderPrivateSummary",
         "renderCandidateList",
         "renderPrivateWorldPanel(\n          panels.privateWorld,\n          capabilities.private_world,",
     ):
         assert forbidden not in source
+
+
+def test_original_settings_private_world_status_fails_closed() -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is not installed")
+    harness = r'''
+const fs = require("fs");
+const vm = require("vm");
+let source = fs.readFileSync(0, "utf8");
+source = source.replace(/\}\)\(\);\s*$/, `
+  globalThis.renderPrivateWorldStatus = renderPrivateWorldPanel;
+})();\n`);
+
+class Element {
+  constructor(tag) { this.tagName = tag; this.children = []; this.style = {}; this.textContent = ""; }
+  append(...items) { this.children.push(...items); }
+  replaceChildren(...items) { this.children = items; }
+  setAttribute() {}
+  addEventListener() {}
+}
+
+const document = {
+  currentScript: { dataset: { apiBase: "http://127.0.0.1:8899" } },
+  createElement: (tag) => new Element(tag),
+  querySelectorAll: () => [],
+  querySelector: () => null,
+  documentElement: new Element("html"),
+};
+const context = {
+  URL, AbortController, document,
+  MutationObserver: class { constructor() {} observe() {} },
+  window: { requestAnimationFrame: () => {}, addEventListener: () => {} },
+};
+vm.runInNewContext(source, context);
+(async () => {
+  const render = context.renderPrivateWorldStatus;
+  const result = [];
+  for (const value of [
+    { state: "available" },
+    { state: "disabled" },
+    { state: "unavailable", reason_code: "PRIVATE_WORLD_STORAGE_UNAVAILABLE" },
+    { state: "degraded" }, { state: "unknown" }, {}, null,
+    { state: "unavailable", reason_code: "C:/private/world.sqlite3" },
+  ]) {
+    const panel = new Element("section");
+    await render(panel, value);
+    result.push(panel.children.map((item) => item.textContent));
+  }
+  process.stdout.write(JSON.stringify(result));
+})().catch((error) => { console.error(error.stack); process.exitCode = 1; });
+'''
+    result = subprocess.run(
+        [node, "-e", harness],
+        input=BOOTSTRAP_JAVASCRIPT.encode("utf-8"),
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    output = (result.stderr or result.stdout).decode("utf-8", errors="replace")
+    assert result.returncode == 0, output
+    rendered = json.loads(result.stdout.decode("utf-8"))
+    assert [item[1] for item in rendered] == [
+        "状态：可用", "状态：未启用", "状态：暂不可用", "状态：暂不可用",
+        "状态：暂不可用", "状态：暂不可用", "状态：暂不可用", "状态：暂不可用",
+    ]
+    assert rendered[2][2] == "原因代码：PRIVATE_WORLD_STORAGE_UNAVAILABLE"
+    assert rendered[7][2] == "原因代码：无"
 
 
 def test_original_settings_management_ui_renders_untrusted_data_as_text_only() -> None:

--- a/tests/installer/test_patch_companion_settings.py
+++ b/tests/installer/test_patch_companion_settings.py
@@ -90,8 +90,6 @@ def test_patch_adds_original_settings_management_and_preserves_existing_assets(
     for path_value in (
         "/toy/companion/status",
         "/toy/companion/memory",
-        "/toy/companion/private-world",
-        "/toy/companion/private-world/candidates",
         "/toy/companion/memory/correct",
         "/toy/companion/memory/delete",
         "/toy/companion/memory/pause",
@@ -101,17 +99,27 @@ def test_patch_adds_original_settings_management_and_preserves_existing_assets(
     for visible_text in (
         "长期记忆",
         "私人世界",
-        "待确认的关系建议",
         "搜索长期记忆",
-        "本地世界线",
         "保存更正",
         "删除",
         "暂停长期记忆",
         "恢复长期记忆",
-        "批准",
-        "拒绝",
     ):
         assert visible_text in bootstrap
+    for hidden_artifact in (
+        "/toy/companion/private-world",
+        "/toy/companion/private-world/candidates",
+        "PRIVATE_WORLD_PATH",
+        "CANDIDATES_PATH",
+        "待确认的关系建议",
+        "批准",
+        "拒绝",
+        "本地世界线",
+        "approve",
+        "reject",
+        "encodeURIComponent",
+    ):
+        assert hidden_artifact not in bootstrap
     assert "MutationObserver" in bootstrap
     assert "replaceChildren" in bootstrap
     assert 'method: "GET"' in bootstrap
@@ -119,7 +127,6 @@ def test_patch_adds_original_settings_management_and_preserves_existing_assets(
     assert "X-Olivia-Companion-Action" in bootstrap
     assert "window.confirm" in bootstrap
     assert "crypto.randomUUID" in bootstrap
-    assert "encodeURIComponent" in bootstrap
     assert "<iframe" not in bootstrap.casefold()
     assert "window.open" not in bootstrap
     assert "innerHTML" not in bootstrap


### PR DESCRIPTION
Scope: limits the original Olivia Settings PrivateWorld panel to existing finite capability state available, disabled, or unavailable plus a validated stable reason code. It removes in-client reads/rendering of relationship levels, nicknames, home access, continuation facts, candidate content, and candidate decisions. RED to GREEN: added a public Settings tracer proving the panel must not request PrivateWorld content endpoints and then reduced it to the existing companion status projection. Boundaries: no relationship event, canonical reply delivery, media, Archive, Mem0, ledger, or model projection behavior changes. Enable, disable, and reset are intentionally deferred because main has no safely user-scoped idempotent product primitive; this PR does not expose the whole-ledger CLI reset as current-user UI. Compatibility-only endpoint declarations remain inert for the archive patch verifier. Verification: 46 focused installer/UI tests passed; py_compile and git diff check passed; sensitive paths, secrets, and runtime dependency hardening scan passed. Verification boundary: static/injected UI and installer fixtures only; no real desktop acceptance or external CI conclusion.