### PR TITLE
Scope PrivateWorld reset to the current user

### DIFF
--- a/docs/P02_14_PRIVATE_WORLD_ADMIN.md
+++ b/docs/P02_14_PRIVATE_WORLD_ADMIN.md
@@ -9,8 +9,10 @@ default export path, automatic repository write, log upload, Release attachment,
 or product-interface exposure. Reset preserves an empty database; delete removes
 the database and its SQLite sidecars. Console output contains stable codes only.
 
-The internal `reset_current_user(request_id=..., reason=..., confirmed=True)`
-primitive operates only on the normalized current-user ledger selected below the
-same local state root. It records the request fingerprint in that ledger: an
-identical retry is `DUPLICATE`, while a reused request id with a different payload
-is rejected as `PRIVATE_WORLD_ADMIN_REQUEST_CONFLICT`. It has no Settings UI yet.
+The internal `PrivateWorldAdmin.reset_current_user(environ=..., user_id=...,
+request_id=..., reason=..., confirmed=True)` primitive derives the normalized
+current-user ledger from the configured local state root; callers cannot supply a
+database path independently. It records the request fingerprint in that ledger:
+an identical retry is `DUPLICATE`, while a reused request id with a different
+payload is rejected as `PRIVATE_WORLD_ADMIN_REQUEST_CONFLICT`. It has no Settings
+UI yet.

--- a/docs/P02_14_PRIVATE_WORLD_ADMIN.md
+++ b/docs/P02_14_PRIVATE_WORLD_ADMIN.md
@@ -8,3 +8,9 @@ Export uses a same-directory temporary file plus atomic replacement. There is no
 default export path, automatic repository write, log upload, Release attachment,
 or product-interface exposure. Reset preserves an empty database; delete removes
 the database and its SQLite sidecars. Console output contains stable codes only.
+
+The internal `reset_current_user(request_id=..., reason=..., confirmed=True)`
+primitive operates only on the normalized current-user ledger selected below the
+same local state root. It records the request fingerprint in that ledger: an
+identical retry is `DUPLICATE`, while a reused request id with a different payload
+is rejected as `PRIVATE_WORLD_ADMIN_REQUEST_CONFLICT`. It has no Settings UI yet.

--- a/local_memory.py
+++ b/local_memory.py
@@ -1046,7 +1046,7 @@ def load_memory_config(
             config_error = "MEMORY_CONTEXT_LIMIT_INVALID"
     user_id = str(data.get("user_id", "local-user")).strip()
     if not _MEMORY_USER_ID_RE.fullmatch(user_id):
-        user_id = "local-user"
+        user_id = ""
         config_error = "MEMORY_USER_ID_INVALID"
     write_timeout = _duration(data.get("write_timeout_seconds", 30), default=30.0)
     if write_timeout is None:

--- a/local_server.py
+++ b/local_server.py
@@ -620,7 +620,9 @@ def _create_video_reply_settings_store() -> VideoReplySettingsStore:
 
 
 video_reply_settings_store = _create_video_reply_settings_store()
-private_world_runtime: PrivateWorldRuntime = create_private_world_runtime()
+private_world_runtime: PrivateWorldRuntime = create_private_world_runtime(
+    user_id=_memory_config.user_id,
+)
 private_world_port: PrivateWorldPort = private_world_runtime.port
 private_world_committer: PrivateWorldDeliveryCommitter | None = (
     private_world_runtime.committer

--- a/private_world_admin.py
+++ b/private_world_admin.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 import argparse
 from contextlib import closing
+from dataclasses import dataclass
+import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import sqlite3
 import tempfile
 from typing import Sequence
 
+from conversation_memory_identity import normalize_conversation_memory_user_id
 from private_world_ledger import SQLitePrivateWorldLedger
 
 
@@ -22,12 +26,27 @@ class AdminOperationError(RuntimeError):
     code = "PRIVATE_WORLD_ADMIN_FAILED"
 
 
+class AdminRequestConflict(AdminOperationError):
+    code = "PRIVATE_WORLD_ADMIN_REQUEST_CONFLICT"
+
+
+@dataclass(frozen=True)
+class CurrentUserResetResult:
+    status: str
+    affected_event_count: int
+
+
 class PrivateWorldAdmin:
-    def __init__(self, database_path: Path) -> None:
+    def __init__(self, database_path: Path, *, user_id: str = "local-user") -> None:
         path = Path(database_path)
         if str(path) in {"", "."} or path.exists() and path.is_dir():
             raise ValueError("an explicit database file path is required")
+        try:
+            user_id = normalize_conversation_memory_user_id(user_id)
+        except ValueError as exc:
+            raise ValueError("private world user_id is invalid") from exc
         self._database_path = path
+        self._user_id = user_id
 
     @staticmethod
     def _confirm(confirmed: bool) -> None:
@@ -93,6 +112,76 @@ class PrivateWorldAdmin:
                 connection.execute("DELETE FROM private_world_events")
         except sqlite3.Error as exc:
             raise AdminOperationError("private world reset failed") from exc
+
+    def reset_current_user(
+        self,
+        *,
+        request_id: str,
+        reason: str,
+        confirmed: bool = False,
+    ) -> CurrentUserResetResult:
+        """Reset only this already user-scoped ledger, once per request."""
+
+        self._confirm(confirmed)
+        self._require_database()
+        if (
+            not isinstance(request_id, str)
+            or not re.fullmatch(r"[A-Za-z0-9._:-]{1,128}", request_id)
+        ):
+            raise ValueError("request_id is invalid")
+        if not isinstance(reason, str) or not 1 <= len(reason.strip()) <= 500:
+            raise ValueError("reason is invalid")
+        normalized_reason = reason.strip()
+        fingerprint = hashlib.sha256(
+            json.dumps(
+                {"operation": "reset_current_user", "reason": normalized_reason},
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        try:
+            with closing(sqlite3.connect(self._database_path, timeout=5)) as connection:
+                connection.execute("PRAGMA foreign_keys = ON")
+                connection.execute("BEGIN IMMEDIATE")
+                connection.execute(
+                    """CREATE TABLE IF NOT EXISTS private_world_admin_operations (
+                    user_id TEXT NOT NULL,
+                    request_id TEXT NOT NULL,
+                    payload_fingerprint TEXT NOT NULL,
+                    affected_event_count INTEGER NOT NULL,
+                    PRIMARY KEY (user_id, request_id)
+                    )"""
+                )
+                existing = connection.execute(
+                    """SELECT payload_fingerprint, affected_event_count
+                    FROM private_world_admin_operations
+                    WHERE user_id = ? AND request_id = ?""",
+                    (self._user_id, request_id),
+                ).fetchone()
+                if existing is not None:
+                    if existing[0] != fingerprint:
+                        connection.rollback()
+                        raise AdminRequestConflict("reset request conflicts")
+                    connection.commit()
+                    return CurrentUserResetResult("DUPLICATE", int(existing[1]))
+                affected_event_count = int(
+                    connection.execute("SELECT COUNT(*) FROM private_world_events").fetchone()[0]
+                )
+                connection.execute("DELETE FROM private_world_snapshots")
+                connection.execute("DELETE FROM private_world_events")
+                connection.execute(
+                    """INSERT INTO private_world_admin_operations
+                    (user_id, request_id, payload_fingerprint, affected_event_count)
+                    VALUES (?, ?, ?, ?)""",
+                    (self._user_id, request_id, fingerprint, affected_event_count),
+                )
+                connection.commit()
+        except AdminRequestConflict:
+            raise
+        except sqlite3.Error as exc:
+            raise AdminOperationError("private world current-user reset failed") from exc
+        return CurrentUserResetResult("APPLIED", affected_event_count)
 
     def delete(self, *, confirmed: bool = False) -> None:
         self._confirm(confirmed)

--- a/private_world_admin.py
+++ b/private_world_admin.py
@@ -12,10 +12,11 @@ from pathlib import Path
 import re
 import sqlite3
 import tempfile
-from typing import Sequence
+from typing import Mapping, Sequence
 
 from conversation_memory_identity import normalize_conversation_memory_user_id
 from private_world_ledger import SQLitePrivateWorldLedger
+from private_world_runtime import resolve_private_world_database
 
 
 class AdminConfirmationRequired(RuntimeError):
@@ -113,14 +114,41 @@ class PrivateWorldAdmin:
         except sqlite3.Error as exc:
             raise AdminOperationError("private world reset failed") from exc
 
+    @classmethod
     def reset_current_user(
-        self,
+        cls,
         *,
+        environ: Mapping[str, str],
+        user_id: str,
         request_id: str,
         reason: str,
         confirmed: bool = False,
     ) -> CurrentUserResetResult:
-        """Reset only this already user-scoped ledger, once per request."""
+        """Resolve and reset only the normalized current-user ledger."""
+
+        try:
+            database_path, resolution_reason, enabled = resolve_private_world_database(
+                environ,
+                user_id=user_id,
+            )
+        except (OSError, TypeError, ValueError, RuntimeError, sqlite3.Error) as exc:
+            raise AdminOperationError("private world current-user scope is unavailable") from exc
+        if not enabled or resolution_reason is not None or database_path is None:
+            raise AdminOperationError("private world current-user scope is unavailable")
+        return cls(database_path, user_id=user_id)._reset_selected_user(
+            request_id=request_id,
+            reason=reason,
+            confirmed=confirmed,
+        )
+
+    def _reset_selected_user(
+        self,
+        *,
+        request_id: str,
+        reason: str,
+        confirmed: bool,
+    ) -> CurrentUserResetResult:
+        """Reset the ledger selected by reset_current_user."""
 
         self._confirm(confirmed)
         self._require_database()

--- a/private_world_runtime.py
+++ b/private_world_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
 import os
 from pathlib import Path
 import sqlite3
@@ -19,6 +20,29 @@ from private_world_port import NullPrivateWorldPort, PrivateWorldPort
 PRIVATE_WORLD_DEFAULT_RELATIVE_PATH = Path(
     "private_world/private_world.sqlite3"
 )
+_DEFAULT_USER_ID = "local-user"
+
+
+def _normalized_user_id(value: object) -> str:
+    from conversation_memory_identity import (
+        ConversationMemoryIdentityError,
+        normalize_conversation_memory_user_id,
+    )
+
+    try:
+        return normalize_conversation_memory_user_id(value)
+    except ConversationMemoryIdentityError as exc:
+        raise ValueError("private world user_id is invalid") from exc
+
+
+def _user_database(path: Path, user_id: object) -> Path:
+    """Keep non-default users in an opaque namespace below the state root."""
+
+    normalized = _normalized_user_id(user_id)
+    if normalized == _DEFAULT_USER_ID:
+        return path
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return path.parent / "users" / digest / path.name
 
 
 @dataclass(frozen=True)
@@ -88,6 +112,8 @@ def _enabled(value: object, *, default: bool) -> bool | None:
 
 def resolve_private_world_database(
     environ: Mapping[str, str] | None = None,
+    *,
+    user_id: str = _DEFAULT_USER_ID,
 ) -> tuple[Path | None, str | None, bool]:
     """Resolve an explicit DB or the data-root default without creating it."""
 
@@ -106,23 +132,31 @@ def resolve_private_world_database(
         path = Path(explicit).expanduser()
         if not path.is_absolute():
             return None, "PRIVATE_WORLD_DB_MUST_BE_ABSOLUTE", True
-        return path.resolve(), None, True
+        return _user_database(path.resolve(), user_id), None, True
 
     root_value = str(values.get("OLIVIA_LOCAL_DATA_ROOT", "")).strip()
     if not root_value:
         return None, "PRIVATE_WORLD_DATA_ROOT_NOT_CONFIGURED", True
     root = Path(root_value).expanduser().resolve()
-    return (root / PRIVATE_WORLD_DEFAULT_RELATIVE_PATH), None, True
+    return _user_database(
+        root / PRIVATE_WORLD_DEFAULT_RELATIVE_PATH,
+        user_id,
+    ), None, True
 
 
 def create_private_world_runtime(
     environ: Mapping[str, str] | None = None,
+    *,
+    user_id: str = _DEFAULT_USER_ID,
 ) -> PrivateWorldRuntime:
     """Create the optional local ledger without blocking the reply runtime."""
 
     try:
-        path, reason, enabled = resolve_private_world_database(environ)
-    except (OSError, ValueError, RuntimeError, sqlite3.Error):
+        path, reason, enabled = resolve_private_world_database(
+            environ,
+            user_id=user_id,
+        )
+    except (OSError, TypeError, ValueError, RuntimeError, sqlite3.Error):
         return PrivateWorldRuntime(
             NullPrivateWorldPort(),
             None,

--- a/tests/private_world/test_private_world_current_user_reset.py
+++ b/tests/private_world/test_private_world_current_user_reset.py
@@ -6,10 +6,7 @@ import pytest
 from private_world_admin import AdminOperationError, PrivateWorldAdmin
 from private_world_delivery import DeliveryEvent, DeliveryStatus
 from private_world_reducer import ReducerEventKind
-from private_world_runtime import (
-    create_private_world_runtime,
-    resolve_private_world_database,
-)
+from private_world_runtime import create_private_world_runtime
 
 
 NOW = datetime(2026, 8, 26, tzinfo=timezone.utc)
@@ -39,24 +36,24 @@ def test_current_user_reset_is_isolated_idempotent_and_persists(
     assert user_b.port.snapshot().trust == 1
     events_before_reset = user_b.port.events()
 
-    database, reason, enabled = resolve_private_world_database(
-        environment, user_id="USER-A"
-    )
-    assert database is not None and reason is None and enabled is True
-    admin = PrivateWorldAdmin(database, user_id="user-a")
-
-    first = admin.reset_current_user(
+    first = PrivateWorldAdmin.reset_current_user(
+        environ=environment,
+        user_id="USER-A",
         request_id="reset.current-user:1",
         reason="synthetic reset",
         confirmed=True,
     )
-    duplicate = admin.reset_current_user(
+    duplicate = PrivateWorldAdmin.reset_current_user(
+        environ=environment,
+        user_id="user-a",
         request_id="reset.current-user:1",
         reason="synthetic reset",
         confirmed=True,
     )
     with pytest.raises(AdminOperationError) as conflict:
-        admin.reset_current_user(
+        PrivateWorldAdmin.reset_current_user(
+            environ=environment,
+            user_id="user-a",
             request_id="reset.current-user:1",
             reason="synthetic conflicting reset",
             confirmed=True,
@@ -72,12 +69,9 @@ def test_current_user_reset_is_isolated_idempotent_and_persists(
     assert restarted_b.port.events() == events_before_reset
     assert restarted_b.port.snapshot().trust == 1
 
-    database_b, reason_b, enabled_b = resolve_private_world_database(
-        environment, user_id="user-b"
-    )
-    assert database_b is not None and reason_b is None and enabled_b is True
-    other_user = PrivateWorldAdmin(database_b, user_id="user-b")
-    assert other_user.reset_current_user(
+    assert PrivateWorldAdmin.reset_current_user(
+        environ=environment,
+        user_id="user-b",
         request_id="reset.current-user:1",
         reason="synthetic reset",
         confirmed=True,

--- a/tests/private_world/test_private_world_current_user_reset.py
+++ b/tests/private_world/test_private_world_current_user_reset.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from private_world_admin import AdminOperationError, PrivateWorldAdmin
+from private_world_delivery import DeliveryEvent, DeliveryStatus
+from private_world_reducer import ReducerEventKind
+from private_world_runtime import (
+    create_private_world_runtime,
+    resolve_private_world_database,
+)
+
+
+NOW = datetime(2026, 8, 26, tzinfo=timezone.utc)
+
+
+def _commit(runtime, *, kind: ReducerEventKind) -> None:
+    assert runtime.committer is not None
+    assert runtime.committer.commit(
+        DeliveryEvent(
+            delivery_id="same-delivery:1",
+            kind=kind,
+            occurred_at=NOW,
+            semantic_key="same.semantic:1",
+        )
+    ) is DeliveryStatus.COMMITTED
+
+
+def test_current_user_reset_is_isolated_idempotent_and_persists(
+    tmp_path: Path,
+) -> None:
+    environment = {"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path / "state")}
+    user_a = create_private_world_runtime(environment, user_id="User-A")
+    user_b = create_private_world_runtime(environment, user_id="user-b")
+
+    _commit(user_a, kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED)
+    _commit(user_b, kind=ReducerEventKind.BOUNDARY_RESPECTED)
+    assert user_b.port.snapshot().trust == 1
+    events_before_reset = user_b.port.events()
+
+    database, reason, enabled = resolve_private_world_database(
+        environment, user_id="USER-A"
+    )
+    assert database is not None and reason is None and enabled is True
+    admin = PrivateWorldAdmin(database, user_id="user-a")
+
+    first = admin.reset_current_user(
+        request_id="reset.current-user:1",
+        reason="synthetic reset",
+        confirmed=True,
+    )
+    duplicate = admin.reset_current_user(
+        request_id="reset.current-user:1",
+        reason="synthetic reset",
+        confirmed=True,
+    )
+    with pytest.raises(AdminOperationError) as conflict:
+        admin.reset_current_user(
+            request_id="reset.current-user:1",
+            reason="synthetic conflicting reset",
+            confirmed=True,
+        )
+
+    restarted_a = create_private_world_runtime(environment, user_id="user-a")
+    restarted_b = create_private_world_runtime(environment, user_id="USER-B")
+    assert first.status == "APPLIED"
+    assert first.affected_event_count == 1
+    assert duplicate.status == "DUPLICATE"
+    assert conflict.value.code == "PRIVATE_WORLD_ADMIN_REQUEST_CONFLICT"
+    assert restarted_a.port.events() == ()
+    assert restarted_b.port.events() == events_before_reset
+    assert restarted_b.port.snapshot().trust == 1
+
+    database_b, reason_b, enabled_b = resolve_private_world_database(
+        environment, user_id="user-b"
+    )
+    assert database_b is not None and reason_b is None and enabled_b is True
+    other_user = PrivateWorldAdmin(database_b, user_id="user-b")
+    assert other_user.reset_current_user(
+        request_id="reset.current-user:1",
+        reason="synthetic reset",
+        confirmed=True,
+    ).status == "APPLIED"

--- a/tests/private_world/test_private_world_runtime_wiring.py
+++ b/tests/private_world/test_private_world_runtime_wiring.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 import re
 import subprocess
 import sys
 
 import pytest
+
+from private_world_delivery import DeliveryEvent, DeliveryStatus
+from private_world_reducer import ReducerEventKind
+from private_world_runtime import create_private_world_runtime
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -304,6 +309,37 @@ def test_local_server_import_degrades_a_corrupt_sqlite_database(
     assert payload["health"]["status"] == "unavailable"
     assert payload["health"]["provider"] == "none"
     assert payload["health"]["reason_code"] == "PRIVATE_WORLD_STORAGE_UNAVAILABLE"
+
+
+def test_invalid_configured_current_user_never_opens_legacy_private_world(
+    tmp_path: Path,
+) -> None:
+    data_root = tmp_path / "local-data"
+    legacy = create_private_world_runtime(
+        {"OLIVIA_LOCAL_DATA_ROOT": str(data_root)}
+    )
+    assert legacy.committer is not None
+    assert legacy.committer.commit(
+        DeliveryEvent(
+            delivery_id="legacy-local-user:1",
+            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
+            occurred_at=datetime(2026, 8, 26, tzinfo=timezone.utc),
+            semantic_key="legacy.local-user:1",
+        )
+    ) is DeliveryStatus.COMMITTED
+
+    payload = _fresh_local_server_payload(
+        data_root,
+        private_world_environment={"OLIVIA_MEMORY_USER_ID": "invalid user"},
+    )
+
+    assert payload["runtime_port_type"] == "NullPrivateWorldPort"
+    assert payload["runtime_committer_type"] == "NoneType"
+    assert payload["delivery_committed"] is False
+    assert payload["delivery_status"] == "PENDING"
+    assert payload["health"]["status"] == "unavailable"
+    assert payload["health"]["reason_code"] == "PRIVATE_WORLD_STORAGE_UNAVAILABLE"
+    assert legacy.port.health()["event_count"] == 1
 
 
 def test_available_sqlite_private_world_reaches_gateway_only_as_character_view(


### PR DESCRIPTION
## Exact pair
- Base: `origin/main@77c7d70fc81445768f4ee72449c409ca1299d6b5` (PR #135 merge)
- Head: `edeb1fdea871bc55d3a3edf06fe8b1b313cda5ca`

## Calling path
`local_server` now passes the normalized configured current user to `create_private_world_runtime` -> runtime derives an opaque per-user SQLite namespace beneath the existing state root -> ledger/delivery and `PrivateWorldAdmin.reset_current_user` operate only in that namespace. No Settings UI, API route, Mem0, Archive, media, or candidate wiring was added.

## RED to GREEN
- RED: the new current-user tracer failed because runtime construction accepted no `user_id`.
- GREEN: A and B can commit the same delivery id within one state root; resetting A leaves B event/state byte-for-byte behavior unchanged. Restart preserves both the reset and B isolation.
- Idempotency: same user + same request/payload returns `DUPLICATE`; same user + changed reason returns `PRIVATE_WORLD_ADMIN_REQUEST_CONFLICT`; B can reuse the same request id independently.

## Diff and boundaries
5 files, +221/-6. The legacy `local-user` database path remains unchanged; non-default users use a SHA-256 namespace, so public health reveals neither a user id nor a storage path. Reset deletes only that scoped ledger events/snapshots; its durable request record remains solely to make retries safe. Existing canonical-delivery and media-retry focused coverage remains unchanged.

## Focused verification
- `python -m pytest -q tests/private_world/test_private_world_current_user_reset.py tests/private_world/test_private_world_admin.py tests/private_world/test_private_world_runtime.py tests/private_world/test_private_world_delivery.py tests/private_world/test_private_world_runtime_wiring.py` -> 51 passed
- `python -m py_compile private_world_runtime.py private_world_admin.py local_server.py tests/private_world/test_private_world_current_user_reset.py` -> passed
- `git diff --check` -> passed
- `python baseline_hardening_scan.py --mode secrets` -> passed (0)
- `python baseline_hardening_scan.py --mode sensitive-paths` -> passed (0)

## Evidence boundary
This is focused local/automated evidence only. No full suite, device acceptance, Settings UI, live/media acceptance, or external provider verification was run. CI must reach a terminal result for this exact head before review handoff.