### PR TITLE
fix(installer): keep managed Python path portable

### DIFF
--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -14,6 +14,58 @@ $runtimeZip = Join-Path $env:TEMP 'python-3.12.10-embed-amd64.zip'
 $runtimeUrl = 'https://www.python.org/ftp/python/3.12.10/python-3.12.10-embed-amd64.zip'
 $runtimeSha256 = '4acbed6dd1c744b0376e3b1cf57ce906f9dc9e95e68824584c8099a63025a3c3'
 
+function Update-ManagedPythonPath {
+    param(
+        [Parameter(Mandatory)]
+        [string]$PthPath,
+        [Parameter(Mandatory)]
+        [string]$SitePackages
+    )
+
+    $pthDirectory = Split-Path -Parent $PthPath
+    $sitePackagesFull = [IO.Path]::GetFullPath($SitePackages)
+    $keptLines = New-Object 'System.Collections.Generic.List[string]'
+    $hasSitePackages = $false
+    $hasImportSite = $false
+    foreach ($line in @(Get-Content -LiteralPath $PthPath)) {
+        $trimmed = $line.Trim()
+        if ($trimmed -eq 'import site') {
+            if (-not $hasImportSite) {
+                $keptLines.Add('import site')
+                $hasImportSite = $true
+            }
+            continue
+        }
+
+        $candidate = $null
+        if ($trimmed -and -not $trimmed.StartsWith('#')) {
+            try {
+                $candidate = if ([IO.Path]::IsPathRooted($trimmed)) {
+                    [IO.Path]::GetFullPath($trimmed)
+                } else {
+                    [IO.Path]::GetFullPath((Join-Path $pthDirectory $trimmed))
+                }
+            } catch {
+                $candidate = $null
+            }
+        }
+        if ($candidate -and [StringComparer]::OrdinalIgnoreCase.Equals($candidate, $sitePackagesFull)) {
+            if (-not $hasSitePackages) {
+                $keptLines.Add('site-packages')
+                $hasSitePackages = $true
+            }
+            continue
+        }
+        if ([IO.Path]::IsPathRooted($trimmed)) { continue }
+        $keptLines.Add($line)
+    }
+
+    if (-not $hasSitePackages) { $keptLines.Add('site-packages') }
+    if (-not $hasImportSite) { $keptLines.Add('import site') }
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [IO.File]::WriteAllLines($PthPath, $keptLines.ToArray(), $utf8NoBom)
+}
+
 $runner = @{ File = $runtimeExe; Args = @() }
 if (-not (Test-Path -LiteralPath $runtimeExe)) {
     Write-Host 'The managed Python 3.12 runtime is not installed. The next step downloads the official PSF embeddable runtime.'
@@ -27,24 +79,13 @@ if (-not (Test-Path -LiteralPath $runtimeExe)) {
     if ($actual -ne $runtimeSha256) { Remove-Item -LiteralPath $runtimeZip -Force; throw 'PYTHON_RUNTIME_HASH_MISMATCH' }
     Expand-Archive -LiteralPath $runtimeZip -DestinationPath $runtimeRoot -Force
     Remove-Item -LiteralPath $runtimeZip -Force
-    $pth = Get-ChildItem -LiteralPath $runtimeRoot -Filter '*._pth' | Select-Object -First 1
-    if ($pth) {
-        $pthLines = @(Get-Content -LiteralPath $pth.FullName)
-        if ($pthLines -notcontains $PayloadRoot) { Add-Content -LiteralPath $pth.FullName -Value $PayloadRoot }
-        if ($pthLines -notcontains 'import site') { Add-Content -LiteralPath $pth.FullName -Value 'import site' }
-    }
 }
 
 if ($runner.File -eq $runtimeExe) {
     $sitePackages = Join-Path $runtimeRoot 'site-packages'
     New-Item -ItemType Directory -Force -Path $sitePackages | Out-Null
     $pth = Get-ChildItem -LiteralPath $runtimeRoot -Filter '*._pth' | Select-Object -First 1
-    if ($pth) {
-        $pthLines = @(Get-Content -LiteralPath $pth.FullName)
-        foreach ($entry in @($PayloadRoot, $sitePackages, 'import site')) {
-            if ($pthLines -notcontains $entry) { Add-Content -LiteralPath $pth.FullName -Value $entry }
-        }
-    }
+    if ($pth) { Update-ManagedPythonPath -PthPath $pth.FullName -SitePackages $sitePackages }
     & $runner.File '-c' 'import aiohttp,jsonschema' 2>$null
     if ($LASTEXITCODE -ne 0) {
         Write-Host 'The local server needs aiohttp, jsonschema, and their fixed Windows/Python 3.12 dependency closure.'

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -19,11 +19,31 @@ function Update-ManagedPythonPath {
         [Parameter(Mandatory)]
         [string]$PthPath,
         [Parameter(Mandatory)]
-        [string]$SitePackages
+        [string]$SitePackages,
+        [Parameter(Mandatory)]
+        [string]$PayloadRoot,
+        [Parameter(Mandatory)]
+        [string]$OwnershipPath
     )
 
     $pthDirectory = Split-Path -Parent $PthPath
     $sitePackagesFull = [IO.Path]::GetFullPath($SitePackages)
+    $ownedPayloadRoots = [System.Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::OrdinalIgnoreCase
+    )
+    $currentPayloadRoot = [IO.Path]::GetFullPath($PayloadRoot)
+    $ownedPayloadRoots.Add($currentPayloadRoot) | Out-Null
+    if (Test-Path -LiteralPath $OwnershipPath) {
+        foreach ($ownedRoot in @(Get-Content -LiteralPath $OwnershipPath)) {
+            $ownedRoot = $ownedRoot.Trim()
+            if (-not [IO.Path]::IsPathRooted($ownedRoot)) { continue }
+            try {
+                $ownedPayloadRoots.Add([IO.Path]::GetFullPath($ownedRoot)) | Out-Null
+            } catch {
+                continue
+            }
+        }
+    }
     $keptLines = New-Object 'System.Collections.Generic.List[string]'
     $hasSitePackages = $false
     $hasImportSite = $false
@@ -56,7 +76,7 @@ function Update-ManagedPythonPath {
             }
             continue
         }
-        if ([IO.Path]::IsPathRooted($trimmed)) { continue }
+        if ($candidate -and $ownedPayloadRoots.Contains($candidate)) { continue }
         $keptLines.Add($line)
     }
 
@@ -64,6 +84,11 @@ function Update-ManagedPythonPath {
     if (-not $hasImportSite) { $keptLines.Add('import site') }
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
     [IO.File]::WriteAllLines($PthPath, $keptLines.ToArray(), $utf8NoBom)
+    [IO.File]::WriteAllLines(
+        $OwnershipPath,
+        [string[]]@($currentPayloadRoot),
+        $utf8NoBom
+    )
 }
 
 $runner = @{ File = $runtimeExe; Args = @() }
@@ -83,9 +108,16 @@ if (-not (Test-Path -LiteralPath $runtimeExe)) {
 
 if ($runner.File -eq $runtimeExe) {
     $sitePackages = Join-Path $runtimeRoot 'site-packages'
+    $payloadRootOwnership = Join-Path $runtimeRoot '.bside-owned-payload-root'
     New-Item -ItemType Directory -Force -Path $sitePackages | Out-Null
     $pth = Get-ChildItem -LiteralPath $runtimeRoot -Filter '*._pth' | Select-Object -First 1
-    if ($pth) { Update-ManagedPythonPath -PthPath $pth.FullName -SitePackages $sitePackages }
+    if ($pth) {
+        Update-ManagedPythonPath `
+            -PthPath $pth.FullName `
+            -SitePackages $sitePackages `
+            -PayloadRoot $PayloadRoot `
+            -OwnershipPath $payloadRootOwnership
+    }
     & $runner.File '-c' 'import aiohttp,jsonschema' 2>$null
     if ($LASTEXITCODE -ne 0) {
         Write-Host 'The local server needs aiohttp, jsonschema, and their fixed Windows/Python 3.12 dependency closure.'

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -17,38 +17,22 @@ $runtimeSha256 = '4acbed6dd1c744b0376e3b1cf57ce906f9dc9e95e68824584c8099a63025a3
 function Update-ManagedPythonPath {
     param(
         [Parameter(Mandatory)]
-        [string]$PthPath,
-        [Parameter(Mandatory)]
-        [string]$SitePackages,
-        [Parameter(Mandatory)]
-        [string]$PayloadRoot,
-        [Parameter(Mandatory)]
-        [string]$OwnershipPath
+        [string]$PthPath
     )
 
-    $pthDirectory = Split-Path -Parent $PthPath
-    $sitePackagesFull = [IO.Path]::GetFullPath($SitePackages)
-    $ownedPayloadRoots = [System.Collections.Generic.HashSet[string]]::new(
-        [StringComparer]::OrdinalIgnoreCase
-    )
-    $currentPayloadRoot = [IO.Path]::GetFullPath($PayloadRoot)
-    $ownedPayloadRoots.Add($currentPayloadRoot) | Out-Null
-    if (Test-Path -LiteralPath $OwnershipPath) {
-        foreach ($ownedRoot in @(Get-Content -LiteralPath $OwnershipPath)) {
-            $ownedRoot = $ownedRoot.Trim()
-            if (-not [IO.Path]::IsPathRooted($ownedRoot)) { continue }
-            try {
-                $ownedPayloadRoots.Add([IO.Path]::GetFullPath($ownedRoot)) | Out-Null
-            } catch {
-                continue
-            }
-        }
-    }
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
     $keptLines = New-Object 'System.Collections.Generic.List[string]'
     $hasSitePackages = $false
     $hasImportSite = $false
-    foreach ($line in @(Get-Content -LiteralPath $PthPath)) {
+    foreach ($line in @([IO.File]::ReadAllLines($PthPath, $utf8NoBom))) {
         $trimmed = $line.Trim()
+        if ($trimmed -eq 'site-packages') {
+            if (-not $hasSitePackages) {
+                $keptLines.Add('site-packages')
+                $hasSitePackages = $true
+            }
+            continue
+        }
         if ($trimmed -eq 'import site') {
             if (-not $hasImportSite) {
                 $keptLines.Add('import site')
@@ -56,39 +40,12 @@ function Update-ManagedPythonPath {
             }
             continue
         }
-
-        $candidate = $null
-        if ($trimmed -and -not $trimmed.StartsWith('#')) {
-            try {
-                $candidate = if ([IO.Path]::IsPathRooted($trimmed)) {
-                    [IO.Path]::GetFullPath($trimmed)
-                } else {
-                    [IO.Path]::GetFullPath((Join-Path $pthDirectory $trimmed))
-                }
-            } catch {
-                $candidate = $null
-            }
-        }
-        if ($candidate -and [StringComparer]::OrdinalIgnoreCase.Equals($candidate, $sitePackagesFull)) {
-            if (-not $hasSitePackages) {
-                $keptLines.Add('site-packages')
-                $hasSitePackages = $true
-            }
-            continue
-        }
-        if ($candidate -and $ownedPayloadRoots.Contains($candidate)) { continue }
         $keptLines.Add($line)
     }
 
     if (-not $hasSitePackages) { $keptLines.Add('site-packages') }
     if (-not $hasImportSite) { $keptLines.Add('import site') }
-    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
     [IO.File]::WriteAllLines($PthPath, $keptLines.ToArray(), $utf8NoBom)
-    [IO.File]::WriteAllLines(
-        $OwnershipPath,
-        [string[]]@($currentPayloadRoot),
-        $utf8NoBom
-    )
 }
 
 $runner = @{ File = $runtimeExe; Args = @() }
@@ -108,16 +65,9 @@ if (-not (Test-Path -LiteralPath $runtimeExe)) {
 
 if ($runner.File -eq $runtimeExe) {
     $sitePackages = Join-Path $runtimeRoot 'site-packages'
-    $payloadRootOwnership = Join-Path $runtimeRoot '.bside-owned-payload-root'
     New-Item -ItemType Directory -Force -Path $sitePackages | Out-Null
     $pth = Get-ChildItem -LiteralPath $runtimeRoot -Filter '*._pth' | Select-Object -First 1
-    if ($pth) {
-        Update-ManagedPythonPath `
-            -PthPath $pth.FullName `
-            -SitePackages $sitePackages `
-            -PayloadRoot $PayloadRoot `
-            -OwnershipPath $payloadRootOwnership
-    }
+    if ($pth) { Update-ManagedPythonPath -PthPath $pth.FullName }
     & $runner.File '-c' 'import aiohttp,jsonschema' 2>$null
     if ($LASTEXITCODE -ne 0) {
         Write-Host 'The local server needs aiohttp, jsonschema, and their fixed Windows/Python 3.12 dependency closure.'

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -20,11 +20,12 @@ function Update-ManagedPythonPath {
         [string]$PthPath
     )
 
+    $pthFullPath = [IO.Path]::GetFullPath($PthPath)
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
     $keptLines = New-Object 'System.Collections.Generic.List[string]'
     $hasSitePackages = $false
     $hasImportSite = $false
-    foreach ($line in @([IO.File]::ReadAllLines($PthPath, $utf8NoBom))) {
+    foreach ($line in @([IO.File]::ReadAllLines($pthFullPath, $utf8NoBom))) {
         $trimmed = $line.Trim()
         if ($trimmed -eq 'site-packages') {
             if (-not $hasSitePackages) {
@@ -45,7 +46,22 @@ function Update-ManagedPythonPath {
 
     if (-not $hasSitePackages) { $keptLines.Add('site-packages') }
     if (-not $hasImportSite) { $keptLines.Add('import site') }
-    [IO.File]::WriteAllLines($PthPath, $keptLines.ToArray(), $utf8NoBom)
+    $transactionId = [guid]::NewGuid().ToString('N')
+    $tempName = '.' + [IO.Path]::GetFileName($pthFullPath) + '.' + $transactionId + '.tmp'
+    $backupName = '.' + [IO.Path]::GetFileName($pthFullPath) + '.' + $transactionId + '.bak'
+    $tempPath = Join-Path ([IO.Path]::GetDirectoryName($pthFullPath)) $tempName
+    $backupPath = Join-Path ([IO.Path]::GetDirectoryName($pthFullPath)) $backupName
+    try {
+        [IO.File]::WriteAllLines($tempPath, $keptLines.ToArray(), $utf8NoBom)
+        [IO.File]::Replace($tempPath, $pthFullPath, $backupPath)
+    } finally {
+        if (Test-Path -LiteralPath $tempPath) {
+            Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue
+        }
+        if (Test-Path -LiteralPath $backupPath) {
+            Remove-Item -LiteralPath $backupPath -Force -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 $runner = @{ File = $runtimeExe; Args = @() }

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -160,9 +160,6 @@ def test_managed_runtime_installs_all_server_dependencies() -> None:
 def _run_managed_python_path_helper(
     *,
     pth_path: Path,
-    site_packages: Path,
-    payload_root: Path,
-    ownership_path: Path,
 ) -> subprocess.CompletedProcess[str]:
     repo_root = Path(__file__).parents[2]
     command = (
@@ -175,19 +172,13 @@ def _run_managed_python_path_helper(
         " -and $node.Name -eq 'Update-ManagedPythonPath'},$true);"
         "if(-not $function){throw 'MANAGED_PYTHON_PATH_HELPER_MISSING'};"
         ". ([scriptblock]::Create($function.Extent.Text));"
-        "Update-ManagedPythonPath -PthPath $env:BSIDE_PTH_PATH "
-        "-SitePackages $env:BSIDE_SITE_PACKAGES "
-        "-PayloadRoot $env:BSIDE_PAYLOAD_ROOT "
-        "-OwnershipPath $env:BSIDE_OWNERSHIP_PATH"
+        "Update-ManagedPythonPath -PthPath $env:BSIDE_PTH_PATH"
     )
     env = os.environ.copy()
     env.update(
         {
             "BSIDE_INSTALL_SCRIPT": str(repo_root / "installer" / "Install.ps1"),
             "BSIDE_PTH_PATH": str(pth_path),
-            "BSIDE_SITE_PACKAGES": str(site_packages),
-            "BSIDE_PAYLOAD_ROOT": str(payload_root),
-            "BSIDE_OWNERSHIP_PATH": str(ownership_path),
         }
     )
     powershell = (
@@ -213,7 +204,7 @@ def _run_managed_python_path_helper(
     )
 
 
-def test_managed_runtime_pth_stays_portable_across_install_and_upgrade(
+def test_managed_runtime_pth_never_writes_payload_and_preserves_existing_paths(
     tmp_path: Path,
 ) -> None:
     if os.name != "nt":
@@ -222,9 +213,7 @@ def test_managed_runtime_pth_stays_portable_across_install_and_upgrade(
     runtime_root = tmp_path / "runtime"
     runtime_root.mkdir()
     pth_path = runtime_root / "python312._pth"
-    site_packages = runtime_root / "site-packages"
-    first_payload = tmp_path / "first payload"
-    ownership_path = runtime_root / ".bside-owned-payload-root"
+    payload_root = tmp_path / "fresh payload"
     pth_path.write_text(
         "python312.zip\n.\n#import site\n",
         encoding="utf-8",
@@ -232,9 +221,6 @@ def test_managed_runtime_pth_stays_portable_across_install_and_upgrade(
 
     result = _run_managed_python_path_helper(
         pth_path=pth_path,
-        site_packages=site_packages,
-        payload_root=first_payload,
-        ownership_path=ownership_path,
     )
 
     assert result.returncode == 0, result.stderr or result.stdout
@@ -245,21 +231,21 @@ def test_managed_runtime_pth_stays_portable_across_install_and_upgrade(
         "site-packages",
         "import site",
     ]
-    assert ownership_path.read_text(encoding="utf-8").splitlines() == [
-        str(first_payload)
-    ]
+    assert str(payload_root) not in pth_path.read_text(encoding="utf-8")
 
-    current_payload = tmp_path / "current payload"
-    unrelated_root = tmp_path / "user python modules"
+    current_payload = tmp_path / "当前解压目录"
+    legacy_payload = tmp_path / "旧版解压目录"
+    unrelated_root = tmp_path / "用户 Python 模块"
     pth_path.write_text(
         "\n".join(
             (
                 "python312.zip",
                 ".",
                 str(current_payload),
-                str(first_payload),
+                str(legacy_payload),
                 str(unrelated_root),
-                str(site_packages),
+                "site-packages",
+                "site-packages",
                 "import site",
                 "import site",
             )
@@ -270,21 +256,17 @@ def test_managed_runtime_pth_stays_portable_across_install_and_upgrade(
 
     result = _run_managed_python_path_helper(
         pth_path=pth_path,
-        site_packages=site_packages,
-        payload_root=current_payload,
-        ownership_path=ownership_path,
     )
 
     assert result.returncode == 0, result.stderr or result.stdout
     assert pth_path.read_text(encoding="utf-8").splitlines() == [
         "python312.zip",
         ".",
+        str(current_payload),
+        str(legacy_payload),
         str(unrelated_root),
         "site-packages",
         "import site",
-    ]
-    assert ownership_path.read_text(encoding="utf-8").splitlines() == [
-        str(current_payload)
     ]
 
 

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -157,22 +157,135 @@ def test_managed_runtime_installs_all_server_dependencies() -> None:
     assert "rpds-py==2026.6.3" in requirements
 
 
-def test_managed_runtime_pth_does_not_persist_payload_root() -> None:
+def _run_managed_python_path_helper(
+    *,
+    pth_path: Path,
+    site_packages: Path,
+    payload_root: Path,
+    ownership_path: Path,
+) -> subprocess.CompletedProcess[str]:
     repo_root = Path(__file__).parents[2]
-    script = (repo_root / "installer" / "Install.ps1").read_text(
-        encoding="utf-8-sig"
+    command = (
+        "$tokens=$null;$errors=$null;"
+        "$ast=[System.Management.Automation.Language.Parser]::ParseFile("
+        "$env:BSIDE_INSTALL_SCRIPT,[ref]$tokens,[ref]$errors);"
+        "if($errors.Count){throw 'INSTALL_SCRIPT_PARSE_FAILED'};"
+        "$function=$ast.Find({param($node)"
+        "$node -is [System.Management.Automation.Language.FunctionDefinitionAst]"
+        " -and $node.Name -eq 'Update-ManagedPythonPath'},$true);"
+        "if(-not $function){throw 'MANAGED_PYTHON_PATH_HELPER_MISSING'};"
+        ". ([scriptblock]::Create($function.Extent.Text));"
+        "Update-ManagedPythonPath -PthPath $env:BSIDE_PTH_PATH "
+        "-SitePackages $env:BSIDE_SITE_PACKAGES "
+        "-PayloadRoot $env:BSIDE_PAYLOAD_ROOT "
+        "-OwnershipPath $env:BSIDE_OWNERSHIP_PATH"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "BSIDE_INSTALL_SCRIPT": str(repo_root / "installer" / "Install.ps1"),
+            "BSIDE_PTH_PATH": str(pth_path),
+            "BSIDE_SITE_PACKAGES": str(site_packages),
+            "BSIDE_PAYLOAD_ROOT": str(payload_root),
+            "BSIDE_OWNERSHIP_PATH": str(ownership_path),
+        }
+    )
+    powershell = (
+        Path(os.environ.get("WINDIR", r"C:\Windows"))
+        / "System32"
+        / "WindowsPowerShell"
+        / "v1.0"
+        / "powershell.exe"
+    )
+    return subprocess.run(
+        [
+            str(powershell),
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            command,
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
     )
 
-    assert "function Update-ManagedPythonPath" in script
-    assert (
-        "Update-ManagedPythonPath -PthPath $pth.FullName "
-        "-SitePackages $sitePackages"
-    ) in script
-    assert "Add-Content -LiteralPath $pth.FullName -Value $PayloadRoot" not in script
-    assert "foreach ($entry in @($PayloadRoot, $sitePackages, 'import site'))" not in script
-    assert "[IO.Path]::IsPathRooted($trimmed)" in script
-    assert "'site-packages'" in script
-    assert "'import site'" in script
+
+def test_managed_runtime_pth_stays_portable_across_install_and_upgrade(
+    tmp_path: Path,
+) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows PowerShell is only available on Windows")
+
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    pth_path = runtime_root / "python312._pth"
+    site_packages = runtime_root / "site-packages"
+    first_payload = tmp_path / "first payload"
+    ownership_path = runtime_root / ".bside-owned-payload-root"
+    pth_path.write_text(
+        "python312.zip\n.\n#import site\n",
+        encoding="utf-8",
+    )
+
+    result = _run_managed_python_path_helper(
+        pth_path=pth_path,
+        site_packages=site_packages,
+        payload_root=first_payload,
+        ownership_path=ownership_path,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert pth_path.read_text(encoding="utf-8").splitlines() == [
+        "python312.zip",
+        ".",
+        "#import site",
+        "site-packages",
+        "import site",
+    ]
+    assert ownership_path.read_text(encoding="utf-8").splitlines() == [
+        str(first_payload)
+    ]
+
+    current_payload = tmp_path / "current payload"
+    unrelated_root = tmp_path / "user python modules"
+    pth_path.write_text(
+        "\n".join(
+            (
+                "python312.zip",
+                ".",
+                str(current_payload),
+                str(first_payload),
+                str(unrelated_root),
+                str(site_packages),
+                "import site",
+                "import site",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_managed_python_path_helper(
+        pth_path=pth_path,
+        site_packages=site_packages,
+        payload_root=current_payload,
+        ownership_path=ownership_path,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert pth_path.read_text(encoding="utf-8").splitlines() == [
+        "python312.zip",
+        ".",
+        str(unrelated_root),
+        "site-packages",
+        "import site",
+    ]
+    assert ownership_path.read_text(encoding="utf-8").splitlines() == [
+        str(current_payload)
+    ]
 
 
 def test_published_powershell_scripts_are_utf8_bom_safe() -> None:

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -161,6 +161,7 @@ def test_managed_runtime_installs_all_server_dependencies() -> None:
 def _run_managed_python_path_helper(
     *,
     pth_path: Path,
+    deny_replace: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     repo_root = Path(__file__).parents[2]
     command = (
@@ -173,13 +174,19 @@ def _run_managed_python_path_helper(
         " -and $node.Name -eq 'Update-ManagedPythonPath'},$true);"
         "if(-not $function){throw 'MANAGED_PYTHON_PATH_HELPER_MISSING'};"
         ". ([scriptblock]::Create($function.Extent.Text));"
-        "Update-ManagedPythonPath -PthPath $env:BSIDE_PTH_PATH"
+        "$lock=$null;"
+        "if($env:BSIDE_DENY_REPLACE -eq '1'){"
+        "$lock=[IO.File]::Open($env:BSIDE_PTH_PATH,[IO.FileMode]::Open,"
+        "[IO.FileAccess]::Read,[IO.FileShare]::ReadWrite)};"
+        "try{Update-ManagedPythonPath -PthPath $env:BSIDE_PTH_PATH}"
+        "finally{if($lock){$lock.Dispose()}}"
     )
     env = os.environ.copy()
     env.update(
         {
             "BSIDE_INSTALL_SCRIPT": str(repo_root / "installer" / "Install.ps1"),
             "BSIDE_PTH_PATH": str(pth_path),
+            "BSIDE_DENY_REPLACE": "1" if deny_replace else "0",
         }
     )
     powershell = (
@@ -233,6 +240,24 @@ def test_managed_runtime_pth_never_writes_payload_and_preserves_existing_paths(
         "import site",
     ]
     assert str(payload_root) not in pth_path.read_text(encoding="utf-8")
+    assert not pth_path.read_bytes().startswith(b"\xef\xbb\xbf")
+    assert not list(runtime_root.glob(f".{pth_path.name}.*"))
+
+    original = (
+        "python312.zip\n.\n"
+        f"{tmp_path / '替换失败时保留'}\n"
+        "site-packages\nsite-packages\n"
+    ).encode("utf-8")
+    pth_path.write_bytes(original)
+
+    result = _run_managed_python_path_helper(
+        pth_path=pth_path,
+        deny_replace=True,
+    )
+
+    assert result.returncode != 0
+    assert pth_path.read_bytes() == original
+    assert not list(runtime_root.glob(f".{pth_path.name}.*"))
 
     current_payload = tmp_path / "当前解压目录"
     legacy_payload = tmp_path / "旧版解压目录"

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -157,6 +157,24 @@ def test_managed_runtime_installs_all_server_dependencies() -> None:
     assert "rpds-py==2026.6.3" in requirements
 
 
+def test_managed_runtime_pth_does_not_persist_payload_root() -> None:
+    repo_root = Path(__file__).parents[2]
+    script = (repo_root / "installer" / "Install.ps1").read_text(
+        encoding="utf-8-sig"
+    )
+
+    assert "function Update-ManagedPythonPath" in script
+    assert (
+        "Update-ManagedPythonPath -PthPath $pth.FullName "
+        "-SitePackages $sitePackages"
+    ) in script
+    assert "Add-Content -LiteralPath $pth.FullName -Value $PayloadRoot" not in script
+    assert "foreach ($entry in @($PayloadRoot, $sitePackages, 'import site'))" not in script
+    assert "[IO.Path]::IsPathRooted($trimmed)" in script
+    assert "'site-packages'" in script
+    assert "'import site'" in script
+
+
 def test_published_powershell_scripts_are_utf8_bom_safe() -> None:
     repo_root = Path(__file__).parents[2]
     for relative in (


### PR DESCRIPTION
## Summary

- Stop persisting PayloadRoot in managed Python *._pth files.
- Preserve every existing standard, non-ASCII, relative, and absolute entry except duplicate exact site-packages and import site control lines.
- Ensure one relative site-packages entry and one active import site entry.
- Update boot-critical *._pth through same-directory temporary files and atomic File.Replace, preserving the original file on replacement failure.
- Keep dependency installation and installer startup on the existing PYTHONPATH plus sys.path bootstrap.

## Exact base and head

- Repository: Ornn8/bside-olivia-community
- Base: main @ 78a4cd7a71b9303291b59f4dbb3fa6de54b0cbb8
- Head: codex/installer-portable-pth @ 6fa78e81fb2ba33bf2b67a2a6bd5829406a1c6dd

## Implementation evidence

- installer/Install.ps1:17-48 reads existing lines as explicit UTF-8 without BOM, preserves unrelated entries, and only deduplicates/adds relative site-packages and import site.
- installer/Install.ps1:49-64 writes a same-directory unique temporary file, atomically replaces the destination with a same-directory backup, and cleans both temporary siblings in finally.
- installer/Install.ps1:83-86 creates managed site-packages and applies the helper without passing PayloadRoot.
- installer/Install.ps1:112-114 retains the existing PYTHONPATH and runpy/sys.path bootstrap.
- tests/installer/test_windows_full_patch.py:215 executes the real Windows PowerShell helper for fresh, non-ASCII/absolute preservation, atomic success, and forced replace failure with byte-exact original preservation and no temporary residue.

## Verification

- Focused RED: the previous direct writer returned success under a lock that allowed writes but denied delete/replace, modifying the destination instead of failing safely.
- PowerShell 5.1 compatibility RED: File.Replace rejected a null backup path; the final implementation uses unique same-directory .tmp and .bak paths.
- Focused GREEN: 5 passed, 20 deselected.
- git diff --check: pass.
- CI: pending for exact head 6fa78e81fb2ba33bf2b67a2a6bd5829406a1c6dd.

## Boundary

- Existing or legacy absolute *._pth entries are intentionally not identified, migrated, or deleted.
- No sidecar, ownership ledger, legacy recognition, or migration subsystem is introduced.
- No full-suite, real runtime download, real dependency download, or hardware/device acceptance claim.
- Draft PR only; not ready and not merged.