### PR TITLE
installer: copy only tracked git payload files

### DIFF
--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import shutil
+import subprocess
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -282,6 +283,91 @@ def _ignore_payload_copy(directory: str, names: list[str]) -> set[str]:
     return excluded
 
 
+def _git_tracked_payload_files(payload_root: Path) -> set[str] | None:
+    """Return tracked paths for a clone/worktree, or None for an archive."""
+
+    git_marker = payload_root / ".git"
+    if not git_marker.is_dir() and not git_marker.is_file():
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(payload_root), "ls-files", "-z"],
+            check=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise PatchInstallError("PATCH_PAYLOAD_GIT_QUERY_FAILED") from exc
+    output = result.stdout
+    try:
+        if isinstance(output, bytes):
+            values = output.decode("utf-8").split("\0")
+        elif isinstance(output, str):
+            values = output.split("\0")
+        else:
+            raise TypeError("git ls-files returned no text")
+    except (UnicodeError, TypeError) as exc:
+        raise PatchInstallError("PATCH_PAYLOAD_GIT_QUERY_FAILED") from exc
+    return {value for value in values if value}
+
+
+def _payload_path_is_tracked(
+    payload_root: Path,
+    path: Path,
+    tracked_files: set[str] | None,
+) -> bool:
+    if tracked_files is None:
+        return True
+    try:
+        relative = path.resolve().relative_to(payload_root.resolve())
+    except ValueError:
+        return False
+    return relative.as_posix() in tracked_files
+
+
+def _payload_tree_contains_tracked(
+    payload_root: Path,
+    directory: Path,
+    tracked_files: set[str] | None,
+) -> bool:
+    if tracked_files is None:
+        return True
+    try:
+        relative = directory.resolve().relative_to(payload_root.resolve())
+    except ValueError:
+        return False
+    prefix = relative.as_posix().rstrip("/") + "/"
+    return any(path.startswith(prefix) for path in tracked_files)
+
+
+def _ignore_tracked_payload_copy(
+    payload_root: Path,
+    tracked_files: set[str] | None,
+):
+    def ignore(directory: str, names: list[str]) -> set[str]:
+        excluded = _ignore_payload_copy(directory, names)
+        if tracked_files is None:
+            return excluded
+        directory_path = Path(directory)
+        for name in names:
+            source = directory_path / name
+            if source.is_dir():
+                if not _payload_tree_contains_tracked(
+                    payload_root,
+                    source,
+                    tracked_files,
+                ):
+                    excluded.add(name)
+            elif not _payload_path_is_tracked(
+                payload_root,
+                source,
+                tracked_files,
+            ):
+                excluded.add(name)
+        return excluded
+
+    return ignore
+
+
 def copy_project_payload(
     payload_root: Path,
     destination: Path,
@@ -289,6 +375,7 @@ def copy_project_payload(
     """Copy project source/config scripts, never original or model payloads."""
 
     copied: list[str] = []
+    tracked_files = _git_tracked_payload_files(payload_root)
     destination.mkdir(parents=True, exist_ok=True)
     for child in payload_root.iterdir():
         if child.name in {
@@ -311,29 +398,43 @@ def copy_project_payload(
                 child,
                 target,
                 dirs_exist_ok=True,
-                ignore=_ignore_payload_copy,
+                ignore=_ignore_tracked_payload_copy(
+                    payload_root,
+                    tracked_files,
+                ),
             )
             copied.append(child.name + "/")
         elif child.is_file() and (
             child.name in PAYLOAD_ROOT_FILES
             or child.suffix.lower() in PAYLOAD_SUFFIXES
-        ):
+        ) and _payload_path_is_tracked(payload_root, child, tracked_files):
             _copy_file(child, target)
             copied.append(child.name)
     for relative in PAYLOAD_EXTRA_DIRS:
         source_dir = payload_root / Path(*relative.split("/"))
-        if source_dir.is_dir():
+        if source_dir.is_dir() and _payload_tree_contains_tracked(
+            payload_root,
+            source_dir,
+            tracked_files,
+        ):
             target_dir = destination / Path(*relative.split("/"))
             shutil.copytree(
                 source_dir,
                 target_dir,
                 dirs_exist_ok=True,
-                ignore=_ignore_payload_copy,
+                ignore=_ignore_tracked_payload_copy(
+                    payload_root,
+                    tracked_files,
+                ),
             )
             copied.append(relative + "/")
     for relative in PAYLOAD_EXTRA_FILES:
         source_file = payload_root / Path(*relative.split("/"))
-        if source_file.is_file():
+        if source_file.is_file() and _payload_path_is_tracked(
+            payload_root,
+            source_file,
+            tracked_files,
+        ):
             target_file = destination / Path(*relative.split("/"))
             _copy_file(source_file, target_file)
             copied.append(relative)

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -294,6 +294,7 @@ def _git_tracked_payload_files(payload_root: Path) -> set[str] | None:
             ["git", "-C", str(payload_root), "ls-files", "-z"],
             check=True,
             capture_output=True,
+            timeout=10,
         )
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
         raise PatchInstallError("PATCH_PAYLOAD_GIT_QUERY_FAILED") from exc

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -568,6 +568,31 @@ def test_copy_payload_git_query_failure_is_stable(
     assert not destination.exists()
 
 
+def test_copy_payload_git_query_timeout_is_stable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = Path(__file__).parents[2]
+    source = _make_payload(repo_root, tmp_path / "payload")
+    (source / ".git").mkdir()
+    observed: dict[str, object] = {}
+
+    def timeout_git_query(command, **kwargs):
+        observed["timeout"] = kwargs.get("timeout")
+        raise subprocess.TimeoutExpired(command, kwargs.get("timeout"))
+
+    monkeypatch.setattr(full_patch.subprocess, "run", timeout_git_query)
+    destination = tmp_path / "installed" / "local_backend"
+
+    with pytest.raises(
+        PatchInstallError,
+        match="PATCH_PAYLOAD_GIT_QUERY_FAILED",
+    ):
+        copy_project_payload(source, destination)
+    assert observed["timeout"] == 10
+    assert not destination.exists()
+
+
 def test_copy_payload_rejects_missing_original_client_runtime(
     tmp_path: Path,
 ) -> None:

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from installer import full_patch
 from installer.full_patch import (
     PAYLOAD_REQUIRED_RELATIVE_FILES,
     PAYLOAD_REQUIRED_ROOT_FILES,
@@ -345,6 +346,10 @@ def test_copy_payload_excludes_non_runtime_project_files(
     source.mkdir()
     for name in PAYLOAD_REQUIRED_ROOT_FILES | {"dynamic_renderer.py"}:
         (source / name).write_text("# fixture", encoding="utf-8")
+    (source / "archive_config.json").write_text(
+        "archive fixture",
+        encoding="utf-8",
+    )
     for name in (
         "test_fixture.py",
         "pytest.ini",
@@ -400,6 +405,8 @@ def test_copy_payload_excludes_non_runtime_project_files(
     assert not (destination / "runtime" / "packaging").exists()
     assert "dynamic_renderer.py" in copied
     assert (destination / "dynamic_renderer.py").is_file()
+    assert "archive_config.json" in copied
+    assert (destination / "archive_config.json").is_file()
     for name in PAYLOAD_REQUIRED_ROOT_FILES:
         assert name in copied
         assert (destination / name).is_file()
@@ -413,6 +420,152 @@ def test_copy_payload_excludes_non_runtime_project_files(
         assert not (destination / name).exists()
     assert not (destination / ".evidence").exists()
     assert not (destination / "__pycache__").exists()
+
+
+def test_copy_payload_from_git_tree_excludes_untracked_files(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).parents[2]
+    source = _make_payload(repo_root, tmp_path / "payload")
+    (source / "dynamic_renderer.py").write_text(
+        "# tracked runtime fixture",
+        encoding="utf-8",
+    )
+    (source / ".gitignore").write_text(
+        "ignored_config.json\ncontrol_center/ignored_config.json\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["git", "init"],
+        cwd=source,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "add", "."],
+        cwd=source,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (source / "untracked_config.json").write_text(
+        "untracked",
+        encoding="utf-8",
+    )
+    (source / "ignored_config.json").write_text(
+        "ignored",
+        encoding="utf-8",
+    )
+    (source / "control_center" / "untracked_config.json").write_text(
+        "untracked",
+        encoding="utf-8",
+    )
+    (source / "control_center" / "ignored_config.json").write_text(
+        "ignored",
+        encoding="utf-8",
+    )
+
+    destination = tmp_path / "installed" / "local_backend"
+    copied = copy_project_payload(source, destination)
+
+    assert "dynamic_renderer.py" in copied
+    assert not (destination / "untracked_config.json").exists()
+    assert not (destination / "ignored_config.json").exists()
+    assert not (
+        destination / "control_center" / "untracked_config.json"
+    ).exists()
+    assert not (
+        destination / "control_center" / "ignored_config.json"
+    ).exists()
+
+
+def test_copy_payload_from_linked_worktree_uses_tracked_files(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).parents[2]
+    repository = _make_payload(repo_root, tmp_path / "repository")
+    (repository / ".gitignore").write_text(
+        "ignored_config.json\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["git", "init"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "add", "."],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=payload-test",
+            "-c",
+            "user.email=payload-test@example.invalid",
+            "commit",
+            "-m",
+            "payload",
+        ],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    source = tmp_path / "linked-worktree"
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(source), "HEAD"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert (source / ".git").is_file()
+    (source / "untracked_config.json").write_text(
+        "untracked",
+        encoding="utf-8",
+    )
+    (source / "ignored_config.json").write_text(
+        "ignored",
+        encoding="utf-8",
+    )
+
+    destination = tmp_path / "installed" / "local_backend"
+    copy_project_payload(source, destination)
+
+    assert not (destination / "untracked_config.json").exists()
+    assert not (destination / "ignored_config.json").exists()
+    for name in PAYLOAD_REQUIRED_ROOT_FILES:
+        assert (destination / name).is_file()
+
+
+def test_copy_payload_git_query_failure_is_stable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = Path(__file__).parents[2]
+    source = _make_payload(repo_root, tmp_path / "payload")
+    (source / ".git").mkdir()
+
+    def fail_git_query(*args, **kwargs):
+        raise OSError("host-specific git failure")
+
+    monkeypatch.setattr(full_patch.subprocess, "run", fail_git_query)
+    destination = tmp_path / "installed" / "local_backend"
+
+    with pytest.raises(
+        PatchInstallError,
+        match="PATCH_PAYLOAD_GIT_QUERY_FAILED",
+    ):
+        copy_project_payload(source, destination)
+    assert not destination.exists()
 
 
 def test_copy_payload_rejects_missing_original_client_runtime(


### PR DESCRIPTION
## Summary

- Restrict payload copies from Git clones and linked worktrees to `git ls-files` tracked paths.
- Fail closed with `PATCH_PAYLOAD_GIT_QUERY_FAILED` when Git is unavailable, fails, returns invalid output, or exceeds 10 seconds.
- Preserve the existing explicit payload boundary for source archives without `.git`.

## Exact pair

- Base: `fc907ed83c8cda29268b042b231d502a65772a48`
- Head: `7fda18932ff05b557c8413bb1312e15a61569dec`

## Verification

- Focused tracked/archive/timeout slice: 3 passed.
- Timeout regression: 1 passed.
- `git diff --check`: passed.
- Both Windows Public smoke checks: passed.

## Boundary

- Guarantees tracked path names, not clean tracked-file contents.
- No full-suite, real Steam install, or end-user archive acceptance claim.
- Draft only; not Ready and not merged.
