### PR TITLE
fix(asr): portable local storage paths

### DIFF
--- a/asr/config.py
+++ b/asr/config.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass, replace
-from pathlib import Path
+from dataclasses import dataclass, field, replace
+from pathlib import Path, PureWindowsPath
 from urllib.parse import urlparse
 
 from .errors import AsrError
@@ -26,8 +26,20 @@ RUNTIME_REVISION = "1118951337094db3b362fbf1b27e871696f10590"
 RUNTIME_LICENSE = "Apache-2.0"
 
 
+def default_asr_root() -> Path:
+    configured = os.environ.get("LOCALAPPDATA", "").strip()
+    if configured:
+        return Path(configured).expanduser() / "BSideOliviaLocal" / "asr"
+    return Path.home() / "AppData" / "Local" / "BSideOliviaLocal" / "asr"
+
+
 def _default_root(name: str) -> Path:
-    return Path("F:/Bside-olivia-local/asr") / name
+    return default_asr_root() / name
+
+
+def is_local_absolute_path(path: Path | str) -> bool:
+    windows = PureWindowsPath(str(path))
+    return windows.is_absolute() and len(windows.drive) == 2 and windows.drive[1] == ":"
 
 
 @dataclass(frozen=True)
@@ -44,9 +56,9 @@ class AsrConfig:
     endpointing_ms: int = 600
     word_timestamps: bool = False
     connect_timeout_ms: int = 3_000
-    runtime_root: Path = _default_root("runtime")
-    model_root: Path = _default_root("models")
-    cache_root: Path = _default_root("cache")
+    runtime_root: Path = field(default_factory=lambda: _default_root("runtime"))
+    model_root: Path = field(default_factory=lambda: _default_root("models"))
+    cache_root: Path = field(default_factory=lambda: _default_root("cache"))
     runtime_executable: Path | None = None
     model_path: Path | None = None
     strict_storage: bool = True
@@ -78,10 +90,10 @@ class AsrConfig:
             paths.append(self.model_path)
         for path in paths:
             path = Path(path)
-            if not path.is_absolute() or path.drive.upper() not in {"D:", "F:"}:
+            if not is_local_absolute_path(path):
                 raise AsrError(
                     "ASR_CONFIG_INVALID",
-                    "runtime, model, cache, and evidence paths must be absolute D:/ or F:/ paths",
+                    "runtime, model, and cache paths must be absolute local Windows paths",
                     {"path": str(path)},
                 )
 

--- a/asr/config.py
+++ b/asr/config.py
@@ -39,7 +39,13 @@ def _default_root(name: str) -> Path:
 
 def is_local_absolute_path(path: Path | str) -> bool:
     windows = PureWindowsPath(str(path))
-    return windows.is_absolute() and len(windows.drive) == 2 and windows.drive[1] == ":"
+    return (
+        windows.is_absolute()
+        and len(windows.drive) == 2
+        and windows.drive[1] == ":"
+        and len(windows.parts) > 1
+        and ".." not in windows.parts
+    )
 
 
 @dataclass(frozen=True)

--- a/asr/cuda_toolchain.py
+++ b/asr/cuda_toolchain.py
@@ -1,8 +1,8 @@
 """Manifest-driven, portable CUDA 13.3 assembly for the B05 build boundary.
 
 This module never downloads anything.  It verifies NVIDIA redistributable
-archives supplied through an explicit D:/ or F:/ transfer root, assembles an
-owned toolchain under D:/ or F:/, and returns diagnostics suitable for the
+archives supplied through an explicit local absolute transfer root, assembles an
+owned toolchain under a local absolute root, and returns diagnostics suitable for the
 management CLI.  A ready toolchain is only build-ready; it is not native ASR
 acceptance evidence.
 """
@@ -23,6 +23,7 @@ from typing import Any, Mapping, Sequence
 from urllib.parse import urljoin
 
 from .errors import AsrError
+from .config import is_local_absolute_path
 
 
 CUDA_REDIST_MANIFEST_URL = (
@@ -78,10 +79,10 @@ class CudaPackage:
 
 def _external_root(path: Path | str, label: str) -> Path:
     root = Path(path)
-    if not root.is_absolute() or root.drive.upper() not in {"D:", "F:"}:
+    if not is_local_absolute_path(root):
         raise AsrError(
             "ASR_CONFIG_INVALID",
-            f"{label} must be an absolute D:/ or F:/ path",
+            f"{label} must be an absolute local Windows path",
             {"path": str(root), "label": label},
         )
     return root

--- a/asr/management.py
+++ b/asr/management.py
@@ -19,6 +19,7 @@ from .config import (
     RUNTIME_REPO,
     RUNTIME_REVISION,
     AsrConfig,
+    is_local_absolute_path,
 )
 from .errors import AsrError
 
@@ -31,13 +32,13 @@ HTTP_SNAPSHOT_PATCH = "tools/b05_native_http_snapshot.patch"
 
 def _external_paths(config: AsrConfig) -> bool:
     paths = [config.runtime_root, config.model_root, config.cache_root]
-    return all(Path(path).is_absolute() and Path(path).drive.upper() in {"D:", "F:"} for path in paths)
+    return all(is_local_absolute_path(path) for path in paths)
 
 
 def _external_path(path: Path, *, label: str) -> Path:
-    path = Path(path).absolute()
-    if not path.is_absolute() or path.drive.upper() not in {"D:", "F:"}:
-        raise AsrError("ASR_CONFIG_INVALID", f"{label} must be an absolute D:/ or F:/ path", {"path": str(path)})
+    path = Path(path)
+    if not is_local_absolute_path(path):
+        raise AsrError("ASR_CONFIG_INVALID", f"{label} must be an absolute local Windows path", {"path": str(path)})
     return path
 
 
@@ -183,11 +184,11 @@ def install(config: AsrConfig, *, apply: bool = False, transfer_root: Path | Non
     if not apply:
         return plan
     if not plan["paths_are_external"]:
-        raise AsrError("ASR_CONFIG_INVALID", "install roots must be on D:/ or F:/")
+        raise AsrError("ASR_CONFIG_INVALID", "install roots must be absolute local Windows paths")
     if transfer_root is None:
         raise AsrError(
             "ASR_CONFIG_INVALID",
-            "apply requires an explicit D:/ or F:/ transfer_root; network downloads are disabled",
+            "apply requires an explicit local absolute transfer_root; network downloads are disabled",
         )
     source = _validate_transfer_source(transfer_root)
     model = _validate_model(config.effective_model_path)
@@ -252,7 +253,7 @@ def uninstall(config: AsrConfig, *, apply: bool = False) -> dict[str, Any]:
     if not plan["owned"]:
         raise AsrError("ASR_CONFIG_INVALID", "refusing to delete paths without the B05 ownership manifest")
     if not _external_paths(config):
-        raise AsrError("ASR_CONFIG_INVALID", "uninstall roots must be on D:/ or F:/")
+        raise AsrError("ASR_CONFIG_INVALID", "uninstall roots must be absolute local Windows paths")
     deleted: list[str] = []
     for path in (config.runtime_root, config.model_root, config.cache_root):
         if Path(path).exists():

--- a/asr/management.py
+++ b/asr/management.py
@@ -6,8 +6,9 @@ import hashlib
 import json
 import shutil
 import subprocess
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
+from uuid import uuid4
 
 from .config import (
     MODEL_FILENAME,
@@ -28,6 +29,56 @@ GGML_REVISION = "c03b4e2bcece5134827881af90242086daf75be5"
 CPP_HTTPLIB_REVISION = "62d899feac3cf9215a55f2b43da250fdd98d2156"
 TRANSFER_SOURCE_DIR = "NeMo-Speech.cpp"
 HTTP_SNAPSHOT_PATCH = "tools/b05_native_http_snapshot.patch"
+OWNER = "b05-streaming-asr"
+OWNERSHIP_MARKER = ".b05-owned-root.json"
+
+
+def _managed_roots(config: AsrConfig) -> dict[str, Path]:
+    return {
+        "runtime": Path(config.runtime_root),
+        "model": Path(config.model_root),
+        "cache": Path(config.cache_root),
+    }
+
+
+def _normalized_root(path: Path) -> str:
+    return str(PureWindowsPath(path)).casefold()
+
+
+def _read_owned_json(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AsrError("ASR_CONFIG_INVALID", f"refusing to delete without a valid {label}") from exc
+    if not isinstance(value, dict):
+        raise AsrError("ASR_CONFIG_INVALID", f"refusing to delete without a valid {label}")
+    return value
+
+
+def _validate_owned_roots(config: AsrConfig) -> dict[str, Path]:
+    roots: dict[str, Path] = {}
+    operation_ids: set[str] = set()
+    for kind, configured_root in _managed_roots(config).items():
+        root = _external_path(configured_root, label=f"{kind}_root")
+        marker = _read_owned_json(root / OWNERSHIP_MARKER, label=f"{kind} ownership marker")
+        operation_id = marker.get("operation_id")
+        if (
+            marker.get("owner") != OWNER
+            or marker.get("kind") != kind
+            or marker.get("normalized_root") != _normalized_root(root)
+            or not isinstance(operation_id, str)
+            or not operation_id
+        ):
+            raise AsrError("ASR_CONFIG_INVALID", f"refusing to delete without a matching {kind} ownership marker")
+        roots[kind] = root
+        operation_ids.add(operation_id)
+    if len(operation_ids) != 1:
+        raise AsrError("ASR_CONFIG_INVALID", "ownership markers do not share one install operation identity")
+    manifest = _read_owned_json(config.runtime_root / ".b05-install.json", label="B05 ownership manifest")
+    operation_id = next(iter(operation_ids))
+    if manifest.get("owner") != OWNER or manifest.get("operation_id") != operation_id:
+        raise AsrError("ASR_CONFIG_INVALID", "B05 ownership manifest does not match the install operation")
+    return roots
 
 
 def _external_paths(config: AsrConfig) -> bool:
@@ -198,8 +249,10 @@ def install(config: AsrConfig, *, apply: bool = False, transfer_root: Path | Non
     config.runtime_root.mkdir(parents=True, exist_ok=True)
     config.model_root.mkdir(parents=True, exist_ok=True)
     config.cache_root.mkdir(parents=True, exist_ok=True)
+    operation_id = uuid4().hex
     manifest = {
-        "owner": "b05-streaming-asr",
+        "owner": OWNER,
+        "operation_id": operation_id,
         "mode": "external-transfer-assembly",
         "runtime_repo": RUNTIME_REPO,
         "runtime_revision": RUNTIME_REVISION,
@@ -216,6 +269,14 @@ def install(config: AsrConfig, *, apply: bool = False, transfer_root: Path | Non
         "uninstall_boundary": plan["provenance"]["uninstall_boundary"],
     }
     config.runtime_root.joinpath(".b05-install.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    for kind, root in _managed_roots(config).items():
+        marker = {
+            "owner": OWNER,
+            "operation_id": operation_id,
+            "kind": kind,
+            "normalized_root": _normalized_root(root),
+        }
+        root.joinpath(OWNERSHIP_MARKER).write_text(json.dumps(marker, indent=2), encoding="utf-8")
     return {**plan, "mode": "applied", "manifest": manifest, "network": {"called": False}}
 
 
@@ -234,10 +295,12 @@ def switch_provider(
 
 def uninstall_plan(config: AsrConfig) -> dict[str, Any]:
     owned_manifest = config.runtime_root / ".b05-install.json"
-    owned = owned_manifest.is_file()
+    owned_markers = [root / OWNERSHIP_MARKER for root in _managed_roots(config).values()]
+    owned = owned_manifest.is_file() and all(marker.is_file() for marker in owned_markers)
     return {
         "mode": "dry-run",
         "owned_manifest": str(owned_manifest),
+        "owned_markers": [str(marker) for marker in owned_markers],
         "owned": owned,
         "paths": [str(config.runtime_root), str(config.model_root), str(config.cache_root)],
         "deleted": [],
@@ -251,12 +314,11 @@ def uninstall(config: AsrConfig, *, apply: bool = False) -> dict[str, Any]:
     if not apply:
         return plan
     if not plan["owned"]:
-        raise AsrError("ASR_CONFIG_INVALID", "refusing to delete paths without the B05 ownership manifest")
-    if not _external_paths(config):
-        raise AsrError("ASR_CONFIG_INVALID", "uninstall roots must be absolute local Windows paths")
+        raise AsrError("ASR_CONFIG_INVALID", "refusing to delete paths without complete B05 ownership markers")
+    owned_roots = _validate_owned_roots(config)
     deleted: list[str] = []
-    for path in (config.runtime_root, config.model_root, config.cache_root):
-        if Path(path).exists():
+    for path in sorted(owned_roots.values(), key=lambda value: len(PureWindowsPath(value).parts), reverse=True):
+        if path.exists():
             shutil.rmtree(path)
             deleted.append(str(path))
     return {**plan, "mode": "applied", "deleted": deleted}

--- a/docs/B05_STREAMING_ASR.md
+++ b/docs/B05_STREAMING_ASR.md
@@ -42,9 +42,9 @@ manifest, `redistrib_13.3.0.json`, read from an ignored local transfer root,
 for example `.evidence/b05-runtime-transfer/redistrib_13.3.0.json`.
 The verified manifest is 47,431 bytes with SHA-256
 `507EDDAAB1360336BC0FE17B77552E0B7DFE1E74DA888671C3A2F5FAD7775DB1`.
-The manager performs no download: it accepts a D:/ or F:/ transfer root,
-checks size, SHA-256, ZIP CRC, and safe members, then assembles an owned
-prefix under D:/ or F:/.
+The manager performs no download: it accepts any non-root local absolute
+Windows drive path as the transfer root, checks size, SHA-256, ZIP CRC, and
+safe members, then assembles an owned prefix under the selected local root.
 
 The static Windows x86_64 compile closure is the following.  It is deliberately
 recorded as a build-toolchain closure, not as native ASR acceptance evidence.
@@ -86,7 +86,7 @@ VS/MSVC, CMake, Ninja, NVCC 13.3.33, CUDA ABI, and `sm_86` build cache was
 incrementally rebuilt only for the affected `nemo_speech_cli` target after the
 upstream HTTP patch below.  CUDA and model assets were reused; no duplicate
 build or model download was performed.  The resulting executable and model
-remain outside Git under the ignored D:/F: evidence boundary.
+remain outside Git under the ignored external evidence boundary.
 
 ### Fixed upstream HTTP inventory patch
 
@@ -141,14 +141,17 @@ The default provider is `text-fallback`.  Native selection is explicit through
 `ASR_PROVIDER=nemotron-speech-cpp` or the external JSON configuration written by
 `tools/asr_manage.py switch --provider nemotron-speech-cpp`.
 
-All runtime, model, cache, and acceptance-evidence roots must be absolute D:/
-or F:/ paths in production.  Installation is an idempotent offline assembly
-from an explicit, verified D:/ or F:/ transfer root: it validates the fixed
+All runtime, model, cache, and acceptance-evidence roots must be non-root local
+absolute Windows drive paths in production. Relative, drive-relative, URL,
+UNC, drive-root, and parent-traversal paths are rejected. Installation is an
+idempotent offline assembly from an explicit, verified local absolute transfer root: it validates the fixed
 NeMo-Speech.cpp/ggml/cpp-httplib revisions, the fixed model SHA-256, and the
 official HTTP snapshot patch, then registers the already-built external
 runtime.  It does not download weights or invent an ASR implementation; no
-weights are vendored.  Uninstall requires the B05 ownership manifest and
-`--apply`; a dry run never deletes external runtime/model assets.  The runtime
+weights are vendored. Uninstall requires a matching marker in each managed
+runtime/model/cache root, with the exact normalized root and one shared install
+operation identity, plus `--apply`; legacy roots without those markers fail
+closed. A dry run never deletes external runtime/model assets. The runtime
 has no release artifact to pin, so the source commit, upstream submodule pins,
 patch, and provenance are part of the install manifest.
 
@@ -157,20 +160,20 @@ Useful commands:
 ```text
 rtk python tools/asr_manage.py status
 rtk python tools/asr_manage.py install
-rtk python tools/asr_manage.py install --transfer-root D:/transfer
-rtk python tools/asr_manage.py install --apply --transfer-root D:/transfer
+rtk python tools/asr_manage.py install --transfer-root "$env:LOCALAPPDATA/BSideOliviaLocal/asr-transfer"
+rtk python tools/asr_manage.py install --apply --transfer-root "$env:LOCALAPPDATA/BSideOliviaLocal/asr-transfer"
 rtk python tools/asr_manage.py uninstall
 rtk python tools/asr_manage.py uninstall --apply
-rtk python tools/asr_manage.py cuda-toolchain --action status --cuda-root F:/Bside-olivia-local/asr/cuda-toolchain
-rtk python tools/asr_manage.py cuda-toolchain --action assemble --apply --cuda-root F:/Bside-olivia-local/asr/cuda-toolchain --cuda-manifest D:/transfer/redistrib_13.3.0.json --cuda-transfer-root D:/transfer/cuda-13.3-zips
-rtk python tools/asr_manage.py cuda-toolchain --action uninstall --cuda-root F:/Bside-olivia-local/asr/cuda-toolchain --apply
+rtk python tools/asr_manage.py cuda-toolchain --action status --cuda-root "$env:LOCALAPPDATA/BSideOliviaLocal/asr/cuda-toolchain"
+rtk python tools/asr_manage.py cuda-toolchain --action assemble --apply --cuda-root "$env:LOCALAPPDATA/BSideOliviaLocal/asr/cuda-toolchain" --cuda-manifest "$env:LOCALAPPDATA/BSideOliviaLocal/asr-transfer/redistrib_13.3.0.json" --cuda-transfer-root "$env:LOCALAPPDATA/BSideOliviaLocal/asr-transfer/cuda-13.3-zips"
+rtk python tools/asr_manage.py cuda-toolchain --action uninstall --cuda-root "$env:LOCALAPPDATA/BSideOliviaLocal/asr/cuda-toolchain" --apply
 rtk python tools/asr_healthcheck.py
 rtk python tools/asr_healthcheck.py --probe --require-ready
 rtk python tools/healthcheck.py --profile asr
 ```
 
 The first install command is a plan.  Actual downloads/builds are intentionally
-not part of default CI and must remain on D:/F:.
+not part of default CI and must remain in an external local absolute directory.
 
 ## Truthful readiness gate
 

--- a/tests/asr/test_config.py
+++ b/tests/asr/test_config.py
@@ -17,15 +17,44 @@ def test_default_is_text_fallback_and_provenance_is_pinned() -> None:
     assert config.to_dict(include_paths=False)["runtime_revision"] == RUNTIME_REVISION
 
 
+def test_default_storage_roots_follow_localappdata(monkeypatch, tmp_path: Path) -> None:
+    local_appdata = tmp_path / "LocalAppData"
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+
+    config = AsrConfig()
+
+    expected = local_appdata / "BSideOliviaLocal" / "asr"
+    assert config.runtime_root == expected / "runtime"
+    assert config.model_root == expected / "models"
+    assert config.cache_root == expected / "cache"
+
+
+def test_default_storage_roots_use_user_home_when_localappdata_is_missing(monkeypatch) -> None:
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+
+    config = AsrConfig()
+
+    expected = Path.home() / "AppData" / "Local" / "BSideOliviaLocal" / "asr"
+    assert config.runtime_root == expected / "runtime"
+
+
 def test_config_accepts_explicit_test_paths_without_changing_production_policy(tmp_path: Path) -> None:
     config = AsrConfig().with_test_paths(tmp_path)
     assert config.strict_storage is False
     assert config.effective_model_path.name.endswith(".gguf")
 
 
-def test_production_storage_must_be_d_or_f_drive() -> None:
-    with pytest.raises(AsrError, match="D:/ or F:/"):
-        AsrConfig(runtime_root=Path("C:/not-allowed"))
+@pytest.mark.parametrize("drive", ("C:", "D:", "E:", "F:"))
+def test_production_storage_accepts_any_local_drive(drive: str) -> None:
+    config = AsrConfig(runtime_root=Path(f"{drive}/asr/runtime"))
+
+    assert config.runtime_root == Path(f"{drive}/asr/runtime")
+
+
+@pytest.mark.parametrize("value", (Path("relative/asr"), Path("http://example.invalid/asr")))
+def test_production_storage_rejects_relative_and_url_paths(value: Path) -> None:
+    with pytest.raises(AsrError, match="absolute local Windows paths"):
+        AsrConfig(runtime_root=value)
 
 
 def test_server_must_be_loopback() -> None:

--- a/tests/asr/test_config.py
+++ b/tests/asr/test_config.py
@@ -51,8 +51,18 @@ def test_production_storage_accepts_any_local_drive(drive: str) -> None:
     assert config.runtime_root == Path(f"{drive}/asr/runtime")
 
 
-@pytest.mark.parametrize("value", (Path("relative/asr"), Path("http://example.invalid/asr")))
-def test_production_storage_rejects_relative_and_url_paths(value: Path) -> None:
+@pytest.mark.parametrize(
+    "value",
+    (
+        Path("C:/"),
+        Path("C:/bside/../asr"),
+        Path("C:asr/runtime"),
+        Path("relative/asr"),
+        Path("http://example.invalid/asr"),
+        Path("//server/share/asr"),
+    ),
+)
+def test_production_storage_rejects_unsafe_paths(value: Path) -> None:
     with pytest.raises(AsrError, match="absolute local Windows paths"):
         AsrConfig(runtime_root=value)
 

--- a/tests/asr/test_cuda_toolchain.py
+++ b/tests/asr/test_cuda_toolchain.py
@@ -116,8 +116,18 @@ def test_cuda_status_accepts_any_local_drive(drive: str) -> None:
     assert report["toolchain_root"] == str(Path(f"{drive}/bside/cuda"))
 
 
-@pytest.mark.parametrize("value", (Path("relative/cuda"), Path("https://example.invalid/cuda")))
-def test_cuda_status_rejects_non_local_roots(value: Path) -> None:
+@pytest.mark.parametrize(
+    "value",
+    (
+        Path("C:/"),
+        Path("C:/cuda/../toolchain"),
+        Path("C:cuda/toolchain"),
+        Path("relative/cuda"),
+        Path("https://example.invalid/cuda"),
+        Path("//server/share/cuda"),
+    ),
+)
+def test_cuda_status_rejects_unsafe_roots(value: Path) -> None:
     with pytest.raises(AsrError, match="absolute local Windows path"):
         cuda_toolchain_status(value)
 

--- a/tests/asr/test_cuda_toolchain.py
+++ b/tests/asr/test_cuda_toolchain.py
@@ -13,6 +13,7 @@ from asr.cuda_toolchain import (
     build_command,
     build_environment,
     inspect_cuda_transfer,
+    cuda_toolchain_status,
     load_manifest,
     select_cuda_packages,
     uninstall_cuda_toolchain,
@@ -106,6 +107,19 @@ def test_manifest_selection_returns_the_pinned_windows_build_closure(tmp_path: P
     assert packages[0].relative_path == "cccl/windows-x86_64/cccl.zip"
     assert packages[-1].license_path == "libnvvm/LICENSE.txt"
     assert packages[0].size == 7
+
+
+@pytest.mark.parametrize("drive", ("C:", "E:"))
+def test_cuda_status_accepts_any_local_drive(drive: str) -> None:
+    report = cuda_toolchain_status(Path(f"{drive}/bside/cuda"))
+
+    assert report["toolchain_root"] == str(Path(f"{drive}/bside/cuda"))
+
+
+@pytest.mark.parametrize("value", (Path("relative/cuda"), Path("https://example.invalid/cuda")))
+def test_cuda_status_rejects_non_local_roots(value: Path) -> None:
+    with pytest.raises(AsrError, match="absolute local Windows path"):
+        cuda_toolchain_status(value)
 
 
 def test_strict_manifest_pin_rejects_size_or_hash_mismatch(tmp_path: Path) -> None:

--- a/tests/asr/test_management.py
+++ b/tests/asr/test_management.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from pathlib import PureWindowsPath
 
 import pytest
 
@@ -55,7 +57,18 @@ def test_install_rejects_non_local_storage_roots(value: Path) -> None:
         install(config, apply=True, transfer_root=Path("C:/bside/transfer"))
 
 
-def test_install_rejects_non_local_transfer_root() -> None:
+@pytest.mark.parametrize(
+    "value",
+    (
+        Path("C:/"),
+        Path("C:/transfer/../asr"),
+        Path("C:transfer"),
+        Path("relative/transfer"),
+        Path("https://example.invalid/transfer"),
+        Path("//server/share/transfer"),
+    ),
+)
+def test_install_rejects_unsafe_transfer_root(value: Path) -> None:
     config = AsrConfig(
         runtime_root=Path("C:/bside/asr/runtime"),
         model_root=Path("E:/bside/asr/models"),
@@ -63,7 +76,7 @@ def test_install_rejects_non_local_transfer_root() -> None:
     )
 
     with pytest.raises(AsrError, match="absolute local Windows path"):
-        install_plan(config, transfer_root=Path("relative/transfer"))
+        install_plan(config, transfer_root=value)
 
 
 def test_apply_requires_explicit_offline_transfer_root(tmp_path: Path) -> None:
@@ -93,6 +106,22 @@ def test_uninstall_plan_does_not_delete_without_apply(tmp_path: Path) -> None:
     assert plan["deleted"] == []
 
 
+def test_uninstall_apply_rejects_legacy_runtime_only_manifest(tmp_path: Path) -> None:
+    config = AsrConfig(provider="nemotron-speech-cpp").with_test_paths(tmp_path)
+    roots = (config.runtime_root, config.model_root, config.cache_root)
+    for root in roots:
+        root.mkdir(parents=True)
+    config.runtime_root.joinpath(".b05-install.json").write_text(
+        json.dumps({"owner": "b05-streaming-asr"}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AsrError, match="ownership marker"):
+        uninstall(config, apply=True)
+
+    assert all(root.is_dir() for root in roots)
+
+
 def test_install_and_uninstall_apply_roundtrip_removes_only_owned_roots(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -114,6 +143,32 @@ def test_install_and_uninstall_apply_roundtrip_removes_only_owned_roots(
     applied = install(config, apply=True, transfer_root=Path("F:/fixture-transfer"))
     assert applied["mode"] == "applied"
     assert (config.runtime_root / ".b05-install.json").is_file()
+    roots = {
+        "runtime": config.runtime_root,
+        "model": config.model_root,
+        "cache": config.cache_root,
+    }
+    markers = {
+        kind: json.loads((root / ".b05-owned-root.json").read_text(encoding="utf-8"))
+        for kind, root in roots.items()
+    }
+    assert {marker["operation_id"] for marker in markers.values()} == {
+        applied["manifest"]["operation_id"]
+    }
+    for kind, root in roots.items():
+        assert markers[kind]["kind"] == kind
+        assert markers[kind]["normalized_root"] == str(PureWindowsPath(root)).casefold()
+
+    cache_marker_path = config.cache_root / ".b05-owned-root.json"
+    for tampered in (
+        {**markers["cache"], "normalized_root": "C:\\wrong-root"},
+        {**markers["cache"], "operation_id": "different-install"},
+    ):
+        cache_marker_path.write_text(json.dumps(tampered), encoding="utf-8")
+        with pytest.raises(AsrError):
+            uninstall(config, apply=True)
+        assert all(root.is_dir() for root in roots.values())
+    cache_marker_path.write_text(json.dumps(markers["cache"]), encoding="utf-8")
 
     removed = uninstall(config, apply=True)
     assert removed["mode"] == "applied"

--- a/tests/asr/test_management.py
+++ b/tests/asr/test_management.py
@@ -32,6 +32,40 @@ def test_install_plan_is_offline_and_records_fixed_transfer_closure() -> None:
     assert plan["provenance"]["replacement_boundary"]
 
 
+def test_install_plan_accepts_any_local_drive_for_external_roots() -> None:
+    config = AsrConfig(
+        runtime_root=Path("C:/bside/asr/runtime"),
+        model_root=Path("E:/bside/asr/models"),
+        cache_root=Path("C:/bside/asr/cache"),
+    )
+
+    assert install_plan(config)["paths_are_external"] is True
+
+
+@pytest.mark.parametrize("value", (Path("relative/asr"), Path("https://example.invalid/asr")))
+def test_install_rejects_non_local_storage_roots(value: Path) -> None:
+    config = AsrConfig(
+        runtime_root=value,
+        model_root=Path("C:/bside/asr/models"),
+        cache_root=Path("E:/bside/asr/cache"),
+        strict_storage=False,
+    )
+
+    with pytest.raises(AsrError, match="absolute local Windows paths"):
+        install(config, apply=True, transfer_root=Path("C:/bside/transfer"))
+
+
+def test_install_rejects_non_local_transfer_root() -> None:
+    config = AsrConfig(
+        runtime_root=Path("C:/bside/asr/runtime"),
+        model_root=Path("E:/bside/asr/models"),
+        cache_root=Path("C:/bside/asr/cache"),
+    )
+
+    with pytest.raises(AsrError, match="absolute local Windows path"):
+        install_plan(config, transfer_root=Path("relative/transfer"))
+
+
 def test_apply_requires_explicit_offline_transfer_root(tmp_path: Path) -> None:
     config = AsrConfig(provider="nemotron-speech-cpp").with_test_paths(tmp_path)
 

--- a/tests/asr/test_tools.py
+++ b/tests/asr/test_tools.py
@@ -28,3 +28,12 @@ def test_asr_manage_switch_cli_writes_only_config(capsys, tmp_path: Path) -> Non
     assert asr_manage.main(["switch", "--config", str(config_path), "--provider", "text-fallback"]) == 0
     json.loads(capsys.readouterr().out)
     assert AsrConfig.from_json(config_path).provider == "text-fallback"
+
+
+def test_asr_manage_default_config_follows_localappdata(monkeypatch, capsys, tmp_path: Path) -> None:
+    local_appdata = tmp_path / "LocalAppData"
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+
+    assert asr_manage.main(["switch", "--provider", "text-fallback"]) == 0
+    json.loads(capsys.readouterr().out)
+    assert (local_appdata / "BSideOliviaLocal" / "asr" / "config.json").is_file()

--- a/tests/asr/test_tools.py
+++ b/tests/asr/test_tools.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from asr.config import AsrConfig
 from tools import asr_healthcheck, asr_manage
 
@@ -37,3 +39,23 @@ def test_asr_manage_default_config_follows_localappdata(monkeypatch, capsys, tmp
     assert asr_manage.main(["switch", "--provider", "text-fallback"]) == 0
     json.loads(capsys.readouterr().out)
     assert (local_appdata / "BSideOliviaLocal" / "asr" / "config.json").is_file()
+
+
+def test_asr_manage_rejects_relative_data_root_before_resolution(capsys, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+
+    with pytest.raises(SystemExit):
+        asr_manage.main(
+            [
+                "switch",
+                "--config",
+                str(config_path),
+                "--provider",
+                "text-fallback",
+                "--data-root",
+                "relative/asr",
+            ]
+        )
+
+    assert "--data-root must be an absolute local Windows path" in capsys.readouterr().err
+    assert not config_path.exists()

--- a/tools/asr_manage.py
+++ b/tools/asr_manage.py
@@ -12,7 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from asr.config import AsrConfig  # noqa: E402
+from asr.config import AsrConfig, default_asr_root  # noqa: E402
 from asr.cuda_toolchain import (  # noqa: E402
     assemble_cuda_toolchain,
     build_environment,
@@ -24,20 +24,24 @@ from asr.management import install, switch_provider, uninstall  # noqa: E402
 from asr.provider import NemotronProvider, create_provider  # noqa: E402
 
 
-DEFAULT_CONFIG = Path("F:/Bside-olivia-local/asr/config.json")
+DEFAULT_CONFIG = default_asr_root() / "config.json"
+
+
+def _default_config_path() -> Path:
+    return default_asr_root() / "config.json"
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Manage the optional local B05 ASR runtime")
     parser.add_argument("command", choices=["status", "install", "uninstall", "switch", "cuda-toolchain"])
-    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--config", type=Path, default=None)
     parser.add_argument("--provider", choices=["text-fallback", "nemotron-speech-cpp"])
     parser.add_argument(
         "--data-root",
         type=Path,
-        help="explicit D:/ or F:/ root for runtime, model, cache, and acceptance evidence",
+        help="explicit local absolute root for runtime, model, cache, and acceptance evidence",
     )
-    parser.add_argument("--transfer-root", type=Path, help="verified offline D:/ or F:/ transfer root")
+    parser.add_argument("--transfer-root", type=Path, help="verified offline local absolute transfer root")
     parser.add_argument("--apply", action="store_true")
     parser.add_argument("--action", choices=["status", "assemble", "uninstall"], default="status")
     parser.add_argument("--cuda-root", type=Path)
@@ -48,6 +52,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--vswhere", type=Path)
     parser.add_argument("--cuda-arch", default="86")
     args = parser.parse_args(argv)
+    config_path = args.config or _default_config_path()
 
     if args.command == "cuda-toolchain":
         if not args.cuda_root:
@@ -77,7 +82,7 @@ def main(argv: list[str] | None = None) -> int:
     elif args.command == "switch":
         if not args.provider:
             parser.error("switch requires --provider")
-        seed = AsrConfig.from_json(args.config) if args.config.is_file() else AsrConfig.from_env()
+        seed = AsrConfig.from_json(config_path) if config_path.is_file() else AsrConfig.from_env()
         if args.data_root:
             data_root = args.data_root.absolute()
             seed = replace(
@@ -88,9 +93,9 @@ def main(argv: list[str] | None = None) -> int:
                 model_path=data_root / "models" / "nemotron-3.5-asr-streaming-0.6b.q8_0.gguf",
             )
             seed.validate_storage_roots()
-        result = switch_provider(args.config, args.provider, base_config=seed).to_dict()
+        result = switch_provider(config_path, args.provider, base_config=seed).to_dict()
     else:
-        config = AsrConfig.from_json(args.config) if args.config.is_file() else AsrConfig.from_env()
+        config = AsrConfig.from_json(config_path) if config_path.is_file() else AsrConfig.from_env()
         if args.command == "status":
             provider = create_provider(config)
             result = {"config": config.to_dict(include_paths=False), "status": provider.status()}

--- a/tools/asr_manage.py
+++ b/tools/asr_manage.py
@@ -12,7 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from asr.config import AsrConfig, default_asr_root  # noqa: E402
+from asr.config import AsrConfig, default_asr_root, is_local_absolute_path  # noqa: E402
 from asr.cuda_toolchain import (  # noqa: E402
     assemble_cuda_toolchain,
     build_environment,
@@ -84,7 +84,9 @@ def main(argv: list[str] | None = None) -> int:
             parser.error("switch requires --provider")
         seed = AsrConfig.from_json(config_path) if config_path.is_file() else AsrConfig.from_env()
         if args.data_root:
-            data_root = args.data_root.absolute()
+            if not is_local_absolute_path(args.data_root):
+                parser.error("--data-root must be an absolute local Windows path")
+            data_root = args.data_root
             seed = replace(
                 seed,
                 runtime_root=data_root / "runtime",


### PR DESCRIPTION
## Summary
- Exact pair: base `fc907ed83c8cda29268b042b231d502a65772a48`, head `278f253af17805ca5c371a102bffa067bab67ec2`.
- Scope: 9 files covering ASR config, management, CUDA path use, CLI defaults, focused tests, and the active B05 document.
- The default ASR root is `%LOCALAPPDATA%/BSideOliviaLocal/asr`, with a user-home fallback when `LOCALAPPDATA` is unavailable.
- Local paths may use any Windows drive letter, but drive roots, parent traversal, drive-relative paths, relative paths, URLs, and UNC paths are rejected.
- Install writes an exact-root ownership marker to runtime/model/cache with one shared operation identity. Uninstall validates all three markers and the runtime install manifest before deleting any root; legacy or tampered markers fail closed.
- `--data-root` is validated before resolution, so relative CLI input cannot be converted into an accepted absolute path.
- B05 documentation now uses portable `%LOCALAPPDATA%` examples and no longer states a D:/F: restriction.

## TDD and validation
- RED: drive-root and parent-traversal config cases failed before the predicate fix.
- RED: a runtime-only legacy manifest deleted all three roots before per-root ownership validation.
- RED: relative `--data-root` was resolved and accepted before the CLI fix.
- GREEN: `rtk python -m pytest tests/asr/test_config.py tests/asr/test_management.py tests/asr/test_cuda_toolchain.py tests/asr/test_tools.py -q` — 53 passed.
- Documentation assertion: `rtk rg -n "D:/|F:/|Bside-olivia-local" docs/B05_STREAMING_ASR.md` — zero matches.
- `rtk git diff --check` — passed before commit.

## Boundaries
- No full suite, model, provider, GPU, or native acceptance run was performed.
- LiveTalking and B10B are unchanged; their existing path policies remain outside this PR.
- Model/provider behavior is unchanged. The repair is limited to path selection, validation, uninstall ownership, CLI handling, documentation, and focused tests.

## Reviewer comment
This head repairs the prior terminal BLOCK only. Please review the frozen pair above; the PR remains Draft and is not approved for merge by this update.