### PR TITLE
fix(media): resolve configured paths from project root

### DIFF
--- a/latentsync_reply.py
+++ b/latentsync_reply.py
@@ -9,6 +9,8 @@ import tempfile
 from pathlib import Path
 from typing import Mapping
 
+from media_paths import resolve_media_path
+
 
 class LatentSyncReplyError(RuntimeError):
     """Stable product error for the external LatentSync process."""
@@ -20,8 +22,8 @@ def resolve_ffmpeg_executable(env: Mapping[str, str] | None = None) -> Path:
     environment = os.environ if env is None else env
     configured = str(environment.get("OLIVIA_FFMPEG_EXE", "")).strip()
     if configured:
-        configured_path = Path(configured)
-        if not configured_path.is_file():
+        configured_path = resolve_media_path(configured, environment)
+        if configured_path is None or not configured_path.is_file():
             raise LatentSyncReplyError("LATENTSYNC_FFMPEG_UNAVAILABLE")
         executable = configured_path
     else:
@@ -51,23 +53,35 @@ def media_runtime_available(env: Mapping[str, str] | None = None) -> bool:
         return False
 
 
-def _environment_with_ffmpeg(shim_root: Path, cache_root: Path) -> dict[str, str]:
-    resolved = resolve_ffmpeg_executable()
+def _environment_with_ffmpeg(
+    shim_root: Path,
+    cache_root: Path,
+    *,
+    ffmpeg_path: Path | None = None,
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    resolved = (
+        resolve_ffmpeg_executable(environment)
+        if ffmpeg_path is None
+        else Path(ffmpeg_path)
+    )
+    if not resolved.is_absolute() or not resolved.is_file():
+        raise LatentSyncReplyError("LATENTSYNC_FFMPEG_UNAVAILABLE")
     directory = resolved.parent
     if resolved.stem.casefold() != "ffmpeg":
         shim = Path(shim_root) / "ffmpeg.exe"
         shutil.copy2(resolved, shim)
         directory = shim.parent
-    environment = dict(os.environ)
-    environment["PATH"] = str(directory) + os.pathsep + environment.get("PATH", "")
+    runtime_environment = dict(os.environ if environment is None else environment)
+    runtime_environment["PATH"] = str(directory) + os.pathsep + runtime_environment.get("PATH", "")
     cache_root.mkdir(parents=True, exist_ok=True)
-    environment["HF_HOME"] = str(cache_root / "huggingface")
-    environment["HF_HUB_CACHE"] = str(cache_root / "huggingface" / "hub")
-    environment["TORCH_HOME"] = str(cache_root / "torch")
-    environment["XDG_CACHE_HOME"] = str(cache_root)
-    environment["TEMP"] = str(shim_root)
-    environment["TMP"] = str(shim_root)
-    return environment
+    runtime_environment["HF_HOME"] = str(cache_root / "huggingface")
+    runtime_environment["HF_HUB_CACHE"] = str(cache_root / "huggingface" / "hub")
+    runtime_environment["TORCH_HOME"] = str(cache_root / "torch")
+    runtime_environment["XDG_CACHE_HOME"] = str(cache_root)
+    runtime_environment["TEMP"] = str(shim_root)
+    runtime_environment["TMP"] = str(shim_root)
+    return runtime_environment
 
 
 def _prepare_source_clip(
@@ -133,6 +147,9 @@ def render_latentsync_video(
     python_path: Path,
     latentsync_root: Path,
     timeout_seconds: float = 21600.0,
+    ffmpeg_path: Path | None = None,
+    provider_cache_root: Path | None = None,
+    environment: Mapping[str, str] | None = None,
 ) -> dict[str, object]:
     """Apply the accepted 1.5 settings to an original-motion source video."""
 
@@ -157,17 +174,28 @@ def render_latentsync_video(
         raise LatentSyncReplyError("LATENTSYNC_INPUT_UNAVAILABLE")
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    cache_value = os.environ.get("OLIVIA_PROVIDER_CACHE_ROOT", "").strip()
-    cache_root = (
-        Path(cache_value).expanduser()
-        if cache_value
-        else output_path.parent.parent / "provider-cache"
-    )
+    source_environment = os.environ if environment is None else environment
+    cache_root = provider_cache_root
+    if cache_root is None:
+        cache_root = resolve_media_path(
+            source_environment.get("OLIVIA_PROVIDER_CACHE_ROOT", ""),
+            source_environment,
+        )
+    if cache_root is None:
+        cache_root = output_path.parent.parent / "provider-cache"
+    cache_root = Path(cache_root)
+    if not cache_root.is_absolute():
+        raise LatentSyncReplyError("LATENTSYNC_INPUT_UNAVAILABLE")
     work_root = cache_root / "latentsync-work"
     work_root.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="job-", dir=work_root) as temporary:
         temporary_root = Path(temporary)
-        environment = _environment_with_ffmpeg(temporary_root, cache_root)
+        runtime_environment = _environment_with_ffmpeg(
+            temporary_root,
+            cache_root,
+            ffmpeg_path=ffmpeg_path,
+            environment=source_environment,
+        )
         prepared_video = temporary_root / "source-h264.mp4"
         working_output = temporary_root / "reply.mp4"
         pipeline_temp = temporary_root / "pipeline-temp"
@@ -175,7 +203,7 @@ def render_latentsync_video(
             source_video,
             audio_path,
             prepared_video,
-            environment=environment,
+            environment=runtime_environment,
         )
         command = [
             str(python_path),
@@ -208,7 +236,7 @@ def render_latentsync_video(
                 capture_output=True,
                 check=False,
                 timeout=timeout_seconds,
-                env=environment,
+                env=runtime_environment,
             )
         except (OSError, subprocess.TimeoutExpired) as exc:
             raise LatentSyncReplyError("LATENTSYNC_FAILED") from exc

--- a/letter_triage.py
+++ b/letter_triage.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Mapping, Protocol
 
 from llm_gateway import GatewayError
+from media_paths import configured_media_path
 from music_reply import musical_reply_configured
 
 
@@ -424,21 +425,21 @@ def routing_context_from_environment(
 
 
 def _spoken_video_configured(env: Mapping[str, str]) -> bool:
-    data_root = Path(str(env.get("OLIVIA_LOCAL_DATA_ROOT", ""))).expanduser()
-    tts_config = Path(str(env.get("OLIVIA_TTS_CONFIG", ""))).expanduser()
+    data_root = configured_media_path(env, "OLIVIA_LOCAL_DATA_ROOT")
+    tts_config = configured_media_path(env, "OLIVIA_TTS_CONFIG")
     scene = _current_scene(env)
-    latentsync_python = Path(
-        str(env.get("OLIVIA_LATENTSYNC_PYTHON", ""))
-    ).expanduser()
-    latentsync_root = Path(
-        str(env.get("OLIVIA_LATENTSYNC_ROOT", ""))
-    ).expanduser()
+    latentsync_python = configured_media_path(env, "OLIVIA_LATENTSYNC_PYTHON")
+    latentsync_root = configured_media_path(env, "OLIVIA_LATENTSYNC_ROOT")
     return bool(
-        data_root.is_absolute()
+        data_root is not None
+        and data_root.is_absolute()
+        and tts_config is not None
         and tts_config.is_file()
         and scene is not None
         and scene.is_file()
+        and latentsync_python is not None
         and latentsync_python.is_file()
+        and latentsync_root is not None
         and latentsync_root.is_dir()
     )
 
@@ -461,8 +462,7 @@ def _current_scene(env: Mapping[str, str]) -> Path | None:
         if 17 <= hour < 20
         else "NIGHT"
     )
-    value = str(env.get(f"OLIVIA_SCENE_{key}", "")).strip()
-    return Path(value).expanduser() if value else None
+    return configured_media_path(env, f"OLIVIA_SCENE_{key}")
 
 
 def _current_music_performance(
@@ -485,8 +485,7 @@ def _current_music_performance(
         if 16 <= local_hour < 19
         else "NIGHT"
     )
-    value = str(env.get(f"OLIVIA_MUSIC_SCENE_{key}", "")).strip()
-    return Path(value).expanduser() if value else None
+    return configured_media_path(env, f"OLIVIA_MUSIC_SCENE_{key}")
 
 
 def _context_items(value: object) -> tuple[str, ...]:

--- a/local_server.py
+++ b/local_server.py
@@ -48,6 +48,7 @@ from persona_provider import (
 )
 from reply_orchestrator import ReplyOrchestrator, ReplyRequest, ReplyState
 from letter_triage import LetterEmotionTriage, TriageResult, _current_music_performance
+from media_paths import configured_media_path
 from music_reply import MusicReplyError, render_musical_reply, select_speaking_scene, speaking_scene_candidates
 from music_duration import MUSIC_DURATION_OPTIONS
 from reply_media import ReplyMediaError, render_reply_video
@@ -2041,9 +2042,11 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
         output_path = output_dir / f"{letter_id}.mp4"
         try:
             output_dir.mkdir(parents=True, exist_ok=True)
-            tts_config = Path(_os.environ.get("OLIVIA_TTS_CONFIG", ""))
-            visual_config = Path(_os.environ.get("OLIVIA_VISUAL_CONFIG", ""))
-            worker = Path(_os.environ.get("OLIVIA_LIVETALKING_WORKER", ""))
+            tts_config = configured_media_path(_os.environ, "OLIVIA_TTS_CONFIG")
+            visual_config = configured_media_path(_os.environ, "OLIVIA_VISUAL_CONFIG")
+            worker = configured_media_path(_os.environ, "OLIVIA_LIVETALKING_WORKER")
+            if tts_config is None or visual_config is None or worker is None:
+                raise ReplyMediaError("MEDIA_PROVIDER_UNAVAILABLE")
             if reply_mode == "musical_video":
                 voice_plan = await _music_voice_plan_for_letter(letter, reply_text)
                 music_duration_seconds = int(letter.get("music_duration_seconds", 60))
@@ -2074,10 +2077,19 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
 
                 hour = datetime.now().hour
                 scene_key = "morning" if 5 <= hour < 10 else "day" if 10 <= hour < 17 else "dusk" if 17 <= hour < 20 else "night"
-                normal_scene_value = _os.environ.get(f"OLIVIA_SCENE_{scene_key.upper()}", "")
-                normal_scene = Path(normal_scene_value).expanduser() if normal_scene_value else None
+                normal_scene = configured_media_path(
+                    _os.environ, f"OLIVIA_SCENE_{scene_key.upper()}"
+                )
                 if normal_scene is None or not normal_scene.is_file():
                     raise ReplyMediaError("ORDINARY_SCENE_NOT_CONFIGURED")
+                latentsync_python = configured_media_path(
+                    _os.environ, "OLIVIA_LATENTSYNC_PYTHON"
+                )
+                latentsync_root = configured_media_path(
+                    _os.environ, "OLIVIA_LATENTSYNC_ROOT"
+                )
+                if latentsync_python is None or latentsync_root is None:
+                    raise ReplyMediaError("MEDIA_PROVIDER_UNAVAILABLE")
                 await asyncio.to_thread(render_reply_video,
                     reply_text,
                     output_path,
@@ -2085,8 +2097,8 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
                     visual_config_path=visual_config,
                     worker_path=worker,
                     scene_path=normal_scene,
-                    latentsync_python_path=Path(_os.environ.get("OLIVIA_LATENTSYNC_PYTHON", "")),
-                    latentsync_root=Path(_os.environ.get("OLIVIA_LATENTSYNC_ROOT", "")),
+                    latentsync_python_path=latentsync_python,
+                    latentsync_root=latentsync_root,
                     adaptive_delivery=True,
                     voice_performance_plan=voice_plan,
                     enforce_content_gate=True,

--- a/local_server.py
+++ b/local_server.py
@@ -509,7 +509,8 @@ store = Store()
 
 
 def _local_data_root() -> Path | None:
-    return configured_media_path(_os.environ, "OLIVIA_LOCAL_DATA_ROOT")
+    configured = configured_media_path(_os.environ, "OLIVIA_LOCAL_DATA_ROOT")
+    return configured.resolve(strict=False) if configured is not None else None
 
 
 def _conversation_state_root() -> Path | None:

--- a/local_server.py
+++ b/local_server.py
@@ -508,6 +508,10 @@ class Store:
 store = Store()
 
 
+def _local_data_root() -> Path | None:
+    return configured_media_path(_os.environ, "OLIVIA_LOCAL_DATA_ROOT")
+
+
 def _conversation_state_root() -> Path | None:
     """Return the validated Mem0-owned canonical state root, when selected."""
 
@@ -535,8 +539,7 @@ def _state_root() -> Path | None:
     configured = _conversation_state_root()
     if configured is not None:
         return configured
-    configured = _os.environ.get("OLIVIA_LOCAL_DATA_ROOT", "")
-    return Path(configured).expanduser().resolve() if configured else None
+    return _local_data_root()
 
 
 def _load_store_state() -> None:
@@ -883,8 +886,8 @@ _MEDIA_NAME = _re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\.mp4$")
 
 
 def _media_root() -> Path | None:
-    configured = _os.environ.get("OLIVIA_LOCAL_DATA_ROOT", "")
-    return (Path(configured).expanduser().resolve() / "media") if configured else None
+    configured = _local_data_root()
+    return configured / "media" if configured is not None else None
 
 
 async def _media_handler(request: web.Request) -> web.StreamResponse:
@@ -2031,8 +2034,8 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
     async with media_semaphore:
         letter["media_status"] = "PROCESSING"
         _persist_media_state()
-        data_root = Path(_os.environ.get("OLIVIA_LOCAL_DATA_ROOT", ""))
-        output_dir = data_root / "media" if data_root.is_absolute() else None
+        data_root = _local_data_root()
+        output_dir = data_root / "media" if data_root is not None else None
         if output_dir is None:
             letter["media_status"] = "UNAVAILABLE"
             letter["media_error_code"] = "MEDIA_PROVIDER_UNAVAILABLE"

--- a/local_server.py
+++ b/local_server.py
@@ -17,7 +17,8 @@ import hashlib
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable
+from types import MappingProxyType
+from typing import Callable, Mapping
 
 from aiohttp import web
 
@@ -508,8 +509,11 @@ class Store:
 store = Store()
 
 
-def _local_data_root() -> Path | None:
-    configured = configured_media_path(_os.environ, "OLIVIA_LOCAL_DATA_ROOT")
+def _local_data_root(environment: Mapping[str, str] | None = None) -> Path | None:
+    configured = configured_media_path(
+        _os.environ if environment is None else environment,
+        "OLIVIA_LOCAL_DATA_ROOT",
+    )
     return configured.resolve(strict=False) if configured is not None else None
 
 
@@ -2035,7 +2039,8 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
     async with media_semaphore:
         letter["media_status"] = "PROCESSING"
         _persist_media_state()
-        data_root = _local_data_root()
+        environment = MappingProxyType(dict(_os.environ))
+        data_root = _local_data_root(environment)
         output_dir = data_root / "media" if data_root is not None else None
         if output_dir is None:
             letter["media_status"] = "UNAVAILABLE"
@@ -2047,8 +2052,8 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
         try:
             output_dir.mkdir(parents=True, exist_ok=True)
             def runtime_path(name: str) -> Path:
-                configured = configured_media_path(_os.environ, name)
-                if configured is None and _os.environ.get(name, "").strip():
+                configured = configured_media_path(environment, name)
+                if configured is None and environment.get(name, "").strip():
                     raise ReplyMediaError("MEDIA_PROVIDER_UNAVAILABLE")
                 return configured if configured is not None else Path()
 
@@ -2058,7 +2063,7 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
             if reply_mode == "musical_video":
                 voice_plan = await _music_voice_plan_for_letter(letter, reply_text)
                 music_duration_seconds = int(letter.get("music_duration_seconds", 60))
-                performance_scene = _current_music_performance(_os.environ)
+                performance_scene = _current_music_performance(environment)
                 if performance_scene is None or not performance_scene.is_file():
                     raise MusicReplyError("MUSIC_PERFORMANCE_SCENE_NOT_CONFIGURED")
                 await asyncio.to_thread(render_musical_reply,
@@ -2070,7 +2075,7 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
                         f"{letter_id}-song-v2-{music_duration_seconds}s.mp4"
                     ),
                     official_reply_reference_path=select_speaking_scene(
-                        speaking_scene_candidates(_os.environ)
+                        speaking_scene_candidates(environment)
                     ) or Path(),
                     tts_config_path=tts_config,
                     visual_config_path=visual_config,
@@ -2078,6 +2083,7 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
                     performance_video_path=performance_scene,
                     duration_seconds=music_duration_seconds,
                     voice_performance_plan=voice_plan,
+                    environment=environment,
                 )
             else:
                 voice_plan = await _voice_plan_for_letter(letter, reply_text)
@@ -2086,7 +2092,7 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
                 hour = datetime.now().hour
                 scene_key = "morning" if 5 <= hour < 10 else "day" if 10 <= hour < 17 else "dusk" if 17 <= hour < 20 else "night"
                 normal_scene = configured_media_path(
-                    _os.environ, f"OLIVIA_SCENE_{scene_key.upper()}"
+                    environment, f"OLIVIA_SCENE_{scene_key.upper()}"
                 )
                 if normal_scene is None or not normal_scene.is_file():
                     raise ReplyMediaError("ORDINARY_SCENE_NOT_CONFIGURED")
@@ -2104,6 +2110,7 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
                     adaptive_delivery=True,
                     voice_performance_plan=voice_plan,
                     enforce_content_gate=True,
+                    environment=environment,
                 )
             letter["reply_video_url"] = f"http://127.0.0.1:{PORT}/toy/media/{output_path.name}"
             letter["media_status"] = "COMPLETED"

--- a/local_server.py
+++ b/local_server.py
@@ -2042,11 +2042,15 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
         output_path = output_dir / f"{letter_id}.mp4"
         try:
             output_dir.mkdir(parents=True, exist_ok=True)
-            tts_config = configured_media_path(_os.environ, "OLIVIA_TTS_CONFIG")
-            visual_config = configured_media_path(_os.environ, "OLIVIA_VISUAL_CONFIG")
-            worker = configured_media_path(_os.environ, "OLIVIA_LIVETALKING_WORKER")
-            if tts_config is None or visual_config is None or worker is None:
-                raise ReplyMediaError("MEDIA_PROVIDER_UNAVAILABLE")
+            def runtime_path(name: str) -> Path:
+                configured = configured_media_path(_os.environ, name)
+                if configured is None and _os.environ.get(name, "").strip():
+                    raise ReplyMediaError("MEDIA_PROVIDER_UNAVAILABLE")
+                return configured if configured is not None else Path()
+
+            tts_config = runtime_path("OLIVIA_TTS_CONFIG")
+            visual_config = runtime_path("OLIVIA_VISUAL_CONFIG")
+            worker = runtime_path("OLIVIA_LIVETALKING_WORKER")
             if reply_mode == "musical_video":
                 voice_plan = await _music_voice_plan_for_letter(letter, reply_text)
                 music_duration_seconds = int(letter.get("music_duration_seconds", 60))
@@ -2082,14 +2086,8 @@ async def _render_media_job(letter_id: str, content: str, reply_text: str, reply
                 )
                 if normal_scene is None or not normal_scene.is_file():
                     raise ReplyMediaError("ORDINARY_SCENE_NOT_CONFIGURED")
-                latentsync_python = configured_media_path(
-                    _os.environ, "OLIVIA_LATENTSYNC_PYTHON"
-                )
-                latentsync_root = configured_media_path(
-                    _os.environ, "OLIVIA_LATENTSYNC_ROOT"
-                )
-                if latentsync_python is None or latentsync_root is None:
-                    raise ReplyMediaError("MEDIA_PROVIDER_UNAVAILABLE")
+                latentsync_python = runtime_path("OLIVIA_LATENTSYNC_PYTHON")
+                latentsync_root = runtime_path("OLIVIA_LATENTSYNC_ROOT")
                 await asyncio.to_thread(render_reply_video,
                     reply_text,
                     output_path,

--- a/media_paths.py
+++ b/media_paths.py
@@ -4,19 +4,25 @@ from pathlib import Path
 from typing import Mapping
 
 
+def resolve_media_path(value: object, environ: Mapping[str, str]) -> Path | None:
+    """Resolve one configured path without consulting the process cwd."""
+
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        project_root = Path(str(environ.get("OLIVIA_PROJECT_ROOT", ""))).expanduser()
+        if not project_root.is_absolute():
+            return None
+        path = project_root / path
+    return path.resolve(strict=False)
+
+
 def configured_media_path(
     environ: Mapping[str, str],
     name: str,
 ) -> Path | None:
     """Resolve a configured media path without depending on process cwd."""
 
-    raw = str(environ.get(name, "")).strip()
-    if not raw:
-        return None
-    path = Path(raw).expanduser()
-    if path.is_absolute():
-        return path
-    project_root = Path(str(environ.get("OLIVIA_PROJECT_ROOT", ""))).expanduser()
-    if not project_root.is_absolute():
-        return None
-    return project_root / path
+    return resolve_media_path(environ.get(name, ""), environ)

--- a/media_paths.py
+++ b/media_paths.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+
+def configured_media_path(
+    environ: Mapping[str, str],
+    name: str,
+) -> Path | None:
+    """Resolve a configured media path without depending on process cwd."""
+
+    raw = str(environ.get(name, "")).strip()
+    if not raw:
+        return None
+    path = Path(raw).expanduser()
+    if path.is_absolute():
+        return path
+    project_root = Path(str(environ.get("OLIVIA_PROJECT_ROOT", ""))).expanduser()
+    if not project_root.is_absolute():
+        return None
+    return project_root / path

--- a/music_reply.py
+++ b/music_reply.py
@@ -20,6 +20,7 @@ from latentsync_reply import (
     render_latentsync_video,
     resolve_ffmpeg_executable,
 )
+from media_paths import configured_media_path
 from music_duration import MUSIC_DURATION_OPTIONS, normalize_music_duration as _normalize_music_duration
 from reply_media import (
     ReplyMediaError,
@@ -54,7 +55,9 @@ def speaking_scene_candidates(env: Mapping[str, str]) -> tuple[Path, ...]:
     values = raw.split(os.pathsep) if raw else [str(env.get("OLIVIA_OFFICIAL_REPLY_REFERENCE", ""))]
     result: list[Path] = []
     for value in values:
-        candidate = Path(value.strip()).expanduser() if value.strip() else None
+        candidate_env = dict(env)
+        candidate_env["_OLIVIA_SCENE_CANDIDATE"] = value
+        candidate = configured_media_path(candidate_env, "_OLIVIA_SCENE_CANDIDATE")
         if candidate is not None and candidate not in result:
             result.append(candidate)
     return tuple(result)
@@ -76,35 +79,50 @@ def musical_reply_configured(
 ) -> bool:
     """Return whether the renderer's complete musical delivery closure exists."""
 
-    def configured_path(name: str) -> Path:
-        return Path(str(env.get(name, ""))).expanduser()
+    def configured_path(name: str) -> Path | None:
+        return configured_media_path(env, name)
 
     minimax_root = configured_path("OLIVIA_MINIMAX_COMFY_ROOT")
     latentsync_root = configured_path("OLIVIA_LATENTSYNC_ROOT")
     speaking_scene = select_speaking_scene(speaking_scene_candidates(env))
+    delivery_paths = (
+        configured_path("OLIVIA_TTS_CONFIG"),
+        configured_path("OLIVIA_VISUAL_CONFIG"),
+        configured_path("OLIVIA_LIVETALKING_WORKER"),
+        configured_path("OLIVIA_LOCAL_DATA_ROOT"),
+    )
+    if minimax_root is None or latentsync_root is None or any(
+        path is None for path in delivery_paths
+    ):
+        return False
     try:
         assemble_complete_video_delivery(
-            configured_path("OLIVIA_TTS_CONFIG"),
-            configured_path("OLIVIA_VISUAL_CONFIG"),
-            configured_path("OLIVIA_LIVETALKING_WORKER"),
-            configured_path("OLIVIA_LOCAL_DATA_ROOT"),
+            delivery_paths[0],
+            delivery_paths[1],
+            delivery_paths[2],
+            delivery_paths[3],
             env,
         )
     except ReplyMediaError:
         return False
-    required = (
-        speaking_scene or Path(""),
+    configured_files = (
         configured_path("OLIVIA_ROFORMER_EXE"),
         configured_path("OLIVIA_ROFORMER_MODEL_PATH"),
         configured_path("OLIVIA_ROFORMER_CONFIG_PATH"),
         configured_path("OLIVIA_MINIMAX_COMFY_PYTHON"),
         configured_path("OLIVIA_MINIMAX_WORKER"),
+        configured_path("OLIVIA_LATENTSYNC_PYTHON"),
+    )
+    if speaking_scene is None or any(path is None for path in configured_files):
+        return False
+    required = (
+        speaking_scene,
+        *configured_files[:6],
         minimax_root / "main.py",
         minimax_root / "comfy_extras" / "nodes_minimax_music.py",
         minimax_root / "models" / "unet" / "minimax_music3_dit_int8_convrot.safetensors",
         minimax_root / "models" / "clip" / "minimax_music3_text_encoder_pruned_int8_convrot.safetensors",
         minimax_root / "models" / "vae" / "minimax_music3_dav.safetensors",
-        configured_path("OLIVIA_LATENTSYNC_PYTHON"),
         latentsync_root / "scripts" / "inference.py",
         latentsync_root / "configs" / "unet" / "stage2_efficient.yaml",
         latentsync_root / "checkpoints" / "latentsync_unet.pt",

--- a/music_reply.py
+++ b/music_reply.py
@@ -54,10 +54,14 @@ class MusicProviderPathSnapshot:
     roformer_config: Path | None
     latentsync_python: Path | None
     latentsync_root: Path | None
+    ffmpeg_executable: Path | None
+    provider_cache_root: Path | None
 
 
-def _music_provider_path_snapshot() -> MusicProviderPathSnapshot:
-    environment = MappingProxyType(dict(os.environ))
+def _music_provider_path_snapshot(
+    environment: Mapping[str, str] | None = None,
+) -> MusicProviderPathSnapshot:
+    environment = MappingProxyType(dict(os.environ if environment is None else environment))
     return MusicProviderPathSnapshot(
         environment=environment,
         minimax_python=configured_media_path(environment, "OLIVIA_MINIMAX_COMFY_PYTHON"),
@@ -68,6 +72,8 @@ def _music_provider_path_snapshot() -> MusicProviderPathSnapshot:
         roformer_config=configured_media_path(environment, "OLIVIA_ROFORMER_CONFIG_PATH"),
         latentsync_python=configured_media_path(environment, "OLIVIA_LATENTSYNC_PYTHON"),
         latentsync_root=configured_media_path(environment, "OLIVIA_LATENTSYNC_ROOT"),
+        ffmpeg_executable=configured_media_path(environment, "OLIVIA_FFMPEG_EXE"),
+        provider_cache_root=configured_media_path(environment, "OLIVIA_PROVIDER_CACHE_ROOT"),
     )
 
 
@@ -371,8 +377,12 @@ class AceStepClient:
         raise MusicReplyError("ACESTEP_TIMEOUT")
 
 
-def _ffmpeg() -> str:
+def _ffmpeg(ffmpeg_path: Path | None = None) -> str:
     try:
+        if ffmpeg_path is not None:
+            if not ffmpeg_path.is_absolute() or not ffmpeg_path.is_file():
+                raise LatentSyncReplyError("LATENTSYNC_FFMPEG_UNAVAILABLE")
+            return str(ffmpeg_path)
         return str(resolve_ffmpeg_executable())
     except LatentSyncReplyError as exc:
         raise MusicReplyError("FFMPEG_UNAVAILABLE") from exc
@@ -399,7 +409,12 @@ def _run(
         raise MusicReplyError(error_code)
 
 
-def prepare_official_spoken_base(reference_path: Path, destination: Path) -> Path:
+def prepare_official_spoken_base(
+    reference_path: Path,
+    destination: Path,
+    *,
+    ffmpeg_path: Path | None = None,
+) -> Path:
     """Create the verified 0-35s speaking-performance base for musical replies."""
 
     reference_path = Path(reference_path)
@@ -413,7 +428,7 @@ def prepare_official_spoken_base(reference_path: Path, destination: Path) -> Pat
     partial.unlink(missing_ok=True)
     _run(
         [
-            _ffmpeg(),
+            _ffmpeg(ffmpeg_path),
             "-hide_banner",
             "-loglevel",
             "error",
@@ -456,6 +471,7 @@ def separate_vocals(
     model_path: Path | None,
     config_path: Path | None,
     environment: Mapping[str, str],
+    ffmpeg_path: Path | None = None,
 ) -> None:
     if any(
         value is None or not value.is_file()
@@ -471,7 +487,7 @@ def separate_vocals(
         source = inputs / "song.wav"
         _run(
             [
-                _ffmpeg(),
+                _ffmpeg(ffmpeg_path),
                 "-y",
                 "-i",
                 str(song_path),
@@ -517,6 +533,9 @@ def render_full_face_performance(
     *,
     latentsync_python_path: Path | None,
     latentsync_root: Path | None,
+    ffmpeg_path: Path | None = None,
+    provider_cache_root: Path | None = None,
+    environment: Mapping[str, str] | None = None,
 ) -> dict[str, object]:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     if latentsync_python_path is None or latentsync_root is None:
@@ -530,12 +549,15 @@ def render_full_face_performance(
                 raw_video,
                 python_path=latentsync_python_path,
                 latentsync_root=latentsync_root,
+                ffmpeg_path=ffmpeg_path,
+                provider_cache_root=provider_cache_root,
+                environment=environment,
             )
         except LatentSyncReplyError as exc:
             raise MusicReplyError(str(exc)) from exc
         _run(
             [
-                _ffmpeg(), "-hide_banner", "-loglevel", "error", "-y",
+                _ffmpeg(ffmpeg_path), "-hide_banner", "-loglevel", "error", "-y",
                 "-i", str(raw_video), "-i", str(full_song_path),
                 "-map", "0:v:0", "-map", "1:a:0",
                 "-c:v", "copy", "-c:a", "aac", "-b:a", "192k",
@@ -569,6 +591,7 @@ def concat_videos(
     transition_start_seconds: float = 35.0,
     transition_end_seconds: float = 43.0,
     end_fade_seconds: float = 2.0,
+    ffmpeg_path: Path | None = None,
 ) -> None:
     """Join speech and performance, optionally preserving the reference turn/transition.
 
@@ -651,7 +674,7 @@ def concat_videos(
         assembled = root / "assembled-lossless.mkv"
         _run(
             [
-                _ffmpeg(), "-hide_banner", "-loglevel", "error", "-y",
+                _ffmpeg(ffmpeg_path), "-hide_banner", "-loglevel", "error", "-y",
                 *inputs,
                 "-filter_complex", ";".join(filters),
                 "-map", "[final_v]", "-map", "[final_a]",
@@ -664,7 +687,7 @@ def concat_videos(
         result = root / "complete.mp4"
         _run(
             [
-                _ffmpeg(), "-hide_banner", "-loglevel", "error", "-y",
+                _ffmpeg(ffmpeg_path), "-hide_banner", "-loglevel", "error", "-y",
                 "-i", str(assembled),
                 "-vf", "tpad=stop_mode=clone:stop_duration=1",
                 "-af", (
@@ -917,11 +940,12 @@ def render_musical_reply(
     performance_video_path: Path,
     duration_seconds: int,
     voice_performance_plan: VoicePerformancePlan | None = None,
+    environment: Mapping[str, str] | None = None,
 ) -> dict[str, object]:
     """Render the ordinary reply, append an original-view song performance."""
 
     duration_seconds = normalize_music_duration(duration_seconds)
-    provider_paths = _music_provider_path_snapshot()
+    provider_paths = _music_provider_path_snapshot(environment)
     transition_reference = _official_transition_reference(provider_paths.environment)
     minimax_python = provider_paths.minimax_python
     minimax_root = provider_paths.minimax_root
@@ -931,6 +955,12 @@ def render_musical_reply(
     latentsync_python = provider_paths.latentsync_python
     latentsync_root = provider_paths.latentsync_root
     if latentsync_python is None or latentsync_root is None:
+        raise MusicReplyError("LATENTSYNC_INPUT_UNAVAILABLE")
+    ffmpeg_path = provider_paths.ffmpeg_executable
+    if ffmpeg_path is None or not ffmpeg_path.is_file():
+        raise MusicReplyError("FFMPEG_UNAVAILABLE")
+    provider_cache_root = provider_paths.provider_cache_root
+    if provider_cache_root is None or not provider_cache_root.is_absolute():
         raise MusicReplyError("LATENTSYNC_INPUT_UNAVAILABLE")
     try:
         song_plan = plan_song_content(content, reply_text, duration_seconds)
@@ -980,7 +1010,11 @@ def render_musical_reply(
     else:
         if not _stage_reusable(manifest, "spoken_base", spoken_base):
             spoken_base.unlink(missing_ok=True)
-            prepare_official_spoken_base(official_reply_reference_path, spoken_base)
+            prepare_official_spoken_base(
+                official_reply_reference_path,
+                spoken_base,
+                ffmpeg_path=ffmpeg_path,
+            )
             _record_stage(manifest, manifest_path, "spoken_base", spoken_base)
         normal_metadata = render_reply_video(
             reply_text,
@@ -994,6 +1028,8 @@ def render_musical_reply(
             adaptive_delivery=True,
             voice_performance_plan=voice_performance_plan,
             environment=provider_paths.environment,
+            ffmpeg_path=ffmpeg_path,
+            provider_cache_root=provider_cache_root,
         )
         _record_stage(
             manifest,
@@ -1045,6 +1081,7 @@ def render_musical_reply(
             model_path=provider_paths.roformer_model,
             config_path=provider_paths.roformer_config,
             environment=provider_paths.environment,
+            ffmpeg_path=ffmpeg_path,
         )
         partial_vocals.replace(vocals)
         _record_stage(
@@ -1074,6 +1111,9 @@ def render_musical_reply(
             partial_video,
             latentsync_python_path=provider_paths.latentsync_python,
             latentsync_root=provider_paths.latentsync_root,
+            ffmpeg_path=ffmpeg_path,
+            provider_cache_root=provider_cache_root,
+            environment=provider_paths.environment,
         )
         partial_video.replace(song_video_path)
         _record_stage(
@@ -1089,6 +1129,7 @@ def render_musical_reply(
         song_video_path,
         output_path,
         transition_video_path=transition_reference,
+        ffmpeg_path=ffmpeg_path,
     )
     _record_stage(
         manifest,

--- a/music_reply.py
+++ b/music_reply.py
@@ -9,7 +9,9 @@ import shutil
 import subprocess
 import tempfile
 import time
+from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType
 from typing import Mapping
 from urllib.error import HTTPError, URLError
 from urllib.parse import urljoin, urlsplit
@@ -39,8 +41,34 @@ class MusicReplyError(RuntimeError):
     """Stable product error raised when a song stage cannot complete."""
 
 
-def _configured_provider_path(name: str) -> Path | None:
-    return configured_media_path(os.environ, name)
+@dataclass(frozen=True)
+class MusicProviderPathSnapshot:
+    """Immutable provider paths resolved once for one musical render."""
+
+    environment: Mapping[str, str]
+    minimax_python: Path | None
+    minimax_root: Path | None
+    minimax_worker: Path | None
+    roformer_executable: Path | None
+    roformer_model: Path | None
+    roformer_config: Path | None
+    latentsync_python: Path | None
+    latentsync_root: Path | None
+
+
+def _music_provider_path_snapshot() -> MusicProviderPathSnapshot:
+    environment = MappingProxyType(dict(os.environ))
+    return MusicProviderPathSnapshot(
+        environment=environment,
+        minimax_python=configured_media_path(environment, "OLIVIA_MINIMAX_COMFY_PYTHON"),
+        minimax_root=configured_media_path(environment, "OLIVIA_MINIMAX_COMFY_ROOT"),
+        minimax_worker=configured_media_path(environment, "OLIVIA_MINIMAX_WORKER"),
+        roformer_executable=configured_media_path(environment, "OLIVIA_ROFORMER_EXE"),
+        roformer_model=configured_media_path(environment, "OLIVIA_ROFORMER_MODEL_PATH"),
+        roformer_config=configured_media_path(environment, "OLIVIA_ROFORMER_CONFIG_PATH"),
+        latentsync_python=configured_media_path(environment, "OLIVIA_LATENTSYNC_PYTHON"),
+        latentsync_root=configured_media_path(environment, "OLIVIA_LATENTSYNC_ROOT"),
+    )
 
 
 def normalize_music_duration(value: object) -> int:
@@ -420,10 +448,15 @@ def prepare_official_spoken_base(reference_path: Path, destination: Path) -> Pat
     return destination
 
 
-def separate_vocals(song_path: Path, vocals_path: Path) -> None:
-    executable = _configured_provider_path("OLIVIA_ROFORMER_EXE")
-    model_path = _configured_provider_path("OLIVIA_ROFORMER_MODEL_PATH")
-    config_path = _configured_provider_path("OLIVIA_ROFORMER_CONFIG_PATH")
+def separate_vocals(
+    song_path: Path,
+    vocals_path: Path,
+    *,
+    executable: Path | None,
+    model_path: Path | None,
+    config_path: Path | None,
+    environment: Mapping[str, str],
+) -> None:
     if any(
         value is None or not value.is_file()
         for value in (executable, model_path, config_path)
@@ -464,7 +497,7 @@ def separate_vocals(song_path: Path, vocals_path: Path) -> None:
             ],
             "ROFORMER_FAILED",
             env={
-                **os.environ,
+                **environment,
                 "PYTHONUTF8": "1",
                 "PYTHONIOENCODING": "utf-8",
             },
@@ -481,11 +514,12 @@ def render_full_face_performance(
     vocals_path: Path,
     full_song_path: Path,
     output_path: Path,
+    *,
+    latentsync_python_path: Path | None,
+    latentsync_root: Path | None,
 ) -> dict[str, object]:
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    latentsync_python = _configured_provider_path("OLIVIA_LATENTSYNC_PYTHON")
-    latentsync_root = _configured_provider_path("OLIVIA_LATENTSYNC_ROOT")
-    if latentsync_python is None or latentsync_root is None:
+    if latentsync_python_path is None or latentsync_root is None:
         raise MusicReplyError("LATENTSYNC_INPUT_UNAVAILABLE")
     with tempfile.TemporaryDirectory(prefix="olivia-music-face-", dir=output_path.parent) as temporary:
         raw_video = Path(temporary) / "latentsync-vocals.mp4"
@@ -494,7 +528,7 @@ def render_full_face_performance(
                 performance_video_path,
                 vocals_path,
                 raw_video,
-                python_path=latentsync_python,
+                python_path=latentsync_python_path,
                 latentsync_root=latentsync_root,
             )
         except LatentSyncReplyError as exc:
@@ -650,8 +684,8 @@ def concat_videos(
         result.replace(output_path)
 
 
-def _official_transition_reference() -> Path:
-    reference = select_speaking_scene(speaking_scene_candidates(os.environ))
+def _official_transition_reference(environment: Mapping[str, str]) -> Path:
+    reference = select_speaking_scene(speaking_scene_candidates(environment))
     if reference is None:
         raise MusicReplyError("MUSIC_REPLY_TRANSITION_UNAVAILABLE")
     if not reference.is_file():
@@ -688,11 +722,6 @@ def _file_fingerprint(path: Path | None) -> dict[str, object]:
         return {"status": "unavailable"}
 
 
-def _optional_path(value: str) -> Path | None:
-    value = str(value).strip()
-    return Path(value) if value else None
-
-
 def _build_music_stage_manifest(
     content: str,
     reply_text: str,
@@ -707,14 +736,11 @@ def _build_music_stage_manifest(
     worker_path: Path,
     minimax_worker_path: Path,
     minimax_root: Path,
+    provider_paths: MusicProviderPathSnapshot,
     voice_performance_plan: VoicePerformancePlan | None,
 ) -> dict[str, object]:
     """Bind resumable stages to canonical text, inputs, and provider revisions."""
 
-    latentsync_root = _configured_provider_path("OLIVIA_LATENTSYNC_ROOT")
-    roformer_executable = _configured_provider_path("OLIVIA_ROFORMER_EXE")
-    roformer_model = _configured_provider_path("OLIVIA_ROFORMER_MODEL_PATH")
-    roformer_config = _configured_provider_path("OLIVIA_ROFORMER_CONFIG_PATH")
     return {
         "schema_version": _MUSIC_STAGE_MANIFEST_VERSION,
         "inputs": {
@@ -749,7 +775,7 @@ def _build_music_stage_manifest(
             "music": {
                 "name": "MiniMax-Music-3",
                 "python": _file_fingerprint(
-                    _configured_provider_path("OLIVIA_MINIMAX_COMFY_PYTHON")
+                    provider_paths.minimax_python
                 ),
                 "worker": _file_fingerprint(minimax_worker_path),
                 "entry": _file_fingerprint(minimax_root / "main.py"),
@@ -779,28 +805,28 @@ def _build_music_stage_manifest(
             },
             "vocal_separator": {
                 "name": "MelBand-RoFormer",
-                "executable": _file_fingerprint(roformer_executable),
-                "model": _file_fingerprint(roformer_model),
-                "config": _file_fingerprint(roformer_config),
+                "executable": _file_fingerprint(provider_paths.roformer_executable),
+                "model": _file_fingerprint(provider_paths.roformer_model),
+                "config": _file_fingerprint(provider_paths.roformer_config),
             },
             "face_sync": {
                 "name": "LatentSync-1.5",
                 "python": _file_fingerprint(
-                    _configured_provider_path("OLIVIA_LATENTSYNC_PYTHON")
+                    provider_paths.latentsync_python
                 ),
                 "inference": _file_fingerprint(
-                    latentsync_root / "scripts" / "inference.py"
-                    if latentsync_root is not None
+                    provider_paths.latentsync_root / "scripts" / "inference.py"
+                    if provider_paths.latentsync_root is not None
                     else None
                 ),
                 "config": _file_fingerprint(
-                    latentsync_root / "configs" / "unet" / "stage2_efficient.yaml"
-                    if latentsync_root is not None
+                    provider_paths.latentsync_root / "configs" / "unet" / "stage2_efficient.yaml"
+                    if provider_paths.latentsync_root is not None
                     else None
                 ),
                 "checkpoint": _file_fingerprint(
-                    latentsync_root / "checkpoints" / "latentsync_unet.pt"
-                    if latentsync_root is not None
+                    provider_paths.latentsync_root / "checkpoints" / "latentsync_unet.pt"
+                    if provider_paths.latentsync_root is not None
                     else None
                 ),
             },
@@ -895,14 +921,15 @@ def render_musical_reply(
     """Render the ordinary reply, append an original-view song performance."""
 
     duration_seconds = normalize_music_duration(duration_seconds)
-    transition_reference = _official_transition_reference()
-    minimax_python = _configured_provider_path("OLIVIA_MINIMAX_COMFY_PYTHON")
-    minimax_root = _configured_provider_path("OLIVIA_MINIMAX_COMFY_ROOT")
-    minimax_worker = _configured_provider_path("OLIVIA_MINIMAX_WORKER")
+    provider_paths = _music_provider_path_snapshot()
+    transition_reference = _official_transition_reference(provider_paths.environment)
+    minimax_python = provider_paths.minimax_python
+    minimax_root = provider_paths.minimax_root
+    minimax_worker = provider_paths.minimax_worker
     if any(path is None for path in (minimax_python, minimax_root, minimax_worker)):
         raise MusicReplyError("MINIMAX_MUSIC3_UNAVAILABLE")
-    latentsync_python = _configured_provider_path("OLIVIA_LATENTSYNC_PYTHON")
-    latentsync_root = _configured_provider_path("OLIVIA_LATENTSYNC_ROOT")
+    latentsync_python = provider_paths.latentsync_python
+    latentsync_root = provider_paths.latentsync_root
     if latentsync_python is None or latentsync_root is None:
         raise MusicReplyError("LATENTSYNC_INPUT_UNAVAILABLE")
     try:
@@ -927,6 +954,7 @@ def render_musical_reply(
         worker_path=worker_path,
         minimax_worker_path=minimax_worker,
         minimax_root=minimax_root,
+        provider_paths=provider_paths,
         voice_performance_plan=voice_performance_plan,
     )
     try:
@@ -965,6 +993,7 @@ def render_musical_reply(
             latentsync_root=latentsync_root,
             adaptive_delivery=True,
             voice_performance_plan=voice_performance_plan,
+            environment=provider_paths.environment,
         )
         _record_stage(
             manifest,
@@ -1009,7 +1038,14 @@ def render_musical_reply(
     ):
         partial_vocals = stage_root / "vocals.partial.wav"
         partial_vocals.unlink(missing_ok=True)
-        separate_vocals(song_audio, partial_vocals)
+        separate_vocals(
+            song_audio,
+            partial_vocals,
+            executable=provider_paths.roformer_executable,
+            model_path=provider_paths.roformer_model,
+            config_path=provider_paths.roformer_config,
+            environment=provider_paths.environment,
+        )
         partial_vocals.replace(vocals)
         _record_stage(
             manifest,
@@ -1036,6 +1072,8 @@ def render_musical_reply(
             vocals,
             song_audio,
             partial_video,
+            latentsync_python_path=provider_paths.latentsync_python,
+            latentsync_root=provider_paths.latentsync_root,
         )
         partial_video.replace(song_video_path)
         _record_stage(

--- a/music_reply.py
+++ b/music_reply.py
@@ -20,6 +20,7 @@ from latentsync_reply import (
     render_latentsync_video,
     resolve_ffmpeg_executable,
 )
+from media_paths import configured_media_path
 from music_duration import MUSIC_DURATION_OPTIONS, normalize_music_duration as _normalize_music_duration
 from reply_media import (
     ReplyMediaError,
@@ -54,7 +55,9 @@ def speaking_scene_candidates(env: Mapping[str, str]) -> tuple[Path, ...]:
     values = raw.split(os.pathsep) if raw else [str(env.get("OLIVIA_OFFICIAL_REPLY_REFERENCE", ""))]
     result: list[Path] = []
     for value in values:
-        candidate = Path(value.strip()).expanduser() if value.strip() else None
+        candidate_env = dict(env)
+        candidate_env["_OLIVIA_SCENE_CANDIDATE"] = value
+        candidate = configured_media_path(candidate_env, "_OLIVIA_SCENE_CANDIDATE")
         if candidate is not None and candidate not in result:
             result.append(candidate)
     return tuple(result)
@@ -76,35 +79,50 @@ def musical_reply_configured(
 ) -> bool:
     """Return whether the renderer's complete musical delivery closure exists."""
 
-    def configured_path(name: str) -> Path:
-        return Path(str(env.get(name, ""))).expanduser()
+    def configured_path(name: str) -> Path | None:
+        return configured_media_path(env, name)
 
     minimax_root = configured_path("OLIVIA_MINIMAX_COMFY_ROOT")
     latentsync_root = configured_path("OLIVIA_LATENTSYNC_ROOT")
     speaking_scene = select_speaking_scene(speaking_scene_candidates(env))
+    delivery_paths = (
+        configured_path("OLIVIA_TTS_CONFIG"),
+        configured_path("OLIVIA_VISUAL_CONFIG"),
+        configured_path("OLIVIA_LIVETALKING_WORKER"),
+        configured_path("OLIVIA_LOCAL_DATA_ROOT"),
+    )
+    if minimax_root is None or latentsync_root is None or any(
+        path is None for path in delivery_paths
+    ):
+        return False
     try:
         assemble_complete_video_delivery(
-            configured_path("OLIVIA_TTS_CONFIG"),
-            configured_path("OLIVIA_VISUAL_CONFIG"),
-            configured_path("OLIVIA_LIVETALKING_WORKER"),
-            configured_path("OLIVIA_LOCAL_DATA_ROOT"),
+            delivery_paths[0],
+            delivery_paths[1],
+            delivery_paths[2],
+            delivery_paths[3],
             env,
         )
     except ReplyMediaError:
         return False
-    required = (
-        speaking_scene or Path(""),
+    configured_files = (
         configured_path("OLIVIA_ROFORMER_EXE"),
         configured_path("OLIVIA_ROFORMER_MODEL_PATH"),
         configured_path("OLIVIA_ROFORMER_CONFIG_PATH"),
         configured_path("OLIVIA_MINIMAX_COMFY_PYTHON"),
         configured_path("OLIVIA_MINIMAX_WORKER"),
+        configured_path("OLIVIA_LATENTSYNC_PYTHON"),
+    )
+    if speaking_scene is None or any(path is None for path in configured_files):
+        return False
+    required = (
+        speaking_scene,
+        *configured_files[:6],
         minimax_root / "main.py",
         minimax_root / "comfy_extras" / "nodes_minimax_music.py",
         minimax_root / "models" / "diffusion_models" / "minimax_music3_dit_int8_convrot.safetensors",
         minimax_root / "models" / "text_encoders" / "minimax_music3_text_encoder_pruned_int8_convrot.safetensors",
         minimax_root / "models" / "vae" / "minimax_music3_dav.safetensors",
-        configured_path("OLIVIA_LATENTSYNC_PYTHON"),
         latentsync_root / "scripts" / "inference.py",
         latentsync_root / "configs" / "unet" / "stage2_efficient.yaml",
         latentsync_root / "checkpoints" / "latentsync_unet.pt",

--- a/music_reply.py
+++ b/music_reply.py
@@ -901,6 +901,10 @@ def render_musical_reply(
     minimax_worker = _configured_provider_path("OLIVIA_MINIMAX_WORKER")
     if any(path is None for path in (minimax_python, minimax_root, minimax_worker)):
         raise MusicReplyError("MINIMAX_MUSIC3_UNAVAILABLE")
+    latentsync_python = _configured_provider_path("OLIVIA_LATENTSYNC_PYTHON")
+    latentsync_root = _configured_provider_path("OLIVIA_LATENTSYNC_ROOT")
+    if latentsync_python is None or latentsync_root is None:
+        raise MusicReplyError("LATENTSYNC_INPUT_UNAVAILABLE")
     try:
         song_plan = plan_song_content(content, reply_text, duration_seconds)
     except Exception as exc:
@@ -957,10 +961,8 @@ def render_musical_reply(
             visual_config_path=visual_config_path,
             worker_path=worker_path,
             scene_path=spoken_base,
-            latentsync_python_path=_configured_provider_path(
-                "OLIVIA_LATENTSYNC_PYTHON"
-            ),
-            latentsync_root=_configured_provider_path("OLIVIA_LATENTSYNC_ROOT"),
+            latentsync_python_path=latentsync_python,
+            latentsync_root=latentsync_root,
             adaptive_delivery=True,
             voice_performance_plan=voice_performance_plan,
         )

--- a/music_reply.py
+++ b/music_reply.py
@@ -39,6 +39,10 @@ class MusicReplyError(RuntimeError):
     """Stable product error raised when a song stage cannot complete."""
 
 
+def _configured_provider_path(name: str) -> Path | None:
+    return configured_media_path(os.environ, name)
+
+
 def normalize_music_duration(value: object) -> int:
     """Return one of the two product durations; intermediate values are invalid."""
 
@@ -417,11 +421,11 @@ def prepare_official_spoken_base(reference_path: Path, destination: Path) -> Pat
 
 
 def separate_vocals(song_path: Path, vocals_path: Path) -> None:
-    executable = os.environ.get("OLIVIA_ROFORMER_EXE", "").strip()
-    model_path = os.environ.get("OLIVIA_ROFORMER_MODEL_PATH", "").strip()
-    config_path = os.environ.get("OLIVIA_ROFORMER_CONFIG_PATH", "").strip()
+    executable = _configured_provider_path("OLIVIA_ROFORMER_EXE")
+    model_path = _configured_provider_path("OLIVIA_ROFORMER_MODEL_PATH")
+    config_path = _configured_provider_path("OLIVIA_ROFORMER_CONFIG_PATH")
     if any(
-        not value or not Path(value).is_file()
+        value is None or not value.is_file()
         for value in (executable, model_path, config_path)
     ):
         raise MusicReplyError("ROFORMER_UNAVAILABLE")
@@ -448,15 +452,15 @@ def separate_vocals(song_path: Path, vocals_path: Path) -> None:
         )
         _run(
             [
-                executable,
+                str(executable),
                 "--input_folder",
                 str(inputs),
                 "--store_dir",
                 str(outputs),
                 "--model_path",
-                model_path,
+                str(model_path),
                 "--config_path",
-                config_path,
+                str(config_path),
             ],
             "ROFORMER_FAILED",
             env={
@@ -479,6 +483,10 @@ def render_full_face_performance(
     output_path: Path,
 ) -> dict[str, object]:
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    latentsync_python = _configured_provider_path("OLIVIA_LATENTSYNC_PYTHON")
+    latentsync_root = _configured_provider_path("OLIVIA_LATENTSYNC_ROOT")
+    if latentsync_python is None or latentsync_root is None:
+        raise MusicReplyError("LATENTSYNC_INPUT_UNAVAILABLE")
     with tempfile.TemporaryDirectory(prefix="olivia-music-face-", dir=output_path.parent) as temporary:
         raw_video = Path(temporary) / "latentsync-vocals.mp4"
         try:
@@ -486,8 +494,8 @@ def render_full_face_performance(
                 performance_video_path,
                 vocals_path,
                 raw_video,
-                python_path=Path(os.environ.get("OLIVIA_LATENTSYNC_PYTHON", "")),
-                latentsync_root=Path(os.environ.get("OLIVIA_LATENTSYNC_ROOT", "")),
+                python_path=latentsync_python,
+                latentsync_root=latentsync_root,
             )
         except LatentSyncReplyError as exc:
             raise MusicReplyError(str(exc)) from exc
@@ -703,10 +711,10 @@ def _build_music_stage_manifest(
 ) -> dict[str, object]:
     """Bind resumable stages to canonical text, inputs, and provider revisions."""
 
-    latentsync_root = _optional_path(os.environ.get("OLIVIA_LATENTSYNC_ROOT", ""))
-    roformer_executable = _optional_path(os.environ.get("OLIVIA_ROFORMER_EXE", ""))
-    roformer_model = _optional_path(os.environ.get("OLIVIA_ROFORMER_MODEL_PATH", ""))
-    roformer_config = _optional_path(os.environ.get("OLIVIA_ROFORMER_CONFIG_PATH", ""))
+    latentsync_root = _configured_provider_path("OLIVIA_LATENTSYNC_ROOT")
+    roformer_executable = _configured_provider_path("OLIVIA_ROFORMER_EXE")
+    roformer_model = _configured_provider_path("OLIVIA_ROFORMER_MODEL_PATH")
+    roformer_config = _configured_provider_path("OLIVIA_ROFORMER_CONFIG_PATH")
     return {
         "schema_version": _MUSIC_STAGE_MANIFEST_VERSION,
         "inputs": {
@@ -741,7 +749,7 @@ def _build_music_stage_manifest(
             "music": {
                 "name": "MiniMax-Music-3",
                 "python": _file_fingerprint(
-                    _optional_path(os.environ.get("OLIVIA_MINIMAX_COMFY_PYTHON", ""))
+                    _configured_provider_path("OLIVIA_MINIMAX_COMFY_PYTHON")
                 ),
                 "worker": _file_fingerprint(minimax_worker_path),
                 "entry": _file_fingerprint(minimax_root / "main.py"),
@@ -778,7 +786,7 @@ def _build_music_stage_manifest(
             "face_sync": {
                 "name": "LatentSync-1.5",
                 "python": _file_fingerprint(
-                    _optional_path(os.environ.get("OLIVIA_LATENTSYNC_PYTHON", ""))
+                    _configured_provider_path("OLIVIA_LATENTSYNC_PYTHON")
                 ),
                 "inference": _file_fingerprint(
                     latentsync_root / "scripts" / "inference.py"
@@ -888,11 +896,10 @@ def render_musical_reply(
 
     duration_seconds = normalize_music_duration(duration_seconds)
     transition_reference = _official_transition_reference()
-    minimax_python = os.environ.get("OLIVIA_MINIMAX_COMFY_PYTHON", "").strip()
-    minimax_root = os.environ.get("OLIVIA_MINIMAX_COMFY_ROOT", "").strip()
-    minimax_worker = os.environ.get("OLIVIA_MINIMAX_WORKER", "").strip()
-    use_minimax = bool(minimax_python and minimax_root and minimax_worker)
-    if not use_minimax:
+    minimax_python = _configured_provider_path("OLIVIA_MINIMAX_COMFY_PYTHON")
+    minimax_root = _configured_provider_path("OLIVIA_MINIMAX_COMFY_ROOT")
+    minimax_worker = _configured_provider_path("OLIVIA_MINIMAX_WORKER")
+    if any(path is None for path in (minimax_python, minimax_root, minimax_worker)):
         raise MusicReplyError("MINIMAX_MUSIC3_UNAVAILABLE")
     try:
         song_plan = plan_song_content(content, reply_text, duration_seconds)
@@ -914,8 +921,8 @@ def render_musical_reply(
         tts_config_path=tts_config_path,
         visual_config_path=visual_config_path,
         worker_path=worker_path,
-        minimax_worker_path=Path(minimax_worker),
-        minimax_root=Path(minimax_root),
+        minimax_worker_path=minimax_worker,
+        minimax_root=minimax_root,
         voice_performance_plan=voice_performance_plan,
     )
     try:
@@ -950,8 +957,10 @@ def render_musical_reply(
             visual_config_path=visual_config_path,
             worker_path=worker_path,
             scene_path=spoken_base,
-            latentsync_python_path=Path(os.environ.get("OLIVIA_LATENTSYNC_PYTHON", "")),
-            latentsync_root=Path(os.environ.get("OLIVIA_LATENTSYNC_ROOT", "")),
+            latentsync_python_path=_configured_provider_path(
+                "OLIVIA_LATENTSYNC_PYTHON"
+            ),
+            latentsync_root=_configured_provider_path("OLIVIA_LATENTSYNC_ROOT"),
             adaptive_delivery=True,
             voice_performance_plan=voice_performance_plan,
         )
@@ -976,9 +985,9 @@ def render_musical_reply(
         partial_song = stage_root / "song.partial.flac"
         partial_song.unlink(missing_ok=True)
         song_metadata = MiniMaxMusic3Worker(
-            python_path=Path(minimax_python),
-            worker_path=Path(minimax_worker),
-            comfy_root=Path(minimax_root),
+            python_path=minimax_python,
+            worker_path=minimax_worker,
+            comfy_root=minimax_root,
         ).generate(
             content,
             reply_text,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ py-modules = [
     "local_memory",
     "local_server",
     "latentsync_reply",
+    "media_paths",
     "mem0_memory",
     "mem0_embedding_install",
     "memory_isolation_case01",

--- a/reply_media.py
+++ b/reply_media.py
@@ -269,6 +269,8 @@ def render_reply_video(
     voice_performance_plan: VoicePerformancePlan | None = None,
     enforce_content_gate: bool = False,
     environment: Mapping[str, str] | None = None,
+    ffmpeg_path: Path | None = None,
+    provider_cache_root: Path | None = None,
 ) -> dict[str, object]:
     if scene_path is not None and (
         latentsync_python_path is None
@@ -346,8 +348,11 @@ def render_reply_video(
                     scene_path,
                     audio_path,
                     output_path,
-                    python_path=latentsync_python_path,
-                    latentsync_root=latentsync_root,
+                python_path=latentsync_python_path,
+                latentsync_root=latentsync_root,
+                environment=environment,
+                ffmpeg_path=ffmpeg_path,
+                provider_cache_root=provider_cache_root,
                 )
             except LatentSyncReplyError as exc:
                 raise ReplyMediaError(str(exc)) from exc

--- a/reply_media.py
+++ b/reply_media.py
@@ -247,6 +247,13 @@ def render_reply_video(
     voice_performance_plan: VoicePerformancePlan | None = None,
     enforce_content_gate: bool = False,
 ) -> dict[str, object]:
+    if scene_path is not None and (
+        latentsync_python_path is None
+        or latentsync_root is None
+        or not latentsync_python_path.is_absolute()
+        or not latentsync_root.is_absolute()
+    ):
+        raise ReplyMediaError("LATENTSYNC_INPUT_UNAVAILABLE")
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="olivia-reply-", dir=output_path.parent) as temporary:
         root = Path(temporary)
@@ -315,10 +322,8 @@ def render_reply_video(
                     scene_path,
                     audio_path,
                     output_path,
-                    python_path=latentsync_python_path
-                    or Path(os.environ.get("OLIVIA_LATENTSYNC_PYTHON", "")),
-                    latentsync_root=latentsync_root
-                    or Path(os.environ.get("OLIVIA_LATENTSYNC_ROOT", "")),
+                    python_path=latentsync_python_path,
+                    latentsync_root=latentsync_root,
                 )
             except LatentSyncReplyError as exc:
                 raise ReplyMediaError(str(exc)) from exc

--- a/reply_media.py
+++ b/reply_media.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Mapping
 
 from latentsync_reply import LatentSyncReplyError, media_runtime_available, render_latentsync_video, resolve_ffmpeg_executable
+from media_paths import resolve_media_path
 from reply_delivery import ReplyDeliveryPlan, plan_reply_delivery
 from voice_direction import VoicePerformancePlan
 try:
@@ -90,18 +91,37 @@ def _tts_config(
     env: Mapping[str, str] | None = None,
 ) -> TTSConfig:
     settings = _settings(path)
-    runtime_root = Path(str(settings.get("runtime_root", "")))
+    environment = os.environ if env is None else env
+
+    def configured_path(value: object) -> Path:
+        resolved = resolve_media_path(value, environment)
+        if resolved is None:
+            raise ReplyMediaError("TTS_CONFIG_PATH_UNAVAILABLE")
+        return resolved
+
+    runtime_root = configured_path(settings.get("runtime_root", ""))
+    model_dir = configured_path(settings.get("model_dir", ""))
+    reference_audio = configured_path(settings.get("reference_audio", ""))
     external_python = runtime_root / "venv" / "Scripts" / "python.exe"
+    settings.update(
+        {
+            "runtime_root": str(runtime_root),
+            "model_dir": str(model_dir),
+            "reference_audio": str(reference_audio),
+        }
+    )
     provider_options = settings.get("provider_options")
     if not isinstance(provider_options, dict):
         provider_options = {}
     else:
         provider_options = dict(provider_options)
+    for key in ("numba_cache_dir", "quality_gate_cache_root", "wetext_fst_root"):
+        if key in provider_options and str(provider_options[key]).strip():
+            provider_options[key] = str(configured_path(provider_options[key]))
     if ordinary_video:
-        environment = os.environ if env is None else env
         configured_reference = environment.get("OLIVIA_REPLY_VOICE_REFERENCE")
-        if configured_reference is not None:
-            official_reference = Path(configured_reference)
+        if configured_reference is not None and str(configured_reference).strip():
+            official_reference = configured_path(configured_reference)
             if not official_reference.is_file():
                 raise ReplyMediaError("VOICE_REFERENCE_UNAVAILABLE")
             settings["reference_audio"] = str(
@@ -112,9 +132,11 @@ def _tts_config(
         quality_cache_root = environment.get(
             "OLIVIA_TTS_QUALITY_GATE_CACHE_ROOT"
         )
-        if quality_cache_root is not None:
-            provider_options["quality_gate_cache_root"] = quality_cache_root
-    reference_audio = Path(str(settings.get("reference_audio", "")))
+        if quality_cache_root is not None and str(quality_cache_root).strip():
+            provider_options["quality_gate_cache_root"] = str(
+                configured_path(quality_cache_root)
+            )
+    reference_audio = Path(str(settings["reference_audio"]))
     leading_trim = settings.get("leading_trim_seconds")
     if leading_trim is None and reference_audio.is_file():
         try:
@@ -125,7 +147,7 @@ def _tts_config(
     provider_options.update(
         {
             "external_python": str(external_python),
-            "temp_root": str(temporary_root),
+            "temp_root": str(temporary_root.resolve(strict=False)),
         }
     )
     settings.update(
@@ -246,6 +268,7 @@ def render_reply_video(
     adaptive_delivery: bool = False,
     voice_performance_plan: VoicePerformancePlan | None = None,
     enforce_content_gate: bool = False,
+    environment: Mapping[str, str] | None = None,
 ) -> dict[str, object]:
     if scene_path is not None and (
         latentsync_python_path is None
@@ -262,6 +285,7 @@ def render_reply_video(
             visual_config_path,
             worker_path,
             root,
+            environment,
             require_quality_gate=enforce_content_gate,
         )
         audio_path = root / "reply.wav"

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -396,6 +396,19 @@ def test_complete_video_readiness_fails_closed_for_every_missing_renderer_depend
 
     assert routing_context_from_environment(env) == RoutingContext(True, True)
 
+    env["OLIVIA_PROJECT_ROOT"] = str(tmp_path)
+    for name, value in tuple(env.items()):
+        if not name.startswith("OLIVIA_") or name in {
+            "OLIVIA_FFMPEG_EXE",
+            "OLIVIA_PROJECT_ROOT",
+        }:
+            continue
+        try:
+            env[name] = Path(value).relative_to(tmp_path).as_posix()
+        except (TypeError, ValueError):
+            pass
+    assert routing_context_from_environment(env) == RoutingContext(True, True)
+
     quality_checkpoint.unlink()
     assert routing_context_from_environment(env) == RoutingContext(True, True)
     quality_checkpoint.write_bytes(b"synthetic")

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+import subprocess
 
 import pytest
 from aiohttp import web
@@ -189,18 +190,35 @@ def test_spoken_media_resolves_relative_renderer_paths_from_project_root(
     assert observed["latentsync_root"] == latentsync_root
 
 
-def test_relative_local_data_root_drives_state_and_media_from_project_root(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    "root_alias",
+    ("anchor/../data", "data-junction"),
+    ids=("dotdot", "directory-junction"),
+)
+def test_local_data_root_alias_drives_state_and_serves_rendered_media(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, root_alias: str
 ) -> None:
     project_root = tmp_path / "app"
     unrelated_cwd = tmp_path / "unrelated-cwd"
     unrelated_cwd.mkdir()
+    data_root = project_root / "data"
+    if root_alias == "data-junction":
+        data_root.mkdir(parents=True)
+        junction = project_root / root_alias
+        result = subprocess.run(
+            ["cmd", "/d", "/c", "mklink", "/J", str(junction), str(data_root)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            pytest.skip(f"directory junctions are unavailable: {result.stderr}")
     scene = project_root / "assets" / "scene.mp4"
     scene.parent.mkdir(parents=True)
     scene.write_bytes(b"scene")
     monkeypatch.chdir(unrelated_cwd)
     monkeypatch.setenv("OLIVIA_PROJECT_ROOT", str(project_root))
-    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", "data")
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", root_alias)
     for period in ("MORNING", "DAY", "DUSK", "NIGHT"):
         monkeypatch.setenv(f"OLIVIA_SCENE_{period}", "assets/scene.mp4")
 
@@ -237,7 +255,6 @@ def test_relative_local_data_root_drives_state_and_media_from_project_root(
         )
     )
 
-    data_root = project_root / "data"
     media_path = data_root / "media" / f"{letter['letter_id']}.mp4"
     assert media_path.read_bytes() == b"video"
     assert (data_root / "state.json").is_file()

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
 
 import local_server
 from letter_triage import TriageResult
@@ -186,6 +187,66 @@ def test_spoken_media_resolves_relative_renderer_paths_from_project_root(
     assert observed["worker_path"] == worker
     assert observed["latentsync_python_path"] == latentsync_python
     assert observed["latentsync_root"] == latentsync_root
+
+
+def test_relative_local_data_root_drives_state_and_media_from_project_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project_root = tmp_path / "app"
+    unrelated_cwd = tmp_path / "unrelated-cwd"
+    unrelated_cwd.mkdir()
+    scene = project_root / "assets" / "scene.mp4"
+    scene.parent.mkdir(parents=True)
+    scene.write_bytes(b"scene")
+    monkeypatch.chdir(unrelated_cwd)
+    monkeypatch.setenv("OLIVIA_PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", "data")
+    for period in ("MORNING", "DAY", "DUSK", "NIGHT"):
+        monkeypatch.setenv(f"OLIVIA_SCENE_{period}", "assets/scene.mp4")
+
+    letter = {
+        "letter_id": "relative-data-root",
+        "content": "letter",
+        "reply_text": "reply",
+        "reply_mode": ReplyMode.SPOKEN_VIDEO.value,
+        "letter_status": "COMPLETED",
+        "media_status": "PENDING",
+        "reply_not_before": 0.0,
+    }
+    local_server.store.letters[:] = [letter]
+
+    async def voice_plan(_letter, text):
+        return VoicePerformancePlan(
+            reply_text=text,
+            overall_emotion="steady",
+            global_speed=1.0,
+            energy=0.5,
+            breath_before_sentences=(),
+            emphasize_sentences=(),
+        )
+
+    def render(_reply, output, **_kwargs):
+        Path(output).write_bytes(b"video")
+
+    monkeypatch.setattr(local_server, "_voice_plan_for_letter", voice_plan)
+    monkeypatch.setattr(local_server, "render_reply_video", render)
+
+    asyncio.run(
+        local_server._render_media_job(
+            letter["letter_id"], letter["content"], letter["reply_text"], letter["reply_mode"]
+        )
+    )
+
+    data_root = project_root / "data"
+    media_path = data_root / "media" / f"{letter['letter_id']}.mp4"
+    assert media_path.read_bytes() == b"video"
+    assert (data_root / "state.json").is_file()
+    assert not (unrelated_cwd / "data").exists()
+    response = asyncio.run(
+        local_server.handler(make_mocked_request("GET", f"/toy/media/{media_path.name}"))
+    )
+    assert isinstance(response, web.FileResponse)
+    assert response._path == media_path
 
 
 @pytest.mark.parametrize(

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -125,6 +125,69 @@ def test_successful_media_retry_clears_the_previous_failure_code(
     assert observed["song_video_path"].name.endswith("-song-v2-60s.mp4")
 
 
+def test_spoken_media_resolves_relative_renderer_paths_from_project_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_root = tmp_path / "app"
+    scene = project_root / "assets" / "scene.mp4"
+    tts_config = project_root / "config" / "tts.json"
+    visual_config = project_root / "config" / "visual.json"
+    worker = project_root / "workers" / "visual.py"
+    latentsync_python = project_root / "providers" / "latentsync" / "python.exe"
+    latentsync_root = project_root / "providers" / "latentsync"
+    for path in (scene, tts_config, visual_config, worker, latentsync_python):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"synthetic")
+
+    data_root = tmp_path / "data"
+    letter = {"letter_id": "relative-media", "media_status": "PENDING"}
+    local_server.store.letters[:] = [letter]
+    monkeypatch.setenv("OLIVIA_PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(data_root))
+    monkeypatch.setenv("OLIVIA_TTS_CONFIG", "config/tts.json")
+    monkeypatch.setenv("OLIVIA_VISUAL_CONFIG", "config/visual.json")
+    monkeypatch.setenv("OLIVIA_LIVETALKING_WORKER", "workers/visual.py")
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_PYTHON", "providers/latentsync/python.exe")
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_ROOT", "providers/latentsync")
+    for period in ("MORNING", "DAY", "DUSK", "NIGHT"):
+        monkeypatch.setenv(f"OLIVIA_SCENE_{period}", "assets/scene.mp4")
+    monkeypatch.setattr(local_server, "_persist_media_state", lambda: None)
+
+    async def voice_plan(_letter, text):
+        return VoicePerformancePlan(
+            reply_text=text,
+            overall_emotion="steady",
+            global_speed=1.0,
+            energy=0.5,
+            breath_before_sentences=(),
+            emphasize_sentences=(),
+        )
+
+    observed: dict[str, Path] = {}
+
+    def render(_reply, output, **kwargs):
+        observed.update(kwargs)
+        Path(output).write_bytes(b"video")
+
+    monkeypatch.setattr(local_server, "_voice_plan_for_letter", voice_plan)
+    monkeypatch.setattr(local_server, "render_reply_video", render)
+
+    asyncio.run(
+        local_server._render_media_job(
+            "relative-media", "letter", "reply", ReplyMode.SPOKEN_VIDEO.value
+        )
+    )
+
+    assert letter["media_status"] == "COMPLETED"
+    assert observed["scene_path"] == scene
+    assert observed["tts_config_path"] == tts_config
+    assert observed["visual_config_path"] == visual_config
+    assert observed["worker_path"] == worker
+    assert observed["latentsync_python_path"] == latentsync_python
+    assert observed["latentsync_root"] == latentsync_root
+
+
 @pytest.mark.parametrize(
     ("error_code", "expected_status", "expected_retryable"),
     [

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -190,6 +190,75 @@ def test_spoken_media_resolves_relative_renderer_paths_from_project_root(
     assert observed["latentsync_root"] == latentsync_root
 
 
+def test_spoken_media_keeps_its_entry_environment_across_voice_plan_await(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_root = tmp_path / "app"
+    scene = project_root / "assets" / "scene.mp4"
+    tts_config = project_root / "config" / "tts.json"
+    visual_config = project_root / "config" / "visual.json"
+    worker = project_root / "workers" / "visual.py"
+    latentsync_python = project_root / "providers" / "latentsync" / "python.exe"
+    latentsync_root = project_root / "providers" / "latentsync"
+    for path in (scene, tts_config, visual_config, worker, latentsync_python):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"synthetic")
+
+    environment = {
+        "OLIVIA_PROJECT_ROOT": str(project_root),
+        "OLIVIA_TTS_CONFIG": "config/tts.json",
+        "OLIVIA_VISUAL_CONFIG": "config/visual.json",
+        "OLIVIA_LIVETALKING_WORKER": "workers/visual.py",
+        "OLIVIA_LATENTSYNC_PYTHON": "providers/latentsync/python.exe",
+        "OLIVIA_LATENTSYNC_ROOT": "providers/latentsync",
+    }
+    for period in ("MORNING", "DAY", "DUSK", "NIGHT"):
+        environment[f"OLIVIA_SCENE_{period}"] = "assets/scene.mp4"
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path / "data"))
+    letter = {"letter_id": "immutable-spoken-media", "media_status": "PENDING"}
+    local_server.store.letters[:] = [letter]
+    monkeypatch.setattr(local_server, "_persist_media_state", lambda: None)
+
+    async def voice_plan(_letter, text):
+        for name in environment:
+            monkeypatch.delenv(name, raising=False)
+        return VoicePerformancePlan(
+            reply_text=text,
+            overall_emotion="steady",
+            global_speed=1.0,
+            energy=0.5,
+            breath_before_sentences=(),
+            emphasize_sentences=(),
+        )
+
+    observed: dict[str, object] = {}
+
+    def render(_reply, output, **kwargs):
+        observed.update(kwargs)
+        Path(output).write_bytes(b"video")
+
+    monkeypatch.setattr(local_server, "_voice_plan_for_letter", voice_plan)
+    monkeypatch.setattr(local_server, "render_reply_video", render)
+
+    asyncio.run(
+        local_server._render_media_job(
+            "immutable-spoken-media", "letter", "reply", ReplyMode.SPOKEN_VIDEO.value
+        )
+    )
+
+    assert letter["media_status"] == "COMPLETED"
+    assert observed["tts_config_path"] == tts_config
+    assert observed["visual_config_path"] == visual_config
+    assert observed["worker_path"] == worker
+    assert observed["scene_path"] == scene
+    assert observed["latentsync_python_path"] == latentsync_python
+    assert observed["latentsync_root"] == latentsync_root
+    assert observed["environment"]["OLIVIA_PROJECT_ROOT"] == str(project_root)
+
+
 @pytest.mark.parametrize(
     "root_alias",
     ("anchor/../data", "data-junction"),

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -68,7 +68,7 @@ def test_prepare_official_spoken_base_uses_only_first_35_seconds(
     destination = tmp_path / "stages" / "official-spoken-000-035s.mp4"
     observed: list[tuple[list[str], str]] = []
 
-    monkeypatch.setattr(music_reply, "_ffmpeg", lambda: "ffmpeg")
+    monkeypatch.setattr(music_reply, "_ffmpeg", lambda *_args: "ffmpeg")
 
     def fake_run(command, error_code, *, timeout=900.0):
         del timeout
@@ -100,7 +100,7 @@ def test_concat_videos_inserts_silent_transition_between_spoken_and_performance(
     frames = {normal: 100, song: 200}
     commands: list[tuple[list[str], str]] = []
 
-    monkeypatch.setattr(music_reply, "_ffmpeg", lambda: "ffmpeg")
+    monkeypatch.setattr(music_reply, "_ffmpeg", lambda *_args: "ffmpeg")
     monkeypatch.setattr(
         music_reply,
         "_target_frame_count",
@@ -160,7 +160,7 @@ def test_concat_videos_without_transition_preserves_two_segment_order(
     frames = {normal: 125, song: 250}
     commands: list[list[str]] = []
 
-    monkeypatch.setattr(music_reply, "_ffmpeg", lambda: "ffmpeg")
+    monkeypatch.setattr(music_reply, "_ffmpeg", lambda *_args: "ffmpeg")
     monkeypatch.setattr(
         music_reply,
         "_target_frame_count",
@@ -211,6 +211,8 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
     observed: dict[str, object] = {}
 
     monkeypatch.setenv("OLIVIA_PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setenv("OLIVIA_FFMPEG_EXE", str(_write(tmp_path / "ffmpeg.exe")))
+    monkeypatch.setenv("OLIVIA_PROVIDER_CACHE_ROOT", str(tmp_path / "provider-cache"))
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", "synthetic-python")
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", "synthetic-root")
     monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", "synthetic-worker")
@@ -265,7 +267,7 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
     monkeypatch.setattr(
         music_reply,
         "prepare_official_spoken_base",
-        lambda reference, destination: (
+        lambda reference, destination, **_kwargs: (
             observed.setdefault(
                 "spoken_reference", (Path(reference), Path(destination))
             )
@@ -312,7 +314,10 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
         normal,
         song_video,
         output,
-        {"transition_video_path": transition},
+        {
+            "transition_video_path": transition,
+            "ffmpeg_path": tmp_path / "ffmpeg.exe",
+        },
     )
     assert output.read_bytes() == b"final"
     assert result["reply_structure"] == (
@@ -380,6 +385,8 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     calls = {"spoken": 0, "minimax": 0, "separate": 0}
 
     monkeypatch.setenv("OLIVIA_PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setenv("OLIVIA_FFMPEG_EXE", str(_write(tmp_path / "ffmpeg.exe")))
+    monkeypatch.setenv("OLIVIA_PROVIDER_CACHE_ROOT", str(tmp_path / "provider-cache"))
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", "synthetic-python")
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", "synthetic-root")
     monkeypatch.setenv(
@@ -442,7 +449,7 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     monkeypatch.setattr(
         music_reply,
         "prepare_official_spoken_base",
-        lambda _reference, destination: _write(Path(destination), b"official-spoken"),
+        lambda _reference, destination, **_kwargs: _write(Path(destination), b"official-spoken"),
     )
     kwargs = {
         "normal_video_path": normal,
@@ -491,6 +498,8 @@ def test_render_musical_reply_rebuilds_downstream_stages_when_song_audio_is_rebu
     calls = {"minimax": 0, "separate": 0, "performance": 0}
 
     monkeypatch.setenv("OLIVIA_PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setenv("OLIVIA_FFMPEG_EXE", str(_write(tmp_path / "ffmpeg.exe")))
+    monkeypatch.setenv("OLIVIA_PROVIDER_CACHE_ROOT", str(tmp_path / "provider-cache"))
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", "synthetic-python")
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", "synthetic-root")
     monkeypatch.setenv(
@@ -511,7 +520,7 @@ def test_render_musical_reply_rebuilds_downstream_stages_when_song_audio_is_rebu
     monkeypatch.setattr(
         music_reply,
         "prepare_official_spoken_base",
-        lambda _reference, destination: _write(Path(destination), b"official-spoken"),
+        lambda _reference, destination, **_kwargs: _write(Path(destination), b"official-spoken"),
     )
     monkeypatch.setattr(
         music_reply,
@@ -603,6 +612,8 @@ def test_render_musical_reply_invalidates_cache_when_configured_provider_assets_
     calls = {"minimax": 0, "separate": 0, "performance": 0}
 
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", str(minimax_python))
+    monkeypatch.setenv("OLIVIA_FFMPEG_EXE", str(_write(tmp_path / "ffmpeg.exe")))
+    monkeypatch.setenv("OLIVIA_PROVIDER_CACHE_ROOT", str(tmp_path / "provider-cache"))
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", str(minimax_root))
     monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", str(minimax_worker))
     monkeypatch.setenv("OLIVIA_LATENTSYNC_PYTHON", str(tmp_path / "latentsync-python.exe"))
@@ -620,7 +631,7 @@ def test_render_musical_reply_invalidates_cache_when_configured_provider_assets_
     monkeypatch.setattr(
         music_reply,
         "prepare_official_spoken_base",
-        lambda _reference, destination: _write(Path(destination), b"official-spoken"),
+        lambda _reference, destination, **_kwargs: _write(Path(destination), b"official-spoken"),
     )
     monkeypatch.setattr(
         music_reply,

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -214,6 +214,8 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", "synthetic-python")
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", "synthetic-root")
     monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", "synthetic-worker")
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_PYTHON", "synthetic-python")
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_ROOT", "synthetic-root")
 
     def fake_plan(content, reply_text, duration_seconds):
         order.append("plan")
@@ -381,6 +383,8 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     monkeypatch.setenv(
         "OLIVIA_MINIMAX_WORKER", minimax_worker.relative_to(tmp_path).as_posix()
     )
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_PYTHON", "synthetic-python")
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_ROOT", "synthetic-root")
     monkeypatch.setattr(
         music_reply,
         "plan_song_content",
@@ -490,6 +494,8 @@ def test_render_musical_reply_rebuilds_downstream_stages_when_song_audio_is_rebu
     monkeypatch.setenv(
         "OLIVIA_MINIMAX_WORKER", minimax_worker.relative_to(tmp_path).as_posix()
     )
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_PYTHON", "synthetic-python")
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_ROOT", "synthetic-root")
     monkeypatch.setattr(
         music_reply,
         "plan_song_content",
@@ -597,6 +603,7 @@ def test_render_musical_reply_invalidates_cache_when_configured_provider_assets_
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", str(minimax_python))
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", str(minimax_root))
     monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", str(minimax_worker))
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_PYTHON", str(tmp_path / "latentsync-python.exe"))
     monkeypatch.setenv("OLIVIA_LATENTSYNC_ROOT", str(latentsync_root))
     monkeypatch.setattr(
         music_reply,

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -235,12 +235,12 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
         _write(Path(destination), b"song")
         return {"music_stage": "completed"}
 
-    def fake_separate(source, destination):
+    def fake_separate(source, destination, **_kwargs):
         order.append("separate")
         observed["separate"] = (Path(source), Path(destination))
         _write(Path(destination), b"vocals")
 
-    def fake_face(base, vocals, full_song, destination):
+    def fake_face(base, vocals, full_song, destination, **_kwargs):
         order.append("performance")
         observed["performance"] = (
             Path(base),
@@ -276,7 +276,9 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
     monkeypatch.setattr(music_reply.MiniMaxMusic3Worker, "generate", fake_generate)
     monkeypatch.setattr(music_reply, "separate_vocals", fake_separate)
     monkeypatch.setattr(music_reply, "render_full_face_performance", fake_face)
-    monkeypatch.setattr(music_reply, "_official_transition_reference", lambda: transition)
+    monkeypatch.setattr(
+        music_reply, "_official_transition_reference", lambda _environment: transition
+    )
     monkeypatch.setattr(music_reply, "concat_videos", fake_concat)
 
     result = music_reply.render_musical_reply(
@@ -407,7 +409,7 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
         _write(Path(destination), b"expensive-song")
         return {"music_stage": "completed"}
 
-    def flaky_separate(_source, destination):
+    def flaky_separate(_source, destination, **_kwargs):
         calls["separate"] += 1
         if calls["separate"] == 1:
             raise music_reply.MusicReplyError("ROFORMER_FAILED")
@@ -419,14 +421,14 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     monkeypatch.setattr(
         music_reply,
         "render_full_face_performance",
-        lambda _base, _vocals, _song, destination: (
+            lambda _base, _vocals, _song, destination, **_kwargs: (
             _write(Path(destination), b"performance")
             and {"performance_stage": "completed"}
         ),
     )
     transition = _write(tmp_path / "official-transition.mp4")
     monkeypatch.setattr(
-        music_reply, "_official_transition_reference", lambda: transition
+        music_reply, "_official_transition_reference", lambda _environment: transition
     )
     monkeypatch.setattr(
         music_reply,
@@ -525,11 +527,11 @@ def test_render_musical_reply_rebuilds_downstream_stages_when_song_audio_is_rebu
         _write(Path(destination), f"song-{calls['minimax']}".encode())
         return {"music_stage": "completed"}
 
-    def fake_separate(_source, destination):
+    def fake_separate(_source, destination, **_kwargs):
         calls["separate"] += 1
         _write(Path(destination), f"vocals-{calls['separate']}".encode())
 
-    def fake_face(_base, _vocals, _song, destination):
+    def fake_face(_base, _vocals, _song, destination, **_kwargs):
         calls["performance"] += 1
         _write(Path(destination), f"performance-{calls['performance']}".encode())
         return {"performance_stage": "completed"}
@@ -539,7 +541,7 @@ def test_render_musical_reply_rebuilds_downstream_stages_when_song_audio_is_rebu
     monkeypatch.setattr(music_reply, "render_full_face_performance", fake_face)
     transition = _write(tmp_path / "official-transition.mp4")
     monkeypatch.setattr(
-        music_reply, "_official_transition_reference", lambda: transition
+        music_reply, "_official_transition_reference", lambda _environment: transition
     )
     monkeypatch.setattr(
         music_reply,
@@ -634,11 +636,11 @@ def test_render_musical_reply_invalidates_cache_when_configured_provider_assets_
         _write(Path(destination), f"song-{calls['minimax']}".encode())
         return {"music_stage": "completed"}
 
-    def fake_separate(_source, destination):
+    def fake_separate(_source, destination, **_kwargs):
         calls["separate"] += 1
         _write(Path(destination), f"vocals-{calls['separate']}".encode())
 
-    def fake_face(_base, _vocals, _song, destination):
+    def fake_face(_base, _vocals, _song, destination, **_kwargs):
         calls["performance"] += 1
         _write(Path(destination), f"performance-{calls['performance']}".encode())
         return {"performance_stage": "completed"}
@@ -648,7 +650,7 @@ def test_render_musical_reply_invalidates_cache_when_configured_provider_assets_
     monkeypatch.setattr(music_reply, "render_full_face_performance", fake_face)
     transition = _write(tmp_path / "official-transition.mp4")
     monkeypatch.setattr(
-        music_reply, "_official_transition_reference", lambda: transition
+        music_reply, "_official_transition_reference", lambda _environment: transition
     )
     monkeypatch.setattr(
         music_reply,

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -210,6 +210,7 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
     order: list[str] = []
     observed: dict[str, object] = {}
 
+    monkeypatch.setenv("OLIVIA_PROJECT_ROOT", str(tmp_path))
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", "synthetic-python")
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", "synthetic-root")
     monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", "synthetic-worker")
@@ -374,9 +375,12 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     minimax_worker = _write(tmp_path / "minimax-worker.py", b"provider-v1")
     calls = {"spoken": 0, "minimax": 0, "separate": 0}
 
+    monkeypatch.setenv("OLIVIA_PROJECT_ROOT", str(tmp_path))
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", "synthetic-python")
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", "synthetic-root")
-    monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", str(minimax_worker))
+    monkeypatch.setenv(
+        "OLIVIA_MINIMAX_WORKER", minimax_worker.relative_to(tmp_path).as_posix()
+    )
     monkeypatch.setattr(
         music_reply,
         "plan_song_content",
@@ -480,9 +484,12 @@ def test_render_musical_reply_rebuilds_downstream_stages_when_song_audio_is_rebu
     minimax_worker = _write(tmp_path / "minimax-worker.py", b"provider-v1")
     calls = {"minimax": 0, "separate": 0, "performance": 0}
 
+    monkeypatch.setenv("OLIVIA_PROJECT_ROOT", str(tmp_path))
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", "synthetic-python")
     monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", "synthetic-root")
-    monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", str(minimax_worker))
+    monkeypatch.setenv(
+        "OLIVIA_MINIMAX_WORKER", minimax_worker.relative_to(tmp_path).as_posix()
+    )
     monkeypatch.setattr(
         music_reply,
         "plan_song_content",

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -534,3 +534,139 @@ def test_speaking_scene_candidates_are_stable_and_legacy_compatible(tmp_path: Pa
             ),
         }
     ) == (first, second)
+
+
+def test_musical_renderer_resolves_all_provider_paths_from_project_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project_root = tmp_path / "app"
+    unrelated_cwd = tmp_path / "unrelated-cwd"
+    unrelated_cwd.mkdir()
+    ffmpeg = tmp_path / "ffmpeg.exe"
+    ffmpeg.write_bytes(b"synthetic")
+    performance = project_root / "assets" / "performance.mp4"
+    reference = project_root / "assets" / "reference.mp4"
+    for path in (performance, reference):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"synthetic")
+
+    provider_paths = {
+        "OLIVIA_MINIMAX_COMFY_PYTHON": project_root / "providers" / "minimax" / "python.exe",
+        "OLIVIA_MINIMAX_COMFY_ROOT": project_root / "providers" / "minimax",
+        "OLIVIA_MINIMAX_WORKER": project_root / "providers" / "minimax" / "worker.py",
+        "OLIVIA_ROFORMER_EXE": project_root / "providers" / "roformer" / "roformer.exe",
+        "OLIVIA_ROFORMER_MODEL_PATH": project_root / "providers" / "roformer" / "model.ckpt",
+        "OLIVIA_ROFORMER_CONFIG_PATH": project_root / "providers" / "roformer" / "config.yaml",
+        "OLIVIA_LATENTSYNC_PYTHON": project_root / "providers" / "latentsync" / "python.exe",
+        "OLIVIA_LATENTSYNC_ROOT": project_root / "providers" / "latentsync",
+    }
+    provider_roots = {
+        provider_paths["OLIVIA_MINIMAX_COMFY_ROOT"],
+        provider_paths["OLIVIA_LATENTSYNC_ROOT"],
+    }
+    for path in provider_paths.values():
+        path.mkdir(parents=True, exist_ok=True) if path in provider_roots else path.parent.mkdir(
+            parents=True, exist_ok=True
+        )
+        if path not in provider_roots:
+            path.write_bytes(b"synthetic")
+
+    monkeypatch.chdir(unrelated_cwd)
+    monkeypatch.setenv("OLIVIA_PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("OLIVIA_FFMPEG_EXE", str(ffmpeg))
+    monkeypatch.setenv("OLIVIA_SPOKEN_SCENE_CANDIDATES", "assets/reference.mp4")
+    for name, path in provider_paths.items():
+        monkeypatch.setenv(name, path.relative_to(project_root).as_posix())
+
+    observed: dict[str, object] = {}
+
+    class FakeMiniMaxWorker:
+        def __init__(self, *, python_path, worker_path, comfy_root, **_kwargs):
+            observed["minimax_paths"] = (python_path, worker_path, comfy_root)
+
+        def generate(self, _content, _reply_text, destination, **_kwargs):
+            Path(destination).write_bytes(b"song")
+            return {"audio_model": "synthetic"}
+
+    def fake_run(command, error_code, **_kwargs):
+        observed.setdefault("commands", []).append((command, error_code))
+        if error_code == "ROFORMER_FAILED":
+            output_root = Path(command[command.index("--store_dir") + 1])
+            (output_root / "synthetic_vocals.wav").write_bytes(b"vocals")
+        elif error_code == "ROFORMER_INPUT_CONVERSION_FAILED":
+            Path(command[-1]).write_bytes(b"wav")
+        elif error_code == "MUSIC_REPLY_AUDIO_MUX_FAILED":
+            Path(command[-1]).write_bytes(b"song-video")
+
+    def fake_render_reply(_reply_text, output, **kwargs):
+        observed["ordinary_kwargs"] = kwargs
+        Path(output).write_bytes(b"normal-video")
+        return {}
+
+    def fake_latentsync(_source, _audio, output, *, python_path, latentsync_root):
+        observed["latentsync_paths"] = (python_path, latentsync_root)
+        Path(output).write_bytes(b"face-video")
+        return {}
+
+    def fake_prepare(_reference, destination):
+        Path(destination).write_bytes(b"spoken-base")
+        return destination
+
+    monkeypatch.setattr(music_reply, "MiniMaxMusic3Worker", FakeMiniMaxWorker)
+    monkeypatch.setattr(music_reply, "_run", fake_run)
+    monkeypatch.setattr(music_reply, "_ffmpeg", lambda: str(ffmpeg))
+    monkeypatch.setattr(music_reply, "render_reply_video", fake_render_reply)
+    monkeypatch.setattr(music_reply, "render_latentsync_video", fake_latentsync)
+    monkeypatch.setattr(music_reply, "prepare_official_spoken_base", fake_prepare)
+    monkeypatch.setattr(
+        music_reply,
+        "plan_song_content",
+        lambda *_args: SimpleNamespace(lyrics="lyrics", caption="caption", emotion="steady"),
+    )
+    monkeypatch.setattr(
+        music_reply,
+        "concat_videos",
+        lambda _normal, _song, output, **_kwargs: Path(output).write_bytes(b"final-video"),
+    )
+
+    output = tmp_path / "out" / "reply.mp4"
+    render_musical_reply(
+        "letter",
+        "reply",
+        output,
+        normal_video_path=tmp_path / "out" / "normal.mp4",
+        official_reply_reference_path=reference,
+        song_video_path=tmp_path / "out" / "song.mp4",
+        tts_config_path=tmp_path / "tts.json",
+        visual_config_path=tmp_path / "visual.json",
+        worker_path=tmp_path / "worker.py",
+        performance_video_path=performance,
+        duration_seconds=40,
+    )
+
+    assert observed["minimax_paths"] == (
+        provider_paths["OLIVIA_MINIMAX_COMFY_PYTHON"],
+        provider_paths["OLIVIA_MINIMAX_WORKER"],
+        provider_paths["OLIVIA_MINIMAX_COMFY_ROOT"],
+    )
+    assert observed["ordinary_kwargs"]["latentsync_python_path"] == provider_paths[
+        "OLIVIA_LATENTSYNC_PYTHON"
+    ]
+    assert observed["ordinary_kwargs"]["latentsync_root"] == provider_paths[
+        "OLIVIA_LATENTSYNC_ROOT"
+    ]
+    assert observed["latentsync_paths"] == (
+        provider_paths["OLIVIA_LATENTSYNC_PYTHON"],
+        provider_paths["OLIVIA_LATENTSYNC_ROOT"],
+    )
+    roformer_commands = [
+        command for command, error_code in observed["commands"] if error_code == "ROFORMER_FAILED"
+    ]
+    assert roformer_commands[0][-4:] == [
+        "--model_path",
+        str(provider_paths["OLIVIA_ROFORMER_MODEL_PATH"]),
+        "--config_path",
+        str(provider_paths["OLIVIA_ROFORMER_CONFIG_PATH"]),
+    ]
+    assert roformer_commands[0][0] == str(provider_paths["OLIVIA_ROFORMER_EXE"])
+    assert output.read_bytes() == b"final-video"

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -284,6 +284,8 @@ def test_musical_render_uses_one_immutable_provider_path_snapshot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     project_root = tmp_path / "project"
+    unrelated_cwd = tmp_path / "unrelated-cwd"
+    unrelated_cwd.mkdir()
 
     def write(path: Path, payload: bytes) -> Path:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -292,6 +294,7 @@ def test_musical_render_uses_one_immutable_provider_path_snapshot(
 
     transition = write(project_root / "scenes" / "transition.mp4", b"transition")
     performance = write(project_root / "scenes" / "performance.mp4", b"performance")
+    ffmpeg = write(project_root / "tools" / "ffmpeg.exe", b"ffmpeg")
     environment = {
         "OLIVIA_PROJECT_ROOT": str(project_root),
         "OLIVIA_OFFICIAL_REPLY_REFERENCE": "scenes/transition.mp4",
@@ -303,9 +306,12 @@ def test_musical_render_uses_one_immutable_provider_path_snapshot(
         "OLIVIA_ROFORMER_CONFIG_PATH": "providers/roformer/config.yaml",
         "OLIVIA_LATENTSYNC_PYTHON": "providers/latentsync/python.exe",
         "OLIVIA_LATENTSYNC_ROOT": "providers/latentsync/root",
+        "OLIVIA_FFMPEG_EXE": "tools/ffmpeg.exe",
+        "OLIVIA_PROVIDER_CACHE_ROOT": "provider-cache",
     }
     for name, value in environment.items():
         monkeypatch.setenv(name, value)
+    monkeypatch.chdir(unrelated_cwd)
     observed: dict[str, object] = {}
     output = tmp_path / "output.mp4"
 
@@ -322,7 +328,7 @@ def test_musical_render_uses_one_immutable_provider_path_snapshot(
     monkeypatch.setattr(
         music_reply,
         "prepare_official_spoken_base",
-        lambda _reference, destination: write(Path(destination), b"spoken-base"),
+        lambda _reference, destination, **_kwargs: write(Path(destination), b"spoken-base"),
     )
 
     def fake_spoken(_text, destination, **kwargs):
@@ -359,6 +365,9 @@ def test_musical_render_uses_one_immutable_provider_path_snapshot(
             kwargs["latentsync_python_path"],
             kwargs["latentsync_root"],
         )
+        observed["face_ffmpeg"] = kwargs.get("ffmpeg_path")
+        observed["face_cache"] = kwargs.get("provider_cache_root")
+        observed["face_environment"] = kwargs.get("environment")
         write(Path(destination), b"face")
         return {"performance_stage": "completed"}
 
@@ -397,6 +406,9 @@ def test_musical_render_uses_one_immutable_provider_path_snapshot(
         project_root / "providers/latentsync/python.exe",
         project_root / "providers/latentsync/root",
     )
+    assert observed["face_ffmpeg"] == ffmpeg
+    assert observed["face_cache"] == project_root / "provider-cache"
+    assert observed["face_environment"]["OLIVIA_PROJECT_ROOT"] == str(project_root)
     assert observed["tts_environment"]["OLIVIA_PROJECT_ROOT"] == str(project_root)
     assert observed["roformer_environment"]["OLIVIA_PROJECT_ROOT"] == str(project_root)
     assert output.read_bytes() == b"final"
@@ -414,7 +426,7 @@ def test_roformer_uses_explicit_f_drive_assets_and_utf8(tmp_path, monkeypatch):
     monkeypatch.setenv("OLIVIA_ROFORMER_EXE", str(executable))
     monkeypatch.setenv("OLIVIA_ROFORMER_MODEL_PATH", str(model))
     monkeypatch.setenv("OLIVIA_ROFORMER_CONFIG_PATH", str(config))
-    monkeypatch.setattr(music_reply, "_ffmpeg", lambda: "ffmpeg")
+    monkeypatch.setattr(music_reply, "_ffmpeg", lambda *_args: "ffmpeg")
     observed = []
 
     def fake_run(command, error_code, *, timeout=900.0, env=None):
@@ -888,6 +900,7 @@ def test_musical_renderer_resolves_all_provider_paths_from_project_root(
     monkeypatch.chdir(unrelated_cwd)
     monkeypatch.setenv("OLIVIA_PROJECT_ROOT", str(project_root))
     monkeypatch.setenv("OLIVIA_FFMPEG_EXE", str(ffmpeg))
+    monkeypatch.setenv("OLIVIA_PROVIDER_CACHE_ROOT", "provider-cache")
     monkeypatch.setenv("OLIVIA_SPOKEN_SCENE_CANDIDATES", "assets/reference.mp4")
     for name, path in provider_paths.items():
         monkeypatch.setenv(name, path.relative_to(project_root).as_posix())
@@ -917,18 +930,18 @@ def test_musical_renderer_resolves_all_provider_paths_from_project_root(
         Path(output).write_bytes(b"normal-video")
         return {}
 
-    def fake_latentsync(_source, _audio, output, *, python_path, latentsync_root):
+    def fake_latentsync(_source, _audio, output, *, python_path, latentsync_root, **_kwargs):
         observed["latentsync_paths"] = (python_path, latentsync_root)
         Path(output).write_bytes(b"face-video")
         return {}
 
-    def fake_prepare(_reference, destination):
+    def fake_prepare(_reference, destination, **_kwargs):
         Path(destination).write_bytes(b"spoken-base")
         return destination
 
     monkeypatch.setattr(music_reply, "MiniMaxMusic3Worker", FakeMiniMaxWorker)
     monkeypatch.setattr(music_reply, "_run", fake_run)
-    monkeypatch.setattr(music_reply, "_ffmpeg", lambda: str(ffmpeg))
+    monkeypatch.setattr(music_reply, "_ffmpeg", lambda *_args: str(ffmpeg))
     monkeypatch.setattr(music_reply, "render_reply_video", fake_render_reply)
     monkeypatch.setattr(music_reply, "render_latentsync_video", fake_latentsync)
     monkeypatch.setattr(music_reply, "prepare_official_spoken_base", fake_prepare)

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -75,6 +75,27 @@ def test_media_workers_fail_closed_without_external_provider(tmp_path):
         )
 
 
+def test_reply_video_rejects_relative_latentsync_paths_without_project_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    unrelated_cwd = tmp_path / "unrelated-cwd"
+    unrelated_cwd.mkdir()
+    monkeypatch.chdir(unrelated_cwd)
+    monkeypatch.delenv("OLIVIA_PROJECT_ROOT", raising=False)
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_PYTHON", "providers/latentsync/python.exe")
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_ROOT", "providers/latentsync")
+
+    with pytest.raises(ReplyMediaError, match="^LATENTSYNC_INPUT_UNAVAILABLE$"):
+        render_reply_video(
+            "synthetic reply",
+            tmp_path / "reply.mp4",
+            tts_config_path=tmp_path / "missing-tts.json",
+            visual_config_path=tmp_path / "missing-visual.json",
+            worker_path=tmp_path / "missing-worker.py",
+            scene_path=tmp_path / "scene.mp4",
+        )
+
+
 def test_ordinary_quality_preflight_preserves_retryable_gate_error(
     tmp_path,
     monkeypatch,
@@ -534,6 +555,53 @@ def test_speaking_scene_candidates_are_stable_and_legacy_compatible(tmp_path: Pa
             ),
         }
     ) == (first, second)
+
+
+def test_musical_renderer_rejects_relative_latentsync_paths_without_project_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    unrelated_cwd = tmp_path / "unrelated-cwd"
+    unrelated_cwd.mkdir()
+    transition = tmp_path / "transition.mp4"
+    transition.write_bytes(b"synthetic")
+    monkeypatch.chdir(unrelated_cwd)
+    monkeypatch.delenv("OLIVIA_PROJECT_ROOT", raising=False)
+    monkeypatch.setenv("OLIVIA_SPOKEN_SCENE_CANDIDATES", str(transition))
+    monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", str(tmp_path / "minimax.exe"))
+    monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", str(tmp_path / "minimax"))
+    monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", str(tmp_path / "minimax-worker.py"))
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_PYTHON", "providers/latentsync/python.exe")
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_ROOT", "providers/latentsync")
+    monkeypatch.setattr(
+        music_reply,
+        "plan_song_content",
+        lambda *_args: SimpleNamespace(lyrics="lyrics", caption="caption", emotion="steady"),
+    )
+    monkeypatch.setattr(
+        music_reply,
+        "prepare_official_spoken_base",
+        lambda _reference, destination: Path(destination).write_bytes(b"spoken-base"),
+    )
+    monkeypatch.setattr(
+        music_reply,
+        "render_reply_video",
+        lambda *_args, **_kwargs: pytest.fail("ordinary renderer must not be called"),
+    )
+
+    with pytest.raises(MusicReplyError, match="^LATENTSYNC_INPUT_UNAVAILABLE$"):
+        render_musical_reply(
+            "letter",
+            "reply",
+            tmp_path / "out" / "reply.mp4",
+            normal_video_path=tmp_path / "out" / "normal.mp4",
+            official_reply_reference_path=transition,
+            song_video_path=tmp_path / "out" / "song.mp4",
+            tts_config_path=tmp_path / "tts.json",
+            visual_config_path=tmp_path / "visual.json",
+            worker_path=tmp_path / "worker.py",
+            performance_video_path=tmp_path / "performance.mp4",
+            duration_seconds=40,
+        )
 
 
 def test_musical_renderer_resolves_all_provider_paths_from_project_root(

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -24,7 +24,13 @@ from reply_delivery import (
     ordinary_video_reply_length_ok,
     plan_reply_delivery,
 )
-from reply_media import ReplyMediaError, _tts_config, render_reply_video
+from reply_media import (
+    ReplyMediaError,
+    _tts_config,
+    assemble_complete_video_delivery,
+    render_reply_video,
+)
+from song_content import SongContentPlan
 from tts.delivery import (
     DeliveryAudioError,
     _fit_overlong_wav,
@@ -163,6 +169,239 @@ def test_shared_music_preflight_never_checks_ordinary_quality_gate(
     assert calls == [False]
 
 
+def test_complete_delivery_resolves_tts_internal_paths_from_project_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "project"
+    config_path = project_root / "config" / "tts.json"
+    reference = project_root / "voice" / "reference.wav"
+    worker = project_root / "workers" / "visual.py"
+    for path in (worker,):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"synthetic")
+    reference.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(reference), "wb") as target:
+        target.setnchannels(1)
+        target.setsampwidth(2)
+        target.setframerate(16_000)
+        target.writeframes(b"\0\0" * 16_000)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "settings": {
+                    "runtime_root": "providers/cosyvoice",
+                    "model_dir": "providers/cosyvoice-model",
+                    "reference_audio": "voice/default.wav",
+                    "provider_options": {
+                        "numba_cache_dir": "cache/numba",
+                        "quality_gate_cache_root": "cache/quality-default",
+                        "wetext_fst_root": "cache/wetext",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    environment = {
+        "OLIVIA_PROJECT_ROOT": str(project_root),
+        "OLIVIA_REPLY_VOICE_REFERENCE": "voice/reference.wav",
+        "OLIVIA_TTS_QUALITY_GATE_CACHE_ROOT": "cache/quality-override",
+    }
+    unrelated_cwd = tmp_path / "unrelated-cwd"
+    unrelated_cwd.mkdir()
+    monkeypatch.chdir(unrelated_cwd)
+    monkeypatch.setattr(
+        reply_media,
+        "_visual_config",
+        lambda _path: SimpleNamespace(validate=lambda: None),
+    )
+    monkeypatch.setattr(reply_media, "media_runtime_available", lambda _env: True)
+    monkeypatch.setattr(reply_media, "delivery_configured", lambda _tts: True)
+
+    delivery = assemble_complete_video_delivery(
+        config_path,
+        tmp_path / "unused-visual.json",
+        worker,
+        tmp_path / "temporary",
+        environment,
+    )
+
+    assert Path(delivery.tts.runtime_root) == project_root / "providers" / "cosyvoice"
+    assert Path(delivery.tts.model_dir) == project_root / "providers" / "cosyvoice-model"
+    assert Path(delivery.tts.reference_audio) == reference
+    assert delivery.tts.provider_options["numba_cache_dir"] == str(
+        project_root / "cache" / "numba"
+    )
+    assert delivery.tts.provider_options["quality_gate_cache_root"] == str(
+        project_root / "cache" / "quality-override"
+    )
+    assert delivery.tts.provider_options["wetext_fst_root"] == str(
+        project_root / "cache" / "wetext"
+    )
+
+
+def test_complete_delivery_rejects_relative_tts_paths_without_absolute_project_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "tts.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "settings": {
+                    "runtime_root": "providers/cosyvoice",
+                    "model_dir": "providers/cosyvoice-model",
+                    "reference_audio": "voice/default.wav",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    worker = tmp_path / "worker.py"
+    worker.write_bytes(b"synthetic")
+    monkeypatch.setattr(
+        reply_media,
+        "_visual_config",
+        lambda _path: SimpleNamespace(validate=lambda: None),
+    )
+    monkeypatch.setattr(reply_media, "media_runtime_available", lambda _env: True)
+    monkeypatch.setattr(reply_media, "delivery_configured", lambda _tts: True)
+
+    with pytest.raises(ReplyMediaError, match="COMPLETE_VIDEO_CONFIG_UNAVAILABLE"):
+        assemble_complete_video_delivery(
+            config_path,
+            tmp_path / "unused-visual.json",
+            worker,
+            tmp_path / "temporary",
+            {},
+        )
+
+
+def test_musical_render_uses_one_immutable_provider_path_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "project"
+
+    def write(path: Path, payload: bytes) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+        return path
+
+    transition = write(project_root / "scenes" / "transition.mp4", b"transition")
+    performance = write(project_root / "scenes" / "performance.mp4", b"performance")
+    environment = {
+        "OLIVIA_PROJECT_ROOT": str(project_root),
+        "OLIVIA_OFFICIAL_REPLY_REFERENCE": "scenes/transition.mp4",
+        "OLIVIA_MINIMAX_COMFY_PYTHON": "providers/minimax/python.exe",
+        "OLIVIA_MINIMAX_COMFY_ROOT": "providers/minimax/root",
+        "OLIVIA_MINIMAX_WORKER": "providers/minimax/worker.py",
+        "OLIVIA_ROFORMER_EXE": "providers/roformer/roformer.exe",
+        "OLIVIA_ROFORMER_MODEL_PATH": "providers/roformer/model.ckpt",
+        "OLIVIA_ROFORMER_CONFIG_PATH": "providers/roformer/config.yaml",
+        "OLIVIA_LATENTSYNC_PYTHON": "providers/latentsync/python.exe",
+        "OLIVIA_LATENTSYNC_ROOT": "providers/latentsync/root",
+    }
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+    observed: dict[str, object] = {}
+    output = tmp_path / "output.mp4"
+
+    monkeypatch.setattr(
+        music_reply,
+        "plan_song_content",
+        lambda *_args: SongContentPlan(
+            emotion="gentle_reassurance",
+            lyrics="[Verse]\\nsynthetic",
+            caption="synthetic piano ballad",
+            duration_seconds=40,
+        ),
+    )
+    monkeypatch.setattr(
+        music_reply,
+        "prepare_official_spoken_base",
+        lambda _reference, destination: write(Path(destination), b"spoken-base"),
+    )
+
+    def fake_spoken(_text, destination, **kwargs):
+        observed["tts_environment"] = kwargs["environment"]
+        write(Path(destination), b"spoken")
+        for name in environment:
+            monkeypatch.delenv(name, raising=False)
+        return {"spoken_stage": "completed"}
+
+    monkeypatch.setattr(music_reply, "render_reply_video", fake_spoken)
+
+    def fake_generate(self, _content, _reply_text, destination, **_kwargs):
+        observed["minimax"] = (
+            self.python_path,
+            self.worker_path,
+            self.comfy_root,
+        )
+        write(Path(destination), b"song")
+        return {"music_stage": "completed"}
+
+    monkeypatch.setattr(music_reply.MiniMaxMusic3Worker, "generate", fake_generate)
+
+    def fake_separate(_song, destination, **kwargs):
+        observed["roformer"] = (
+            kwargs["executable"], kwargs["model_path"], kwargs["config_path"]
+        )
+        observed["roformer_environment"] = kwargs["environment"]
+        write(Path(destination), b"vocals")
+
+    monkeypatch.setattr(music_reply, "separate_vocals", fake_separate)
+
+    def fake_face(_base, _vocals, _song, destination, **kwargs):
+        observed["face"] = (
+            kwargs["latentsync_python_path"],
+            kwargs["latentsync_root"],
+        )
+        write(Path(destination), b"face")
+        return {"performance_stage": "completed"}
+
+    monkeypatch.setattr(music_reply, "render_full_face_performance", fake_face)
+    monkeypatch.setattr(
+        music_reply,
+        "concat_videos",
+        lambda _normal, _song, destination, **_kwargs: write(Path(destination), b"final"),
+    )
+
+    music_reply.render_musical_reply(
+        "letter",
+        "reply",
+        output,
+        normal_video_path=tmp_path / "normal.mp4",
+        official_reply_reference_path=transition,
+        song_video_path=tmp_path / "song.mp4",
+        tts_config_path=project_root / "config" / "tts.json",
+        visual_config_path=project_root / "config" / "visual.json",
+        worker_path=project_root / "workers" / "visual.py",
+        performance_video_path=performance,
+        duration_seconds=40,
+    )
+
+    assert observed["minimax"] == (
+        project_root / "providers/minimax/python.exe",
+        project_root / "providers/minimax/worker.py",
+        project_root / "providers/minimax/root",
+    )
+    assert observed["roformer"] == (
+        project_root / "providers/roformer/roformer.exe",
+        project_root / "providers/roformer/model.ckpt",
+        project_root / "providers/roformer/config.yaml",
+    )
+    assert observed["face"] == (
+        project_root / "providers/latentsync/python.exe",
+        project_root / "providers/latentsync/root",
+    )
+    assert observed["tts_environment"]["OLIVIA_PROJECT_ROOT"] == str(project_root)
+    assert observed["roformer_environment"]["OLIVIA_PROJECT_ROOT"] == str(project_root)
+    assert output.read_bytes() == b"final"
+
+
 def test_roformer_uses_explicit_f_drive_assets_and_utf8(tmp_path, monkeypatch):
     executable = tmp_path / "roformer.exe"
     model = tmp_path / "models" / "MelBandRoformer.ckpt"
@@ -186,7 +425,14 @@ def test_roformer_uses_explicit_f_drive_assets_and_utf8(tmp_path, monkeypatch):
 
     monkeypatch.setattr(music_reply, "_run", fake_run)
 
-    music_reply.separate_vocals(song, vocals)
+    music_reply.separate_vocals(
+        song,
+        vocals,
+        executable=executable,
+        model_path=model,
+        config_path=config,
+        environment={},
+    )
 
     assert observed[0][0][:4] == ["ffmpeg", "-y", "-i", str(song)]
     assert observed[0][1] == "ROFORMER_INPUT_CONVERSION_FAILED"

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -526,3 +526,11 @@ def test_speaking_scene_candidates_are_stable_and_legacy_compatible(tmp_path: Pa
     assert candidates == (first, second)
     assert music_reply.select_speaking_scene(candidates) == first
     assert music_reply.speaking_scene_candidates({"OLIVIA_OFFICIAL_REPLY_REFERENCE": str(second)}) == (second,)
+    assert music_reply.speaking_scene_candidates(
+        {
+            "OLIVIA_PROJECT_ROOT": str(tmp_path),
+            "OLIVIA_SPOKEN_SCENE_CANDIDATES": os.pathsep.join(
+                ("first.mp4", "second.mp4")
+            ),
+        }
+    ) == (first, second)


### PR DESCRIPTION
## Scope

- resolve relative media provider, scene, TTS, and LatentSync paths from `OLIVIA_PROJECT_ROOT`
- keep absolute configured paths unchanged
- fail closed when a configured relative path has no absolute project root
- preserve the existing behavior for intentionally empty optional provider values
- resolve `OLIVIA_LOCAL_DATA_ROOT` consistently for server state, media output, and media serving

## Exact pair

- base: `78a4cd7a71b9303291b59f4dbb3fa6de54b0cbb8`
- head: `a057c0f94fd03942d765b1d4296dc724f9ec6a1c`

## Focused verification

- musical runtime path regression: 1 passed
- local-server state/media root regression: 1 passed
- focused media slice: 4 passed, 14 deselected
- focused HTTP slice: 4 passed, 20 deselected
- `python -m py_compile media_paths.py music_reply.py local_server.py tests/media/test_portable_media_boundaries.py tests/http/test_reply_delay_and_media.py`
- `git diff --check`

No model or media rendering was run.