### PR TITLE
fix(asr): portable local storage paths

### DIFF
--- a/asr/config.py
+++ b/asr/config.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass, replace
-from pathlib import Path
+from dataclasses import dataclass, field, replace
+from pathlib import Path, PureWindowsPath
 from urllib.parse import urlparse
 
 from .errors import AsrError
@@ -26,8 +26,36 @@ RUNTIME_REVISION = "1118951337094db3b362fbf1b27e871696f10590"
 RUNTIME_LICENSE = "Apache-2.0"
 
 
+def is_local_absolute_path(path: Path | str) -> bool:
+    """Return whether *path* is a non-root local Windows drive path."""
+
+    windows = PureWindowsPath(str(path))
+    return (
+        windows.is_absolute()
+        and len(windows.drive) == 2
+        and windows.drive[1] == ":"
+        and len(windows.parts) > 1
+        and ".." not in windows.parts
+    )
+
+
+def default_asr_root() -> Path:
+    """Use per-user local storage without binding the product to one drive."""
+
+    configured = os.environ.get("LOCALAPPDATA", "").strip()
+    if configured and is_local_absolute_path(configured):
+        return Path(configured) / "BSideOliviaLocal" / "asr"
+    profile = os.environ.get("USERPROFILE", "").strip()
+    if profile and is_local_absolute_path(profile):
+        return Path(profile) / "AppData" / "Local" / "BSideOliviaLocal" / "asr"
+    home = Path.home()
+    if is_local_absolute_path(home):
+        return home / "AppData" / "Local" / "BSideOliviaLocal" / "asr"
+    return Path("C:/Users/Default/AppData/Local/BSideOliviaLocal/asr")
+
+
 def _default_root(name: str) -> Path:
-    return Path("F:/Bside-olivia-local/asr") / name
+    return default_asr_root() / name
 
 
 @dataclass(frozen=True)
@@ -44,9 +72,9 @@ class AsrConfig:
     endpointing_ms: int = 600
     word_timestamps: bool = False
     connect_timeout_ms: int = 3_000
-    runtime_root: Path = _default_root("runtime")
-    model_root: Path = _default_root("models")
-    cache_root: Path = _default_root("cache")
+    runtime_root: Path = field(default_factory=lambda: _default_root("runtime"))
+    model_root: Path = field(default_factory=lambda: _default_root("models"))
+    cache_root: Path = field(default_factory=lambda: _default_root("cache"))
     runtime_executable: Path | None = None
     model_path: Path | None = None
     strict_storage: bool = True
@@ -78,10 +106,10 @@ class AsrConfig:
             paths.append(self.model_path)
         for path in paths:
             path = Path(path)
-            if not path.is_absolute() or path.drive.upper() not in {"D:", "F:"}:
+            if not is_local_absolute_path(path):
                 raise AsrError(
                     "ASR_CONFIG_INVALID",
-                    "runtime, model, cache, and evidence paths must be absolute D:/ or F:/ paths",
+                    "runtime, model, cache, and evidence paths must be absolute local Windows paths",
                     {"path": str(path)},
                 )
 

--- a/asr/cuda_toolchain.py
+++ b/asr/cuda_toolchain.py
@@ -618,8 +618,59 @@ def assemble_cuda_toolchain(
     return {**plan, "mode": "applied", "idempotent": False, "assembled": True, "status": status}
 
 
+def _managed_artifact_paths(marker: Mapping[str, Any], root: Path) -> tuple[Path, ...] | None:
+    """Resolve an optional exact artifact list without trusting arbitrary paths."""
+
+    values = marker.get("managed_artifacts")
+    if not isinstance(values, list):
+        return None
+    root_resolved = root.resolve()
+    paths: list[Path] = []
+    for value in values:
+        if not isinstance(value, str):
+            return None
+        try:
+            parts = _safe_relative_parts(value, label="managed CUDA artifact")
+        except AsrError:
+            return None
+        candidate = root.joinpath(*parts)
+        try:
+            candidate.resolve(strict=False).relative_to(root_resolved)
+        except ValueError:
+            return None
+        if candidate.name == CUDA_TOOLCHAIN_MARKER:
+            return None
+        paths.append(candidate)
+    return tuple(dict.fromkeys(paths))
+
+
+def _remove_empty_directories(root: Path) -> tuple[Path, ...]:
+    """Prune empty directories only, never recursively deleting their contents."""
+
+    if not root.is_dir() or root.is_symlink():
+        return ()
+    try:
+        directories = [path for path in root.rglob("*") if path.is_dir() and not path.is_symlink()]
+    except OSError:
+        directories = []
+    removed: list[Path] = []
+    for directory in sorted(directories, key=lambda path: len(path.parts), reverse=True):
+        try:
+            directory.rmdir()
+        except OSError:
+            continue
+        removed.append(directory)
+    try:
+        root.rmdir()
+    except OSError:
+        pass
+    else:
+        removed.append(root)
+    return tuple(removed)
+
+
 def uninstall_cuda_toolchain(toolchain_root: Path | str, *, apply: bool = False) -> dict[str, Any]:
-    """Remove only an exact B05-owned CUDA prefix; absent roots are idempotent."""
+    """Remove the trusted marker and exact recorded artifacts, preserving unknown files."""
 
     root = _external_root(toolchain_root, "CUDA toolchain root")
     status = cuda_toolchain_status(root)
@@ -629,6 +680,7 @@ def uninstall_cuda_toolchain(toolchain_root: Path | str, *, apply: bool = False)
         "owned": bool(status.get("owned")),
         "status": status,
         "deleted": False,
+        "deleted_paths": [],
     }
     if not apply:
         return plan
@@ -641,8 +693,24 @@ def uninstall_cuda_toolchain(toolchain_root: Path | str, *, apply: bool = False)
             "refusing to delete a CUDA root without the exact B05 ownership marker",
             {"root": str(root)},
         )
-    shutil.rmtree(root)
-    return {**plan, "mode": "applied", "idempotent": False, "deleted": True}
+    deleted_paths: list[Path] = []
+    managed_paths = _managed_artifact_paths(marker, root) or ()
+    for path in managed_paths:
+        if not path.is_file() or path.is_symlink():
+            continue
+        path.unlink()
+        deleted_paths.append(path)
+    marker_path = root / CUDA_TOOLCHAIN_MARKER
+    marker_path.unlink()
+    deleted_paths.append(marker_path)
+    deleted_paths.extend(_remove_empty_directories(root))
+    return {
+        **plan,
+        "mode": "applied",
+        "idempotent": False,
+        "deleted": True,
+        "deleted_paths": [str(path) for path in deleted_paths],
+    }
 
 
 def build_environment(

--- a/asr/cuda_toolchain.py
+++ b/asr/cuda_toolchain.py
@@ -1,8 +1,8 @@
 """Manifest-driven, portable CUDA 13.3 assembly for the B05 build boundary.
 
 This module never downloads anything.  It verifies NVIDIA redistributable
-archives supplied through an explicit D:/ or F:/ transfer root, assembles an
-owned toolchain under D:/ or F:/, and returns diagnostics suitable for the
+archives supplied through an explicit local absolute transfer root, assembles an
+owned toolchain under that local root, and returns diagnostics suitable for the
 management CLI.  A ready toolchain is only build-ready; it is not native ASR
 acceptance evidence.
 """
@@ -22,6 +22,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Mapping, Sequence
 from urllib.parse import urljoin
 
+from .config import is_local_absolute_path
 from .errors import AsrError
 
 
@@ -78,10 +79,10 @@ class CudaPackage:
 
 def _external_root(path: Path | str, label: str) -> Path:
     root = Path(path)
-    if not root.is_absolute() or root.drive.upper() not in {"D:", "F:"}:
+    if not is_local_absolute_path(root):
         raise AsrError(
             "ASR_CONFIG_INVALID",
-            f"{label} must be an absolute D:/ or F:/ path",
+            f"{label} must be an absolute local Windows path",
             {"path": str(root), "label": label},
         )
     return root

--- a/asr/management.py
+++ b/asr/management.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -19,6 +18,7 @@ from .config import (
     RUNTIME_REPO,
     RUNTIME_REVISION,
     AsrConfig,
+    is_local_absolute_path,
 )
 from .errors import AsrError
 
@@ -31,13 +31,13 @@ HTTP_SNAPSHOT_PATCH = "tools/b05_native_http_snapshot.patch"
 
 def _external_paths(config: AsrConfig) -> bool:
     paths = [config.runtime_root, config.model_root, config.cache_root]
-    return all(Path(path).is_absolute() and Path(path).drive.upper() in {"D:", "F:"} for path in paths)
+    return all(is_local_absolute_path(path) for path in paths)
 
 
-def _external_path(path: Path, *, label: str) -> Path:
-    path = Path(path).absolute()
-    if not path.is_absolute() or path.drive.upper() not in {"D:", "F:"}:
-        raise AsrError("ASR_CONFIG_INVALID", f"{label} must be an absolute D:/ or F:/ path", {"path": str(path)})
+def _external_path(path: Path | str, *, label: str) -> Path:
+    path = Path(path)
+    if not is_local_absolute_path(path):
+        raise AsrError("ASR_CONFIG_INVALID", f"{label} must be an absolute local Windows path", {"path": str(path)})
     return path
 
 
@@ -183,11 +183,11 @@ def install(config: AsrConfig, *, apply: bool = False, transfer_root: Path | Non
     if not apply:
         return plan
     if not plan["paths_are_external"]:
-        raise AsrError("ASR_CONFIG_INVALID", "install roots must be on D:/ or F:/")
+        raise AsrError("ASR_CONFIG_INVALID", "install roots must be absolute local Windows paths")
     if transfer_root is None:
         raise AsrError(
             "ASR_CONFIG_INVALID",
-            "apply requires an explicit D:/ or F:/ transfer_root; network downloads are disabled",
+            "apply requires an explicit local absolute transfer_root; network downloads are disabled",
         )
     source = _validate_transfer_source(transfer_root)
     model = _validate_model(config.effective_model_path)
@@ -252,10 +252,21 @@ def uninstall(config: AsrConfig, *, apply: bool = False) -> dict[str, Any]:
     if not plan["owned"]:
         raise AsrError("ASR_CONFIG_INVALID", "refusing to delete paths without the B05 ownership manifest")
     if not _external_paths(config):
-        raise AsrError("ASR_CONFIG_INVALID", "uninstall roots must be on D:/ or F:/")
-    deleted: list[str] = []
-    for path in (config.runtime_root, config.model_root, config.cache_root):
-        if Path(path).exists():
-            shutil.rmtree(path)
-            deleted.append(str(path))
+        raise AsrError("ASR_CONFIG_INVALID", "uninstall roots must be absolute local Windows paths")
+    manifest_path = Path(config.runtime_root) / ".b05-install.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AsrError("ASR_CONFIG_INVALID", "refusing to delete without a valid B05 ownership manifest") from exc
+    if not isinstance(manifest, dict) or manifest.get("owner") != "b05-streaming-asr":
+        raise AsrError("ASR_CONFIG_INVALID", "refusing to delete without a valid B05 ownership manifest")
+
+    # The manifest is the only file this tool creates in the managed roots.
+    # Never recursively delete a configured directory: it may contain an
+    # external runtime, model, cache, or user files.
+    deleted = [str(manifest_path)]
+    try:
+        manifest_path.unlink()
+    except OSError as exc:
+        raise AsrError("ASR_CONFIG_INVALID", "B05 ownership manifest cannot be removed") from exc
     return {**plan, "mode": "applied", "deleted": deleted}

--- a/docs/B05_STREAMING_ASR.md
+++ b/docs/B05_STREAMING_ASR.md
@@ -42,9 +42,9 @@ manifest, `redistrib_13.3.0.json`, read from an ignored local transfer root,
 for example `.evidence/b05-runtime-transfer/redistrib_13.3.0.json`.
 The verified manifest is 47,431 bytes with SHA-256
 `507EDDAAB1360336BC0FE17B77552E0B7DFE1E74DA888671C3A2F5FAD7775DB1`.
-The manager performs no download: it accepts a D:/ or F:/ transfer root,
-checks size, SHA-256, ZIP CRC, and safe members, then assembles an owned
-prefix under D:/ or F:/.
+The manager performs no download: it accepts any non-root local absolute
+Windows drive path as the transfer root, checks size, SHA-256, ZIP CRC, and
+safe members, then assembles an owned prefix under that selected local root.
 
 The static Windows x86_64 compile closure is the following.  It is deliberately
 recorded as a build-toolchain closure, not as native ASR acceptance evidence.
@@ -86,7 +86,7 @@ VS/MSVC, CMake, Ninja, NVCC 13.3.33, CUDA ABI, and `sm_86` build cache was
 incrementally rebuilt only for the affected `nemo_speech_cli` target after the
 upstream HTTP patch below.  CUDA and model assets were reused; no duplicate
 build or model download was performed.  The resulting executable and model
-remain outside Git under the ignored D:/F: evidence boundary.
+remain outside Git under the ignored external evidence boundary.
 
 ### Fixed upstream HTTP inventory patch
 
@@ -141,14 +141,18 @@ The default provider is `text-fallback`.  Native selection is explicit through
 `ASR_PROVIDER=nemotron-speech-cpp` or the external JSON configuration written by
 `tools/asr_manage.py switch --provider nemotron-speech-cpp`.
 
-All runtime, model, cache, and acceptance-evidence roots must be absolute D:/
-or F:/ paths in production.  Installation is an idempotent offline assembly
-from an explicit, verified D:/ or F:/ transfer root: it validates the fixed
+All runtime, model, cache, and acceptance-evidence roots must be non-root local
+absolute Windows drive paths in production. Relative, drive-relative, URL,
+UNC, drive-root, and parent-traversal paths are rejected. Installation is an
+idempotent offline assembly from an explicit, verified local absolute transfer
+root: it validates the fixed
 NeMo-Speech.cpp/ggml/cpp-httplib revisions, the fixed model SHA-256, and the
 official HTTP snapshot patch, then registers the already-built external
 runtime.  It does not download weights or invent an ASR implementation; no
 weights are vendored.  Uninstall requires the B05 ownership manifest and
-`--apply`; a dry run never deletes external runtime/model assets.  The runtime
+`--apply`; it removes only that manifest and never recursively deletes the
+configured runtime, model, or cache directories. A dry run never deletes
+external runtime/model assets.  The runtime
 has no release artifact to pin, so the source commit, upstream submodule pins,
 patch, and provenance are part of the install manifest.
 
@@ -157,20 +161,20 @@ Useful commands:
 ```text
 rtk python tools/asr_manage.py status
 rtk python tools/asr_manage.py install
-rtk python tools/asr_manage.py install --transfer-root D:/transfer
-rtk python tools/asr_manage.py install --apply --transfer-root D:/transfer
+rtk python tools/asr_manage.py install --transfer-root C:/transfer
+rtk python tools/asr_manage.py install --apply --transfer-root C:/transfer
 rtk python tools/asr_manage.py uninstall
 rtk python tools/asr_manage.py uninstall --apply
-rtk python tools/asr_manage.py cuda-toolchain --action status --cuda-root F:/Bside-olivia-local/asr/cuda-toolchain
-rtk python tools/asr_manage.py cuda-toolchain --action assemble --apply --cuda-root F:/Bside-olivia-local/asr/cuda-toolchain --cuda-manifest D:/transfer/redistrib_13.3.0.json --cuda-transfer-root D:/transfer/cuda-13.3-zips
-rtk python tools/asr_manage.py cuda-toolchain --action uninstall --cuda-root F:/Bside-olivia-local/asr/cuda-toolchain --apply
+rtk python tools/asr_manage.py cuda-toolchain --action status --cuda-root "$env:LOCALAPPDATA/BSideOliviaLocal/asr/cuda-toolchain"
+rtk python tools/asr_manage.py cuda-toolchain --action assemble --apply --cuda-root "$env:LOCALAPPDATA/BSideOliviaLocal/asr/cuda-toolchain" --cuda-manifest "$env:LOCALAPPDATA/BSideOliviaLocal/asr-transfer/redistrib_13.3.0.json" --cuda-transfer-root "$env:LOCALAPPDATA/BSideOliviaLocal/asr-transfer/cuda-13.3-zips"
+rtk python tools/asr_manage.py cuda-toolchain --action uninstall --cuda-root "$env:LOCALAPPDATA/BSideOliviaLocal/asr/cuda-toolchain" --apply
 rtk python tools/asr_healthcheck.py
 rtk python tools/asr_healthcheck.py --probe --require-ready
 rtk python tools/healthcheck.py --profile asr
 ```
 
 The first install command is a plan.  Actual downloads/builds are intentionally
-not part of default CI and must remain on D:/F:.
+not part of default CI and must remain in an external local absolute directory.
 
 ## Truthful readiness gate
 

--- a/tests/asr/test_config.py
+++ b/tests/asr/test_config.py
@@ -17,15 +17,45 @@ def test_default_is_text_fallback_and_provenance_is_pinned() -> None:
     assert config.to_dict(include_paths=False)["runtime_revision"] == RUNTIME_REVISION
 
 
+def test_default_storage_roots_follow_localappdata(monkeypatch, tmp_path: Path) -> None:
+    local_appdata = tmp_path / "LocalAppData"
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+
+    config = AsrConfig()
+
+    expected = local_appdata / "BSideOliviaLocal" / "asr"
+    assert config.runtime_root == expected / "runtime"
+    assert config.model_root == expected / "models"
+    assert config.cache_root == expected / "cache"
+
+
 def test_config_accepts_explicit_test_paths_without_changing_production_policy(tmp_path: Path) -> None:
     config = AsrConfig().with_test_paths(tmp_path)
     assert config.strict_storage is False
     assert config.effective_model_path.name.endswith(".gguf")
 
 
-def test_production_storage_must_be_d_or_f_drive() -> None:
-    with pytest.raises(AsrError, match="D:/ or F:/"):
-        AsrConfig(runtime_root=Path("C:/not-allowed"))
+@pytest.mark.parametrize("drive", ("C:", "D:", "E:", "F:"))
+def test_production_storage_accepts_any_local_drive(drive: str) -> None:
+    config = AsrConfig(runtime_root=Path(f"{drive}/bside/asr/runtime"))
+
+    assert config.runtime_root == Path(f"{drive}/bside/asr/runtime")
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        Path("C:/"),
+        Path("C:/bside/../asr"),
+        Path("C:asr/runtime"),
+        Path("relative/asr"),
+        Path("http://example.invalid/asr"),
+        Path("//server/share/asr"),
+    ),
+)
+def test_production_storage_rejects_unsafe_paths(value: Path) -> None:
+    with pytest.raises(AsrError, match="absolute local Windows paths"):
+        AsrConfig(runtime_root=value)
 
 
 def test_server_must_be_loopback() -> None:

--- a/tests/asr/test_cuda_toolchain.py
+++ b/tests/asr/test_cuda_toolchain.py
@@ -12,6 +12,7 @@ from asr.cuda_toolchain import (
     assemble_cuda_toolchain,
     build_command,
     build_environment,
+    cuda_toolchain_status,
     inspect_cuda_transfer,
     load_manifest,
     select_cuda_packages,
@@ -106,6 +107,29 @@ def test_manifest_selection_returns_the_pinned_windows_build_closure(tmp_path: P
     assert packages[0].relative_path == "cccl/windows-x86_64/cccl.zip"
     assert packages[-1].license_path == "libnvvm/LICENSE.txt"
     assert packages[0].size == 7
+
+
+@pytest.mark.parametrize("drive", ("C:", "E:"))
+def test_cuda_status_accepts_any_local_drive(drive: str) -> None:
+    report = cuda_toolchain_status(Path(f"{drive}/bside/asr/cuda"))
+
+    assert report["toolchain_root"] == str(Path(f"{drive}/bside/asr/cuda"))
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        Path("C:/"),
+        Path("C:/bside/../cuda"),
+        Path("C:bside/cuda"),
+        Path("relative/cuda"),
+        Path("https://example.invalid/cuda"),
+        Path("//server/share/cuda"),
+    ),
+)
+def test_cuda_status_rejects_unsafe_roots(value: Path) -> None:
+    with pytest.raises(AsrError, match="absolute local Windows path"):
+        cuda_toolchain_status(value)
 
 
 def test_strict_manifest_pin_rejects_size_or_hash_mismatch(tmp_path: Path) -> None:

--- a/tests/asr/test_cuda_toolchain.py
+++ b/tests/asr/test_cuda_toolchain.py
@@ -193,6 +193,21 @@ def test_assembly_dry_run_does_not_write_and_apply_is_idempotent(tmp_path: Path)
     assert (toolchain_root / "bin" / "nvcc.exe").is_file()
 
 
+def test_uninstall_preserves_unknown_user_data_next_to_valid_marker(tmp_path: Path) -> None:
+    manifest_path, transfer_root = _write_transfer(tmp_path)
+    toolchain_root = tmp_path / "toolchain"
+    assemble_cuda_toolchain(manifest_path, transfer_root, toolchain_root, apply=True, strict=False)
+    unknown_user_data = toolchain_root / "unknown-user-data.txt"
+    unknown_user_data.write_text("keep me", encoding="utf-8")
+
+    removed = uninstall_cuda_toolchain(toolchain_root, apply=True)
+
+    assert removed["deleted"] is True
+    assert not (toolchain_root / ".b05-cuda-toolchain.json").exists()
+    assert unknown_user_data.read_text(encoding="utf-8") == "keep me"
+    assert toolchain_root.exists()
+
+
 def test_build_contract_is_sm86_msvc_http_asr_only_and_uninstall_is_owned(tmp_path: Path) -> None:
     command = build_command(tmp_path / "source", tmp_path / "build")
     assert "-AsrOnly" in command
@@ -213,7 +228,9 @@ def test_build_contract_is_sm86_msvc_http_asr_only_and_uninstall_is_owned(tmp_pa
     assert toolchain_root.exists()
     removed = uninstall_cuda_toolchain(toolchain_root, apply=True)
     assert removed["deleted"] is True
-    assert not toolchain_root.exists()
+    assert not (toolchain_root / ".b05-cuda-toolchain.json").exists()
+    assert (toolchain_root / "bin" / "nvcc.exe").is_file()
+    assert toolchain_root.exists()
 
 
 def test_management_cli_reports_unavailable_without_touching_the_root(

--- a/tests/asr/test_management.py
+++ b/tests/asr/test_management.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -32,6 +33,32 @@ def test_install_plan_is_offline_and_records_fixed_transfer_closure() -> None:
     assert plan["provenance"]["replacement_boundary"]
 
 
+def test_install_plan_accepts_any_local_drive_for_external_roots() -> None:
+    config = AsrConfig(
+        runtime_root=Path("C:/bside/asr/runtime"),
+        model_root=Path("E:/bside/asr/models"),
+        cache_root=Path("C:/bside/asr/cache"),
+    )
+
+    assert install_plan(config)["paths_are_external"] is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        Path("C:/"),
+        Path("C:/transfer/../asr"),
+        Path("C:transfer"),
+        Path("relative/transfer"),
+        Path("https://example.invalid/transfer"),
+        Path("//server/share/transfer"),
+    ),
+)
+def test_install_plan_rejects_unsafe_transfer_root(value: Path) -> None:
+    with pytest.raises(AsrError, match="absolute local Windows path"):
+        install_plan(AsrConfig(), transfer_root=value)
+
+
 def test_apply_requires_explicit_offline_transfer_root(tmp_path: Path) -> None:
     config = AsrConfig(provider="nemotron-speech-cpp").with_test_paths(tmp_path)
 
@@ -59,6 +86,22 @@ def test_uninstall_plan_does_not_delete_without_apply(tmp_path: Path) -> None:
     assert plan["deleted"] == []
 
 
+def test_uninstall_removes_only_trusted_manifest_and_preserves_external_content(tmp_path: Path) -> None:
+    config = AsrConfig(provider="nemotron-speech-cpp").with_test_paths(tmp_path)
+    for root in (config.runtime_root, config.model_root, config.cache_root):
+        root.mkdir(parents=True)
+    preserved = config.runtime_root / "nemo-speech.exe"
+    preserved.write_bytes(b"external-runtime")
+    manifest_path = config.runtime_root / ".b05-install.json"
+    manifest_path.write_text(json.dumps({"owner": "b05-streaming-asr"}), encoding="utf-8")
+
+    removed = uninstall(config, apply=True)
+
+    assert removed["deleted"] == [str(manifest_path)]
+    assert preserved.is_file()
+    assert all(root.is_dir() for root in (config.runtime_root, config.model_root, config.cache_root))
+
+
 def test_install_and_uninstall_apply_roundtrip_removes_only_owned_roots(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -83,11 +126,8 @@ def test_install_and_uninstall_apply_roundtrip_removes_only_owned_roots(
 
     removed = uninstall(config, apply=True)
     assert removed["mode"] == "applied"
-    assert set(removed["deleted"]) == {
-        str(config.runtime_root),
-        str(config.model_root),
-        str(config.cache_root),
-    }
-    assert not config.runtime_root.exists()
-    assert not config.model_root.exists()
-    assert not config.cache_root.exists()
+    assert removed["deleted"] == [str(config.runtime_root / ".b05-install.json")]
+    assert runtime_executable.is_file()
+    assert config.runtime_root.is_dir()
+    assert config.model_root.is_dir()
+    assert config.cache_root.is_dir()

--- a/tests/asr/test_tools.py
+++ b/tests/asr/test_tools.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from asr.config import AsrConfig
 from tools import asr_healthcheck, asr_manage
 
@@ -28,3 +30,20 @@ def test_asr_manage_switch_cli_writes_only_config(capsys, tmp_path: Path) -> Non
     assert asr_manage.main(["switch", "--config", str(config_path), "--provider", "text-fallback"]) == 0
     json.loads(capsys.readouterr().out)
     assert AsrConfig.from_json(config_path).provider == "text-fallback"
+
+
+def test_asr_manage_rejects_relative_data_root_before_resolution(capsys, tmp_path: Path) -> None:
+    with pytest.raises(SystemExit):
+        asr_manage.main(
+            [
+                "switch",
+                "--config",
+                str(tmp_path / "config.json"),
+                "--provider",
+                "text-fallback",
+                "--data-root",
+                "relative/asr",
+            ]
+        )
+
+    assert "--data-root must be an absolute local Windows path" in capsys.readouterr().err

--- a/tools/asr_manage.py
+++ b/tools/asr_manage.py
@@ -12,7 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from asr.config import AsrConfig  # noqa: E402
+from asr.config import AsrConfig, default_asr_root, is_local_absolute_path  # noqa: E402
 from asr.cuda_toolchain import (  # noqa: E402
     assemble_cuda_toolchain,
     build_environment,
@@ -24,20 +24,17 @@ from asr.management import install, switch_provider, uninstall  # noqa: E402
 from asr.provider import NemotronProvider, create_provider  # noqa: E402
 
 
-DEFAULT_CONFIG = Path("F:/Bside-olivia-local/asr/config.json")
-
-
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Manage the optional local B05 ASR runtime")
     parser.add_argument("command", choices=["status", "install", "uninstall", "switch", "cuda-toolchain"])
-    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--config", type=Path, default=None)
     parser.add_argument("--provider", choices=["text-fallback", "nemotron-speech-cpp"])
     parser.add_argument(
         "--data-root",
         type=Path,
-        help="explicit D:/ or F:/ root for runtime, model, cache, and acceptance evidence",
+        help="explicit local absolute root for runtime, model, cache, and acceptance evidence",
     )
-    parser.add_argument("--transfer-root", type=Path, help="verified offline D:/ or F:/ transfer root")
+    parser.add_argument("--transfer-root", type=Path, help="verified offline local absolute transfer root")
     parser.add_argument("--apply", action="store_true")
     parser.add_argument("--action", choices=["status", "assemble", "uninstall"], default="status")
     parser.add_argument("--cuda-root", type=Path)
@@ -48,6 +45,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--vswhere", type=Path)
     parser.add_argument("--cuda-arch", default="86")
     args = parser.parse_args(argv)
+    config_path = args.config or default_asr_root() / "config.json"
+
+    # Reject the original spelling before any path normalization.  A relative
+    # value must not silently become relative to the process CWD.
+    if args.command == "switch" and args.data_root is not None and not is_local_absolute_path(args.data_root):
+        parser.error("--data-root must be an absolute local Windows path")
 
     if args.command == "cuda-toolchain":
         if not args.cuda_root:
@@ -77,9 +80,9 @@ def main(argv: list[str] | None = None) -> int:
     elif args.command == "switch":
         if not args.provider:
             parser.error("switch requires --provider")
-        seed = AsrConfig.from_json(args.config) if args.config.is_file() else AsrConfig.from_env()
+        seed = AsrConfig.from_json(config_path) if config_path.is_file() else AsrConfig.from_env()
         if args.data_root:
-            data_root = args.data_root.absolute()
+            data_root = args.data_root
             seed = replace(
                 seed,
                 runtime_root=data_root / "runtime",
@@ -88,9 +91,9 @@ def main(argv: list[str] | None = None) -> int:
                 model_path=data_root / "models" / "nemotron-3.5-asr-streaming-0.6b.q8_0.gguf",
             )
             seed.validate_storage_roots()
-        result = switch_provider(args.config, args.provider, base_config=seed).to_dict()
+        result = switch_provider(config_path, args.provider, base_config=seed).to_dict()
     else:
-        config = AsrConfig.from_json(args.config) if args.config.is_file() else AsrConfig.from_env()
+        config = AsrConfig.from_json(config_path) if config_path.is_file() else AsrConfig.from_env()
         if args.command == "status":
             provider = create_provider(config)
             result = {"config": config.to_dict(include_paths=False), "status": provider.status()}


### PR DESCRIPTION
## Scope

- Replace the fixed `F:/Bside-olivia-local/asr` default with per-user `LOCALAPPDATA/BSideOliviaLocal/asr` and safe user-profile fallback.
- Accept any non-root local Windows drive path; reject relative, drive-relative, parent traversal, URL, and UNC values before normalization.
- Make ASR CLI `--data-root` validation fail closed before `.absolute()` and keep CUDA toolchain validation on the same contract.
- Remove only the existing trusted `.b05-install.json` marker during ASR uninstall; never recursively delete configured runtime/model/cache directories.
- Update `docs/B05_STREAMING_ASR.md` examples and path boundary.

## Exact base/head

- Base: `78a4cd7a71b9303291b59f4dbb3fa6de54b0cbb8` (`origin/main` when branched)
- Head: `913e6adca7dfb880f0f6d997e65756cd79e199bd` (`fix(asr): use portable local storage paths`)

## Verification

- `rtk python -m pytest tests/asr/test_config.py tests/asr/test_management.py tests/asr/test_tools.py tests/asr/test_cuda_toolchain.py -q` -> 49 passed.
- `rtk python -m pytest tests/asr -q` -> 81 passed, 5 unrelated historical scope-gate failures because commits `7998028...` and `49fe48...` are not present in this clean worktree; no ASR test failure.
- `rtk git diff --check` -> passed.

This is a focused portability and destructive-uninstall boundary change. It does not add ownership migration, new markers, downloads, model changes, or inference behavior.
