### PR TITLE
fix(installer): preserve LLM environment overrides

### DIFF
--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -128,17 +128,20 @@ def main(argv: list[str] | None = None) -> int:
             "OLIVIA_REPLY_DELAY_ENABLED": "1",
             "OLIVIA_REPLY_DELAY_MINUTES_MIN": "5",
             "OLIVIA_REPLY_DELAY_MINUTES_MAX": "10",
-            "OLIVIA_LLM_PROVIDER": "openai_compatible",
-            "OLIVIA_LLM_BASE_URL": "https://api.deepseek.com",
-            "OLIVIA_LLM_MODEL": "deepseek-v4-flash",
-            "OLIVIA_LLM_API_KEY_ENV": "DEEPSEEK_API_KEY",
-            "OLIVIA_LLM_API_STYLE": "chat_completions",
-            "OLIVIA_LLM_STREAM": "true",
-            "OLIVIA_LLM_TIMEOUT_SECONDS": "25",
-            "OLIVIA_LLM_MAX_RETRIES": "0",
             "OLIVIA_PORT": str(args.port),
         }
     )
+    for name, value in {
+        "OLIVIA_LLM_PROVIDER": "openai_compatible",
+        "OLIVIA_LLM_BASE_URL": "https://api.deepseek.com",
+        "OLIVIA_LLM_MODEL": "deepseek-v4-flash",
+        "OLIVIA_LLM_API_KEY_ENV": "DEEPSEEK_API_KEY",
+        "OLIVIA_LLM_API_STYLE": "chat_completions",
+        "OLIVIA_LLM_STREAM": "true",
+        "OLIVIA_LLM_TIMEOUT_SECONDS": "180",
+        "OLIVIA_LLM_MAX_RETRIES": "0",
+    }.items():
+        environment.setdefault(name, value)
     if not any(environment.get(name) for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")):
         print("LLM_API_KEY_NOT_CONFIGURED: 请先在启动此程序的进程环境中设置 API key；当前仅提供明确的 safe-static/degraded 回退。")
     server = None

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -72,6 +72,98 @@ def test_launcher_starts_combined_server_before_original_client(
     assert not backend_command[-1].endswith("local_server.py")
 
 
+def test_launcher_preserves_compatible_llm_environment_overrides(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    root = _installation(tmp_path)
+    health = iter((False, True, True))
+    backend_environments: list[dict[str, str]] = []
+
+    class Process:
+        @staticmethod
+        def poll():
+            return None
+
+    def popen(_command, **kwargs):
+        backend_environments.append(kwargs["env"])
+        return Process()
+
+    monkeypatch.setattr(start_local, "_health", lambda _port: next(health))
+    monkeypatch.setattr(
+        start_local,
+        "_backend_executable",
+        lambda: Path("pythonw-fixture.exe"),
+    )
+    monkeypatch.setattr(start_local.subprocess, "Popen", popen)
+    monkeypatch.setattr(start_local.subprocess, "call", lambda *_args, **_kwargs: 0)
+    overrides = {
+        "OLIVIA_LLM_BASE_URL": "https://gateway.example/v1",
+        "OLIVIA_LLM_MODEL": "compatible-model",
+        "OLIVIA_LLM_API_STYLE": "responses",
+        "OLIVIA_LLM_STREAM": "false",
+        "OLIVIA_LLM_TIMEOUT_SECONDS": "240",
+        "OLIVIA_LLM_MAX_RETRIES": "2",
+    }
+    for name, value in overrides.items():
+        monkeypatch.setenv(name, value)
+
+    assert start_local.main(["--install-root", str(root), "--port", "8899"]) == 0
+
+    assert len(backend_environments) == 1
+    assert {
+        name: backend_environments[0][name]
+        for name in overrides
+    } == overrides
+
+
+def test_launcher_supplies_deepseek_defaults_when_llm_overrides_are_absent(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    root = _installation(tmp_path)
+    health = iter((False, True, True))
+    backend_environments: list[dict[str, str]] = []
+
+    class Process:
+        @staticmethod
+        def poll():
+            return None
+
+    def popen(_command, **kwargs):
+        backend_environments.append(kwargs["env"])
+        return Process()
+
+    monkeypatch.setattr(start_local, "_health", lambda _port: next(health))
+    monkeypatch.setattr(
+        start_local,
+        "_backend_executable",
+        lambda: Path("pythonw-fixture.exe"),
+    )
+    monkeypatch.setattr(start_local.subprocess, "Popen", popen)
+    monkeypatch.setattr(start_local.subprocess, "call", lambda *_args, **_kwargs: 0)
+    defaults = {
+        "OLIVIA_LLM_PROVIDER": "openai_compatible",
+        "OLIVIA_LLM_BASE_URL": "https://api.deepseek.com",
+        "OLIVIA_LLM_MODEL": "deepseek-v4-flash",
+        "OLIVIA_LLM_API_KEY_ENV": "DEEPSEEK_API_KEY",
+        "OLIVIA_LLM_API_STYLE": "chat_completions",
+        "OLIVIA_LLM_STREAM": "true",
+        "OLIVIA_LLM_TIMEOUT_SECONDS": "180",
+        "OLIVIA_LLM_MAX_RETRIES": "0",
+    }
+    for name in defaults:
+        monkeypatch.delenv(name, raising=False)
+
+    assert start_local.main(["--install-root", str(root), "--port", "8899"]) == 0
+
+    assert len(backend_environments) == 1
+    assert {
+        name: backend_environments[0][name]
+        for name in defaults
+    } == defaults
+
+
 def test_launcher_refuses_payload_without_combined_entrypoint(
     tmp_path: Path,
     capsys,


### PR DESCRIPTION
## Scope\n\nKeep installer launcher LLM defaults compatible with README-supported environment overrides. Existing OLIVIA_LLM_* values are preserved; unset values use the DeepSeek openai-compatible defaults, with a conservative 180-second timeout and zero retries. No UI, config-file, cancellation, or reply-delay changes.\n\n## TDD / verification\n\n- RED: launcher override test failed because update() overwrote all six configured values and timeout 25.\n- GREEN: python -m pytest -q tests/installer/test_original_client_server_launcher.py -> 4 passed.\n- git diff --check -> passed.\n\nBase: 7a418b18c524a4e3891e613214dbc3ca09e4b1c3\nHead: 39e21e702533d1d7ce6509fa39de26766ae17ce\n\n## Acceptance boundary\n\nTests capture the environment passed to the launched backend; no external provider, API key, or real media/model execution is included in this PR.