### PR TITLE
fix(mem0): avoid SameFileError for embedding aliases

### DIFF
--- a/mem0_embedding_install.py
+++ b/mem0_embedding_install.py
@@ -106,7 +106,13 @@ class HuggingFaceEmbeddingDownloader:
             token=False,
         )
         fetched_path = Path(fetched)
-        if fetched_path.resolve() != destination.resolve():
+        try:
+            same_file = os.path.samefile(fetched_path, destination)
+        except FileNotFoundError:
+            # A missing source/destination must still follow the normal copy
+            # path so the caller receives the download error and fails closed.
+            same_file = False
+        if not same_file:
             shutil.copyfile(fetched_path, destination)
 
 

--- a/tests/memory/test_mem0_embedding_install.py
+++ b/tests/memory/test_mem0_embedding_install.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import os
 import sys
 import threading
 import time
@@ -548,6 +549,37 @@ def test_huggingface_download_call_shape_uses_only_supported_pinned_arguments(
     inspect.signature(hf_hub_download).bind(**observed)
     assert observed["revision"] == MEM0_EMBEDDING_MODEL_REVISION
     assert observed["token"] is False
+    assert destination.read_bytes() == b"synthetic"
+
+
+def test_huggingface_downloader_skips_copy_for_physical_file_alias(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "stage" / "1_Pooling" / "config.json"
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"synthetic")
+    fetched = tmp_path / "hf-cache" / "config.json"
+
+    def hf_hub_download(**kwargs: object) -> str:
+        del kwargs
+        fetched.parent.mkdir(parents=True)
+        os.link(destination, fetched)
+        return str(fetched)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(hf_hub_download=hf_hub_download),
+    )
+
+    HuggingFaceEmbeddingDownloader().download(
+        revision=MEM0_EMBEDDING_MODEL_REVISION,
+        relative_path="1_Pooling/config.json",
+        destination=destination,
+    )
+
+    assert fetched.resolve() != destination.resolve()
+    assert os.path.samefile(fetched, destination)
     assert destination.read_bytes() == b"synthetic"
 
 


### PR DESCRIPTION
## Scope\nFix the pinned Mem0 embedding downloader when Hugging Face returns a path referring to the same physical file as the destination. The downloader now uses same-file identity and copies only when the files are distinct.\n\n## TDD evidence\n- RED: focused regression reproduced shutil.SameFileError with distinct lexical paths backed by one hard-linked file.\n- GREEN: 	ests/memory/test_mem0_embedding_install.py: 21 passed.\n- git diff --check: passed.\n\n## Exact pair\n- base: 7a418b18c524a4e3891e613214dbc3ca09e4b1c3\n- head: ad82f30eaeca7cc3b8a64a9712961c5447b15f4\n\n## Boundary\nNo changes to the download manifest, model revision, installer lifecycle, or architecture. Missing paths still follow the normal copy/error path; unexpected filesystem errors remain fail-closed through the existing installer error boundary. No local machine paths, private data, keys, or model files are included.