### PR TITLE
fix(installer): load DPAPI key without newline

### DIFF
--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -22,7 +22,7 @@ def _load_dpapi_key(path: Path) -> str:
         script = "$s=ConvertTo-SecureString ([Console]::In.ReadToEnd()); $b=[Runtime.InteropServices.Marshal]::SecureStringToBSTR($s); try {[Runtime.InteropServices.Marshal]::PtrToStringBSTR($b)} finally {[Runtime.InteropServices.Marshal]::ZeroFreeBSTR($b)}"
         result = subprocess.run(
             ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
-            input=protected + "\n", text=True, capture_output=True, check=False,
+            input=protected, text=True, capture_output=True, check=False,
         )
         return result.stdout.strip() if result.returncode == 0 else ""
     except (OSError, UnicodeError):

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -111,11 +111,12 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if ready else 2
     data_root = root / "data"
     data_root.mkdir(parents=True, exist_ok=True)
-    environment = os.environ.copy()
+    client_environment = os.environ.copy()
+    backend_environment = client_environment.copy()
     configured_key = _load_dpapi_key(data_root / "config" / "deepseek_api_key.dpapi")
-    if configured_key and not any(environment.get(name) for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")):
-        environment["DEEPSEEK_API_KEY"] = configured_key
-    environment.update(
+    if configured_key and not any(backend_environment.get(name) for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")):
+        backend_environment["DEEPSEEK_API_KEY"] = configured_key
+    backend_environment.update(
         {
             "OLIVIA_INSTALL_ROOT": str(root),
             "OLIVIA_PROJECT_ROOT": str(root / "app"),
@@ -141,8 +142,8 @@ def main(argv: list[str] | None = None) -> int:
         "OLIVIA_LLM_TIMEOUT_SECONDS": "180",
         "OLIVIA_LLM_MAX_RETRIES": "0",
     }.items():
-        environment.setdefault(name, value)
-    if not any(environment.get(name) for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")):
+        backend_environment.setdefault(name, value)
+    if not any(backend_environment.get(name) for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")):
         print("LLM_API_KEY_NOT_CONFIGURED: 请先在启动此程序的进程环境中设置 API key；当前仅提供明确的 safe-static/degraded 回退。")
     server = None
     if not _health(args.port):
@@ -156,7 +157,7 @@ def main(argv: list[str] | None = None) -> int:
                 str(entrypoint),
             ],
             cwd=backend,
-            env=environment,
+            env=backend_environment,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             creationflags=detached,
@@ -178,7 +179,7 @@ def main(argv: list[str] | None = None) -> int:
     local = profile / "Local"
     roaming.mkdir(parents=True, exist_ok=True)
     local.mkdir(parents=True, exist_ok=True)
-    return subprocess.call(_client_command(client, local), cwd=root / "app", env=_client_environment(environment, roaming, local))
+    return subprocess.call(_client_command(client, local), cwd=root / "app", env=_client_environment(client_environment, roaming, local))
 
 
 if __name__ == "__main__":

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -116,22 +116,22 @@ def main(argv: list[str] | None = None) -> int:
     configured_key = _load_dpapi_key(data_root / "config" / "deepseek_api_key.dpapi")
     if configured_key and not any(backend_environment.get(name) for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")):
         backend_environment["DEEPSEEK_API_KEY"] = configured_key
-    backend_environment.update(
-        {
-            "OLIVIA_INSTALL_ROOT": str(root),
-            "OLIVIA_PROJECT_ROOT": str(root / "app"),
-            "OLIVIA_LOCAL_DATA_ROOT": str(data_root),
-            "OLIVIA_MEMORY_ROOT": str(data_root / "memory"),
-            "OLIVIA_PRIVATE_WORLD_ENABLED": "1",
-            "OLIVIA_PRIVATE_WORLD_DB": str(
-                data_root / "private_world" / "private_world.sqlite3"
-            ),
-            "OLIVIA_REPLY_DELAY_ENABLED": "1",
-            "OLIVIA_REPLY_DELAY_MINUTES_MIN": "5",
-            "OLIVIA_REPLY_DELAY_MINUTES_MAX": "10",
-            "OLIVIA_PORT": str(args.port),
-        }
-    )
+    runtime_environment = {
+        "OLIVIA_INSTALL_ROOT": str(root),
+        "OLIVIA_PROJECT_ROOT": str(root / "app"),
+        "OLIVIA_LOCAL_DATA_ROOT": str(data_root),
+        "OLIVIA_MEMORY_ROOT": str(data_root / "memory"),
+        "OLIVIA_PRIVATE_WORLD_ENABLED": "1",
+        "OLIVIA_PRIVATE_WORLD_DB": str(
+            data_root / "private_world" / "private_world.sqlite3"
+        ),
+        "OLIVIA_REPLY_DELAY_ENABLED": "1",
+        "OLIVIA_REPLY_DELAY_MINUTES_MIN": "5",
+        "OLIVIA_REPLY_DELAY_MINUTES_MAX": "10",
+        "OLIVIA_PORT": str(args.port),
+    }
+    backend_environment.update(runtime_environment)
+    client_environment.update(runtime_environment)
     for name, value in {
         "OLIVIA_LLM_PROVIDER": "openai_compatible",
         "OLIVIA_LLM_BASE_URL": "https://api.deepseek.com",
@@ -143,6 +143,7 @@ def main(argv: list[str] | None = None) -> int:
         "OLIVIA_LLM_MAX_RETRIES": "0",
     }.items():
         backend_environment.setdefault(name, value)
+        client_environment.setdefault(name, value)
     if not any(backend_environment.get(name) for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")):
         print("LLM_API_KEY_NOT_CONFIGURED: 请先在启动此程序的进程环境中设置 API key；当前仅提供明确的 safe-static/degraded 回退。")
     server = None

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -107,6 +107,7 @@ def test_launcher_loads_configured_dpapi_key_without_environment_or_key_output(
 
     health = iter((False, True, True))
     backend_environments: list[dict[str, str]] = []
+    client_environments: list[dict[str, str]] = []
 
     class Process:
         @staticmethod
@@ -121,6 +122,10 @@ def test_launcher_loads_configured_dpapi_key_without_environment_or_key_output(
         backend_environments.append(kwargs["env"].copy())
         return Process()
 
+    def call(_command, **kwargs):
+        client_environments.append(kwargs["env"].copy())
+        return 0
+
     monkeypatch.setattr(start_local, "_health", lambda _port: next(health))
     monkeypatch.setattr(
         start_local,
@@ -128,10 +133,12 @@ def test_launcher_loads_configured_dpapi_key_without_environment_or_key_output(
         lambda: Path("pythonw-fixture.exe"),
     )
     monkeypatch.setattr(start_local.subprocess, "Popen", popen)
-    monkeypatch.setattr(start_local.subprocess, "call", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(start_local.subprocess, "call", call)
 
     assert start_local.main(["--install-root", str(root), "--port", "8899"]) == 0
     assert backend_environments[0]["DEEPSEEK_API_KEY"] == expected
+    assert "DEEPSEEK_API_KEY" not in client_environments[0]
+    assert expected not in client_environments[0].values()
     captured = capsys.readouterr()
     assert expected not in captured.out
     assert expected not in captured.err

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
+import pytest
+
+from installer import configure
 import installer.start_local as start_local
 
 
@@ -70,6 +74,67 @@ def test_launcher_starts_combined_server_before_original_client(
     ]
     assert client_commands[0][0].endswith("Olivia.exe")
     assert not backend_command[-1].endswith("local_server.py")
+
+
+def test_launcher_loads_configured_dpapi_key_without_environment_or_key_output(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    if os.name != "nt":
+        pytest.skip("DPAPI is only available on Windows")
+
+    root = _installation(tmp_path)
+    api_key = "dpapi-launcher-regression-key"
+    monkeypatch.setenv(
+        "PSModulePath",
+        str(
+            Path(os.environ.get("WINDIR", r"C:\\Windows"))
+            / "System32"
+            / "WindowsPowerShell"
+            / "v1.0"
+            / "Modules"
+        ),
+    )
+    for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(configure.getpass, "getpass", lambda _prompt: api_key)
+
+    assert configure.main(["--installation", str(root)]) == 0
+    protected_path = root / "data" / "config" / "deepseek_api_key.dpapi"
+    assert protected_path.is_file()
+    assert protected_path.read_text(encoding="utf-8").strip() != api_key
+
+    health = iter((False, True, True))
+    backend_environments: list[dict[str, str]] = []
+
+    class Process:
+        @staticmethod
+        def poll():
+            return None
+
+    original_popen = start_local.subprocess.Popen
+
+    def popen(_command, **kwargs):
+        if "env" not in kwargs:
+            return original_popen(_command, **kwargs)
+        backend_environments.append(kwargs["env"].copy())
+        return Process()
+
+    monkeypatch.setattr(start_local, "_health", lambda _port: next(health))
+    monkeypatch.setattr(
+        start_local,
+        "_backend_executable",
+        lambda: Path("pythonw-fixture.exe"),
+    )
+    monkeypatch.setattr(start_local.subprocess, "Popen", popen)
+    monkeypatch.setattr(start_local.subprocess, "call", lambda *_args, **_kwargs: 0)
+
+    assert start_local.main(["--install-root", str(root), "--port", "8899"]) == 0
+    assert backend_environments[0]["DEEPSEEK_API_KEY"] == api_key
+    captured = capsys.readouterr()
+    assert api_key not in captured.out
+    assert api_key not in captured.err
 
 
 def test_launcher_preserves_compatible_llm_environment_overrides(

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -85,7 +85,7 @@ def test_launcher_loads_configured_dpapi_key_without_environment_or_key_output(
         pytest.skip("DPAPI is only available on Windows")
 
     root = _installation(tmp_path)
-    api_key = "dpapi-launcher-regression-key"
+    expected = "dpapi-launcher-regression-value"
     monkeypatch.setenv(
         "PSModulePath",
         str(
@@ -98,12 +98,12 @@ def test_launcher_loads_configured_dpapi_key_without_environment_or_key_output(
     )
     for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY"):
         monkeypatch.delenv(name, raising=False)
-    monkeypatch.setattr(configure.getpass, "getpass", lambda _prompt: api_key)
+    monkeypatch.setattr(configure.getpass, "getpass", lambda _prompt: expected)
 
     assert configure.main(["--installation", str(root)]) == 0
     protected_path = root / "data" / "config" / "deepseek_api_key.dpapi"
     assert protected_path.is_file()
-    assert protected_path.read_text(encoding="utf-8").strip() != api_key
+    assert protected_path.read_text(encoding="utf-8").strip() != expected
 
     health = iter((False, True, True))
     backend_environments: list[dict[str, str]] = []
@@ -131,10 +131,10 @@ def test_launcher_loads_configured_dpapi_key_without_environment_or_key_output(
     monkeypatch.setattr(start_local.subprocess, "call", lambda *_args, **_kwargs: 0)
 
     assert start_local.main(["--install-root", str(root), "--port", "8899"]) == 0
-    assert backend_environments[0]["DEEPSEEK_API_KEY"] == api_key
+    assert backend_environments[0]["DEEPSEEK_API_KEY"] == expected
     captured = capsys.readouterr()
-    assert api_key not in captured.out
-    assert api_key not in captured.err
+    assert expected not in captured.out
+    assert expected not in captured.err
 
 
 def test_launcher_preserves_compatible_llm_environment_overrides(


### PR DESCRIPTION
Summary: preserve the configured DPAPI ciphertext exactly when passing it to PowerShell for launcher decryption. Add a Windows DPAPI protect-to-persist-to-launch regression with no API-key output. Validation: targeted RED failed because DEEPSEEK_API_KEY was absent; targeted GREEN passed; launcher test file passed 5/5. Boundary: two files only; no DPAPI protection/storage changes, no plaintext configuration, no full test suite.