### PR TITLE
fix: route letter triage through structured tool

### DIFF
--- a/docs/B03_LLM_GATEWAY.md
+++ b/docs/B03_LLM_GATEWAY.md
@@ -75,13 +75,16 @@ calls = await gateway.complete_with_tools(
   `stream=false` 发起一次请求；它不会回退到自由文本。
 - `api_style="chat_completions"` 发送 OpenAI Chat Completions 的
   `tools`/`tool_choice` 形状，并读取
-  `choices[0].message.tool_calls[*].function`。
+  `choices[0].message.tool_calls[*].function`。唯一兼容例外是
+  `openai_compatible` 的 `deepseek-v4-flash`：其默认 thinking 模式不接受
+  `tool_choice`，因此该请求省略该字段，但仍只发送一次带唯一 function schema 的
+  请求，并在本地严格要求恰好一个有效调用；不会回退为文本或接受任意调用。
 - `api_style="responses"` 将同一输入函数 schema 转为 Responses 的
   `type/name/description/parameters` 形状，并读取
   `output[*]` 中 `type="function_call"` 的 `name` 和 `arguments`。
-- 缺少调用、无效 name、非对象 arguments 或不能解析的 arguments JSON 都是
-  非重试的 `PROVIDER_PROTOCOL`；不支持该能力或 provider 不可用仍为可重试的
-  `PROVIDER_UNAVAILABLE`。调用方不得把这些错误转换成占位成功。
+- 缺少调用、无效 name、非对象 arguments、不能解析的 arguments JSON，或调用数组
+  中任何畸形 sibling 都是非重试的 `PROVIDER_PROTOCOL`；不支持该能力或 provider
+  不可用仍为可重试的 `PROVIDER_UNAVAILABLE`。调用方不得把这些错误转换成占位成功。
 - 自定义 provider 若声明支持此公开能力，必须覆写
   `Gateway.complete_with_tools()` 并返回 `Sequence[GatewayToolCall]`；若不支持，
   保持基类的 `PROVIDER_UNAVAILABLE` 失败边界。自定义实现也必须保留 request ID、

--- a/letter_triage.py
+++ b/letter_triage.py
@@ -303,6 +303,7 @@ def _validated_result(
         or role not in _ALLOWED_MUSIC_ROLES
         or disposition not in _ALLOWED_REQUEST_DISPOSITIONS
         or len(raw_contexts) > len(_ALLOWED_MUSIC_CONTEXTS)
+        or any(type(item) is not str for item in raw_contexts)
     ):
         return None
 

--- a/letter_triage.py
+++ b/letter_triage.py
@@ -282,30 +282,37 @@ def _validated_result(
     value: Mapping[str, Any],
     context: RoutingContext,
 ) -> TriageResult | None:
-    mode = str(value.get("mode", "")).strip().lower()
-    reason = str(value.get("reason_code", "")).strip().lower()
-    emotion = str(value.get("emotion_level", "unknown")).strip().lower()
-    intent = str(value.get("music_intent", "none")).strip().lower()
-    role = str(value.get("music_role", "")).strip().lower()
-    disposition = str(value.get("request_disposition", "")).strip().lower()
-    raw_contexts = value.get("music_contexts", [])
+    mode = value.get("mode")
+    reason = value.get("reason_code")
+    emotion = value.get("emotion_level")
+    intent = value.get("music_intent")
+    role = value.get("music_role")
+    disposition = value.get("request_disposition")
+    raw_contexts = value.get("music_contexts")
 
     if (
-        mode not in _ALLOWED_MODES
+        any(
+            type(item) is not str
+            for item in (mode, reason, emotion, intent, role, disposition)
+        )
+        or type(raw_contexts) is not list
+        or mode not in _ALLOWED_MODES
         or not _REASON.fullmatch(reason)
         or emotion not in _ALLOWED_EMOTIONS
         or intent not in _ALLOWED_MUSIC_INTENTS
         or role not in _ALLOWED_MUSIC_ROLES
         or disposition not in _ALLOWED_REQUEST_DISPOSITIONS
-        or not isinstance(raw_contexts, list)
         or len(raw_contexts) > len(_ALLOWED_MUSIC_CONTEXTS)
     ):
         return None
 
-    contexts = tuple(str(item).strip().lower() for item in raw_contexts)
+    contexts = tuple(raw_contexts)
     if (
         len(contexts) != len(set(contexts))
-        or any(item not in _ALLOWED_MUSIC_CONTEXTS for item in contexts)
+        or any(
+            type(item) is not str or item not in _ALLOWED_MUSIC_CONTEXTS
+            for item in contexts
+        )
         or _ROLE_INTENT[role] != intent
     ):
         return None

--- a/letter_triage.py
+++ b/letter_triage.py
@@ -15,9 +15,9 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Mapping, Protocol
+from typing import Any, Mapping, Protocol, Sequence
 
-from llm_gateway import GatewayError
+from llm_gateway import GatewayError, GatewayToolCall
 from music_reply import musical_reply_configured
 
 
@@ -75,7 +75,7 @@ spoken_video 只有在完整视频链可用、routing_context.spoken_video_avail
 text_letter。
 普通日常默认 text_letter。不要为了证明人格而音乐化。
 
-只输出一个 JSON 对象，不要 Markdown 或解释：
+必须调用 select_reply_mode，不要输出 Markdown 或解释。参数必须符合：
 {
   "mode":"text_letter|spoken_video|musical_video",
   "reason_code":"lower_snake_case",
@@ -135,15 +135,77 @@ _ROLE_INTENT = {
 _REASON = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
 _MAX_CONTEXT_ITEMS = 6
 _MAX_CONTEXT_ITEM_CHARS = 240
+_TOOL_FIELDS = frozenset(
+    {
+        "mode",
+        "reason_code",
+        "emotion_level",
+        "music_contexts",
+        "music_role",
+        "music_intent",
+        "request_disposition",
+        "direct_response_sufficient",
+        "voice_materially_better",
+        "music_materially_better",
+        "character_willing",
+    }
+)
+_ROUTER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "select_reply_mode",
+        "description": "Select exactly one expression mode for the current letter.",
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": sorted(_TOOL_FIELDS),
+            "properties": {
+                "mode": {"type": "string", "enum": sorted(_ALLOWED_MODES)},
+                "reason_code": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9][a-z0-9_]{0,63}$",
+                },
+                "emotion_level": {
+                    "type": "string",
+                    "enum": sorted(_ALLOWED_EMOTIONS),
+                },
+                "music_contexts": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": sorted(_ALLOWED_MUSIC_CONTEXTS)},
+                    "uniqueItems": True,
+                    "maxItems": len(_ALLOWED_MUSIC_CONTEXTS),
+                },
+                "music_role": {
+                    "type": "string",
+                    "enum": sorted(_ALLOWED_MUSIC_ROLES),
+                },
+                "music_intent": {
+                    "type": "string",
+                    "enum": sorted(_ALLOWED_MUSIC_INTENTS),
+                },
+                "request_disposition": {
+                    "type": "string",
+                    "enum": sorted(_ALLOWED_REQUEST_DISPOSITIONS),
+                },
+                "direct_response_sufficient": {"type": "boolean"},
+                "voice_materially_better": {"type": "boolean"},
+                "music_materially_better": {"type": "boolean"},
+                "character_willing": {"type": "boolean"},
+            },
+        },
+    },
+}
 
 
 class RouterGateway(Protocol):
-    async def complete(
+    async def complete_with_tools(
         self,
-        messages: object,
         *,
+        messages: Sequence[Mapping[str, str]],
+        tools: Sequence[Mapping[str, object]],
+        tool_choice: str,
         request_id: str | None = None,
-    ) -> object: ...
+    ) -> Sequence[GatewayToolCall]: ...
 
 
 @dataclass(frozen=True)
@@ -209,24 +271,6 @@ def _failed(code: str, *, called: bool = True) -> TriageResult:
         called,
         character_willing=False,
     )
-
-
-def _parse(raw: object) -> Mapping[str, Any] | None:
-    if not isinstance(raw, str):
-        return None
-    text = raw.strip()
-    if text.startswith("```"):
-        text = re.sub(
-            r"^```(?:json)?\s*|\s*```$",
-            "",
-            text,
-            flags=re.I,
-        ).strip()
-    try:
-        value = json.loads(text)
-    except (TypeError, ValueError, json.JSONDecodeError):
-        return None
-    return value if isinstance(value, Mapping) else None
 
 
 def _bool_field(value: Mapping[str, Any], name: str) -> bool | None:
@@ -373,9 +417,9 @@ class LetterReplyRouter:
             "current_letter": content.strip(),
         }
         try:
-            response = await asyncio.wait_for(
-                self.gateway.complete(
-                    [
+            calls = await asyncio.wait_for(
+                self.gateway.complete_with_tools(
+                    messages=[
                         {"role": "system", "content": ROUTER_SYSTEM_PROMPT},
                         {
                             "role": "user",
@@ -386,6 +430,8 @@ class LetterReplyRouter:
                             ),
                         },
                     ],
+                    tools=[_ROUTER_TOOL],
+                    tool_choice="required",
                     request_id="letter-reply-mode-router",
                 ),
                 timeout=self.timeout_seconds,
@@ -397,10 +443,12 @@ class LetterReplyRouter:
         except Exception:
             return _failed("router_unavailable")
 
-        parsed = _parse(getattr(response, "text", None))
-        if parsed is None:
+        if len(calls) != 1 or getattr(calls[0], "name", None) != "select_reply_mode":
             return _failed("router_invalid_result")
-        result = _validated_result(parsed, context)
+        arguments = getattr(calls[0], "arguments", None)
+        if not isinstance(arguments, Mapping) or set(arguments) != _TOOL_FIELDS:
+            return _failed("router_invalid_result")
+        result = _validated_result(arguments, context)
         return result or _failed("router_invalid_result")
 
 

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -643,7 +643,12 @@ class OpenAICompatibleAdapter(Gateway):
             body["tools"] = converted
         else:
             body["tools"] = list(tools)
-        body["tool_choice"] = tool_choice
+        if not (
+            self.config.provider == "openai_compatible"
+            and self.config.api_style == "chat_completions"
+            and self.config.model.casefold() == "deepseek-v4-flash"
+        ):
+            body["tool_choice"] = tool_choice
         data = await self._post_json(body, request)
         calls = _extract_tool_calls(data)
         if not calls:

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -760,6 +760,8 @@ def _extract_tool_calls(data: Mapping[str, Any]) -> tuple[GatewayToolCall, ...]:
                 tool_calls = message["tool_calls"]
                 if any(not isinstance(item, Mapping) for item in tool_calls):
                     raise ProviderProtocolError()
+                if any(not isinstance(item.get("function"), Mapping) for item in tool_calls):
+                    raise ProviderProtocolError()
                 raw_calls.extend(tool_calls)
     output = data.get("output")
     if isinstance(output, list):

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -757,9 +757,10 @@ def _extract_tool_calls(data: Mapping[str, Any]) -> tuple[GatewayToolCall, ...]:
         if isinstance(choice, Mapping):
             message = choice.get("message", choice)
             if isinstance(message, Mapping) and isinstance(message.get("tool_calls"), list):
-                raw_calls.extend(
-                    item for item in message["tool_calls"] if isinstance(item, Mapping)
-                )
+                tool_calls = message["tool_calls"]
+                if any(not isinstance(item, Mapping) for item in tool_calls):
+                    raise ProviderProtocolError()
+                raw_calls.extend(tool_calls)
     output = data.get("output")
     if isinstance(output, list):
         raw_calls.extend(

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -482,6 +482,26 @@ class OfflineDeterministicAdapter(Gateway):
             raise ProviderProtocolError()
         return GatewayResponse(text, request, self.config.provider, self.config.model or "offline")
 
+    async def complete_with_tools(
+        self,
+        *,
+        messages: Sequence[Mapping[str, Any]],
+        tools: Sequence[Mapping[str, object]],
+        tool_choice: str,
+        request_id: str | None = None,
+    ) -> Sequence[GatewayToolCall]:
+        validate_messages(messages, max_input_chars=self.config.max_input_chars)
+        if tool_choice != "required":
+            raise InvalidGatewayInput("REQUIRED_TOOL_CHOICE")
+        configured = self.config.provider_options.get("tool_call")
+        if not isinstance(configured, Mapping):
+            raise ProviderProtocolError()
+        name = configured.get("name")
+        arguments = configured.get("arguments")
+        if not isinstance(name, str) or not name or not isinstance(arguments, Mapping):
+            raise ProviderProtocolError()
+        return (GatewayToolCall(name=name, arguments=dict(arguments)),)
+
     async def stream(self, messages: Sequence[Mapping[str, Any]], *, request_id: str | None = None) -> AsyncIterator[GatewayDelta]:
         response = await self.complete(messages, request_id=request_id)
         width = _bounded_int(self.config.provider_options.get("chunk_size", 12), 12, 1, 256)

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -242,6 +242,8 @@ def test_router_accepts_one_offline_structured_musical_tool_call():
         ("reason_code", 123),
         ("mode", "TEXT_LETTER"),
         ("mode", " text_letter "),
+        ("music_contexts", [{}]),
+        ("music_contexts", [[]]),
     ],
 )
 def test_router_rejects_noncanonical_tool_schema_arguments(

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -13,26 +13,38 @@ from letter_triage import (
     _current_music_performance,
     routing_context_from_environment,
 )
-
-
-class _Response:
-    def __init__(self, text: str) -> None:
-        self.text = text
+from llm_gateway import GatewayToolCall
 
 
 class _Gateway:
-    def __init__(self, response: str) -> None:
-        self.response = response
+    def __init__(self, arguments: dict[str, object]) -> None:
+        self.arguments = arguments
         self.messages = None
+        self.requests: list[dict[str, object]] = []
 
-    async def complete(self, messages, *, request_id=None):
+    async def complete_with_tools(
+        self,
+        *,
+        messages,
+        tools,
+        tool_choice,
+        request_id=None,
+    ):
         self.messages = messages
-        return _Response(self.response)
+        self.requests.append(
+            {
+                "messages": messages,
+                "tools": tools,
+                "tool_choice": tool_choice,
+                "request_id": request_id,
+            }
+        )
+        return [GatewayToolCall("select_reply_mode", self.arguments)]
 
 
 def test_router_timeout_uses_portable_environment_configuration():
     router = LetterReplyRouter(
-        _Gateway("{}"),
+        _Gateway({}),
         environ={"OLIVIA_REPLY_ROUTER_TIMEOUT_SECONDS": "90"},
     )
 
@@ -76,7 +88,7 @@ def _route(*, context=None, **overrides):
         "character_willing": True,
     }
     payload.update(overrides)
-    gateway = _Gateway(json.dumps(payload))
+    gateway = _Gateway(payload)
     result = asyncio.run(
         LetterReplyRouter(
             gateway,
@@ -182,6 +194,37 @@ def test_all_musical_gates_allow_character_choice():
     )
     assert result.reply_mode == "musical_video"
     assert result.status == "completed"
+
+
+def test_router_accepts_one_offline_structured_musical_tool_call():
+    gateway = _Gateway(
+        {
+            "mode": "musical_video",
+            "reason_code": "performance_carries_this_reply",
+            "emotion_level": "mixed",
+            "music_contexts": ["explicit_performance_or_adaptation_request"],
+            "music_role": "performance",
+            "music_intent": "perform",
+            "request_disposition": "fulfill",
+            "direct_response_sufficient": False,
+            "voice_materially_better": False,
+            "music_materially_better": True,
+            "character_willing": True,
+        }
+    )
+
+    result = asyncio.run(
+        LetterReplyRouter(
+            gateway,
+            routing_context=RoutingContext(True, True),
+        ).classify("请把这段心事唱给我听。")
+    )
+
+    assert result.reply_mode == "musical_video"
+    assert result.status == "completed"
+    assert gateway.requests[0]["tool_choice"] == "required"
+    assert gateway.requests[0]["request_id"] == "letter-reply-mode-router"
+    assert gateway.requests[0]["tools"][0]["function"]["name"] == "select_reply_mode"
 
 
 def test_current_work_relevance_requires_trusted_current_work():
@@ -424,9 +467,10 @@ def test_complete_video_readiness_fails_closed_for_every_missing_renderer_depend
 def test_invalid_router_output_fails_closed_to_text_letter():
     result = asyncio.run(
         LetterReplyRouter(
-            _Gateway("not-json"),
+            _Gateway({}),
             routing_context=RoutingContext(True, True),
         ).classify("普通聊天")
     )
     assert result.reply_mode == "text_letter"
     assert result.status == "unavailable"
+    assert result.reason_code == "router_invalid_result"

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 
 import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
 
 import latentsync_reply
 import tts.delivery as tts_delivery
@@ -291,6 +293,68 @@ def test_public_mock_gateway_routes_configured_tool_result(
     assert result.reply_mode == expected_mode
     assert result.status == "completed"
     assert gateway.network_call_count == 0
+
+
+def test_deepseek_flash_thinking_omits_tool_choice_and_routes_valid_structured_call():
+    async def exercise():
+        seen: dict[str, object] = {}
+        arguments = _route_arguments(
+            mode="musical_video",
+            reason_code="performance_carries_this_reply",
+            emotion_level="mixed",
+            music_contexts=["explicit_performance_or_adaptation_request"],
+            music_role="performance",
+            music_intent="perform",
+            request_disposition="fulfill",
+            direct_response_sufficient=False,
+            music_materially_better=True,
+        )
+
+        async def handler(request: web.Request) -> web.Response:
+            seen["body"] = await request.json()
+            return web.json_response(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "tool_calls": [
+                                    {
+                                        "function": {
+                                            "name": "select_reply_mode",
+                                            "arguments": json.dumps(arguments),
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            )
+
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", handler)
+        async with TestClient(TestServer(app)) as client:
+            gateway = create_gateway(
+                GatewayConfig(
+                    provider="openai_compatible",
+                    base_url=str(client.make_url("/v1")),
+                    model="deepseek-v4-flash",
+                )
+            )
+            result = await LetterReplyRouter(
+                gateway,
+                routing_context=RoutingContext(True, True),
+            ).classify("synthetic current letter")
+        return result, seen["body"]
+
+    result, body = asyncio.run(exercise())
+
+    assert result.reply_mode == "musical_video"
+    assert result.status == "completed"
+    assert body["model"] == "deepseek-v4-flash"
+    assert "thinking" not in body
+    assert "tool_choice" not in body
+    assert body["tools"][0]["function"]["name"] == "select_reply_mode"
 
 
 def test_current_work_relevance_requires_trusted_current_work():

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 import latentsync_reply
 import tts.delivery as tts_delivery
 from letter_triage import (
@@ -13,7 +15,7 @@ from letter_triage import (
     _current_music_performance,
     routing_context_from_environment,
 )
-from llm_gateway import GatewayToolCall
+from llm_gateway import GatewayConfig, GatewayToolCall, create_gateway
 
 
 class _Gateway:
@@ -73,7 +75,7 @@ def test_music_performance_uses_system_tod_with_day_morning_fallback(tmp_path):
     assert _current_music_performance(environ, hour=4) == night
 
 
-def _route(*, context=None, **overrides):
+def _route_arguments(**overrides) -> dict[str, object]:
     payload = {
         "mode": "text_letter",
         "reason_code": "direct_words_are_enough",
@@ -88,6 +90,11 @@ def _route(*, context=None, **overrides):
         "character_willing": True,
     }
     payload.update(overrides)
+    return payload
+
+
+def _route(*, context=None, **overrides):
+    payload = _route_arguments(**overrides)
     gateway = _Gateway(payload)
     result = asyncio.run(
         LetterReplyRouter(
@@ -225,6 +232,65 @@ def test_router_accepts_one_offline_structured_musical_tool_call():
     assert gateway.requests[0]["tool_choice"] == "required"
     assert gateway.requests[0]["request_id"] == "letter-reply-mode-router"
     assert gateway.requests[0]["tools"][0]["function"]["name"] == "select_reply_mode"
+
+
+@pytest.mark.parametrize(
+    ("expected_mode", "overrides"),
+    [
+        ("text_letter", {}),
+        (
+            "spoken_video",
+            {
+                "mode": "spoken_video",
+                "reason_code": "voice_adds_presence",
+                "emotion_level": "high",
+                "direct_response_sufficient": True,
+                "voice_materially_better": True,
+            },
+        ),
+        (
+            "musical_video",
+            {
+                "mode": "musical_video",
+                "reason_code": "performance_carries_this_reply",
+                "emotion_level": "mixed",
+                "music_contexts": ["explicit_performance_or_adaptation_request"],
+                "music_role": "performance",
+                "music_intent": "perform",
+                "request_disposition": "fulfill",
+                "direct_response_sufficient": False,
+                "music_materially_better": True,
+            },
+        ),
+    ],
+)
+def test_public_mock_gateway_routes_configured_tool_result(
+    expected_mode: str,
+    overrides: dict[str, object],
+):
+    arguments = _route_arguments(**overrides)
+    gateway = create_gateway(
+        GatewayConfig(
+            provider="mock",
+            provider_options={
+                "tool_call": {
+                    "name": "select_reply_mode",
+                    "arguments": arguments,
+                }
+            },
+        )
+    )
+
+    result = asyncio.run(
+        LetterReplyRouter(
+            gateway,
+            routing_context=RoutingContext(True, True),
+        ).classify("synthetic current letter")
+    )
+
+    assert result.reply_mode == expected_mode
+    assert result.status == "completed"
+    assert gateway.network_call_count == 0
 
 
 def test_current_work_relevance_requires_trusted_current_work():

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -237,6 +237,25 @@ def test_router_accepts_one_offline_structured_musical_tool_call():
 
 
 @pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        ("reason_code", 123),
+        ("mode", "TEXT_LETTER"),
+        ("mode", " text_letter "),
+    ],
+)
+def test_router_rejects_noncanonical_tool_schema_arguments(
+    field: str,
+    invalid_value: object,
+):
+    result, _ = _route(**{field: invalid_value})
+
+    assert result.reply_mode == "text_letter"
+    assert result.status == "unavailable"
+    assert result.reason_code == "router_invalid_result"
+
+
+@pytest.mark.parametrize(
     ("expected_mode", "overrides"),
     [
         ("text_letter", {}),

--- a/tests/llm/test_gateway.py
+++ b/tests/llm/test_gateway.py
@@ -194,6 +194,54 @@ def test_openai_compatible_adapter_returns_required_tool_calls(
     assert seen["body"]["tools"][0]["function"]["name"] == "apply_voice_performance"
 
 
+def test_openai_compatible_adapter_rejects_malformed_tool_call_sibling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def exercise() -> None:
+        async def handler(_request: web.Request) -> web.Response:
+            return web.json_response(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "tool_calls": [
+                                    42,
+                                    {
+                                        "function": {
+                                            "name": "apply_voice_performance",
+                                            "arguments": '{"overall_emotion":"steady reassurance"}',
+                                        }
+                                    },
+                                ]
+                            }
+                        }
+                    ]
+                }
+            )
+
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", handler)
+        async with TestClient(TestServer(app)) as client:
+            adapter = OpenAICompatibleAdapter(make_config(str(client.make_url("/v1"))))
+            with pytest.raises(ProviderProtocolError):
+                await adapter.complete_with_tools(
+                    messages=ROOT_MESSAGES,
+                    tools=[
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "apply_voice_performance",
+                                "parameters": {"type": "object"},
+                            },
+                        }
+                    ],
+                    tool_choice="required",
+                )
+
+    monkeypatch.setenv("B03_TEST_KEY", "TEST")
+    run(exercise())
+
+
 def test_tool_completion_rejects_non_required_choice_before_provider_call() -> None:
     async def exercise() -> InvalidGatewayInput:
         adapter = OpenAICompatibleAdapter(

--- a/tests/llm/test_gateway.py
+++ b/tests/llm/test_gateway.py
@@ -242,6 +242,52 @@ def test_openai_compatible_adapter_rejects_malformed_tool_call_sibling(
     run(exercise())
 
 
+def test_openai_compatible_adapter_rejects_non_mapping_function_without_top_level_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def exercise() -> None:
+        async def handler(_request: web.Request) -> web.Response:
+            return web.json_response(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "tool_calls": [
+                                    {
+                                        "function": 42,
+                                        "name": "apply_voice_performance",
+                                        "arguments": '{"overall_emotion":"steady reassurance"}',
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            )
+
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", handler)
+        async with TestClient(TestServer(app)) as client:
+            adapter = OpenAICompatibleAdapter(make_config(str(client.make_url("/v1"))))
+            with pytest.raises(ProviderProtocolError):
+                await adapter.complete_with_tools(
+                    messages=ROOT_MESSAGES,
+                    tools=[
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "apply_voice_performance",
+                                "parameters": {"type": "object"},
+                            },
+                        }
+                    ],
+                    tool_choice="required",
+                )
+
+    monkeypatch.setenv("B03_TEST_KEY", "TEST")
+    run(exercise())
+
+
 def test_tool_completion_rejects_non_required_choice_before_provider_call() -> None:
     async def exercise() -> InvalidGatewayInput:
         adapter = OpenAICompatibleAdapter(


### PR DESCRIPTION
Routes letter_triage through one required select_reply_mode tool call so valid DeepSeek structured arguments reach existing fail-closed validation. Scope: letter_triage contract and its focused HTTP router tests only. No media execution or model acceptance in this PR.