### PR TITLE
fix(installer): continue after missing dependency probe

### DIFF
--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -145,6 +145,21 @@ for module in ("mem0", "sentence_transformers", "huggingface_hub"):
     return $LASTEXITCODE -eq 0
 }
 
+function Test-ManagedServerDependencies {
+    param(
+        [Parameter(Mandatory)]
+        [string]$PythonExe
+    )
+
+    try {
+        & $PythonExe '-c' 'import aiohttp,jsonschema' 2>$null
+        return $LASTEXITCODE -eq 0
+    } catch {
+        if ($LASTEXITCODE -eq 0) { throw }
+        return $false
+    }
+}
+
 $runner = @{ File = $runtimeExe; Args = @() }
 if (-not (Test-Path -LiteralPath $runtimeExe)) {
     Write-Host 'The managed Python 3.12 runtime is not installed. The next step downloads the official PSF embeddable runtime.'
@@ -165,8 +180,7 @@ if ($runner.File -eq $runtimeExe) {
     New-Item -ItemType Directory -Force -Path $sitePackages | Out-Null
     $pth = Get-ChildItem -LiteralPath $runtimeRoot -Filter '*._pth' | Select-Object -First 1
     if ($pth) { Update-ManagedPythonPath -PthPath $pth.FullName }
-    & $runner.File '-c' 'import aiohttp,jsonschema' 2>$null
-    if ($LASTEXITCODE -ne 0) {
+    if (-not (Test-ManagedServerDependencies -PythonExe $runner.File)) {
         Write-Host 'The local server needs aiohttp, jsonschema, and their fixed Windows/Python 3.12 dependency closure.'
         Write-Host 'Licenses: aiohttp Apache-2.0; jsonschema MIT; transitive packages retain their upstream licenses.'
         $answer = Read-Host 'Accept these licenses and download the pinned wheels? [Y/N]'

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -75,7 +75,10 @@ def _health(port: int) -> str:
         return "READY" if data["status"] == "HEALTHY" else "UNAVAILABLE"
     except OSError as error:
         reason = error.reason if isinstance(error, URLError) else error
-        if isinstance(reason, OSError) and reason.errno == errno.ECONNREFUSED:
+        if isinstance(reason, OSError) and (
+            reason.errno == errno.ECONNREFUSED
+            or getattr(reason, "winerror", None) == 10061
+        ):
             return "UNAVAILABLE"
         return "PORT_CONFLICT"
     except Exception:

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import argparse
-import errno
 import json
 import os
 from pathlib import Path
+import socket
 import subprocess
 import sys
 import time
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
 
@@ -39,6 +39,15 @@ _CORE_HEALTH_REQUIRED_CHECKS = (
     "music.catalog",
 )
 _CORE_HEALTH_CHECK_STATES = frozenset({"available", "degraded", "unavailable"})
+
+
+def _port_is_bindable(port: int) -> bool:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", port))
+    except OSError:
+        return False
+    return True
 
 
 def _health(port: int) -> str:
@@ -73,16 +82,10 @@ def _health(port: int) -> str:
         if not contract_matches:
             return "PORT_CONFLICT"
         return "READY" if data["status"] == "HEALTHY" else "UNAVAILABLE"
-    except OSError as error:
-        reason = error.reason if isinstance(error, URLError) else error
-        if isinstance(reason, OSError) and (
-            reason.errno == errno.ECONNREFUSED
-            or getattr(reason, "winerror", None) == 10061
-        ):
-            return "UNAVAILABLE"
+    except HTTPError:
         return "PORT_CONFLICT"
     except Exception:
-        return "PORT_CONFLICT"
+        return "UNAVAILABLE" if _port_is_bindable(port) else "PORT_CONFLICT"
 
 
 def _client_executable(root: Path) -> Path:

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -612,6 +612,19 @@ def test_health_treats_connection_refused_as_no_listener(monkeypatch) -> None:
     assert start_local._health(8899) == "UNAVAILABLE"
 
 
+def test_health_treats_windows_connection_refused_as_no_listener(monkeypatch) -> None:
+    class WindowsConnectionRefused(OSError):
+        errno = None
+        winerror = 10061
+
+    def connection_refused(*_args, **_kwargs):
+        raise URLError(WindowsConnectionRefused("connection refused"))
+
+    monkeypatch.setattr(start_local, "urlopen", connection_refused)
+
+    assert start_local._health(8899) == "UNAVAILABLE"
+
+
 def test_health_only_reports_port_conflict_using_the_public_cli_schema(
     tmp_path: Path,
     monkeypatch,

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -625,6 +625,25 @@ def test_health_treats_windows_connection_refused_as_no_listener(monkeypatch) ->
     assert start_local._health(8899) == "UNAVAILABLE"
 
 
+@pytest.mark.parametrize(
+    ("bindable", "expected"),
+    [(True, "UNAVAILABLE"), (False, "PORT_CONFLICT")],
+    ids=("bindable", "occupied"),
+)
+def test_health_resolves_timeout_by_actual_local_port_bindability(
+    monkeypatch,
+    bindable: bool,
+    expected: str,
+) -> None:
+    def timed_out(*_args, **_kwargs):
+        raise URLError(TimeoutError("timed out"))
+
+    monkeypatch.setattr(start_local, "urlopen", timed_out)
+    monkeypatch.setattr(start_local, "_port_is_bindable", lambda _port: bindable)
+
+    assert start_local._health(8899) == expected
+
+
 def test_health_only_reports_port_conflict_using_the_public_cli_schema(
     tmp_path: Path,
     monkeypatch,

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -194,6 +194,51 @@ def test_managed_runtime_installs_all_server_dependencies() -> None:
     assert "rpds-py==2026.6.3" in requirements
 
 
+def test_missing_managed_server_dependencies_are_a_nonfatal_probe_result() -> None:
+    if os.name != "nt":
+        pytest.skip("Windows PowerShell is only available on Windows")
+
+    repo_root = Path(__file__).parents[2]
+    command = (
+        "$tokens=$null;$errors=$null;"
+        "$ast=[System.Management.Automation.Language.Parser]::ParseFile("
+        "$env:BSIDE_INSTALL_SCRIPT,[ref]$tokens,[ref]$errors);"
+        "if($errors.Count){throw 'INSTALL_SCRIPT_PARSE_FAILED'};"
+        "$function=$ast.Find({param($node)"
+        "$node -is [System.Management.Automation.Language.FunctionDefinitionAst]"
+        " -and $node.Name -eq 'Test-ManagedServerDependencies'},$true);"
+        "if(-not $function){throw 'MANAGED_DEPENDENCY_PROBE_MISSING'};"
+        ". ([scriptblock]::Create($function.Extent.Text));"
+        "$ErrorActionPreference='Stop';"
+        "if(Test-ManagedServerDependencies -PythonExe $env:BSIDE_PROBE_EXECUTABLE){exit 3};"
+        "exit 0"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "BSIDE_INSTALL_SCRIPT": str(repo_root / "installer" / "Install.ps1"),
+            "BSIDE_PROBE_EXECUTABLE": str(
+                Path(os.environ.get("WINDIR", r"C:\\Windows"))
+                / "System32"
+                / "WindowsPowerShell"
+                / "v1.0"
+                / "powershell.exe"
+            ),
+        }
+    )
+    powershell = env["BSIDE_PROBE_EXECUTABLE"]
+    result = subprocess.run(
+        [powershell, "-NoProfile", "-NonInteractive", "-Command", command],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
 def _run_managed_python_path_helper(
     *,
     pth_path: Path,


### PR DESCRIPTION
## Summary\n- Treat the expected missing aiohttp/jsonschema probe result as non-fatal under Windows PowerShell.\n- Preserve the existing pinned-wheel license/install flow.\n\n## Verification\n- python -m pytest -q tests/installer/test_windows_full_patch.py (34 passed, 1 skipped)\n- git diff --check\n\n## Acceptance boundary\n- Clean isolated first install reached the dependency license/download flow and completed the patched installation.\n- Startup remains separately blocked by the existing launcher health classification on a refused port; not included in this single-point fix.