### PR TITLE
refactor: move music duration under runtime media

### DIFF
--- a/music_duration.py
+++ b/music_duration.py
@@ -1,15 +1,5 @@
-"""Product-level duration choices shared by song planning and rendering."""
+"""Compatibility entry point for product-level music duration choices."""
 
-from __future__ import annotations
-
-
-MUSIC_DURATION_OPTIONS = (40, 60)
-
-
-def normalize_music_duration(value: object) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value not in MUSIC_DURATION_OPTIONS:
-        raise ValueError("MUSIC_DURATION_INVALID")
-    return value
-
+from runtime.media.music_duration import MUSIC_DURATION_OPTIONS, normalize_music_duration
 
 __all__ = ["MUSIC_DURATION_OPTIONS", "normalize_music_duration"]

--- a/runtime/media/__init__.py
+++ b/runtime/media/__init__.py
@@ -1,0 +1,1 @@
+"""Media planning and rendering implementation modules."""

--- a/runtime/media/music_duration.py
+++ b/runtime/media/music_duration.py
@@ -1,0 +1,15 @@
+"""Product-level duration choices shared by song planning and rendering."""
+
+from __future__ import annotations
+
+
+MUSIC_DURATION_OPTIONS = (40, 60)
+
+
+def normalize_music_duration(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value not in MUSIC_DURATION_OPTIONS:
+        raise ValueError("MUSIC_DURATION_INVALID")
+    return value
+
+
+__all__ = ["MUSIC_DURATION_OPTIONS", "normalize_music_duration"]


### PR DESCRIPTION
Scope: fifth mechanical root-Python layout batch. Mapping: music_duration -> runtime.media.music_duration; the root module remains a compatibility shim exporting MUSIC_DURATION_OPTIONS and normalize_music_duration. Callers are unchanged. Verification: compileall and legacy/new export identity checks passed; four related focused nodes passed (12 parametrized cases). Boundary: no full suite, unrelated modules, protocol changes, or governance expansion.