### PR TITLE
refactor(memory): retire bounded daemon root shim

### DIFF
--- a/bounded_daemon_call.py
+++ b/bounded_daemon_call.py
@@ -1,5 +1,0 @@
-"""Compatibility entry point for bounded daemon-thread calls."""
-
-from runtime.memory.bounded_daemon_call import BoundedDaemonCall, validate_timeout_seconds
-
-__all__ = ["BoundedDaemonCall", "validate_timeout_seconds"]

--- a/conversation_memory_delivery.py
+++ b/conversation_memory_delivery.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from enum import StrEnum
 import re
 
-from bounded_daemon_call import BoundedDaemonCall, validate_timeout_seconds
+from runtime.memory.bounded_daemon_call import BoundedDaemonCall, validate_timeout_seconds
 from conversation_memory_port import (
     ConversationMemoryPort,
     MemoryWriteResult,

--- a/mem0_memory.py
+++ b/mem0_memory.py
@@ -21,7 +21,7 @@ import threading
 import time
 from typing import Callable, Mapping, Protocol, Sequence
 
-from bounded_daemon_call import BoundedDaemonCall
+from runtime.memory.bounded_daemon_call import BoundedDaemonCall
 from conversation_memory_port import (
     ConversationMemoryPort,
     ConversationMemoryRecord,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ memory-mem0 = [
 [tool.setuptools]
 py-modules = [
     "baseline_hardening_scan",
-    "bounded_daemon_call",
     "companion_memory_context",
     "conversation_memory_admin",
     "conversation_memory_delivery",

--- a/tests/memory/test_bounded_daemon_call.py
+++ b/tests/memory/test_bounded_daemon_call.py
@@ -6,7 +6,7 @@ import time
 
 import pytest
 
-from bounded_daemon_call import BoundedDaemonCall
+from runtime.memory.bounded_daemon_call import BoundedDaemonCall
 
 
 def test_permanently_blocked_call_times_out_without_starting_another_worker() -> None:


### PR DESCRIPTION
## Summary

- remove the internal-only root `bounded_daemon_call.py` compatibility shim
- point the two production consumers and focused test at `runtime.memory.bounded_daemon_call`
- remove the retired root module from the setuptools `py-modules` list

## Migration mapping

| Retired root path | Canonical path | Updated consumers |
| --- | --- | --- |
| `bounded_daemon_call.py` | `runtime/memory/bounded_daemon_call.py` | `conversation_memory_delivery.py`, `mem0_memory.py`, `tests/memory/test_bounded_daemon_call.py` |

## Frozen pair

- base: `main@97fe2f509d4d5ea7f3e4e4e79b54f13104329d3b`
- head: `8de2c82642ce751b581c4799fe74fbff8bda8060`

## Verification

- `python -m pytest -q tests/memory/test_bounded_daemon_call.py tests/memory/test_conversation_memory_delivery.py tests/memory/test_mem0_memory.py` — `74 passed in 1.27s`
- `python -m compileall -q runtime/memory/bounded_daemon_call.py conversation_memory_delivery.py mem0_memory.py tests/memory/test_bounded_daemon_call.py tests/memory/test_conversation_memory_delivery.py tests/memory/test_mem0_memory.py` — passed
- `python -c "import importlib.util; assert importlib.util.find_spec('bounded_daemon_call') is None; spec = importlib.util.find_spec('runtime.memory.bounded_daemon_call'); assert spec is not None; from runtime.memory.bounded_daemon_call import BoundedDaemonCall, validate_timeout_seconds; assert validate_timeout_seconds(1) == 1.0; assert BoundedDaemonCall(thread_name='verify').call(lambda: 'ok', timeout_seconds=1) == ('completed', 'ok')"` — passed
- `python -c "import conversation_memory_delivery, mem0_memory"` — passed
- `git diff --check origin/main...HEAD` — passed
- repository reference scan finds only canonical `runtime.memory.bounded_daemon_call` imports

## Boundary

The effective diff against frozen `main` is exactly five files and `+3/-9`. It is a mechanical retirement and contains no inherited #173 changes. It does not change daemon-call behavior, memory protocols, supported installer/CLI/original-client entry points, or adjacent modules; it removes only the internal top-level `bounded_daemon_call` packaging module. No full suite was run.

## Rollback

Revert implementation commit `aa00896` to restore the root shim, old imports, and its `py-modules` entry as one atomic change.
