### PR TITLE
refactor(media): import canonical music caption module

### DIFF
--- a/docs/P03_01C_MINIMAX_MUSIC_STABILIZATION.md
+++ b/docs/P03_01C_MINIMAX_MUSIC_STABILIZATION.md
@@ -107,7 +107,7 @@ avoid soul
 
 ### 4.2 程序构造唯一的正向 Structured Caption
 
-新增 `music_caption.py`，由程序把枚举渲染为固定三段式 Caption。核心基线：
+新增 `runtime/media/music_caption.py`，由程序把枚举渲染为固定三段式 Caption。核心基线：
 
 ```text
 ### Global Metadata
@@ -220,7 +220,7 @@ song_content.py
   ├─ 枚举、歌词与标签验证
   └─ 不再接受自由 Caption
 
-music_caption.py（新增）
+runtime/media/music_caption.py（新增）
   ├─ 固定正向核心模板
   ├─ 枚举 -> 正向片段
   ├─ render_minimax_caption(plan)
@@ -376,7 +376,7 @@ canonical reply
 
 ### MUSIC-02：固定正向 Caption Renderer
 
-新增 `music_caption.py`、模板快照和枚举组合测试。最终 Caption 必须完全由程序生成。
+新增 `runtime/media/music_caption.py`、模板快照和枚举组合测试。最终 Caption 必须完全由程序生成。
 
 ### MUSIC-03：切换生产链
 

--- a/song_content.py
+++ b/song_content.py
@@ -315,7 +315,7 @@ def plan_song_content(
     # Imported lazily because music_caption imports the typed plan definitions
     # from this module. The production output remains compatible with the
     # established music-video renderer while the model no longer writes captions.
-    from music_caption import render_minimax_caption
+    from runtime.media.music_caption import render_minimax_caption
 
     caption = render_minimax_caption(semantic_plan)
     return SongContentPlan(

--- a/tests/media/test_minimax_music3_worker.py
+++ b/tests/media/test_minimax_music3_worker.py
@@ -13,7 +13,7 @@ from tools.minimax_profile import (
     OFFICIAL_COMFY_MINIMAX_PROFILE,
     minimax_profile_from_mapping,
 )
-from music_caption import render_minimax_caption
+from runtime.media.music_caption import render_minimax_caption
 from song_content import (
     PianoTexture,
     SongDynamicArc,

--- a/tests/media/test_music_calibration.py
+++ b/tests/media/test_music_calibration.py
@@ -10,7 +10,7 @@ from tools.minimax_profile import (
     CURRENT_MINIMAX_PROFILE,
     OFFICIAL_COMFY_MINIMAX_PROFILE,
 )
-from music_caption import MINIMAX_CAPTION_VERSION, validate_minimax_caption
+from runtime.media.music_caption import MINIMAX_CAPTION_VERSION, validate_minimax_caption
 from song_content import SongSemanticPlan
 
 

--- a/tests/media/test_music_caption.py
+++ b/tests/media/test_music_caption.py
@@ -4,7 +4,7 @@ from itertools import product
 
 import pytest
 
-from music_caption import (
+from runtime.media.music_caption import (
     MINIMAX_CAPTION_VERSION,
     render_minimax_caption,
     validate_minimax_caption,

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 import music_reply
-from music_caption import render_minimax_caption
+from runtime.media.music_caption import render_minimax_caption
 from song_content import (
     PianoTexture,
     SongContentPlan,

--- a/tests/media/test_song_content_pipeline.py
+++ b/tests/media/test_song_content_pipeline.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from music_caption import validate_minimax_caption
+from runtime.media.music_caption import validate_minimax_caption
 from song_content import (
     SONG_SEMANTIC_PLAN_SCHEMA_VERSION,
     SongContentPlan,

--- a/tools/music_calibration.py
+++ b/tools/music_calibration.py
@@ -15,7 +15,7 @@ from tools.minimax_profile import (
     MiniMaxInferenceProfile,
     OFFICIAL_COMFY_MINIMAX_PROFILE,
 )
-from music_caption import MINIMAX_CAPTION_VERSION, render_minimax_caption
+from runtime.media.music_caption import MINIMAX_CAPTION_VERSION, render_minimax_caption
 from song_content import (
     PianoTexture,
     SongDynamicArc,


### PR DESCRIPTION
## Problem

Internal music-caption consumers still import the root compatibility module even though the canonical implementation lives at `runtime.media.music_caption`. This keeps the root shim coupled to internal code and blocks a later, separately reviewable retirement.

## Changes

- Migrate direct imports in `song_content.py` and `tools/music_calibration.py` to `runtime.media.music_caption`.
- Migrate the five directly related media test modules to the canonical import.
- Update the three implementation-path references in `docs/P03_01C_MINIMAX_MUSIC_STABILIZATION.md`.
- Keep root `music_caption.py` and its packaging entry unchanged for compatibility.

Migration mapping: `music_caption` -> `runtime.media.music_caption` for in-repository consumers only.

## Staging

This is stage A. A later stacked stage may remove the root compatibility module and packaging entry only after this consumer migration lands and receives its own focused review.

## Verification

```powershell
python -m pytest -q tests/media/test_minimax_music3_worker.py tests/media/test_music_caption.py tests/media/test_music_calibration.py tests/media/test_music_reply_concat_pipeline.py tests/media/test_song_content_pipeline.py
```

Result: `60 passed in 1.87s`.

```powershell
python -m compileall -q runtime/media/music_caption.py music_caption.py song_content.py tools/music_calibration.py tests/media/test_minimax_music3_worker.py tests/media/test_music_caption.py tests/media/test_music_calibration.py tests/media/test_music_reply_concat_pipeline.py tests/media/test_song_content_pipeline.py
python -c "import music_caption as legacy; import runtime.media.music_caption as canonical; import song_content; import tools.music_calibration; assert legacy.render_minimax_caption is canonical.render_minimax_caption; assert legacy.validate_minimax_caption is canonical.validate_minimax_caption; print('imports-and-legacy-shim: PASS')"
git diff --check
```

Results: compile completed successfully; canonical imports and legacy shim identity checks passed; diff check passed. A scoped search found no remaining direct `music_caption` imports in the seven changed Python consumers/tests.

## Boundary

- No root module deletion.
- No `pyproject.toml` or packaging change.
- No caption behavior, templates, protocol, media pipeline, installer, security, or governance change.
- No full test suite, provider/GPU execution, original-client acceptance, or human media acceptance was run.

## Rollback

Revert this PR's merge commit to restore the internal imports and documentation references to the root compatibility module; the root shim remains present throughout this stage.
