### PR TITLE
feat(installer): add verified component update foundation

### DIFF
--- a/contracts/component_update_package.example.json
+++ b/contracts/component_update_package.example.json
@@ -4,9 +4,19 @@
   "version": "1.1.0",
   "files": [
     {
-      "path": "new.py",
-      "size_bytes": 3,
-      "sha256": "11507a0e2f5e69d5dfa40a62a1bd7b6ee57e6bcd85c67c9b8431b36fff21c437"
+      "path": "installer/configure.py",
+      "size_bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "installer/start_local.py",
+      "size_bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "installer/uninstall.py",
+      "size_bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     }
   ]
 }

--- a/contracts/component_update_package.example.json
+++ b/contracts/component_update_package.example.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "olivia.component-package.v1",
+  "component": "local_backend",
+  "version": "1.1.0",
+  "files": [
+    {
+      "path": "new.py",
+      "size_bytes": 3,
+      "sha256": "11507a0e2f5e69d5dfa40a62a1bd7b6ee57e6bcd85c67c9b8431b36fff21c437"
+    }
+  ]
+}

--- a/contracts/component_update_package.schema.json
+++ b/contracts/component_update_package.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Ornn8/bside-olivia-community/blob/main/contracts/component_update_package.schema.json",
+  "title": "Olivia local component update package manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "component", "version", "files"],
+  "properties": {
+    "schema_version": {"const": "olivia.component-package.v1"},
+    "component": {"const": "local_backend"},
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9A-Za-z][0-9A-Za-z.+-]{0,63}$"
+    },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "size_bytes", "sha256"],
+        "properties": {
+          "path": {"type": "string", "minLength": 1},
+          "size_bytes": {"type": "integer", "minimum": 0},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        }
+      }
+    }
+  }
+}

--- a/contracts/component_update_package.schema.json
+++ b/contracts/component_update_package.schema.json
@@ -15,6 +15,29 @@
     "files": {
       "type": "array",
       "minItems": 1,
+      "allOf": [
+        {
+          "contains": {
+            "type": "object",
+            "required": ["path"],
+            "properties": {"path": {"const": "installer/start_local.py"}}
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": ["path"],
+            "properties": {"path": {"const": "installer/configure.py"}}
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": ["path"],
+            "properties": {"path": {"const": "installer/uninstall.py"}}
+          }
+        }
+      ],
       "items": {
         "type": "object",
         "additionalProperties": false,

--- a/contracts/component_update_state.example.json
+++ b/contracts/component_update_state.example.json
@@ -7,5 +7,11 @@
       "payload_path": "versions/local_backend/1.1.0-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     }
   },
-  "previous_components": {}
+  "previous_components": {
+    "local_backend": {
+      "version": "0.0.0+legacy",
+      "manifest_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "payload_path": "local_backend"
+    }
+  }
 }

--- a/contracts/component_update_state.example.json
+++ b/contracts/component_update_state.example.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "olivia.update-state.v1",
+  "active_components": {
+    "local_backend": {
+      "version": "1.1.0",
+      "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "payload_path": "versions/local_backend/1.1.0-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  },
+  "previous_components": {}
+}

--- a/contracts/component_update_state.schema.json
+++ b/contracts/component_update_state.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Ornn8/bside-olivia-community/blob/main/contracts/component_update_state.schema.json",
+  "title": "Olivia active component version pointer",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "active_components", "previous_components"],
+  "$defs": {
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "manifest_sha256", "payload_path"],
+      "properties": {
+        "version": {
+          "type": "string",
+          "pattern": "^[0-9A-Za-z][0-9A-Za-z.+-]{0,63}$"
+        },
+        "manifest_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "payload_path": {
+          "type": "string",
+          "pattern": "^versions/local_backend/[0-9A-Za-z][0-9A-Za-z.+-]{0,63}-[0-9a-f]{64}$"
+        }
+      }
+    }
+  },
+  "properties": {
+    "schema_version": {"const": "olivia.update-state.v1"},
+    "active_components": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["local_backend"],
+      "properties": {"local_backend": {"$ref": "#/$defs/component"}}
+    },
+    "previous_components": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {"local_backend": {"$ref": "#/$defs/component"}}
+    }
+  }
+}

--- a/contracts/component_update_state.schema.json
+++ b/contracts/component_update_state.schema.json
@@ -6,7 +6,7 @@
   "additionalProperties": false,
   "required": ["schema_version", "active_components", "previous_components"],
   "$defs": {
-    "component": {
+    "versioned_component": {
       "type": "object",
       "additionalProperties": false,
       "required": ["version", "manifest_sha256", "payload_path"],
@@ -24,6 +24,24 @@
           "pattern": "^versions/local_backend/[0-9A-Za-z][0-9A-Za-z.+-]{0,63}-[0-9a-f]{64}$"
         }
       }
+    },
+    "legacy_component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "manifest_sha256", "payload_path"],
+      "properties": {
+        "version": {"const": "0.0.0+legacy"},
+        "manifest_sha256": {
+          "const": "0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "payload_path": {"const": "local_backend"}
+      }
+    },
+    "component": {
+      "oneOf": [
+        {"$ref": "#/$defs/versioned_component"},
+        {"$ref": "#/$defs/legacy_component"}
+      ]
     }
   },
   "properties": {

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -72,7 +72,7 @@ embeddable Python 仅解决解释器获取；`aiohttp`、TTS、视觉、音频�
 
 安装后的 `START.cmd`、`CONFIGURE.cmd` 和 `UNINSTALL.cmd` 只调用安装根目录中的稳定启动器 `launcher/version_launcher.py`。稳定启动器读取一次 `.olivia-update-state.json` 原子指针，从 `versions/local_backend/<version>-<manifest-sha256>` 选择完整后端；没有更新状态时继续使用初装的 `local_backend`。因此更新期间不会把正在使用的后端目录临时移走，也不会要求用户重新运行完整安装器。
 
-当前版本只提供经过外部渠道取得的本地 `.oliviapatch` 文件安装，不联网检查或下载更新。包必须是 ZIP，并且只能包含一个 `manifest.json` 和清单声明的 `payload/...` 普通文件。公开契约及示例见：
+当前版本只提供经过外部渠道取得的本地 `.oliviapatch` 文件安装，不联网检查或下载更新。包必须是 ZIP，并且只能包含一个 `manifest.json` 和清单声明的 `payload/...` 普通文件。`local_backend` 包必须包含 `installer/start_local.py`、`installer/configure.py` 和 `installer/uninstall.py` 三个普通文件入口，否则不会激活。公开契约及示例见：
 
 - `contracts/component_update_package.schema.json`
 - `contracts/component_update_package.example.json`
@@ -89,7 +89,7 @@ python -m installer apply-update --installation <安装目录> --package <补丁
 
 每个 payload 文件还会按清单校验大小和 SHA-256。路径会按 Windows 规则拒绝目录穿越、大小写别名、尾随点/空格、ADS、设备名、符号链接和 reparse point；解包完成后会重新枚举暂存目录并逐文件复验。校验成功后先发布不可变版本目录，最后仅用一次原子替换切换状态指针。指针替换失败时，旧指针或初装后端仍可启动，新目录只是未激活版本。
 
-上一版本存在时可原子交换活动/上一版本指针：
+第一次更新会把初装 `local_backend` 记录为 `0.0.0+legacy` 回滚基线；后续更新记录上一个活动版本。重复应用当前活动版本不会覆盖真正的上一版本。可原子交换活动/上一版本指针：
 
 ```powershell
 python -m installer rollback-update --installation <安装目录>

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -67,3 +67,32 @@ webplayer.dat.orig
 embeddable Python 仅解决解释器获取；`aiohttp`、TTS、视觉、音频分离和音乐模型仍需按第三方下载清单单独准备。缺失时 `START.cmd` / 本地 health 会报告不可用原因；不会自动下载未固定来源、许可证或 SHA-256 的内容。用户 API key 只从启动进程环境或 `CONFIGURE.cmd` 生成的当前用户 DPAPI 文件读取，不写入安装包或日志；DPAPI 解密值只存在于后端子进程环境中。
 
 启动时若没有 `OLIVIA_LLM_API_KEY`、`DEEPSEEK_API_KEY` 或 `OPENAI_API_KEY`，命令行会明确提示未配置，不能把 safe-static 回退误认为真实模型回信。
+
+## 本地组件补丁与回滚
+
+安装后的 `START.cmd`、`CONFIGURE.cmd` 和 `UNINSTALL.cmd` 只调用安装根目录中的稳定启动器 `launcher/version_launcher.py`。稳定启动器读取一次 `.olivia-update-state.json` 原子指针，从 `versions/local_backend/<version>-<manifest-sha256>` 选择完整后端；没有更新状态时继续使用初装的 `local_backend`。因此更新期间不会把正在使用的后端目录临时移走，也不会要求用户重新运行完整安装器。
+
+当前版本只提供经过外部渠道取得的本地 `.oliviapatch` 文件安装，不联网检查或下载更新。包必须是 ZIP，并且只能包含一个 `manifest.json` 和清单声明的 `payload/...` 普通文件。公开契约及示例见：
+
+- `contracts/component_update_package.schema.json`
+- `contracts/component_update_package.example.json`
+- `contracts/component_update_state.schema.json`
+- `contracts/component_update_state.example.json`
+
+安装命令：
+
+```powershell
+python -m installer apply-update --installation <安装目录> --package <补丁.oliviapatch> --manifest-sha256 <64位小写SHA-256>
+```
+
+`--manifest-sha256` 是包外信任锚，必须来自经过认证的发布元数据或用户已验证的官方发布页面，不能从同一个补丁包内自行读取后当作可信值。当前实现不包含签名验证或在线发布元数据获取；自动下载器接入前必须保持这条边界。
+
+每个 payload 文件还会按清单校验大小和 SHA-256。路径会按 Windows 规则拒绝目录穿越、大小写别名、尾随点/空格、ADS、设备名、符号链接和 reparse point；解包完成后会重新枚举暂存目录并逐文件复验。校验成功后先发布不可变版本目录，最后仅用一次原子替换切换状态指针。指针替换失败时，旧指针或初装后端仍可启动，新目录只是未激活版本。
+
+上一版本存在时可原子交换活动/上一版本指针：
+
+```powershell
+python -m installer rollback-update --installation <安装目录>
+```
+
+CLI 成功时输出一行 JSON 并返回 `0`；失败时输出 `{"status":"ERROR","code":"..."}` 并返回 `2`。稳定错误码包括：`UPDATE_INSTALLATION_INVALID`、`UPDATE_MANIFEST_DIGEST_INVALID`、`UPDATE_MANIFEST_DIGEST_MISMATCH`、`UPDATE_MANIFEST_INVALID`、`UPDATE_PACKAGE_INVALID`、`UPDATE_PAYLOAD_DIGEST_MISMATCH`、`UPDATE_STAGED_TREE_MISMATCH`、`UPDATE_COMPONENT_UNSUPPORTED`、`UPDATE_COMPONENT_UNAVAILABLE`、`UPDATE_VERSION_CONFLICT`、`UPDATE_STATE_INVALID`、`UPDATE_ROLLBACK_UNAVAILABLE` 和 `UPDATE_ACTIVATION_FAILED`。

--- a/installer/__main__.py
+++ b/installer/__main__.py
@@ -4,7 +4,11 @@ import argparse
 import json
 from pathlib import Path
 
-from .component_update import ComponentUpdateError, apply_component_update
+from .component_update import (
+    ComponentUpdateError,
+    apply_component_update,
+    rollback_component_update,
+)
 from .full_patch import PatchInstallError, discover_steam_install, install_full_patch, load_manifest, uninstall_full_patch, validate_official_source
 
 
@@ -26,6 +30,8 @@ def main(argv: list[str] | None = None) -> int:
     update.add_argument("--installation", type=Path, required=True)
     update.add_argument("--package", type=Path, required=True)
     update.add_argument("--manifest-sha256", required=True)
+    rollback = sub.add_parser("rollback-update")
+    rollback.add_argument("--installation", type=Path, required=True)
     args = parser.parse_args(argv)
     try:
         if args.command == "doctor":
@@ -38,12 +44,14 @@ def main(argv: list[str] | None = None) -> int:
             result = install_full_patch(source, args.destination, args.payload, args.manifest, port=args.port)
         elif args.command == "uninstall":
             result = uninstall_full_patch(args.installation, apply=args.apply)
-        else:
+        elif args.command == "apply-update":
             result = apply_component_update(
                 args.installation,
                 args.package,
                 expected_manifest_sha256=args.manifest_sha256,
             )
+        else:
+            result = rollback_component_update(args.installation)
         print(json.dumps(result, ensure_ascii=False, sort_keys=True))
         return 0
     except (PatchInstallError, ComponentUpdateError) as exc:

--- a/installer/__main__.py
+++ b/installer/__main__.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
+from .component_update import ComponentUpdateError, apply_component_update
 from .full_patch import PatchInstallError, discover_steam_install, install_full_patch, load_manifest, uninstall_full_patch, validate_official_source
 
 
@@ -21,6 +22,10 @@ def main(argv: list[str] | None = None) -> int:
     remove = sub.add_parser("uninstall")
     remove.add_argument("--installation", type=Path, required=True)
     remove.add_argument("--apply", action="store_true")
+    update = sub.add_parser("apply-update")
+    update.add_argument("--installation", type=Path, required=True)
+    update.add_argument("--package", type=Path, required=True)
+    update.add_argument("--manifest-sha256", required=True)
     args = parser.parse_args(argv)
     try:
         if args.command == "doctor":
@@ -31,11 +36,17 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "install":
             source = (args.official_root or discover_steam_install()).resolve()
             result = install_full_patch(source, args.destination, args.payload, args.manifest, port=args.port)
-        else:
+        elif args.command == "uninstall":
             result = uninstall_full_patch(args.installation, apply=args.apply)
+        else:
+            result = apply_component_update(
+                args.installation,
+                args.package,
+                expected_manifest_sha256=args.manifest_sha256,
+            )
         print(json.dumps(result, ensure_ascii=False, sort_keys=True))
         return 0
-    except PatchInstallError as exc:
+    except (PatchInstallError, ComponentUpdateError) as exc:
         print(json.dumps({"status": "ERROR", "code": str(exc)}, ensure_ascii=False))
         return 2
 

--- a/installer/component_update.py
+++ b/installer/component_update.py
@@ -24,6 +24,18 @@ _INSTALL_MARKER = ".olivia-full-patch.json"
 _SHA256_RE = re.compile(r"[0-9a-f]{64}")
 _VERSION_RE = re.compile(r"[0-9A-Za-z][0-9A-Za-z.+-]{0,63}")
 _COMPONENT_TARGETS = {"local_backend": "local_backend"}
+_COMPONENT_REQUIRED_FILES = {
+    "local_backend": frozenset(
+        {
+            "installer/start_local.py",
+            "installer/configure.py",
+            "installer/uninstall.py",
+        }
+    )
+}
+_LEGACY_VERSION = "0.0.0+legacy"
+_LEGACY_MANIFEST_SHA256 = "0" * 64
+_LEGACY_PAYLOAD_PATH = "local_backend"
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
 _WINDOWS_RESERVED_CHARS = frozenset('<>:"|?*')
 _WINDOWS_DEVICE_NAMES = frozenset(
@@ -123,6 +135,10 @@ def _validate_manifest(value: dict[str, Any]) -> tuple[str, str, list[dict[str, 
             raise ComponentUpdateError("UPDATE_MANIFEST_INVALID")
         seen.add(relative.casefold())
         normalized.append({"path": relative, "size_bytes": size, "sha256": digest})
+    if not _COMPONENT_REQUIRED_FILES[component].issubset(
+        {item["path"] for item in normalized}
+    ):
+        raise ComponentUpdateError("UPDATE_MANIFEST_INVALID")
     return component, version, normalized
 
 
@@ -242,6 +258,13 @@ def _validate_state_descriptor(component: str, value: object) -> dict[str, str]:
     version = value.get("version")
     manifest_sha256 = value.get("manifest_sha256")
     payload_path = value.get("payload_path")
+    legacy_descriptor = {
+        "version": _LEGACY_VERSION,
+        "manifest_sha256": _LEGACY_MANIFEST_SHA256,
+        "payload_path": _LEGACY_PAYLOAD_PATH,
+    }
+    if value == legacy_descriptor:
+        return legacy_descriptor
     if (
         component not in _COMPONENT_TARGETS
         or not isinstance(version, str)
@@ -274,6 +297,7 @@ def _read_state(path: Path) -> dict[str, Any]:
         or state.get("schema_version") != STATE_SCHEMA
         or not isinstance(state.get("active_components"), dict)
         or not isinstance(state.get("previous_components"), dict)
+        or set(state["active_components"]) != {"local_backend"}
     ):
         raise ComponentUpdateError("UPDATE_STATE_INVALID")
     for section_name in ("active_components", "previous_components"):
@@ -307,19 +331,55 @@ def _next_state(
     payload_path: str,
 ) -> dict[str, Any]:
     active = dict(current["active_components"])
-    previous: dict[str, dict[str, str]] = {}
-    if component in active:
-        previous[component] = active[component]
-    active[component] = {
+    new_descriptor = {
         "version": version,
         "manifest_sha256": manifest_sha256,
         "payload_path": payload_path,
     }
+    if active.get(component) == new_descriptor:
+        return {
+            "schema_version": STATE_SCHEMA,
+            "active_components": active,
+            "previous_components": dict(current["previous_components"]),
+        }
+    previous = dict(current["previous_components"])
+    previous[component] = active.get(
+        component,
+        {
+            "version": _LEGACY_VERSION,
+            "manifest_sha256": _LEGACY_MANIFEST_SHA256,
+            "payload_path": _LEGACY_PAYLOAD_PATH,
+        },
+    )
+    active[component] = new_descriptor
     return {
         "schema_version": STATE_SCHEMA,
         "active_components": active,
         "previous_components": previous,
     }
+
+
+def _resolve_state_payload(
+    root: Path,
+    component: str,
+    descriptor: object,
+) -> Path:
+    validated = _validate_state_descriptor(component, descriptor)
+    current = root
+    try:
+        for part in PurePosixPath(validated["payload_path"]).parts:
+            current = current / part
+            metadata = current.lstat()
+            if current.is_symlink() or bool(
+                getattr(metadata, "st_file_attributes", 0)
+                & _FILE_ATTRIBUTE_REPARSE_POINT
+            ):
+                raise ComponentUpdateError("UPDATE_STATE_INVALID")
+    except OSError as exc:
+        raise ComponentUpdateError("UPDATE_STATE_INVALID") from exc
+    if not current.is_dir():
+        raise ComponentUpdateError("UPDATE_STATE_INVALID")
+    return current
 
 
 def apply_component_update(
@@ -395,9 +455,7 @@ def rollback_component_update(
     previous = state["previous_components"].get(component)
     if active is None or previous is None:
         raise ComponentUpdateError("UPDATE_ROLLBACK_UNAVAILABLE")
-    previous_path = root.joinpath(*PurePosixPath(previous["payload_path"]).parts)
-    if not previous_path.is_dir():
-        raise ComponentUpdateError("UPDATE_ROLLBACK_UNAVAILABLE")
+    _resolve_state_payload(root, component, previous)
 
     next_state = {
         "schema_version": STATE_SCHEMA,

--- a/installer/component_update.py
+++ b/installer/component_update.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import uuid
 import zipfile
 from pathlib import Path, PurePosixPath
@@ -23,6 +24,13 @@ _INSTALL_MARKER = ".olivia-full-patch.json"
 _SHA256_RE = re.compile(r"[0-9a-f]{64}")
 _VERSION_RE = re.compile(r"[0-9A-Za-z][0-9A-Za-z.+-]{0,63}")
 _COMPONENT_TARGETS = {"local_backend": "local_backend"}
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
+_WINDOWS_RESERVED_CHARS = frozenset('<>:"|?*')
+_WINDOWS_DEVICE_NAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{suffix}" for suffix in (*range(1, 10), "¹", "²", "³")}
+    | {f"LPT{suffix}" for suffix in (*range(1, 10), "¹", "²", "³")}
+)
 
 
 class ComponentUpdateError(RuntimeError):
@@ -62,8 +70,21 @@ def _validate_relative_path(value: object) -> str:
     if not isinstance(value, str) or not value or "\x00" in value or "\\" in value:
         raise ComponentUpdateError("UPDATE_MANIFEST_INVALID")
     path = PurePosixPath(value)
-    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+    if (
+        path.is_absolute()
+        or path.as_posix() != value
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
         raise ComponentUpdateError("UPDATE_MANIFEST_INVALID")
+    for part in path.parts:
+        stem = part.split(".", 1)[0].upper()
+        if (
+            part.endswith((" ", "."))
+            or any(character in _WINDOWS_RESERVED_CHARS for character in part)
+            or any(ord(character) < 32 for character in part)
+            or stem in _WINDOWS_DEVICE_NAMES
+        ):
+            raise ComponentUpdateError("UPDATE_MANIFEST_INVALID")
     return path.as_posix()
 
 
@@ -105,11 +126,66 @@ def _validate_manifest(value: dict[str, Any]) -> tuple[str, str, list[dict[str, 
     return component, version, normalized
 
 
+def _is_reparse_point(path: Path) -> bool:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise ComponentUpdateError("UPDATE_STAGED_TREE_MISMATCH") from exc
+    return path.is_symlink() or bool(
+        getattr(metadata, "st_file_attributes", 0)
+        & _FILE_ATTRIBUTE_REPARSE_POINT
+    )
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for block in iter(lambda: stream.read(1 << 20), b""):
+                digest.update(block)
+    except OSError as exc:
+        raise ComponentUpdateError("UPDATE_STAGED_TREE_MISMATCH") from exc
+    return digest.hexdigest()
+
+
+def _verify_staged_tree(root: Path, files: list[dict[str, Any]]) -> None:
+    expected = {item["path"]: item for item in files}
+    actual: dict[str, Path] = {}
+    try:
+        for current, directories, filenames in os.walk(root, followlinks=False):
+            current_path = Path(current)
+            for name in directories:
+                if _is_reparse_point(current_path / name):
+                    raise ComponentUpdateError("UPDATE_STAGED_TREE_MISMATCH")
+            for name in filenames:
+                candidate = current_path / name
+                if _is_reparse_point(candidate) or not candidate.is_file():
+                    raise ComponentUpdateError("UPDATE_STAGED_TREE_MISMATCH")
+                relative = candidate.relative_to(root).as_posix()
+                if relative in actual:
+                    raise ComponentUpdateError("UPDATE_STAGED_TREE_MISMATCH")
+                actual[relative] = candidate
+    except ComponentUpdateError:
+        raise
+    except OSError as exc:
+        raise ComponentUpdateError("UPDATE_STAGED_TREE_MISMATCH") from exc
+    if set(actual) != set(expected):
+        raise ComponentUpdateError("UPDATE_STAGED_TREE_MISMATCH")
+    for relative, candidate in actual.items():
+        item = expected[relative]
+        try:
+            size = candidate.stat().st_size
+        except OSError as exc:
+            raise ComponentUpdateError("UPDATE_STAGED_TREE_MISMATCH") from exc
+        if size != item["size_bytes"] or _file_sha256(candidate) != item["sha256"]:
+            raise ComponentUpdateError("UPDATE_STAGED_TREE_MISMATCH")
+
+
 def _stage_package(
     package: Path,
     staging: Path,
     expected_manifest_sha256: str,
-) -> tuple[str, str]:
+) -> tuple[str, str, list[dict[str, Any]]]:
     if not _SHA256_RE.fullmatch(expected_manifest_sha256):
         raise ComponentUpdateError("UPDATE_MANIFEST_DIGEST_INVALID")
     try:
@@ -117,6 +193,14 @@ def _stage_package(
             names = archive.namelist()
             if len(names) != len(set(names)) or names.count("manifest.json") != 1:
                 raise ComponentUpdateError("UPDATE_PACKAGE_INVALID")
+            for info in archive.infolist():
+                member_kind = stat.S_IFMT(info.external_attr >> 16)
+                if (
+                    info.is_dir()
+                    or info.flag_bits & 0x1
+                    or member_kind not in {0, stat.S_IFREG}
+                ):
+                    raise ComponentUpdateError("UPDATE_PACKAGE_INVALID")
             manifest_bytes = archive.read("manifest.json")
             actual_manifest_sha256 = hashlib.sha256(manifest_bytes).hexdigest()
             if actual_manifest_sha256 != expected_manifest_sha256:
@@ -140,33 +224,102 @@ def _stage_package(
                 destination = component_root.joinpath(*PurePosixPath(item["path"]).parts)
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 destination.write_bytes(content)
+            _verify_staged_tree(component_root, files)
     except ComponentUpdateError:
         raise
     except (OSError, KeyError, RuntimeError, zipfile.BadZipFile) as exc:
         raise ComponentUpdateError("UPDATE_PACKAGE_INVALID") from exc
-    return component, version
+    return component, version, files
 
 
-def _write_state(
-    path: Path,
+def _validate_state_descriptor(component: str, value: object) -> dict[str, str]:
+    if not isinstance(value, dict) or set(value) != {
+        "version",
+        "manifest_sha256",
+        "payload_path",
+    }:
+        raise ComponentUpdateError("UPDATE_STATE_INVALID")
+    version = value.get("version")
+    manifest_sha256 = value.get("manifest_sha256")
+    payload_path = value.get("payload_path")
+    if (
+        component not in _COMPONENT_TARGETS
+        or not isinstance(version, str)
+        or not _VERSION_RE.fullmatch(version)
+        or not isinstance(manifest_sha256, str)
+        or not _SHA256_RE.fullmatch(manifest_sha256)
+        or payload_path != f"versions/{component}/{version}-{manifest_sha256}"
+    ):
+        raise ComponentUpdateError("UPDATE_STATE_INVALID")
+    return {
+        "version": version,
+        "manifest_sha256": manifest_sha256,
+        "payload_path": payload_path,
+    }
+
+
+def _read_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {
+            "schema_version": STATE_SCHEMA,
+            "active_components": {},
+            "previous_components": {},
+        }
+    try:
+        state = _load_object(path.read_bytes(), "UPDATE_STATE_INVALID")
+    except OSError as exc:
+        raise ComponentUpdateError("UPDATE_STATE_INVALID") from exc
+    if (
+        set(state) != {"schema_version", "active_components", "previous_components"}
+        or state.get("schema_version") != STATE_SCHEMA
+        or not isinstance(state.get("active_components"), dict)
+        or not isinstance(state.get("previous_components"), dict)
+    ):
+        raise ComponentUpdateError("UPDATE_STATE_INVALID")
+    for section_name in ("active_components", "previous_components"):
+        section = state[section_name]
+        if any(component not in _COMPONENT_TARGETS for component in section):
+            raise ComponentUpdateError("UPDATE_STATE_INVALID")
+        state[section_name] = {
+            component: _validate_state_descriptor(component, descriptor)
+            for component, descriptor in section.items()
+        }
+    return state
+
+
+def _write_state(path: Path, state: dict[str, Any]) -> None:
+    try:
+        with path.open("w", encoding="utf-8", newline="\n") as stream:
+            json.dump(state, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+    except OSError as exc:
+        raise ComponentUpdateError("UPDATE_ACTIVATION_FAILED") from exc
+
+
+def _next_state(
+    current: dict[str, Any],
     *,
     component: str,
     version: str,
     manifest_sha256: str,
-) -> None:
-    state = {
-        "schema_version": STATE_SCHEMA,
-        "active_components": {
-            component: {
-                "version": version,
-                "manifest_sha256": manifest_sha256,
-            }
-        },
+    payload_path: str,
+) -> dict[str, Any]:
+    active = dict(current["active_components"])
+    previous: dict[str, dict[str, str]] = {}
+    if component in active:
+        previous[component] = active[component]
+    active[component] = {
+        "version": version,
+        "manifest_sha256": manifest_sha256,
+        "payload_path": payload_path,
     }
-    path.write_text(
-        json.dumps(state, ensure_ascii=False, indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
+    return {
+        "schema_version": STATE_SCHEMA,
+        "active_components": active,
+        "previous_components": previous,
+    }
 
 
 def apply_component_update(
@@ -180,53 +333,98 @@ def apply_component_update(
     root = _validate_installation(Path(installation))
     package_path = Path(package).expanduser().resolve()
     staging = root / STAGING_ROOT / uuid.uuid4().hex
-    active: Path | None = None
-    backup: Path | None = None
     state_path = root / STATE_NAME
-    state_backup = staging / "previous-state.json"
-    active_backed_up = False
-    state_published = False
     try:
         staging.mkdir(parents=True)
-        component, version = _stage_package(
+        component, version, files = _stage_package(
             package_path,
             staging,
             expected_manifest_sha256.lower(),
         )
-        active = root / _COMPONENT_TARGETS[component]
-        if not active.is_dir():
+        current_state = _read_state(state_path)
+        legacy = root / _COMPONENT_TARGETS[component]
+        if not legacy.is_dir():
             raise ComponentUpdateError("UPDATE_COMPONENT_UNAVAILABLE")
-        backup = staging / "previous-component"
+        relative_version = PurePosixPath(
+            "versions",
+            component,
+            f"{version}-{expected_manifest_sha256.lower()}",
+        )
+        version_root = root.joinpath(*relative_version.parts)
+        version_root.parent.mkdir(parents=True, exist_ok=True)
+        if version_root.exists():
+            try:
+                if _is_reparse_point(version_root) or not version_root.is_dir():
+                    raise ComponentUpdateError("UPDATE_VERSION_CONFLICT")
+                _verify_staged_tree(version_root, files)
+            except ComponentUpdateError as exc:
+                raise ComponentUpdateError("UPDATE_VERSION_CONFLICT") from exc
+        else:
+            os.replace(staging / "payload", version_root)
         staged_state = staging / "next-state.json"
-        _write_state(
-            staged_state,
+        next_state = _next_state(
+            current_state,
             component=component,
             version=version,
             manifest_sha256=expected_manifest_sha256.lower(),
+            payload_path=relative_version.as_posix(),
         )
-        if state_path.exists():
-            shutil.copyfile(state_path, state_backup)
-        os.replace(active, backup)
-        active_backed_up = True
-        os.replace(staging / "payload", active)
+        _write_state(staged_state, next_state)
         os.replace(staged_state, state_path)
-        state_published = True
         return {"status": "APPLIED", "component": component, "version": version}
     except ComponentUpdateError:
         raise
     except OSError as exc:
         raise ComponentUpdateError("UPDATE_ACTIVATION_FAILED") from exc
     finally:
-        if active_backed_up and not state_published and active is not None and backup is not None:
-            if active.is_dir():
-                shutil.rmtree(active, ignore_errors=True)
-            if backup.exists():
-                os.replace(backup, active)
-            if state_backup.exists():
-                os.replace(state_backup, state_path)
-            else:
-                state_path.unlink(missing_ok=True)
         shutil.rmtree(staging, ignore_errors=True)
 
 
-__all__ = ["ComponentUpdateError", "apply_component_update"]
+def rollback_component_update(
+    installation: str | os.PathLike[str],
+    component: str = "local_backend",
+) -> dict[str, str]:
+    """Atomically swap the active and previous pointers for one component."""
+
+    root = _validate_installation(Path(installation))
+    if component not in _COMPONENT_TARGETS:
+        raise ComponentUpdateError("UPDATE_COMPONENT_UNSUPPORTED")
+    state_path = root / STATE_NAME
+    state = _read_state(state_path)
+    active = state["active_components"].get(component)
+    previous = state["previous_components"].get(component)
+    if active is None or previous is None:
+        raise ComponentUpdateError("UPDATE_ROLLBACK_UNAVAILABLE")
+    previous_path = root.joinpath(*PurePosixPath(previous["payload_path"]).parts)
+    if not previous_path.is_dir():
+        raise ComponentUpdateError("UPDATE_ROLLBACK_UNAVAILABLE")
+
+    next_state = {
+        "schema_version": STATE_SCHEMA,
+        "active_components": {**state["active_components"], component: previous},
+        "previous_components": {component: active},
+    }
+    staging = root / STAGING_ROOT / uuid.uuid4().hex
+    try:
+        staging.mkdir(parents=True)
+        staged_state = staging / "rollback-state.json"
+        _write_state(staged_state, next_state)
+        os.replace(staged_state, state_path)
+    except ComponentUpdateError:
+        raise
+    except OSError as exc:
+        raise ComponentUpdateError("UPDATE_ACTIVATION_FAILED") from exc
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+    return {
+        "status": "ROLLED_BACK",
+        "component": component,
+        "version": previous["version"],
+    }
+
+
+__all__ = [
+    "ComponentUpdateError",
+    "apply_component_update",
+    "rollback_component_update",
+]

--- a/installer/component_update.py
+++ b/installer/component_update.py
@@ -1,0 +1,232 @@
+"""Apply one verified local component package to a managed installation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import uuid
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from installer.uninstall_safety import safe_owned_targets
+
+
+PACKAGE_SCHEMA = "olivia.component-package.v1"
+STATE_SCHEMA = "olivia.update-state.v1"
+STATE_NAME = ".olivia-update-state.json"
+STAGING_ROOT = Path("runtime/update-staging")
+_INSTALL_MARKER = ".olivia-full-patch.json"
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_VERSION_RE = re.compile(r"[0-9A-Za-z][0-9A-Za-z.+-]{0,63}")
+_COMPONENT_TARGETS = {"local_backend": "local_backend"}
+
+
+class ComponentUpdateError(RuntimeError):
+    """Stable, user-safe component update failure code."""
+
+
+def _load_object(raw: bytes, code: str) -> dict[str, Any]:
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise ComponentUpdateError(code) from exc
+    if not isinstance(value, dict):
+        raise ComponentUpdateError(code)
+    return value
+
+
+def _validate_installation(installation: Path) -> Path:
+    root = installation.expanduser().resolve()
+    try:
+        safe_owned_targets(root)
+    except (OSError, ValueError) as exc:
+        raise ComponentUpdateError("UPDATE_INSTALLATION_INVALID") from exc
+    marker_path = root / _INSTALL_MARKER
+    try:
+        marker = _load_object(marker_path.read_bytes(), "UPDATE_INSTALLATION_INVALID")
+    except OSError as exc:
+        raise ComponentUpdateError("UPDATE_INSTALLATION_INVALID") from exc
+    if (
+        marker.get("schema_version") != "olivia.full-patch.install.v2"
+        or marker.get("owned_root") != str(root)
+    ):
+        raise ComponentUpdateError("UPDATE_INSTALLATION_INVALID")
+    return root
+
+
+def _validate_relative_path(value: object) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value or "\\" in value:
+        raise ComponentUpdateError("UPDATE_MANIFEST_INVALID")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ComponentUpdateError("UPDATE_MANIFEST_INVALID")
+    return path.as_posix()
+
+
+def _validate_manifest(value: dict[str, Any]) -> tuple[str, str, list[dict[str, Any]]]:
+    if set(value) != {"schema_version", "component", "version", "files"}:
+        raise ComponentUpdateError("UPDATE_MANIFEST_INVALID")
+    component = value.get("component")
+    version = value.get("version")
+    files = value.get("files")
+    if (
+        value.get("schema_version") != PACKAGE_SCHEMA
+        or component not in _COMPONENT_TARGETS
+        or not isinstance(version, str)
+        or not _VERSION_RE.fullmatch(version)
+        or not isinstance(files, list)
+        or not files
+    ):
+        raise ComponentUpdateError("UPDATE_MANIFEST_INVALID")
+
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in files:
+        if not isinstance(item, dict) or set(item) != {"path", "size_bytes", "sha256"}:
+            raise ComponentUpdateError("UPDATE_MANIFEST_INVALID")
+        relative = _validate_relative_path(item.get("path"))
+        size = item.get("size_bytes")
+        digest = item.get("sha256")
+        if (
+            relative.casefold() in seen
+            or not isinstance(size, int)
+            or isinstance(size, bool)
+            or size < 0
+            or not isinstance(digest, str)
+            or not _SHA256_RE.fullmatch(digest)
+        ):
+            raise ComponentUpdateError("UPDATE_MANIFEST_INVALID")
+        seen.add(relative.casefold())
+        normalized.append({"path": relative, "size_bytes": size, "sha256": digest})
+    return component, version, normalized
+
+
+def _stage_package(
+    package: Path,
+    staging: Path,
+    expected_manifest_sha256: str,
+) -> tuple[str, str]:
+    if not _SHA256_RE.fullmatch(expected_manifest_sha256):
+        raise ComponentUpdateError("UPDATE_MANIFEST_DIGEST_INVALID")
+    try:
+        with zipfile.ZipFile(package) as archive:
+            names = archive.namelist()
+            if len(names) != len(set(names)) or names.count("manifest.json") != 1:
+                raise ComponentUpdateError("UPDATE_PACKAGE_INVALID")
+            manifest_bytes = archive.read("manifest.json")
+            actual_manifest_sha256 = hashlib.sha256(manifest_bytes).hexdigest()
+            if actual_manifest_sha256 != expected_manifest_sha256:
+                raise ComponentUpdateError("UPDATE_MANIFEST_DIGEST_MISMATCH")
+            component, version, files = _validate_manifest(
+                _load_object(manifest_bytes, "UPDATE_MANIFEST_INVALID")
+            )
+            expected_names = {"manifest.json"} | {
+                f"payload/{item['path']}" for item in files
+            }
+            if set(names) != expected_names:
+                raise ComponentUpdateError("UPDATE_PACKAGE_INVALID")
+            component_root = staging / "payload"
+            for item in files:
+                content = archive.read(f"payload/{item['path']}")
+                if (
+                    len(content) != item["size_bytes"]
+                    or hashlib.sha256(content).hexdigest() != item["sha256"]
+                ):
+                    raise ComponentUpdateError("UPDATE_PAYLOAD_DIGEST_MISMATCH")
+                destination = component_root.joinpath(*PurePosixPath(item["path"]).parts)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_bytes(content)
+    except ComponentUpdateError:
+        raise
+    except (OSError, KeyError, RuntimeError, zipfile.BadZipFile) as exc:
+        raise ComponentUpdateError("UPDATE_PACKAGE_INVALID") from exc
+    return component, version
+
+
+def _write_state(
+    path: Path,
+    *,
+    component: str,
+    version: str,
+    manifest_sha256: str,
+) -> None:
+    state = {
+        "schema_version": STATE_SCHEMA,
+        "active_components": {
+            component: {
+                "version": version,
+                "manifest_sha256": manifest_sha256,
+            }
+        },
+    }
+    path.write_text(
+        json.dumps(state, ensure_ascii=False, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def apply_component_update(
+    installation: str | os.PathLike[str],
+    package: str | os.PathLike[str],
+    *,
+    expected_manifest_sha256: str,
+) -> dict[str, str]:
+    """Verify, stage and atomically activate one managed component update."""
+
+    root = _validate_installation(Path(installation))
+    package_path = Path(package).expanduser().resolve()
+    staging = root / STAGING_ROOT / uuid.uuid4().hex
+    active: Path | None = None
+    backup: Path | None = None
+    state_path = root / STATE_NAME
+    state_backup = staging / "previous-state.json"
+    active_backed_up = False
+    state_published = False
+    try:
+        staging.mkdir(parents=True)
+        component, version = _stage_package(
+            package_path,
+            staging,
+            expected_manifest_sha256.lower(),
+        )
+        active = root / _COMPONENT_TARGETS[component]
+        if not active.is_dir():
+            raise ComponentUpdateError("UPDATE_COMPONENT_UNAVAILABLE")
+        backup = staging / "previous-component"
+        staged_state = staging / "next-state.json"
+        _write_state(
+            staged_state,
+            component=component,
+            version=version,
+            manifest_sha256=expected_manifest_sha256.lower(),
+        )
+        if state_path.exists():
+            shutil.copyfile(state_path, state_backup)
+        os.replace(active, backup)
+        active_backed_up = True
+        os.replace(staging / "payload", active)
+        os.replace(staged_state, state_path)
+        state_published = True
+        return {"status": "APPLIED", "component": component, "version": version}
+    except ComponentUpdateError:
+        raise
+    except OSError as exc:
+        raise ComponentUpdateError("UPDATE_ACTIVATION_FAILED") from exc
+    finally:
+        if active_backed_up and not state_published and active is not None and backup is not None:
+            if active.is_dir():
+                shutil.rmtree(active, ignore_errors=True)
+            if backup.exists():
+                os.replace(backup, active)
+            if state_backup.exists():
+                os.replace(state_backup, state_path)
+            else:
+                state_path.unlink(missing_ok=True)
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+__all__ = ["ComponentUpdateError", "apply_component_update"]

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -76,6 +76,10 @@ PAYLOAD_REQUIRED_ROOT_FILES = {
     "video_reply_settings.py",
 }
 PAYLOAD_REQUIRED_RELATIVE_FILES = {
+    "contracts/component_update_package.example.json",
+    "contracts/component_update_package.schema.json",
+    "contracts/component_update_state.example.json",
+    "contracts/component_update_state.schema.json",
     "contracts/letter_status.py",
     "contracts/third_party_manifest.example.json",
     "contracts/third_party_manifest.schema.json",
@@ -88,6 +92,7 @@ PAYLOAD_REQUIRED_RELATIVE_FILES = {
     "control_center/private_world_candidate_backend.py",
     "control_center/private_world_candidate_ui.py",
     "control_center/runtime.py",
+    "installer/version_launcher.py",
     "runtime/__init__.py",
     "runtime/original_client_media_http.py",
     "runtime/video_reply_settings.py",
@@ -476,16 +481,19 @@ def copy_official_runtime(
 
 
 def _write_start_scripts(root: Path, port: int) -> None:
+    launcher = root / "launcher" / "version_launcher.py"
+    launcher.parent.mkdir(parents=True, exist_ok=True)
+    _copy_file(root / "local_backend" / "installer" / "version_launcher.py", launcher)
     (root / "START.cmd").write_text(
-        f"@echo off\nsetlocal\nset ROOT=%~dp0\nset OLIVIA_PORT={port}\nset PYTHON_EXE=%LOCALAPPDATA%\\BSideOliviaLocal\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%local_backend\\installer\\start_local.py\" --install-root \"%ROOT%.\" --port %OLIVIA_PORT%\nexit /b %ERRORLEVEL%\n",
+        f"@echo off\nsetlocal\nset ROOT=%~dp0\nset OLIVIA_PORT={port}\nset PYTHON_EXE=%LOCALAPPDATA%\\BSideOliviaLocal\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" start --port %OLIVIA_PORT%\nexit /b %ERRORLEVEL%\n",
         encoding="utf-8",
     )
     (root / "UNINSTALL.cmd").write_text(
-        "@echo off\nsetlocal\nset ROOT=%~dp0\nset PYTHON_EXE=%LOCALAPPDATA%\\BSideOliviaLocal\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%local_backend\\installer\\uninstall.py\" --installation \"%ROOT%.\" --apply\nexit /b %ERRORLEVEL%\n",
+        "@echo off\nsetlocal\nset ROOT=%~dp0\nset PYTHON_EXE=%LOCALAPPDATA%\\BSideOliviaLocal\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" uninstall --apply\nexit /b %ERRORLEVEL%\n",
         encoding="utf-8",
     )
     (root / "CONFIGURE.cmd").write_text(
-        "@echo off\nsetlocal\nset ROOT=%~dp0\nset PYTHON_EXE=%LOCALAPPDATA%\\BSideOliviaLocal\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%local_backend\\installer\\configure.py\" --installation \"%ROOT%.\"\nexit /b %ERRORLEVEL%\n",
+        "@echo off\nsetlocal\nset ROOT=%~dp0\nset PYTHON_EXE=%LOCALAPPDATA%\\BSideOliviaLocal\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" configure\nexit /b %ERRORLEVEL%\n",
         encoding="utf-8",
     )
 
@@ -502,7 +510,14 @@ def _refresh_existing_install(
     rollback = staging / ".rollback"
     published: list[Path] = []
     backed_up: list[tuple[Path, Path]] = []
-    names = ("local_backend", "START.cmd", "CONFIGURE.cmd", "UNINSTALL.cmd", MARKER_NAME)
+    names = (
+        "local_backend",
+        "launcher",
+        "START.cmd",
+        "CONFIGURE.cmd",
+        "UNINSTALL.cmd",
+        MARKER_NAME,
+    )
     try:
         copied = copy_project_payload(payload, staging / "local_backend")
         _write_start_scripts(staging, port)

--- a/installer/uninstall_safety.py
+++ b/installer/uninstall_safety.py
@@ -17,6 +17,8 @@ OWNED_PATHS = (
     "UNINSTALL.cmd",
     "runtime/mem0-site-packages",
     "runtime/mem0-site-packages.staging",
+    "runtime/update-staging",
+    ".olivia-update-state.json",
     MARKER_NAME,
 )
 PRESERVED_PATHS = ("data", "logs", "third-party")

--- a/installer/uninstall_safety.py
+++ b/installer/uninstall_safety.py
@@ -12,6 +12,8 @@ MARKER_NAME = ".olivia-full-patch.json"
 OWNED_PATHS = (
     "app",
     "local_backend",
+    "launcher",
+    "versions",
     "START.cmd",
     "CONFIGURE.cmd",
     "UNINSTALL.cmd",

--- a/installer/version_launcher.py
+++ b/installer/version_launcher.py
@@ -16,6 +16,9 @@ INSTALL_SCHEMA = "olivia.full-patch.install.v2"
 _SHA256_RE = re.compile(r"[0-9a-f]{64}")
 _VERSION_RE = re.compile(r"[0-9A-Za-z][0-9A-Za-z.+-]{0,63}")
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
+_LEGACY_VERSION = "0.0.0+legacy"
+_LEGACY_MANIFEST_SHA256 = "0" * 64
+_LEGACY_PAYLOAD_PATH = "local_backend"
 
 
 class VersionLauncherError(RuntimeError):
@@ -33,7 +36,11 @@ def _is_reparse_point(path: Path) -> bool:
     )
 
 
-def _safe_version_path(root: Path, value: object, version: object, digest: object) -> Path:
+def _validated_relative_path(
+    value: object,
+    version: object,
+    digest: object,
+) -> PurePosixPath:
     if (
         not isinstance(value, str)
         or not isinstance(version, str)
@@ -43,13 +50,25 @@ def _safe_version_path(root: Path, value: object, version: object, digest: objec
     ):
         raise VersionLauncherError("UPDATE_STATE_INVALID")
     relative = PurePosixPath(value)
-    expected = PurePosixPath(
-        "versions",
-        "local_backend",
-        f"{version}-{digest}",
-    )
+    if (
+        version == _LEGACY_VERSION
+        and digest == _LEGACY_MANIFEST_SHA256
+        and value == _LEGACY_PAYLOAD_PATH
+    ):
+        expected = PurePosixPath(_LEGACY_PAYLOAD_PATH)
+    else:
+        expected = PurePosixPath(
+            "versions",
+            "local_backend",
+            f"{version}-{digest}",
+        )
     if relative != expected or relative.as_posix() != value:
         raise VersionLauncherError("UPDATE_STATE_INVALID")
+    return relative
+
+
+def _safe_version_path(root: Path, value: object, version: object, digest: object) -> Path:
+    relative = _validated_relative_path(value, version, digest)
     current = root
     for part in relative.parts:
         current = current / part
@@ -123,8 +142,7 @@ def resolve_active_backend(installation: str | os.PathLike[str]) -> Path:
             "payload_path",
         }:
             raise VersionLauncherError("UPDATE_STATE_INVALID")
-        _safe_version_path(
-            root,
+        _validated_relative_path(
             previous.get("payload_path"),
             previous.get("version"),
             previous.get("manifest_sha256"),

--- a/installer/version_launcher.py
+++ b/installer/version_launcher.py
@@ -1,0 +1,189 @@
+"""Stable root launcher for an atomically selected backend version."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import runpy
+import sys
+from pathlib import Path, PurePosixPath
+
+STATE_NAME = ".olivia-update-state.json"
+STATE_SCHEMA = "olivia.update-state.v1"
+INSTALL_SCHEMA = "olivia.full-patch.install.v2"
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_VERSION_RE = re.compile(r"[0-9A-Za-z][0-9A-Za-z.+-]{0,63}")
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
+
+
+class VersionLauncherError(RuntimeError):
+    """Stable, user-safe launcher failure code."""
+
+
+def _is_reparse_point(path: Path) -> bool:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise VersionLauncherError("UPDATE_STATE_INVALID") from exc
+    return path.is_symlink() or bool(
+        getattr(metadata, "st_file_attributes", 0)
+        & _FILE_ATTRIBUTE_REPARSE_POINT
+    )
+
+
+def _safe_version_path(root: Path, value: object, version: object, digest: object) -> Path:
+    if (
+        not isinstance(value, str)
+        or not isinstance(version, str)
+        or not isinstance(digest, str)
+        or not _VERSION_RE.fullmatch(version)
+        or not _SHA256_RE.fullmatch(digest)
+    ):
+        raise VersionLauncherError("UPDATE_STATE_INVALID")
+    relative = PurePosixPath(value)
+    expected = PurePosixPath(
+        "versions",
+        "local_backend",
+        f"{version}-{digest}",
+    )
+    if relative != expected or relative.as_posix() != value:
+        raise VersionLauncherError("UPDATE_STATE_INVALID")
+    current = root
+    for part in relative.parts:
+        current = current / part
+        if _is_reparse_point(current):
+            raise VersionLauncherError("UPDATE_STATE_INVALID")
+    if not current.is_dir():
+        raise VersionLauncherError("UPDATE_STATE_INVALID")
+    return current
+
+
+def resolve_active_backend(installation: str | os.PathLike[str]) -> Path:
+    """Resolve one complete backend tree from one atomic state-file read."""
+
+    root = Path(installation).expanduser().absolute()
+    try:
+        if _is_reparse_point(root) or not root.is_dir():
+            raise VersionLauncherError("UPDATE_INSTALLATION_INVALID")
+        root = root.resolve()
+        marker_path = root / ".olivia-full-patch.json"
+        if _is_reparse_point(marker_path):
+            raise VersionLauncherError("UPDATE_INSTALLATION_INVALID")
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        if (
+            not isinstance(marker, dict)
+            or marker.get("schema_version") != INSTALL_SCHEMA
+            or marker.get("owned_root") != str(root)
+        ):
+            raise VersionLauncherError("UPDATE_INSTALLATION_INVALID")
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise VersionLauncherError("UPDATE_INSTALLATION_INVALID") from exc
+    state_path = root / STATE_NAME
+    if not state_path.exists():
+        legacy = root / "local_backend"
+        if not legacy.is_dir() or _is_reparse_point(legacy):
+            raise VersionLauncherError("UPDATE_COMPONENT_UNAVAILABLE")
+        return legacy
+    if _is_reparse_point(state_path):
+        raise VersionLauncherError("UPDATE_STATE_INVALID")
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise VersionLauncherError("UPDATE_STATE_INVALID") from exc
+    if (
+        not isinstance(state, dict)
+        or state.get("schema_version") != STATE_SCHEMA
+        or set(state) != {"schema_version", "active_components", "previous_components"}
+        or not isinstance(state.get("active_components"), dict)
+        or set(state["active_components"]) != {"local_backend"}
+        or not isinstance(state.get("previous_components"), dict)
+        or not set(state["previous_components"]).issubset({"local_backend"})
+    ):
+        raise VersionLauncherError("UPDATE_STATE_INVALID")
+    active = state["active_components"]["local_backend"]
+    if not isinstance(active, dict) or set(active) != {
+        "version",
+        "manifest_sha256",
+        "payload_path",
+    }:
+        raise VersionLauncherError("UPDATE_STATE_INVALID")
+    active_path = _safe_version_path(
+        root,
+        active.get("payload_path"),
+        active.get("version"),
+        active.get("manifest_sha256"),
+    )
+    previous = state["previous_components"].get("local_backend")
+    if previous is not None:
+        if not isinstance(previous, dict) or set(previous) != {
+            "version",
+            "manifest_sha256",
+            "payload_path",
+        }:
+            raise VersionLauncherError("UPDATE_STATE_INVALID")
+        _safe_version_path(
+            root,
+            previous.get("payload_path"),
+            previous.get("version"),
+            previous.get("manifest_sha256"),
+        )
+    return active_path
+
+
+def _entrypoint_arguments(
+    action: str,
+    installation: Path,
+) -> tuple[Path, list[str]]:
+    backend = resolve_active_backend(installation)
+    root = installation.expanduser().resolve()
+    entrypoints = {
+        "start": ("start_local.py", "--install-root"),
+        "configure": ("configure.py", "--installation"),
+        "uninstall": ("uninstall.py", "--installation"),
+    }
+    script_name, root_option = entrypoints[action]
+    entrypoint = backend / "installer" / script_name
+    if (
+        not entrypoint.is_file()
+        or _is_reparse_point(entrypoint.parent)
+        or _is_reparse_point(entrypoint)
+    ):
+        raise VersionLauncherError("UPDATE_COMPONENT_UNAVAILABLE")
+    return entrypoint, [root_option, os.fspath(root)]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="olivia-version-launcher")
+    parser.add_argument("--install-root", type=Path, required=True)
+    parser.add_argument("action", choices=("start", "configure", "uninstall"))
+    parser.add_argument("arguments", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    try:
+        entrypoint, root_arguments = _entrypoint_arguments(
+            args.action,
+            args.install_root,
+        )
+        previous_argv = sys.argv
+        previous_path = list(sys.path)
+        try:
+            sys.argv = [os.fspath(entrypoint), *root_arguments, *args.arguments]
+            sys.path.insert(0, os.fspath(entrypoint.parents[1]))
+            runpy.run_path(os.fspath(entrypoint), run_name="__main__")
+        finally:
+            sys.argv = previous_argv
+            sys.path[:] = previous_path
+        return 0
+    except VersionLauncherError as exc:
+        print(json.dumps({"status": "ERROR", "code": str(exc)}))
+        return 2
+    except SystemExit as exc:
+        return int(exc.code or 0)
+
+
+__all__ = ["VersionLauncherError", "main", "resolve_active_backend"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/installer/test_component_update.py
+++ b/tests/installer/test_component_update.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from installer import component_update
+from installer import __main__ as installer_cli
+from installer.component_update import ComponentUpdateError, apply_component_update
+from installer.uninstall_safety import remove_owned_targets
+
+
+def _write_component_package(
+    path: Path,
+    *,
+    version: str,
+    files: dict[str, bytes],
+) -> str:
+    manifest = {
+        "schema_version": "olivia.component-package.v1",
+        "component": "local_backend",
+        "version": version,
+        "files": [
+            {
+                "path": name,
+                "size_bytes": len(content),
+                "sha256": hashlib.sha256(content).hexdigest(),
+            }
+            for name, content in sorted(files.items())
+        ],
+    }
+    manifest_bytes = json.dumps(
+        manifest,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("manifest.json", manifest_bytes)
+        for name, content in files.items():
+            archive.writestr(f"payload/{name}", content)
+    return hashlib.sha256(manifest_bytes).hexdigest()
+
+
+def _make_windows_junction(link: Path, target: Path) -> Path:
+    if os.name != "nt":
+        pytest.skip("Windows junctions are only available on Windows")
+    result = subprocess.run(
+        ["cmd.exe", "/d", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip("Windows junctions are unavailable")
+    return link
+
+
+def _write_install_marker(installation: Path) -> None:
+    (installation / ".olivia-full-patch.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.full-patch.install.v2",
+                "owned_root": str(installation.resolve()),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _managed_installation(tmp_path: Path) -> tuple[Path, Path]:
+    installation = tmp_path / "installation"
+    active = installation / "local_backend"
+    active.mkdir(parents=True)
+    (active / "old.py").write_text("old", encoding="utf-8")
+    _write_install_marker(installation)
+    return installation, active
+
+
+def test_valid_local_backend_component_update_is_activated_atomically(
+    tmp_path: Path,
+) -> None:
+    installation, active = _managed_installation(tmp_path)
+    package = tmp_path / "local-backend.oliviapatch"
+    manifest_sha256 = _write_component_package(
+        package,
+        version="1.1.0",
+        files={"new.py": b"new"},
+    )
+
+    result = apply_component_update(
+        installation,
+        package,
+        expected_manifest_sha256=manifest_sha256,
+    )
+
+    assert result == {
+        "status": "APPLIED",
+        "component": "local_backend",
+        "version": "1.1.0",
+    }
+    assert not (active / "old.py").exists()
+    assert (active / "new.py").read_bytes() == b"new"
+    assert json.loads(
+        (installation / ".olivia-update-state.json").read_text(encoding="utf-8")
+    ) == {
+        "schema_version": "olivia.update-state.v1",
+        "active_components": {
+            "local_backend": {
+                "version": "1.1.0",
+                "manifest_sha256": manifest_sha256,
+            }
+        },
+    }
+
+
+def test_component_update_rejects_payload_path_escape_before_activation(
+    tmp_path: Path,
+) -> None:
+    installation, active = _managed_installation(tmp_path)
+    package = tmp_path / "unsafe.oliviapatch"
+    manifest_sha256 = _write_component_package(
+        package,
+        version="1.1.0",
+        files={"../escape.py": b"escape"},
+    )
+
+    with pytest.raises(ComponentUpdateError, match="UPDATE_MANIFEST_INVALID"):
+        apply_component_update(
+            installation,
+            package,
+            expected_manifest_sha256=manifest_sha256,
+        )
+
+    assert (active / "old.py").read_text(encoding="utf-8") == "old"
+    assert not (installation / "escape.py").exists()
+    assert not (installation / ".olivia-update-state.json").exists()
+    assert not list(installation.glob(".olivia-update-staging-*"))
+
+
+def test_component_update_restores_active_payload_when_publish_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    installation, active = _managed_installation(tmp_path)
+    package = tmp_path / "local-backend.oliviapatch"
+    manifest_sha256 = _write_component_package(
+        package,
+        version="1.1.0",
+        files={"new.py": b"new"},
+    )
+    original_replace = component_update.os.replace
+
+    def fail_new_payload(source: str | Path, destination: str | Path) -> None:
+        if Path(source).name == "payload" and Path(destination) == active:
+            raise OSError("synthetic publish failure")
+        original_replace(source, destination)
+
+    monkeypatch.setattr(component_update.os, "replace", fail_new_payload)
+
+    with pytest.raises(ComponentUpdateError, match="UPDATE_ACTIVATION_FAILED"):
+        apply_component_update(
+            installation,
+            package,
+            expected_manifest_sha256=manifest_sha256,
+        )
+
+    assert (active / "old.py").read_text(encoding="utf-8") == "old"
+    assert not (active / "new.py").exists()
+    assert not (installation / ".olivia-update-state.json").exists()
+
+
+def test_component_update_rejects_untrusted_manifest_before_activation(
+    tmp_path: Path,
+) -> None:
+    installation, active = _managed_installation(tmp_path)
+    package = tmp_path / "local-backend.oliviapatch"
+    _write_component_package(
+        package,
+        version="1.1.0",
+        files={"new.py": b"new"},
+    )
+
+    with pytest.raises(
+        ComponentUpdateError,
+        match="UPDATE_MANIFEST_DIGEST_MISMATCH",
+    ):
+        apply_component_update(
+            installation,
+            package,
+            expected_manifest_sha256="0" * 64,
+        )
+
+    assert (active / "old.py").read_text(encoding="utf-8") == "old"
+    assert not (active / "new.py").exists()
+    assert not (installation / ".olivia-update-state.json").exists()
+
+
+def test_installer_cli_applies_a_verified_local_component_package(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    installation, _active = _managed_installation(tmp_path)
+    package = tmp_path / "local-backend.oliviapatch"
+    manifest_sha256 = _write_component_package(
+        package,
+        version="1.1.0",
+        files={"new.py": b"new"},
+    )
+
+    exit_code = installer_cli.main(
+        [
+            "apply-update",
+            "--installation",
+            str(installation),
+            "--package",
+            str(package),
+            "--manifest-sha256",
+            manifest_sha256,
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "APPLIED",
+        "component": "local_backend",
+        "version": "1.1.0",
+    }
+
+
+def test_uninstall_removes_update_state_and_abandoned_update_staging(
+    tmp_path: Path,
+) -> None:
+    installation = tmp_path / "installation"
+    installation.mkdir()
+    state = installation / ".olivia-update-state.json"
+    state.write_text("{}", encoding="utf-8")
+    abandoned = installation / "runtime" / "update-staging" / "abandoned"
+    abandoned.mkdir(parents=True)
+    (abandoned / "partial.bin").write_bytes(b"partial")
+    preserved = installation / "data" / "keep.txt"
+    preserved.parent.mkdir()
+    preserved.write_text("keep", encoding="utf-8")
+
+    remove_owned_targets(installation)
+
+    assert not state.exists()
+    assert not (installation / "runtime" / "update-staging").exists()
+    assert preserved.read_text(encoding="utf-8") == "keep"
+
+
+def test_component_update_rejects_reparse_component_target(
+    tmp_path: Path,
+) -> None:
+    installation = tmp_path / "installation"
+    installation.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+    (external / "old.py").write_text("external", encoding="utf-8")
+    active = _make_windows_junction(installation / "local_backend", external)
+    _write_install_marker(installation)
+    package = tmp_path / "local-backend.oliviapatch"
+    manifest_sha256 = _write_component_package(
+        package,
+        version="1.1.0",
+        files={"new.py": b"new"},
+    )
+
+    with pytest.raises(ComponentUpdateError, match="UPDATE_INSTALLATION_INVALID"):
+        apply_component_update(
+            installation,
+            package,
+            expected_manifest_sha256=manifest_sha256,
+        )
+
+    assert (external / "old.py").read_text(encoding="utf-8") == "external"
+    assert not (external / "new.py").exists()

--- a/tests/installer/test_component_update.py
+++ b/tests/installer/test_component_update.py
@@ -22,12 +22,24 @@ from installer.component_update import (
 from installer.uninstall_safety import remove_owned_targets
 
 
+_REQUIRED_COMPONENT_ENTRYPOINTS = {
+    "installer/start_local.py": b"",
+    "installer/configure.py": b"",
+    "installer/uninstall.py": b"",
+}
+
+
 def _write_component_package(
     path: Path,
     *,
     version: str,
     files: dict[str, bytes],
+    include_entrypoints: bool = True,
 ) -> str:
+    package_files = dict(files)
+    if include_entrypoints:
+        for name, content in _REQUIRED_COMPONENT_ENTRYPOINTS.items():
+            package_files.setdefault(name, content)
     manifest = {
         "schema_version": "olivia.component-package.v1",
         "component": "local_backend",
@@ -38,7 +50,7 @@ def _write_component_package(
                 "size_bytes": len(content),
                 "sha256": hashlib.sha256(content).hexdigest(),
             }
-            for name, content in sorted(files.items())
+            for name, content in sorted(package_files.items())
         ],
     }
     manifest_bytes = json.dumps(
@@ -49,7 +61,7 @@ def _write_component_package(
     ).encode("utf-8")
     with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
         archive.writestr("manifest.json", manifest_bytes)
-        for name, content in files.items():
+        for name, content in package_files.items():
             archive.writestr(f"payload/{name}", content)
     return hashlib.sha256(manifest_bytes).hexdigest()
 
@@ -132,7 +144,13 @@ def test_valid_local_backend_component_update_is_activated_atomically(
                 "payload_path": versioned.relative_to(installation).as_posix(),
             }
         },
-        "previous_components": {},
+        "previous_components": {
+            "local_backend": {
+                "version": "0.0.0+legacy",
+                "manifest_sha256": "0" * 64,
+                "payload_path": "local_backend",
+            }
+        },
     }
 
 
@@ -161,8 +179,34 @@ def test_stable_launcher_resolves_the_atomically_selected_backend(
         / "local_backend"
         / f"1.1.0-{manifest_sha256}"
     )
+    assert version_launcher.main(
+        ["--install-root", str(installation), "start"]
+    ) == 0
     (installation / ".olivia-update-state.json").unlink()
     assert resolve_active_backend(installation) == legacy
+
+
+def test_component_package_requires_all_stable_launcher_entrypoints(
+    tmp_path: Path,
+) -> None:
+    installation, legacy = _managed_installation(tmp_path)
+    package = tmp_path / "incomplete.oliviapatch"
+    manifest_sha256 = _write_component_package(
+        package,
+        version="1.1.0",
+        files={"new.py": b"new"},
+        include_entrypoints=False,
+    )
+
+    with pytest.raises(ComponentUpdateError, match="UPDATE_MANIFEST_INVALID"):
+        apply_component_update(
+            installation,
+            package,
+            expected_manifest_sha256=manifest_sha256,
+        )
+
+    assert (legacy / "old.py").read_text(encoding="utf-8") == "old"
+    assert not (installation / ".olivia-update-state.json").exists()
 
 
 def test_stable_launcher_runs_without_importing_the_legacy_backend_first(
@@ -298,6 +342,137 @@ def test_next_component_update_preserves_the_previous_version_for_rollback(
         "payload_path": f"versions/local_backend/1.1.0-{first_sha256}",
     }
     assert (legacy / "old.py").read_text(encoding="utf-8") == "old"
+
+
+def test_first_component_update_can_roll_back_to_the_legacy_baseline(
+    tmp_path: Path,
+) -> None:
+    from installer.version_launcher import resolve_active_backend
+
+    installation, legacy = _managed_installation(tmp_path)
+    package = tmp_path / "first.oliviapatch"
+    manifest_sha256 = _write_component_package(
+        package,
+        version="1.1.0",
+        files={"new.py": b"new"},
+    )
+    apply_component_update(
+        installation,
+        package,
+        expected_manifest_sha256=manifest_sha256,
+    )
+
+    result = rollback_component_update(installation)
+
+    assert result == {
+        "status": "ROLLED_BACK",
+        "component": "local_backend",
+        "version": "0.0.0+legacy",
+    }
+    assert resolve_active_backend(installation) == legacy
+
+
+def test_reapplying_the_active_descriptor_preserves_the_real_previous_pointer(
+    tmp_path: Path,
+) -> None:
+    installation, _legacy = _managed_installation(tmp_path)
+    packages: list[tuple[Path, str]] = []
+    for version in ("1.1.0", "1.2.0"):
+        package = tmp_path / f"{version}.oliviapatch"
+        digest = _write_component_package(
+            package,
+            version=version,
+            files={f"{version}.py": version.encode("utf-8")},
+        )
+        packages.append((package, digest))
+        apply_component_update(
+            installation,
+            package,
+            expected_manifest_sha256=digest,
+        )
+    state_path = installation / ".olivia-update-state.json"
+    before = json.loads(state_path.read_text(encoding="utf-8"))
+
+    apply_component_update(
+        installation,
+        packages[-1][0],
+        expected_manifest_sha256=packages[-1][1],
+    )
+
+    assert json.loads(state_path.read_text(encoding="utf-8")) == before
+
+
+def test_existing_state_requires_an_active_local_backend(
+    tmp_path: Path,
+) -> None:
+    installation, _legacy = _managed_installation(tmp_path)
+    state_path = installation / ".olivia-update-state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.update-state.v1",
+                "active_components": {},
+                "previous_components": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    package = tmp_path / "update.oliviapatch"
+    manifest_sha256 = _write_component_package(
+        package,
+        version="1.1.0",
+        files={"new.py": b"new"},
+    )
+
+    with pytest.raises(ComponentUpdateError, match="UPDATE_STATE_INVALID"):
+        apply_component_update(
+            installation,
+            package,
+            expected_manifest_sha256=manifest_sha256,
+        )
+
+
+def test_rollback_rejects_a_reparse_previous_version_without_changing_state(
+    tmp_path: Path,
+) -> None:
+    from installer.version_launcher import resolve_active_backend
+
+    installation, _legacy = _managed_installation(tmp_path)
+    applied: list[tuple[str, str]] = []
+    for version in ("1.1.0", "1.2.0"):
+        package = tmp_path / f"{version}.oliviapatch"
+        digest = _write_component_package(
+            package,
+            version=version,
+            files={f"{version}.py": version.encode("utf-8")},
+        )
+        apply_component_update(
+            installation,
+            package,
+            expected_manifest_sha256=digest,
+        )
+        applied.append((version, digest))
+    previous_version, previous_digest = applied[0]
+    previous_path = (
+        installation
+        / "versions"
+        / "local_backend"
+        / f"{previous_version}-{previous_digest}"
+    )
+    shutil.rmtree(previous_path)
+    external = tmp_path / "external"
+    external.mkdir()
+    _make_windows_junction(previous_path, external)
+    state_path = installation / ".olivia-update-state.json"
+    state_before = state_path.read_bytes()
+
+    with pytest.raises(ComponentUpdateError, match="UPDATE_STATE_INVALID"):
+        rollback_component_update(installation)
+
+    assert state_path.read_bytes() == state_before
+    assert resolve_active_backend(installation).name == (
+        f"{applied[1][0]}-{applied[1][1]}"
+    )
 
 
 def test_component_update_rolls_back_by_atomically_swapping_the_version_pointer(

--- a/tests/installer/test_component_update.py
+++ b/tests/installer/test_component_update.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
+import stat
 import subprocess
 import zipfile
 from pathlib import Path
@@ -11,7 +13,12 @@ import pytest
 
 from installer import component_update
 from installer import __main__ as installer_cli
-from installer.component_update import ComponentUpdateError, apply_component_update
+from installer import version_launcher
+from installer.component_update import (
+    ComponentUpdateError,
+    apply_component_update,
+    rollback_component_update,
+)
 from installer.uninstall_safety import remove_owned_targets
 
 
@@ -105,8 +112,15 @@ def test_valid_local_backend_component_update_is_activated_atomically(
         "component": "local_backend",
         "version": "1.1.0",
     }
-    assert not (active / "old.py").exists()
-    assert (active / "new.py").read_bytes() == b"new"
+    versioned = (
+        installation
+        / "versions"
+        / "local_backend"
+        / f"1.1.0-{manifest_sha256}"
+    )
+    assert (active / "old.py").read_text(encoding="utf-8") == "old"
+    assert not (active / "new.py").exists()
+    assert (versioned / "new.py").read_bytes() == b"new"
     assert json.loads(
         (installation / ".olivia-update-state.json").read_text(encoding="utf-8")
     ) == {
@@ -115,9 +129,272 @@ def test_valid_local_backend_component_update_is_activated_atomically(
             "local_backend": {
                 "version": "1.1.0",
                 "manifest_sha256": manifest_sha256,
+                "payload_path": versioned.relative_to(installation).as_posix(),
             }
         },
+        "previous_components": {},
     }
+
+
+def test_stable_launcher_resolves_the_atomically_selected_backend(
+    tmp_path: Path,
+) -> None:
+    from installer.version_launcher import resolve_active_backend
+
+    installation, legacy = _managed_installation(tmp_path)
+    package = tmp_path / "local-backend.oliviapatch"
+    manifest_sha256 = _write_component_package(
+        package,
+        version="1.1.0",
+        files={"new.py": b"new"},
+    )
+
+    apply_component_update(
+        installation,
+        package,
+        expected_manifest_sha256=manifest_sha256,
+    )
+
+    assert resolve_active_backend(installation) == (
+        installation
+        / "versions"
+        / "local_backend"
+        / f"1.1.0-{manifest_sha256}"
+    )
+    (installation / ".olivia-update-state.json").unlink()
+    assert resolve_active_backend(installation) == legacy
+
+
+def test_stable_launcher_runs_without_importing_the_legacy_backend_first(
+    tmp_path: Path,
+) -> None:
+    installation, legacy = _managed_installation(tmp_path)
+    launcher = installation / "launcher" / "version_launcher.py"
+    launcher.parent.mkdir()
+    shutil.copy2(Path(component_update.__file__).with_name("version_launcher.py"), launcher)
+    entrypoint = legacy / "installer" / "start_local.py"
+    entrypoint.parent.mkdir()
+    entrypoint.write_text(
+        "from pathlib import Path\n"
+        "import sys\n"
+        "record = Path(sys.argv[sys.argv.index('--record') + 1])\n"
+        "record.write_text('\\n'.join(sys.argv), encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    record = tmp_path / "launcher-args.txt"
+
+    completed = subprocess.run(
+        [
+            os.fspath(Path(os.sys.executable)),
+            os.fspath(launcher),
+            "--install-root",
+            os.fspath(installation),
+            "start",
+            "--record",
+            os.fspath(record),
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    arguments = record.read_text(encoding="utf-8").splitlines()
+    assert arguments[0] == os.fspath(entrypoint)
+    assert arguments[1:3] == ["--install-root", os.fspath(installation.resolve())]
+    assert arguments[3:] == ["--record", os.fspath(record)]
+
+
+def test_stable_launcher_cli_rejects_a_reparse_installation_root(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    installation, _legacy = _managed_installation(tmp_path)
+    alias = _make_windows_junction(tmp_path / "installation-alias", installation)
+
+    exit_code = version_launcher.main(
+        ["--install-root", str(alias), "start"]
+    )
+
+    assert exit_code == 2
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "ERROR",
+        "code": "UPDATE_INSTALLATION_INVALID",
+    }
+
+
+def test_stable_launcher_rejects_an_invalid_previous_version_descriptor(
+    tmp_path: Path,
+) -> None:
+    installation, _legacy = _managed_installation(tmp_path)
+    digest = "a" * 64
+    versioned = installation / "versions" / "local_backend" / f"1.1.0-{digest}"
+    versioned.mkdir(parents=True)
+    (installation / ".olivia-update-state.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.update-state.v1",
+                "active_components": {
+                    "local_backend": {
+                        "version": "1.1.0",
+                        "manifest_sha256": digest,
+                        "payload_path": f"versions/local_backend/1.1.0-{digest}",
+                    }
+                },
+                "previous_components": {"local_backend": {"path": "elsewhere"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        version_launcher.VersionLauncherError,
+        match="UPDATE_STATE_INVALID",
+    ):
+        version_launcher.resolve_active_backend(installation)
+
+
+def test_next_component_update_preserves_the_previous_version_for_rollback(
+    tmp_path: Path,
+) -> None:
+    installation, legacy = _managed_installation(tmp_path)
+    first_package = tmp_path / "first.oliviapatch"
+    first_sha256 = _write_component_package(
+        first_package,
+        version="1.1.0",
+        files={"first.py": b"first"},
+    )
+    second_package = tmp_path / "second.oliviapatch"
+    second_sha256 = _write_component_package(
+        second_package,
+        version="1.2.0",
+        files={"second.py": b"second"},
+    )
+    apply_component_update(
+        installation,
+        first_package,
+        expected_manifest_sha256=first_sha256,
+    )
+
+    apply_component_update(
+        installation,
+        second_package,
+        expected_manifest_sha256=second_sha256,
+    )
+
+    state = json.loads(
+        (installation / ".olivia-update-state.json").read_text(encoding="utf-8")
+    )
+    assert state["active_components"]["local_backend"] == {
+        "version": "1.2.0",
+        "manifest_sha256": second_sha256,
+        "payload_path": f"versions/local_backend/1.2.0-{second_sha256}",
+    }
+    assert state["previous_components"]["local_backend"] == {
+        "version": "1.1.0",
+        "manifest_sha256": first_sha256,
+        "payload_path": f"versions/local_backend/1.1.0-{first_sha256}",
+    }
+    assert (legacy / "old.py").read_text(encoding="utf-8") == "old"
+
+
+def test_component_update_rolls_back_by_atomically_swapping_the_version_pointer(
+    tmp_path: Path,
+) -> None:
+    from installer.version_launcher import resolve_active_backend
+
+    installation, _legacy = _managed_installation(tmp_path)
+    first_package = tmp_path / "first.oliviapatch"
+    first_sha256 = _write_component_package(
+        first_package,
+        version="1.1.0",
+        files={"first.py": b"first"},
+    )
+    second_package = tmp_path / "second.oliviapatch"
+    second_sha256 = _write_component_package(
+        second_package,
+        version="1.2.0",
+        files={"second.py": b"second"},
+    )
+    apply_component_update(
+        installation,
+        first_package,
+        expected_manifest_sha256=first_sha256,
+    )
+    apply_component_update(
+        installation,
+        second_package,
+        expected_manifest_sha256=second_sha256,
+    )
+
+    result = rollback_component_update(installation)
+
+    assert result == {
+        "status": "ROLLED_BACK",
+        "component": "local_backend",
+        "version": "1.1.0",
+    }
+    assert resolve_active_backend(installation) == (
+        installation
+        / "versions"
+        / "local_backend"
+        / f"1.1.0-{first_sha256}"
+    )
+    state = json.loads(
+        (installation / ".olivia-update-state.json").read_text(encoding="utf-8")
+    )
+    assert state["previous_components"]["local_backend"] == {
+        "version": "1.2.0",
+        "manifest_sha256": second_sha256,
+        "payload_path": f"versions/local_backend/1.2.0-{second_sha256}",
+    }
+
+
+def test_rollback_update_is_available_through_the_public_cli(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    installation, _legacy = _managed_installation(tmp_path)
+    for version in ("1.1.0", "1.2.0"):
+        package = tmp_path / f"{version}.oliviapatch"
+        manifest_sha256 = _write_component_package(
+            package,
+            version=version,
+            files={f"{version}.py": version.encode("utf-8")},
+        )
+        apply_component_update(
+            installation,
+            package,
+            expected_manifest_sha256=manifest_sha256,
+        )
+
+    exit_code = installer_cli.main(
+        ["rollback-update", "--installation", str(installation)]
+    )
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "ROLLED_BACK",
+        "component": "local_backend",
+        "version": "1.1.0",
+    }
+
+
+def test_component_update_contract_examples_match_their_public_schemas() -> None:
+    from jsonschema import Draft202012Validator
+
+    contract_root = Path(__file__).parents[2] / "contracts"
+    pairs = (
+        ("component_update_package.schema.json", "component_update_package.example.json"),
+        ("component_update_state.schema.json", "component_update_state.example.json"),
+    )
+    for schema_name, example_name in pairs:
+        schema = json.loads((contract_root / schema_name).read_text(encoding="utf-8"))
+        example = json.loads((contract_root / example_name).read_text(encoding="utf-8"))
+        Draft202012Validator.check_schema(schema)
+        assert not list(Draft202012Validator(schema).iter_errors(example))
 
 
 def test_component_update_rejects_payload_path_escape_before_activation(
@@ -144,7 +421,116 @@ def test_component_update_rejects_payload_path_escape_before_activation(
     assert not list(installation.glob(".olivia-update-staging-*"))
 
 
-def test_component_update_restores_active_payload_when_publish_fails(
+@pytest.mark.parametrize(
+    "unsafe_name",
+    [
+        "same.py.",
+        "same.py ",
+        "module.py:shadow",
+        "NUL",
+        "con.txt",
+        "folder/PRN.dat",
+    ],
+)
+def test_component_update_rejects_windows_aliases_before_activation(
+    tmp_path: Path,
+    unsafe_name: str,
+) -> None:
+    installation, active = _managed_installation(tmp_path)
+    package = tmp_path / "unsafe-windows-name.oliviapatch"
+    manifest_sha256 = _write_component_package(
+        package,
+        version="1.1.0",
+        files={unsafe_name: b"unsafe"},
+    )
+
+    with pytest.raises(ComponentUpdateError, match="UPDATE_MANIFEST_INVALID"):
+        apply_component_update(
+            installation,
+            package,
+            expected_manifest_sha256=manifest_sha256,
+        )
+
+    assert (active / "old.py").read_text(encoding="utf-8") == "old"
+    assert not (installation / ".olivia-update-state.json").exists()
+
+
+def test_component_update_rejects_non_regular_zip_members(
+    tmp_path: Path,
+) -> None:
+    installation, active = _managed_installation(tmp_path)
+    package = tmp_path / "symlink-member.oliviapatch"
+    content = b"target.py"
+    manifest = {
+        "schema_version": "olivia.component-package.v1",
+        "component": "local_backend",
+        "version": "1.1.0",
+        "files": [
+            {
+                "path": "link.py",
+                "size_bytes": len(content),
+                "sha256": hashlib.sha256(content).hexdigest(),
+            }
+        ],
+    }
+    manifest_bytes = json.dumps(
+        manifest,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    link = zipfile.ZipInfo("payload/link.py")
+    link.create_system = 3
+    link.external_attr = (stat.S_IFLNK | 0o777) << 16
+    with zipfile.ZipFile(package, "w") as archive:
+        archive.writestr("manifest.json", manifest_bytes)
+        archive.writestr(link, content)
+
+    with pytest.raises(ComponentUpdateError, match="UPDATE_PACKAGE_INVALID"):
+        apply_component_update(
+            installation,
+            package,
+            expected_manifest_sha256=hashlib.sha256(manifest_bytes).hexdigest(),
+        )
+
+    assert (active / "old.py").read_text(encoding="utf-8") == "old"
+    assert not (installation / ".olivia-update-state.json").exists()
+
+
+def test_component_update_reenumerates_the_staged_tree_before_activation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    installation, active = _managed_installation(tmp_path)
+    package = tmp_path / "local-backend.oliviapatch"
+    manifest_sha256 = _write_component_package(
+        package,
+        version="1.1.0",
+        files={"new.py": b"new"},
+    )
+    original_write_bytes = Path.write_bytes
+
+    def inject_extra_file(path: Path, content: bytes) -> int:
+        written = original_write_bytes(path, content)
+        if path.name == "new.py":
+            with (path.parent / "unexpected.py").open("wb") as stream:
+                stream.write(b"unexpected")
+        return written
+
+    monkeypatch.setattr(Path, "write_bytes", inject_extra_file)
+
+    with pytest.raises(ComponentUpdateError, match="UPDATE_STAGED_TREE_MISMATCH"):
+        apply_component_update(
+            installation,
+            package,
+            expected_manifest_sha256=manifest_sha256,
+        )
+
+    assert (active / "old.py").read_text(encoding="utf-8") == "old"
+    assert not (active / "new.py").exists()
+    assert not (active / "unexpected.py").exists()
+
+
+def test_component_update_keeps_the_old_pointer_when_pointer_publish_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -157,12 +543,14 @@ def test_component_update_restores_active_payload_when_publish_fails(
     )
     original_replace = component_update.os.replace
 
-    def fail_new_payload(source: str | Path, destination: str | Path) -> None:
-        if Path(source).name == "payload" and Path(destination) == active:
+    state_path = installation / ".olivia-update-state.json"
+
+    def fail_new_pointer(source: str | Path, destination: str | Path) -> None:
+        if Path(destination) == state_path:
             raise OSError("synthetic publish failure")
         original_replace(source, destination)
 
-    monkeypatch.setattr(component_update.os, "replace", fail_new_payload)
+    monkeypatch.setattr(component_update.os, "replace", fail_new_pointer)
 
     with pytest.raises(ComponentUpdateError, match="UPDATE_ACTIVATION_FAILED"):
         apply_component_update(
@@ -173,7 +561,18 @@ def test_component_update_restores_active_payload_when_publish_fails(
 
     assert (active / "old.py").read_text(encoding="utf-8") == "old"
     assert not (active / "new.py").exists()
-    assert not (installation / ".olivia-update-state.json").exists()
+    assert not state_path.exists()
+
+    monkeypatch.setattr(component_update.os, "replace", original_replace)
+    assert apply_component_update(
+        installation,
+        package,
+        expected_manifest_sha256=manifest_sha256,
+    ) == {
+        "status": "APPLIED",
+        "component": "local_backend",
+        "version": "1.1.0",
+    }
 
 
 def test_component_update_rejects_untrusted_manifest_before_activation(

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -994,10 +994,10 @@ def test_install_isolated_copy_activates_original_client_surfaces(
     assert not (installed / "local_backend" / "llm_config.json").exists()
     assert (installed / "CONFIGURE.cmd").is_file()
     start = (installed / "START.cmd").read_text(encoding="utf-8")
-    assert "installer\\start_local.py" in start
+    assert "launcher\\version_launcher.py" in start
     assert "runtime\\python-3.12.10-embed-amd64\\python.exe" in start
     uninstall = (installed / "UNINSTALL.cmd").read_text(encoding="utf-8")
-    assert "installer\\uninstall.py" in uninstall
+    assert "launcher\\version_launcher.py" in uninstall
     assert "installer_main" not in uninstall
     for script in (installed / "START.cmd", installed / "UNINSTALL.cmd"):
         value = script.read_text(encoding="utf-8").lower()
@@ -1041,7 +1041,9 @@ def test_install_is_idempotent_and_unknown_target_is_not_overwritten(
     assert (target / "local_backend" / "installer" / "uninstall_safety.py").read_text(
         encoding="utf-8"
     ) != "old uninstaller"
-    assert "start_local.py" in (target / "START.cmd").read_text(encoding="utf-8")
+    assert "version_launcher.py" in (target / "START.cmd").read_text(
+        encoding="utf-8"
+    )
     assert "runtime/mem0-site-packages" in repeated["owned_paths"]
     for name in ("data", "logs", "third-party"):
         assert (target / name / "preserve.txt").read_text(encoding="utf-8") == name
@@ -1054,6 +1056,31 @@ def test_install_is_idempotent_and_unknown_target_is_not_overwritten(
     assert (
         unknown / "user-file.txt"
     ).read_text(encoding="utf-8") == "keep"
+
+
+def test_install_scripts_dispatch_through_the_stable_version_launcher(
+    fixture_inputs,
+    tmp_path: Path,
+) -> None:
+    official, payload, manifest, _feapp, _webplayer = fixture_inputs
+    target = tmp_path / "installed"
+
+    install_full_patch(official, target, payload, manifest)
+
+    stable_launcher = target / "launcher" / "version_launcher.py"
+    assert stable_launcher.read_bytes() == (
+        payload / "installer" / "version_launcher.py"
+    ).read_bytes()
+    actions = {
+        "START.cmd": "start",
+        "CONFIGURE.cmd": "configure",
+        "UNINSTALL.cmd": "uninstall",
+    }
+    for name, action in actions.items():
+        script = (target / name).read_text(encoding="utf-8")
+        assert "launcher\\version_launcher.py" in script
+        assert f'--install-root "%ROOT%." {action}' in script
+        assert "local_backend\\installer" not in script
 
 
 def test_repeat_install_atomically_replaces_managed_payload_without_stale_files(


### PR DESCRIPTION
## Summary
- add a verified local `.oliviapatch` contract for the managed `local_backend`
- reject Windows path aliases, ADS/device names, non-regular ZIP entries, reparse points, unexpected files, and staged-tree mutations
- publish immutable version directories and switch one atomic state pointer, preserving the previous version for rollback
- route `START.cmd`, `CONFIGURE.cmd`, and `UNINSTALL.cmd` through a stable root launcher
- publish package/state JSON schemas, examples, CLI behavior, trust boundary, error codes, and rollback instructions

## Repair round 2
Frozen pair for re-review:

- base: `eadd2cdd6571a995cc3d711131012f05fb898e81`
- head: `2b17eaf28981436c2b3e5cda5bb5da46625ff6a0`

The initial BLOCK findings are addressed as follows:

1. Windows archive aliases are rejected before extraction, non-regular members are rejected, and the staged tree is re-enumerated with exact path/size/SHA-256 checks.
2. Activation no longer renames the live backend. A complete immutable version is published first and one state file replacement selects it. Pointer failure leaves the old selection usable; retry verifies and reuses an identical inactive version. Explicit pointer rollback is available.
3. Public package and state schemas/examples plus CLI/trust/error documentation are included.
4. Packages must contain all three stable-launcher entrypoints before activation; apply-then-dispatch is covered.
5. The first update records the legacy backend as a rollback baseline, identical reapply preserves the real previous pointer, and existing state requires an active backend.
6. Rollback validates every target path component without following reparse points and leaves the state bytes unchanged on rejection.

## Validation
- `python -m pytest -q tests/installer`: **163 passed, 1 skipped**
- `python -m pytest -q`: **1064 passed, 1 skipped, 1 deselected**
- `python baseline_hardening_scan.py --mode all`: **PASS**
- `python -m compileall -q installer`: **PASS**
- `git diff --check`: **PASS**

The skipped/deselected tests are existing platform/selection boundaries. These results do not claim a real original-client, GPU/model, provider, or human audiovisual acceptance run.

## Scope rationale
This coherent update-activation lifecycle spans 12 files and 1,808 additions/9 deletions, exceeding the default 10-file/500-line review target. Splitting the parser hardening, atomic launcher selection, schemas, and their regression tests would create an intermediate PR with an unsafe or undocumented public update path; the change remains below the absolute 40-file/2,000-line repository limit and is independently revertible as one feature.

## Boundary
This PR applies trusted local packages only. Network download, release signing, publisher metadata retrieval, automatic health rollback, and client settings UI remain separate follow-up slices. The caller-supplied manifest SHA-256 must come from authenticated release metadata or a user-verified official release page; it is never trusted merely because it appears inside the same package.
