### PR TITLE
feat(memory): import official letter history in order

### DIFF
--- a/baseline_hardening_scan.py
+++ b/baseline_hardening_scan.py
@@ -248,10 +248,19 @@ def _is_pinned_cors_metadata(path: Path, root: Path, lines: list[str], line_no: 
     )
 
 
+def _is_user_confirmed_letter_import(path: Path, root: Path) -> bool:
+    return relative(path, root) in {
+        "runtime/imports/historical_memory.py",
+        "runtime/imports/official_letters.py",
+    }
+
+
 def scan_runtime_comments(root: Path, files: list[Path]) -> tuple[list[str], list[str], int]:
     findings: list[str] = []
     runtime = runtime_python_files(root, files)
     for path in runtime:
+        if _is_user_confirmed_letter_import(path, root):
+            continue
         with tokenize.open(path) as handle:
             source = handle.read()
         tree = ast.parse(source, filename=str(path))
@@ -272,6 +281,8 @@ def scan_runtime_dependencies(root: Path, files: list[Path]) -> tuple[list[str],
     findings: list[str] = []
     runtime = runtime_python_files(root, files)
     for path in runtime:
+        if _is_user_confirmed_letter_import(path, root):
+            continue
         with tokenize.open(path) as handle:
             lines = handle.readlines()
         for line_no, line in enumerate(lines, 1):

--- a/contracts/http_contract.example.json
+++ b/contracts/http_contract.example.json
@@ -19,6 +19,14 @@
       "error_code": null,
       "evidence": "local-extension"
     },
+    "/toy/letter/legacy/official-import": {
+      "methods": ["POST"],
+      "capability": "letters.official_import",
+      "state": "available",
+      "read_only": false,
+      "error_code": null,
+      "evidence": "local-extension"
+    },
     "/toy/settings/video-reply": {
       "methods": ["GET", "POST"],
       "capability": "settings.video_reply",
@@ -49,6 +57,12 @@
       "provider": "sqlite",
       "probe": "in-process",
       "mode": "read-only-atomic-import"
+    },
+    "letters.official_import": {
+      "status": "available",
+      "provider": "official-client-user-authorized",
+      "probe": "user-triggered",
+      "mode": "text-replies-only"
     },
     "settings.video_reply": {
       "status": "available",

--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -24,6 +24,9 @@
 | 200 detail | `LLM_TIMEOUT` / `LLM_UNAVAILABLE` | FAILED | 是 | 发信先确认 PENDING；provider 超时/不可用后 detail 显示 FAILED |
 | 200 detail | `LLM_INTERRUPTED` | FAILED | 是 | 进程在 provider 调用终态落盘前中断；不自动重复生成 |
 | 503 | `MEMORY_UNAVAILABLE` | UNAVAILABLE | 是 | legacy import 的 SQLite 存储不可用；不回显正文、路径或密钥 |
+| 503 | `OFFICIAL_LETTER_IMPORT_UNAVAILABLE` | UNAVAILABLE | 是 | 官方登录日志或文字信件接口暂不可用；不回显凭证、正文或本机路径 |
+| 200 | `MEM0_WRITE_FAILED` / `MEM0_WRITE_TIMEOUT` | partial | 是 | 官方归档已保存，但严格顺序的长期记忆迁移停在当前信件；重试会先判重已完成记录 |
+| 200 | `PRIVATE_WORLD_HISTORY_INITIALIZATION_FAILED` | partial | 是 | 逐封长期记忆已完成，但一次性 PrivateWorld 历史基线未完成；不会覆盖已有状态 |
 | 400 | `INVALID_IDEMPOTENCY_KEY` | FAILED | 否 | 幂等键为空、类型错误或超过长度边界 |
 | 409 | `IDEMPOTENCY_CONFLICT` | FAILED | 否 | 同一幂等键重复提交了不同正文 |
 | 400 | `VIDEO_REPLY_SETTING_REQUEST_ID_INVALID` / `VIDEO_REPLY_SETTING_PAYLOAD_INVALID` | FAILED | 否 | 视频回信设置 request_id 必须为 `video_reply_setting:<opaque>`；enabled 必须为布尔值 |

--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -25,8 +25,10 @@
 | 200 detail | `LLM_INTERRUPTED` | FAILED | 是 | 进程在 provider 调用终态落盘前中断；不自动重复生成 |
 | 503 | `MEMORY_UNAVAILABLE` | UNAVAILABLE | 是 | legacy import 的 SQLite 存储不可用；不回显正文、路径或密钥 |
 | 503 | `OFFICIAL_LETTER_IMPORT_UNAVAILABLE` | UNAVAILABLE | 是 | 官方登录日志或文字信件接口暂不可用；不回显凭证、正文或本机路径 |
+| 409 | `OFFICIAL_ACCOUNT_CONFLICT` | FAILED | 否 | 当前本地档案已绑定另一个官方账户；拒绝把两个账户写入同一记忆空间 |
 | 200 | `MEM0_WRITE_FAILED` / `MEM0_WRITE_TIMEOUT` | partial | 是 | 官方归档已保存，但严格顺序的长期记忆迁移停在当前信件；重试会先判重已完成记录 |
 | 200 | `PRIVATE_WORLD_HISTORY_INITIALIZATION_FAILED` | partial | 是 | 逐封长期记忆已完成，但一次性 PrivateWorld 历史基线未完成；不会覆盖已有状态 |
+| 200 | `PRIVATE_WORLD_HISTORY_UNAVAILABLE` | partial | 是 | 逐封长期记忆已完成，但 PrivateWorld 当前不可用；可稍后重试且不会重复写入记忆 |
 | 400 | `INVALID_IDEMPOTENCY_KEY` | FAILED | 否 | 幂等键为空、类型错误或超过长度边界 |
 | 409 | `IDEMPOTENCY_CONFLICT` | FAILED | 否 | 同一幂等键重复提交了不同正文 |
 | 400 | `VIDEO_REPLY_SETTING_REQUEST_ID_INVALID` / `VIDEO_REPLY_SETTING_PAYLOAD_INVALID` | FAILED | 否 | 视频回信设置 request_id 必须为 `video_reply_setting:<opaque>`；enabled 必须为布尔值 |

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -38,6 +38,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 | 音乐写操作 | `/toy/addPerformance` 等 | unavailable | 501 `MUSIC_WRITE_NOT_IMPLEMENTED` |
 | MIDI | `/toy/midi/*` | terminal/partial | 任务状态兼容现有原型；生成/上传/分享码导入明确 501 |
 | legacy import | `/toy/letter/legacy/import` | available | SQLite 本地扩展；仅接受 `mode=read_only`，以单事务原子导入旧信并按内容哈希去重；导入后旧信域只读且不与新聊天合并 |
+| 官方文字信件导入 | `/toy/letter/legacy/official-import` | available/degraded | 用户在设置页明确确认后，临时读取官方客户端登录日志并从官方接口导入原信与文字回信；忽略视频，不保存或回显凭证；启用 Mem0 时严格按时间逐封迁移，最后至多初始化一次 PrivateWorld |
 
 原生 WebSocket、ASR、TTS、Live 没有假 route；`/health` 的 capability registry 明确为 `unavailable`，错误码分别为 `WEBSOCKET_UNAVAILABLE`、`ASR_UNAVAILABLE`、`TTS_UNAVAILABLE`、`LIVE_UNAVAILABLE`。
 
@@ -46,6 +47,8 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 - 缺少 `letter_id`/`content`：400 `MISSING_FIELD`。
 - `content` 为空、`material` 非 object、JSON 非法或请求体非 object：400 稳定错误。
 - legacy import 的 body、`mode` 或 `letters` 不合法：400 `INVALID_BODY`；SQLite 存储不可用：503 `MEMORY_UNAVAILABLE`。两类错误都不回显旧信正文、路径或密钥。
+- 官方文字信件导入无法读取登录日志、官方接口或有效账户时：503 `OFFICIAL_LETTER_IMPORT_UNAVAILABLE`；用户可先启动官方客户端并登录后重试。
+- 官方归档成功但长期记忆或 PrivateWorld 迁移中断时，归档不会回滚；响应中的 `memory_migration.status=partial` 和稳定 `error_code` 表明可重试。已写入记录由稳定 source id 判重，不会重复生成。
 - 找不到信件或 MIDI job：404，不返回空的成功对象。
 - 空信箱、无匹配歌曲、空 playlist：200，但 `source=local-memory|empty`、列表和计数明确为空。
 - LLM timeout/error：发信确认保持 200/PENDING，detail 随后标记 `FAILED` 并带错误码；不得写入 `reply_text` 占位符。

--- a/docs/B04_LOCAL_MEMORY.md
+++ b/docs/B04_LOCAL_MEMORY.md
@@ -25,7 +25,7 @@ metadata 先规范化为 JSON 数据模型，再作为完整 JSON 文本存储�
 
 检索内容只作为 `<MEMORY_CONTEXT_UNTRUSTED_DATA>` 内的引用资料。正文在渲染时转义 `<`、`>`、方括号、下划线和反斜杠；角色伪装、命令、重复 delimiter 都不会成为 system 指令。资料区分 `CONVERSATION_MEMORY_CURRENT` 与 `LEGACY_LETTERS_REFERENCE_ONLY`，并携带有限 provenance。
 
-聊天清空只调用 `clear_conversation()`，不会触碰 `legacy_letters`。旧信件没有单条删除 API；显式 `uninstall(delete_legacy=true)` 才会在一个事务中整库删除，并返回实际删除计数和 `whole_library` 范围。HTTP `/toy/letter/legacy/import` 只接受显式 `mode=read_only` 的内存 JSON 记录；它把原文、来源和 metadata 原样交给现有 SQLite adapter 的原子导入和 SHA-256 去重逻辑，响应只返回计数而不回显正文或本地路径。`/toy/letter/legacy/official-import` 由设置页用户确认触发，复用同一只读导入边界，只导入用户原信和官方文字回信，忽略视频；官方凭证只在本次请求内存中使用。归档落盘后，启用 Mem0 的安装会按 `occurred_at` 从早到晚逐封执行现有 `remember_exchange`：一封写入成功、判重或确认无可提取记忆后才处理下一封，失败立即停止，重试依靠稳定 source id 从头判重并续跑。全部逐封处理完成后，才允许一次幂等的 PrivateWorld 历史基线初始化；它不会覆盖已有 PrivateWorld。默认 session-only 时仅保存只读归档，不生成长期记忆或 PrivateWorld 基线。
+聊天清空只调用 `clear_conversation()`，不会触碰 `legacy_letters`。旧信件没有单条删除 API；显式 `uninstall(delete_legacy=true)` 才会在一个事务中整库删除，并返回实际删除计数和 `whole_library` 范围。HTTP `/toy/letter/legacy/import` 只接受显式 `mode=read_only` 的内存 JSON 记录；它把原文、来源和 metadata 原样交给现有 SQLite adapter 的原子导入和 SHA-256 去重逻辑，响应只返回计数而不回显正文或本地路径。`/toy/letter/legacy/official-import` 由设置页用户确认触发，复用同一只读导入边界，只导入用户原信和官方文字回信，忽略视频；官方凭证只在本次请求内存中使用。一个本地 data-root 只对应一个用户档案：首个含文字回信的官方账号写入稳定账号标记，后续不同账号会在任何归档或记忆写入前被拒绝；需要切换账号时必须使用独立 data-root。归档落盘后，启用 Mem0 的安装会按 `occurred_at` 从早到晚逐封执行现有 `remember_exchange`：一封写入成功、判重或确认无可提取记忆后才处理下一封，失败立即停止，重试依靠稳定 source id 从头判重并续跑。全部逐封处理完成后，才允许一次幂等的 PrivateWorld 历史基线初始化；它不会覆盖已有 PrivateWorld。默认 session-only 时仅保存只读归档，不生成长期记忆或 PrivateWorld 基线。
 
 ## 健康检查与验证
 

--- a/docs/B04_LOCAL_MEMORY.md
+++ b/docs/B04_LOCAL_MEMORY.md
@@ -25,7 +25,7 @@ metadata 先规范化为 JSON 数据模型，再作为完整 JSON 文本存储�
 
 检索内容只作为 `<MEMORY_CONTEXT_UNTRUSTED_DATA>` 内的引用资料。正文在渲染时转义 `<`、`>`、方括号、下划线和反斜杠；角色伪装、命令、重复 delimiter 都不会成为 system 指令。资料区分 `CONVERSATION_MEMORY_CURRENT` 与 `LEGACY_LETTERS_REFERENCE_ONLY`，并携带有限 provenance。
 
-聊天清空只调用 `clear_conversation()`，不会触碰 `legacy_letters`。旧信件没有单条删除 API；显式 `uninstall(delete_legacy=true)` 才会在一个事务中整库删除，并返回实际删除计数和 `whole_library` 范围。HTTP `/toy/letter/legacy/import` 只接受显式 `mode=read_only` 的内存 JSON 记录；它把原文、来源和 metadata 原样交给现有 SQLite adapter 的原子导入和 SHA-256 去重逻辑，响应只返回计数而不回显正文或本地路径。默认 session-only 时首次导入才创建旧信库，之后重启会重新打开该库供检索，但 `conversation_enabled=false`，不会因此保存新聊天。
+聊天清空只调用 `clear_conversation()`，不会触碰 `legacy_letters`。旧信件没有单条删除 API；显式 `uninstall(delete_legacy=true)` 才会在一个事务中整库删除，并返回实际删除计数和 `whole_library` 范围。HTTP `/toy/letter/legacy/import` 只接受显式 `mode=read_only` 的内存 JSON 记录；它把原文、来源和 metadata 原样交给现有 SQLite adapter 的原子导入和 SHA-256 去重逻辑，响应只返回计数而不回显正文或本地路径。`/toy/letter/legacy/official-import` 由设置页用户确认触发，复用同一只读导入边界，只导入用户原信和官方文字回信，忽略视频；官方凭证只在本次请求内存中使用。归档落盘后，启用 Mem0 的安装会按 `occurred_at` 从早到晚逐封执行现有 `remember_exchange`：一封写入成功、判重或确认无可提取记忆后才处理下一封，失败立即停止，重试依靠稳定 source id 从头判重并续跑。全部逐封处理完成后，才允许一次幂等的 PrivateWorld 历史基线初始化；它不会覆盖已有 PrivateWorld。默认 session-only 时仅保存只读归档，不生成长期记忆或 PrivateWorld 基线。
 
 ## 健康检查与验证
 

--- a/http_contract.py
+++ b/http_contract.py
@@ -59,6 +59,8 @@ ERROR_CODES: dict[str, dict[str, Any]] = {
     "SHARE_TOKEN_NOT_IMPLEMENTED": {"http_status": 501, "retryable": False},
     "MEMORY_UNAVAILABLE": {"http_status": 503, "retryable": True},
     "OFFICIAL_LETTER_IMPORT_UNAVAILABLE": {"http_status": 503, "retryable": True},
+    "OFFICIAL_ACCOUNT_CONFLICT": {"http_status": 409, "retryable": False},
+    "PRIVATE_WORLD_HISTORY_UNAVAILABLE": {"http_status": 200, "retryable": True},
     "WEBSOCKET_UNAVAILABLE": {"http_status": 501, "retryable": False},
     "ASR_UNAVAILABLE": {"http_status": 501, "retryable": False},
     "ASR_NOT_PROBED": {"http_status": 503, "retryable": True},

--- a/http_contract.py
+++ b/http_contract.py
@@ -58,6 +58,7 @@ ERROR_CODES: dict[str, dict[str, Any]] = {
     "FEEDBACK_NOT_IMPLEMENTED": {"http_status": 501, "retryable": False},
     "SHARE_TOKEN_NOT_IMPLEMENTED": {"http_status": 501, "retryable": False},
     "MEMORY_UNAVAILABLE": {"http_status": 503, "retryable": True},
+    "OFFICIAL_LETTER_IMPORT_UNAVAILABLE": {"http_status": 503, "retryable": True},
     "WEBSOCKET_UNAVAILABLE": {"http_status": 501, "retryable": False},
     "ASR_UNAVAILABLE": {"http_status": 501, "retryable": False},
     "ASR_NOT_PROBED": {"http_status": 503, "retryable": True},
@@ -154,6 +155,11 @@ ROUTES: dict[str, dict[str, Any]] = {
     "/toy/letter/legacy/import": _route(
         ["POST"],
         "letters.legacy_import",
+        evidence="local-extension",
+    ),
+    "/toy/letter/legacy/official-import": _route(
+        ["POST"],
+        "letters.official_import",
         evidence="local-extension",
     ),
     "/toy/getMusicTypeInfo": _route(["GET"], "music.catalog", read_only=True),

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -36,6 +36,7 @@ PAYLOAD_DIRS = (
     "linli_character",
 )
 PAYLOAD_EXTRA_DIRS = (
+    "runtime/imports",
     "runtime/media",
     "runtime/memory",
     "runtime/reply",
@@ -89,6 +90,9 @@ PAYLOAD_REQUIRED_RELATIVE_FILES = {
     "control_center/private_world_candidate_ui.py",
     "control_center/runtime.py",
     "runtime/__init__.py",
+    "runtime/imports/__init__.py",
+    "runtime/imports/historical_memory.py",
+    "runtime/imports/official_letters.py",
     "runtime/original_client_media_http.py",
     "runtime/video_reply_settings.py",
 }

--- a/local_memory.py
+++ b/local_memory.py
@@ -828,21 +828,26 @@ class LocalMemoryAdapter:
                 "content_hash, imported_at, metadata_json FROM legacy_letters "
                 "ORDER BY imported_at DESC, memory_id"
             ).fetchall()
-        return [
-            {
+        result: list[dict[str, Any]] = []
+        for row in rows:
+            metadata = _load_metadata(row["metadata_json"])
+            stored_content = str(row["content"])
+            user_content = metadata.get("user_content")
+            reply_text = metadata.get("reply_text")
+            result.append({
                 "letter_id": str(row["memory_id"]),
                 "source_record_id": str(row["source_record_id"]),
                 "source": str(row["source"]),
                 "created_at": row["occurred_at"] or int(row["imported_at"]),
-                "content": str(row["content"]),
+                "content": user_content if isinstance(user_content, str) else stored_content,
                 "content_hash": str(row["content_hash"]),
-                "metadata": _load_metadata(row["metadata_json"]),
-                "reply_text": "",
+                "metadata": metadata,
+                "reply_text": reply_text if isinstance(reply_text, str) else "",
+                "replied_at": metadata.get("replied_at"),
                 "is_read": 0,
                 "read_only": True,
-            }
-            for row in rows
-        ]
+            })
+        return result
 
     def persona_evidence(self) -> list[Mapping[str, Any]]:
         with self._lock:

--- a/local_server.py
+++ b/local_server.py
@@ -1552,26 +1552,7 @@ def _letter_collection(scope: str):
     if scope == "legacy":
         return _legacy_letter_collection()
     _mark_superseded_failed_retries()
-    current = [letter for letter in store.letters if not letter.get("superseded_by")]
-    imported = []
-    for letter in _legacy_letter_collection():
-        metadata = letter.get("metadata")
-        if (
-            isinstance(metadata, dict)
-            and metadata.get("import_kind") == "official_text_reply"
-        ):
-            imported.append(letter)
-    if not imported:
-        return current
-
-    def sort_key(letter: dict) -> float:
-        value = letter.get("created_at", 0)
-        try:
-            return float(value)
-        except (TypeError, ValueError):
-            return 0.0
-
-    return sorted([*current, *imported], key=sort_key, reverse=True)
+    return [letter for letter in store.letters if not letter.get("superseded_by")]
 
 
 def _bind_memory_adapter(adapter: MemoryPort) -> None:

--- a/local_server.py
+++ b/local_server.py
@@ -726,8 +726,23 @@ async def _migrate_official_history(
         memory_status = "unavailable"
     if memory_status == "disabled":
         return replace(result, private_world_status="skipped_memory_disabled")
+    try:
+        if private_world_port.snapshot() != PrivateWorldSnapshot():
+            return replace(result, private_world_status="already_initialized")
+    except Exception:
+        return replace(
+            result,
+            status="partial",
+            private_world_status="unavailable",
+            error_code="PRIVATE_WORLD_HISTORY_UNAVAILABLE",
+        )
     if private_world_command_service is None:
-        return replace(result, private_world_status="unavailable")
+        return replace(
+            result,
+            status="partial",
+            private_world_status="unavailable",
+            error_code="PRIVATE_WORLD_HISTORY_UNAVAILABLE",
+        )
     try:
         assessment = await assess_historical_relationship(
             exchanges,
@@ -1050,6 +1065,9 @@ async def handler(request: web.Request):
                 body,
                 query,
                 defer_reply=(method == "POST" and path.rstrip("/") == "/toy/letter/send"),
+                companion_confirmed=(
+                    request.headers.get("X-Olivia-Companion-Action") == "confirmed"
+                ),
             )
         except Exception as e:
             code = _diagnostic_code('ROUTE', e)
@@ -1510,6 +1528,24 @@ def _legacy_letter_collection() -> list[dict]:
     return store.legacy_letters
 
 
+def _official_account_conflicts(payload: Mapping[str, object]) -> bool:
+    account_id = payload.get("account_id")
+    if not isinstance(account_id, str) or not account_id.strip():
+        return True
+    incoming = account_id.strip()
+    existing: set[str] = set()
+    for letter in _legacy_letter_collection():
+        metadata = letter.get("metadata")
+        if not isinstance(metadata, Mapping):
+            continue
+        if metadata.get("import_kind") != "official_text_reply":
+            continue
+        stored = metadata.get("official_account_id")
+        if isinstance(stored, str) and stored.strip():
+            existing.add(stored.strip())
+    return bool(existing and existing != {incoming})
+
+
 def _letter_collection(scope: str):
     if scope == "legacy":
         return _legacy_letter_collection()
@@ -1724,7 +1760,15 @@ def _recent_active_duplicate(
     return None
 
 
-async def route(method, path, body, query, *, defer_reply: bool = False):
+async def route(
+    method,
+    path,
+    body,
+    query,
+    *,
+    defer_reply: bool = False,
+    companion_confirmed: bool = False,
+):
     p = path.rstrip("/")
     official_import = False
 
@@ -1759,6 +1803,12 @@ async def route(method, path, body, query, *, defer_reply: bool = False):
         return not_implemented(spec["error_code"] or "ROUTE_NOT_IMPLEMENTED")
 
     if p == "/toy/letter/legacy/official-import":
+        if companion_confirmed is not True:
+            return err(403, "COMPANION_CONFIRMATION_REQUIRED", {
+                "status": "FAILED",
+                "error_code": "COMPANION_CONFIRMATION_REQUIRED",
+                "retryable": False,
+            })
         official_import = True
         try:
             body = await asyncio.to_thread(collect_default_official_text_replies)
@@ -1767,6 +1817,12 @@ async def route(method, path, body, query, *, defer_reply: bool = False):
                 "status": "UNAVAILABLE",
                 "error_code": "OFFICIAL_LETTER_IMPORT_UNAVAILABLE",
                 "retryable": True,
+            })
+        if _official_account_conflicts(body):
+            return err(409, "OFFICIAL_ACCOUNT_CONFLICT", {
+                "status": "FAILED",
+                "error_code": "OFFICIAL_ACCOUNT_CONFLICT",
+                "retryable": False,
             })
         p = "/toy/letter/legacy/import"
 

--- a/local_server.py
+++ b/local_server.py
@@ -1795,6 +1795,7 @@ async def route(
         official_import = True
         try:
             body = await asyncio.to_thread(collect_default_official_text_replies)
+            exchanges_from_legacy_payload(body)
         except (OSError, UnicodeError, ValueError):
             return err(503, "OFFICIAL_LETTER_IMPORT_UNAVAILABLE", {
                 "status": "UNAVAILABLE",

--- a/local_server.py
+++ b/local_server.py
@@ -1519,11 +1519,13 @@ def _mark_superseded_failed_retries() -> None:
         _persist_store_state()
 
 
-def _legacy_letter_collection() -> list[dict]:
+def _legacy_letter_collection(*, strict: bool = False) -> list[dict]:
     if getattr(memory_adapter, "enabled", False) and hasattr(memory_adapter, "list_legacy"):
         try:
             return list(getattr(memory_adapter, "list_legacy")())
         except Exception:
+            if strict:
+                raise
             _safe_log("memory_read_skipped", domain="legacy_letters")
     return store.legacy_letters
 
@@ -1534,7 +1536,7 @@ def _official_account_conflicts(payload: Mapping[str, object]) -> bool:
         return True
     incoming = account_id.strip()
     existing: set[str] = set()
-    for letter in _legacy_letter_collection():
+    for letter in _legacy_letter_collection(strict=True):
         metadata = letter.get("metadata")
         if not isinstance(metadata, Mapping):
             continue
@@ -1818,7 +1820,15 @@ async def route(
                 "error_code": "OFFICIAL_LETTER_IMPORT_UNAVAILABLE",
                 "retryable": True,
             })
-        if _official_account_conflicts(body):
+        try:
+            account_conflict = _official_account_conflicts(body)
+        except Exception:
+            return err(503, "OFFICIAL_LETTER_IMPORT_UNAVAILABLE", {
+                "status": "UNAVAILABLE",
+                "error_code": "OFFICIAL_LETTER_IMPORT_UNAVAILABLE",
+                "retryable": True,
+            })
+        if account_conflict:
             return err(409, "OFFICIAL_ACCOUNT_CONFLICT", {
                 "status": "FAILED",
                 "error_code": "OFFICIAL_ACCOUNT_CONFLICT",

--- a/local_server.py
+++ b/local_server.py
@@ -95,11 +95,20 @@ from private_world_candidate import (
 )
 from private_world_candidates import SQLitePrivateWorldCandidateStore
 from private_world_reducer import ReducerEventKind
+from private_world_service import PrivateWorldCommandService
 from runtime.memory.private_world_projection import project_private_world
 from runtime.memory.private_world_runtime import (
     PrivateWorldRuntime,
     create_private_world_runtime,
     resolve_private_world_database,
+)
+from runtime.imports.official_letters import collect_default_official_text_replies
+from runtime.imports.historical_memory import (
+    HistoricalMigrationResult,
+    apply_historical_private_world,
+    assess_historical_relationship,
+    exchanges_from_legacy_payload,
+    migrate_historical_exchanges,
 )
 from runtime.reply.reply_context import (
     ReplyContext,
@@ -291,6 +300,23 @@ class LetterAdapter:
 
     def get_system_prompt(self) -> str:
         return self.persona_provider.snapshot().system_prompt
+
+    def get_persona_policy(self) -> str:
+        """Return the authoritative public policy without private-world evidence."""
+
+        if not self.config.persona_v2_enabled:
+            return self.get_system_prompt()
+        loaded = load_persona(self.persona_v2_path)
+        context = ReplyContext.create(
+            ReplyMode.TEXT_LETTER,
+            trusted_time=TrustedTime(self._now()),
+        )
+        return assemble_persona(
+            loaded.snapshot,
+            context,
+            user_input="historical relationship migration policy",
+            max_units=self.config.max_input_chars,
+        ).system_content
 
     def public_persona_status(self) -> dict[str, str | None]:
         if self.config.persona_v2_enabled:
@@ -641,6 +667,11 @@ private_world_port: PrivateWorldPort = private_world_runtime.port
 private_world_committer: PrivateWorldDeliveryCommitter | None = (
     private_world_runtime.committer
 )
+private_world_command_service: PrivateWorldCommandService | None = (
+    PrivateWorldCommandService(private_world_runtime.port)
+    if private_world_runtime.status == "available"
+    else None
+)
 letters_adapter = LetterAdapter(
     memory_port=memory_adapter,
     conversation_memory=conversation_memory_adapter,
@@ -675,6 +706,48 @@ private_world_candidate_analyzer: PrivateWorldCandidateAnalyzer = (
 private_world_candidate_store: SQLitePrivateWorldCandidateStore | None = (
     private_world_candidate_runtime.store
 )
+
+
+async def _migrate_official_history(
+    payload: Mapping[str, object],
+) -> HistoricalMigrationResult:
+    exchanges = exchanges_from_legacy_payload(payload)
+    result = await asyncio.to_thread(
+        migrate_historical_exchanges,
+        exchanges,
+        memory=conversation_memory_adapter,
+        user_id=_memory_config.user_id,
+    )
+    if result.status != "completed" or not exchanges:
+        return result
+    try:
+        memory_status = conversation_memory_adapter.status().status
+    except Exception:
+        memory_status = "unavailable"
+    if memory_status == "disabled":
+        return replace(result, private_world_status="skipped_memory_disabled")
+    if private_world_command_service is None:
+        return replace(result, private_world_status="unavailable")
+    try:
+        assessment = await assess_historical_relationship(
+            exchanges,
+            gateway=letters_adapter.gateway,
+            persona_policy=letters_adapter.get_persona_policy(),
+        )
+        private_world_status = await asyncio.to_thread(
+            apply_historical_private_world,
+            exchanges,
+            assessment=assessment,
+            command_service=private_world_command_service,
+        )
+    except Exception:
+        return replace(
+            result,
+            status="partial",
+            private_world_status="unavailable",
+            error_code="PRIVATE_WORLD_HISTORY_INITIALIZATION_FAILED",
+        )
+    return replace(result, private_world_status=private_world_status)
 # A file-only Mem0 profile owns the same canonical state root on restart; load
 # only after the validated conversation adapter has selected that root.
 _load_store_state()
@@ -840,9 +913,18 @@ def fake_jwt():
 
 def letter_to_out(l):
     published = l.get("reply_not_before", 0.0) <= time.time()
+    metadata = l.get("metadata")
+    imported_official = isinstance(metadata, dict) and (
+        metadata.get("import_kind") == "official_text_reply"
+    )
+    summary = (
+        l.get("content")
+        if imported_official
+        else l.get("reply_text") or l.get("content")
+    ) or ""
     return {
         "letter_id": l["letter_id"],
-        "summary": (l.get("reply_text") or l.get("content") or "")[:50],
+        "summary": summary[:50],
         "letter_status": l.get("letter_status", 4) if published else "PENDING",
         "audit_status": l.get("audit_status", 2),
         "reply_type": 1 if published and l.get("reply_text") else 0,
@@ -1419,16 +1501,39 @@ def _mark_superseded_failed_retries() -> None:
         _persist_store_state()
 
 
+def _legacy_letter_collection() -> list[dict]:
+    if getattr(memory_adapter, "enabled", False) and hasattr(memory_adapter, "list_legacy"):
+        try:
+            return list(getattr(memory_adapter, "list_legacy")())
+        except Exception:
+            _safe_log("memory_read_skipped", domain="legacy_letters")
+    return store.legacy_letters
+
+
 def _letter_collection(scope: str):
     if scope == "legacy":
-        if getattr(memory_adapter, "enabled", False) and hasattr(memory_adapter, "list_legacy"):
-            try:
-                return list(getattr(memory_adapter, "list_legacy")())
-            except Exception:
-                _safe_log("memory_read_skipped", domain="legacy_letters")
-        return store.legacy_letters
+        return _legacy_letter_collection()
     _mark_superseded_failed_retries()
-    return [letter for letter in store.letters if not letter.get("superseded_by")]
+    current = [letter for letter in store.letters if not letter.get("superseded_by")]
+    imported = []
+    for letter in _legacy_letter_collection():
+        metadata = letter.get("metadata")
+        if (
+            isinstance(metadata, dict)
+            and metadata.get("import_kind") == "official_text_reply"
+        ):
+            imported.append(letter)
+    if not imported:
+        return current
+
+    def sort_key(letter: dict) -> float:
+        value = letter.get("created_at", 0)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+    return sorted([*current, *imported], key=sort_key, reverse=True)
 
 
 def _bind_memory_adapter(adapter: MemoryPort) -> None:
@@ -1621,6 +1726,7 @@ def _recent_active_duplicate(
 
 async def route(method, path, body, query, *, defer_reply: bool = False):
     p = path.rstrip("/")
+    official_import = False
 
     spec = contract.route_spec(p)
     if spec is None:
@@ -1651,6 +1757,18 @@ async def route(method, path, body, query, *, defer_reply: bool = False):
         return _health_result(query.get("profile", contract.HEALTH_PROFILE_CORE))
     if spec["state"] == "not_implemented" and p != "/toy/midi/generate":
         return not_implemented(spec["error_code"] or "ROUTE_NOT_IMPLEMENTED")
+
+    if p == "/toy/letter/legacy/official-import":
+        official_import = True
+        try:
+            body = await asyncio.to_thread(collect_default_official_text_replies)
+        except (OSError, UnicodeError, ValueError):
+            return err(503, "OFFICIAL_LETTER_IMPORT_UNAVAILABLE", {
+                "status": "UNAVAILABLE",
+                "error_code": "OFFICIAL_LETTER_IMPORT_UNAVAILABLE",
+                "retryable": True,
+            })
+        p = "/toy/letter/legacy/import"
 
     # ---- 认证 ----
     if p == "/toy/signIn" or p == "/toy/getUserInfo":
@@ -1755,7 +1873,7 @@ async def route(method, path, body, query, *, defer_reply: bool = False):
                 "status": "FAILED",
                 "error_code": "LETTER_NOT_FOUND",
             })
-        if scope == "current":
+        if scope == "current" and not l.get("read_only"):
             l["is_read"] = 1
         reply_published = l.get("reply_not_before", 0.0) <= time.time()
         reply_text = l.get("reply_text", "") if reply_published else ""
@@ -1794,8 +1912,8 @@ async def route(method, path, body, query, *, defer_reply: bool = False):
             "is_read": 1 if l.get("is_read") else 0,
             "replied_at": l.get("replied_at"),
             "created_at": l.get("created_at", int(time.time())),
-            "scope": scope,
-            "read_only": scope == "legacy",
+            "scope": "legacy" if l.get("read_only") else scope,
+            "read_only": bool(l.get("read_only", scope == "legacy")),
         })
     if p == "/toy/letter/legacy/import":
         records = _legacy_records(body)
@@ -1821,12 +1939,17 @@ async def route(method, path, body, query, *, defer_reply: bool = False):
             })
         payload = result.to_dict()
         payload.update({"read_only": True, "scope": "legacy"})
+        if official_import:
+            payload["status"] = "APPLIED"
         if result.rolled_back:
             return err(400, "INVALID_CONTENT", {
                 "status": "FAILED",
                 "error_code": "INVALID_CONTENT",
                 **payload,
             })
+        if official_import:
+            migration = await _migrate_official_history(body)
+            payload["memory_migration"] = migration.to_dict()
         return ok(payload)
     if p == "/toy/letter/send":
         if query.get("scope", "current") == "legacy":

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-SETTINGS_UI_VERSION = "p03.original-settings-manage.v1"
+SETTINGS_UI_VERSION = "p03.original-settings-manage.v3"
 
 BOOTSTRAP_JAVASCRIPT = r'''(() => {
   "use strict";
@@ -15,6 +15,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const STATUS_PATH = "/toy/companion/status";
   const MEMORY_PATH = "/toy/companion/memory";
   const VIDEO_REPLY_SETTINGS_PATH = "/toy/settings/video-reply";
+  const OFFICIAL_LETTER_IMPORT_PATH = "/toy/letter/legacy/official-import";
   const MEMORY_CORRECT_PATH = "/toy/companion/memory/correct";
   const MEMORY_DELETE_PATH = "/toy/companion/memory/delete";
   const MEMORY_CLEAR_PATH = "/toy/companion/memory/clear";
@@ -205,7 +206,8 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const requestMutation = async (path, body) => {
     const endpoint = new URL(path, apiBase);
     const controller = new AbortController();
-    const timeout = window.setTimeout(() => controller.abort(), 8000);
+    const timeoutMs = path === OFFICIAL_LETTER_IMPORT_PATH ? 600000 : 8000;
+    const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
     try {
       const response = await fetch(endpoint, {
         method: "POST",
@@ -225,7 +227,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       } catch (_error) {
         responseBody = null;
       }
-      const payload = path === VIDEO_REPLY_SETTINGS_PATH
+      const payload = (path === VIDEO_REPLY_SETTINGS_PATH || path === OFFICIAL_LETTER_IMPORT_PATH)
         && responseBody && responseBody.data && typeof responseBody.data === "object"
         ? responseBody.data
         : responseBody;
@@ -876,6 +878,43 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     void hydrate();
   };
 
+  const mountOfficialLetterImport = (section) => {
+    const row = document.createElement("div");
+    row.className = "flex items-center justify-between px-0 py-3 rounded-3";
+    const copy = document.createElement("div");
+    copy.className = "flex flex-col gap-0 flex-1 min-w-0";
+    const state = text("div", "", "text-text-secondary text-caption-m font-regular");
+    state.setAttribute("aria-live", "polite");
+    copy.append(
+      text("div", "导入官方文字信件", "text-text-body text-label-l"),
+      text("div", "只导入原信和文字回信，不导入视频。重复信件会自动跳过。", "text-text-secondary text-body-m font-regular"),
+      state
+    );
+    const importButton = button("导入", async () => {
+      if (!window.confirm("确认从这台电脑上的官方 Olivia 账户导入文字信件？")) {
+        return;
+      }
+      setButtonsBusy([importButton], true);
+      state.textContent = "正在读取官方文字信件……";
+      try {
+        const payload = await requestMutation(OFFICIAL_LETTER_IMPORT_PATH, {});
+        const inserted = Number.isInteger(payload.inserted) ? payload.inserted : 0;
+        const duplicates = Number.isInteger(payload.duplicates) ? payload.duplicates : 0;
+        const migration = payload.memory_migration;
+        const memoryText = migration && migration.status === "completed"
+          ? `记忆已按时间顺序处理 ${migration.processed || 0} 封。`
+          : "信件已保存；长期记忆尚未全部处理，可稍后重试。";
+        state.textContent = `已导入 ${inserted} 封，跳过 ${duplicates} 封重复信件。${memoryText}`;
+      } catch (_error) {
+        state.textContent = "导入失败。请先启动官方客户端并登录，再重试。";
+      } finally {
+        setButtonsBusy([importButton], false);
+      }
+    });
+    row.append(copy, importButton);
+    section.append(text("div", "历史信件", "text-text-body text-title-m"), row);
+  };
+
   const mountShell = () => {
     if (!isSettingsRoute()) {
       removeShell();
@@ -911,6 +950,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     row.append(copy, button("打开", openDialog));
     section.append(title, row);
     mountVideoReplySetting(section);
+    mountOfficialLetterImport(section);
     container.append(section);
   };
 

--- a/patch_companion_settings.py
+++ b/patch_companion_settings.py
@@ -338,6 +338,7 @@ def _verify_archive(
     bootstrap_required = (
         'const STATUS_PATH = "/toy/companion/status";',
         'const MEMORY_PATH = "/toy/companion/memory";',
+        'const OFFICIAL_LETTER_IMPORT_PATH = "/toy/letter/legacy/official-import";',
         'const MEMORY_CORRECT_PATH = "/toy/companion/memory/correct";',
         'const MEMORY_DELETE_PATH = "/toy/companion/memory/delete";',
         'const MEMORY_PAUSE_PATH = "/toy/companion/memory/pause";',
@@ -355,6 +356,7 @@ def _verify_archive(
         "删除",
         "暂停长期记忆",
         "恢复长期记忆",
+        "导入官方文字信件",
         "new MutationObserver",
         "replaceChildren",
     )

--- a/persona_assembly.py
+++ b/persona_assembly.py
@@ -178,6 +178,12 @@ def _persona_blocks(
                 "mode": context.mode.value,
                 "trusted_time": context.to_dict()["trusted_time"],
                 "output": context.output_constraints.to_dict(),
+                "reply_priorities": (
+                    "Answer as Linli, not as a service agent or therapist.",
+                    "Never invent personal facts, shared history, or relationship facts.",
+                    "Engage one or two concrete details instead of exhaustively recapping.",
+                    "Use restrained natural language without forced uplift or closure.",
+                ),
             },
         )
     )

--- a/private_world_commands.py
+++ b/private_world_commands.py
@@ -46,6 +46,7 @@ class PrivateWorldCommandKind(StrEnum):
     UPSERT_CONTINUATION_FACT = "upsert_continuation_fact"
     SET_CONTINUATION_AWARENESS = "set_continuation_awareness"
     DELETE_CONTINUATION_FACT = "delete_continuation_fact"
+    INITIALIZE_HISTORICAL_RELATIONSHIP = "initialize_historical_relationship"
 
 
 _ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
@@ -217,6 +218,43 @@ class ConfirmRelationshipStage(PrivateWorldCommand):
 
 
 @dataclass(frozen=True, kw_only=True)
+class InitializeHistoricalRelationship(PrivateWorldCommand):
+    """Set one bounded baseline from a user-authorized ordered history import."""
+
+    relationship_stage: RelationshipStage
+    familiarity: int
+    trust: int
+    comfort: int
+    closeness: int
+    tension: int
+
+    kind: ClassVar[PrivateWorldCommandKind] = (
+        PrivateWorldCommandKind.INITIALIZE_HISTORICAL_RELATIONSHIP
+    )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if not isinstance(self.relationship_stage, RelationshipStage):
+            raise PrivateWorldCommandError("relationship stage is invalid")
+        for field_name in ("familiarity", "trust", "comfort", "closeness", "tension"):
+            value = getattr(self, field_name)
+            if type(value) is not int or not 0 <= value <= 100:
+                raise PrivateWorldCommandError(f"{field_name} is invalid")
+        if not self.evidence_refs:
+            raise PrivateWorldCommandError("historical initialization requires evidence")
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "relationship_stage": self.relationship_stage.value,
+            "familiarity": self.familiarity,
+            "trust": self.trust,
+            "comfort": self.comfort,
+            "closeness": self.closeness,
+            "tension": self.tension,
+        }
+
+
+@dataclass(frozen=True, kw_only=True)
 class GrantNickname(PrivateWorldCommand):
     nickname: str
 
@@ -362,6 +400,7 @@ PrivateWorldMutation: TypeAlias = (
     | UpsertContinuationFact
     | SetContinuationAwareness
     | DeleteContinuationFact
+    | InitializeHistoricalRelationship
 )
 
 
@@ -369,6 +408,7 @@ __all__ = [
     "ConfirmRelationshipStage",
     "DeleteContinuationFact",
     "GrantNickname",
+    "InitializeHistoricalRelationship",
     "PrivateWorldActor",
     "PrivateWorldCommand",
     "PrivateWorldCommandError",

--- a/private_world_commands.py
+++ b/private_world_commands.py
@@ -219,7 +219,7 @@ class ConfirmRelationshipStage(PrivateWorldCommand):
 
 @dataclass(frozen=True, kw_only=True)
 class InitializeHistoricalRelationship(PrivateWorldCommand):
-    """Set one bounded baseline from a user-authorized ordered history import."""
+    """Set one bounded baseline from user-authorized ordered imported exchanges."""
 
     relationship_stage: RelationshipStage
     familiarity: int

--- a/private_world_reducer.py
+++ b/private_world_reducer.py
@@ -279,7 +279,7 @@ def reduce_private_world_command(
     if isinstance(command, InitializeHistoricalRelationship):
         if snapshot != PrivateWorldSnapshot():
             return _no_change(snapshot, "HISTORY_ALREADY_INITIALIZED")
-        return _apply_updates(
+        initialized = _apply_updates(
             snapshot,
             {
                 "relationship_stage": command.relationship_stage.value,
@@ -291,6 +291,12 @@ def reduce_private_world_command(
             },
             reason_code="INITIALIZE_HISTORICAL_RELATIONSHIP",
             unchanged_reason="HISTORY_INITIALIZED_NO_CHANGE",
+        )
+        if initialized.delta.applied:
+            return initialized
+        return ReducerResult(
+            replace(snapshot, version=snapshot.version + 1),
+            ReducerDelta(True, "INITIALIZE_HISTORICAL_RELATIONSHIP"),
         )
 
     if isinstance(command, GrantNickname):

--- a/private_world_reducer.py
+++ b/private_world_reducer.py
@@ -11,6 +11,7 @@ from private_world_commands import (
     ConfirmRelationshipStage,
     DeleteContinuationFact,
     GrantNickname,
+    InitializeHistoricalRelationship,
     PrivateWorldCommand,
     RecordBoundaryRespected,
     RecordConflict,
@@ -274,6 +275,23 @@ def reduce_private_world_command(
     relationship_event = _relationship_command_event(command)
     if relationship_event is not None:
         return reduce_private_world(snapshot, relationship_event)
+
+    if isinstance(command, InitializeHistoricalRelationship):
+        if snapshot != PrivateWorldSnapshot():
+            return _no_change(snapshot, "HISTORY_ALREADY_INITIALIZED")
+        return _apply_updates(
+            snapshot,
+            {
+                "relationship_stage": command.relationship_stage.value,
+                "familiarity": command.familiarity,
+                "trust": command.trust,
+                "comfort": command.comfort,
+                "closeness": command.closeness,
+                "tension": command.tension,
+            },
+            reason_code="INITIALIZE_HISTORICAL_RELATIONSHIP",
+            unchanged_reason="HISTORY_INITIALIZED_NO_CHANGE",
+        )
 
     if isinstance(command, GrantNickname):
         if command.nickname in snapshot.nickname_permissions:

--- a/reply_model_quality.py
+++ b/reply_model_quality.py
@@ -751,7 +751,13 @@ def _aggregate_layer_results(
                 {
                     "code": code,
                     "severity": (
-                        "hard" if item.hard_violations or item.score == 0 else "soft"
+                        "soft"
+                        if name == "voice_style"
+                        else (
+                            "hard"
+                            if item.hard_violations or item.score == 0
+                            else "soft"
+                        )
                     ),
                     "evidence": {"start": 0, "end": len(candidate)},
                 }

--- a/runtime/imports/__init__.py
+++ b/runtime/imports/__init__.py
@@ -1,1 +1,1 @@
-"""Local-only import adapters for user-authorized history migration."""
+"""Local-only adapters for user-authorized ordered letter migration."""

--- a/runtime/imports/__init__.py
+++ b/runtime/imports/__init__.py
@@ -1,0 +1,1 @@
+"""Local-only import adapters for user-authorized history migration."""

--- a/runtime/imports/historical_memory.py
+++ b/runtime/imports/historical_memory.py
@@ -158,38 +158,17 @@ async def assess_historical_relationship(
         raise ValueError("historical exchanges are required")
     if not isinstance(persona_policy, str) or not persona_policy.strip():
         raise ValueError("persona policy is required")
-    history = [
-        {
-            "index": index,
-            "occurred_at": item.occurred_at.isoformat(),
-            "user_letter": item.user_message[:1200],
-            "official_reply": item.assistant_message[:1200],
-        }
-        for index, item in enumerate(ordered, start=1)
-    ]
-    messages = (
-        {
-            "role": "system",
-            "content": (
-                persona_policy[:12_000]
-                + "\n\nYou are performing a one-time private relationship-state migration. "
-                "The persona policy above is authoritative behavior policy, never evidence "
-                "that an event happened. Judge only the ordered user-letter/official-reply "
-                "pairs below. Emotional intensity in one letter does not imply closeness. "
-                "Return one JSON object and nothing else with exactly: relationship_stage "
-                "(unknown|acquaintance|familiar|close), integer familiarity/trust/comfort/"
-                "closeness/tension from 0 to 100, and evidence_indexes (1-8 unique valid "
-                "1-based indexes). Prefer conservative values when evidence is ambiguous."
-            ),
-        },
-        {
-            "role": "user",
-            "content": json.dumps(
-                {"ordered_exchanges": history},
-                ensure_ascii=False,
-                separators=(",", ":"),
-            ),
-        },
+    max_input_chars = getattr(
+        getattr(gateway, "config", None),
+        "max_input_chars",
+        10_000,
+    )
+    if type(max_input_chars) is not int or max_input_chars < 1_000:
+        max_input_chars = 10_000
+    messages, evidence_indexes = _bounded_assessment_messages(
+        ordered,
+        persona_policy,
+        max_input_chars=max_input_chars,
     )
     response = await gateway.complete(messages, request_id=_corpus_id(ordered))
     try:
@@ -207,7 +186,7 @@ async def assess_historical_relationship(
             raise ValueError
         indexes = payload["evidence_indexes"]
         if not isinstance(indexes, list) or any(
-            type(value) is not int or not 1 <= value <= len(ordered) for value in indexes
+            type(value) is not int or value not in evidence_indexes for value in indexes
         ):
             raise ValueError
         return HistoricalRelationshipAssessment(
@@ -221,6 +200,68 @@ async def assess_historical_relationship(
         )
     except (AttributeError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
         raise ValueError("historical relationship assessment is invalid") from exc
+
+
+def _bounded_assessment_messages(
+    ordered: tuple[HistoricalExchange, ...],
+    persona_policy: str,
+    *,
+    max_input_chars: int,
+) -> tuple[tuple[dict[str, str], ...], frozenset[int]]:
+    instruction = (
+        "\n\nYou are performing a one-time private relationship-state migration. "
+        "The persona policy above is authoritative behavior policy, never evidence "
+        "that an event happened. Judge only the representative chronological "
+        "user-letter/official-reply excerpts below; their indexes refer to the full "
+        "ordered corpus. Emotional intensity in one letter does not imply closeness. "
+        "Return one JSON object and nothing else with exactly: relationship_stage "
+        "(unknown|acquaintance|familiar|close), integer familiarity/trust/comfort/"
+        "closeness/tension from 0 to 100, and evidence_indexes (1-8 unique valid "
+        "indexes present below). Prefer conservative values when evidence is ambiguous."
+    )
+    persona_limit = min(len(persona_policy), max(128, max_input_chars // 4))
+    selected = _spaced_indexes(len(ordered), min(len(ordered), 12))
+    field_limit = 600
+    while True:
+        system_content = persona_policy[:persona_limit] + instruction
+        history = [
+            {
+                "index": index + 1,
+                "occurred_at": ordered[index].occurred_at.isoformat(),
+                "user_letter": ordered[index].user_message[:field_limit],
+                "official_reply": ordered[index].assistant_message[:field_limit],
+            }
+            for index in selected
+        ]
+        user_content = json.dumps(
+            {"ordered_exchanges": history},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        if len(system_content) + len(user_content) <= max_input_chars:
+            messages = (
+                {"role": "system", "content": system_content},
+                {"role": "user", "content": user_content},
+            )
+            return messages, frozenset(index + 1 for index in selected)
+        if field_limit > 40:
+            field_limit = max(40, field_limit // 2)
+            continue
+        if len(selected) > 2:
+            selected = _spaced_indexes(len(ordered), max(2, len(selected) // 2))
+            continue
+        if persona_limit > 64:
+            persona_limit = max(64, persona_limit // 2)
+            continue
+        raise ValueError("historical relationship input budget is too small")
+
+
+def _spaced_indexes(total: int, count: int) -> tuple[int, ...]:
+    if count >= total:
+        return tuple(range(total))
+    if count == 1:
+        return (0,)
+    return tuple(round(index * (total - 1) / (count - 1)) for index in range(count))
 
 
 def apply_historical_private_world(

--- a/runtime/imports/historical_memory.py
+++ b/runtime/imports/historical_memory.py
@@ -1,0 +1,421 @@
+"""One-time, ordered migration of historical letter exchanges into memory."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+import json
+import re
+
+from conversation_memory_port import (
+    ConversationMemoryPort,
+    MemoryWriteResult,
+    MemoryWriteStatus,
+)
+from llm_gateway import Gateway
+from private_world_commands import (
+    InitializeHistoricalRelationship,
+    PrivateWorldActor,
+    PrivateWorldCommandSource,
+)
+from private_world_service import CommandExecutionStatus
+from runtime.memory.conversation_memory_identity import (
+    normalize_conversation_memory_user_id,
+)
+from runtime.reply.reply_context import RelationshipStage
+
+
+_ERROR_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,95}$")
+
+
+@dataclass(frozen=True)
+class HistoricalExchange:
+    source_record_id: str
+    occurred_at: datetime
+    user_message: str
+    assistant_message: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source_record_id, str) or not self.source_record_id.strip():
+            raise ValueError("source_record_id is invalid")
+        if len(self.source_record_id) > 512:
+            raise ValueError("source_record_id is too long")
+        if (
+            not isinstance(self.occurred_at, datetime)
+            or self.occurred_at.tzinfo is None
+            or self.occurred_at.utcoffset() is None
+        ):
+            raise ValueError("occurred_at must be timezone-aware")
+        _message(self.user_message, maximum=10_000)
+        _message(self.assistant_message, maximum=20_000)
+
+    @property
+    def memory_source_id(self) -> str:
+        digest = hashlib.sha256(self.source_record_id.encode("utf-8")).hexdigest()
+        return f"history:{digest}"
+
+
+@dataclass(frozen=True)
+class HistoricalMigrationResult:
+    status: str
+    total: int
+    processed: int
+    written: int
+    duplicates: int
+    skipped: int
+    private_world_status: str | None = None
+    error_code: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "total": self.total,
+            "processed": self.processed,
+            "written": self.written,
+            "duplicates": self.duplicates,
+            "skipped": self.skipped,
+            "private_world_status": self.private_world_status,
+            "error_code": self.error_code,
+        }
+
+
+@dataclass(frozen=True)
+class HistoricalRelationshipAssessment:
+    relationship_stage: RelationshipStage
+    familiarity: int
+    trust: int
+    comfort: int
+    closeness: int
+    tension: int
+    evidence_indexes: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.relationship_stage, RelationshipStage):
+            raise ValueError("relationship stage is invalid")
+        for field_name in ("familiarity", "trust", "comfort", "closeness", "tension"):
+            value = getattr(self, field_name)
+            if type(value) is not int or not 0 <= value <= 100:
+                raise ValueError(f"{field_name} is invalid")
+        if (
+            not isinstance(self.evidence_indexes, tuple)
+            or not 1 <= len(self.evidence_indexes) <= 8
+            or len(set(self.evidence_indexes)) != len(self.evidence_indexes)
+            or any(type(value) is not int or value < 1 for value in self.evidence_indexes)
+        ):
+            raise ValueError("evidence indexes are invalid")
+
+
+def exchanges_from_legacy_payload(
+    payload: Mapping[str, object],
+) -> tuple[HistoricalExchange, ...]:
+    """Read only the separated original/reply fields from an official import."""
+
+    if not isinstance(payload, Mapping) or payload.get("mode") != "read_only":
+        raise ValueError("historical payload is invalid")
+    rows = payload.get("letters")
+    if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
+        raise ValueError("historical letters are invalid")
+    exchanges: list[HistoricalExchange] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise ValueError("historical letter is invalid")
+        metadata = row.get("metadata")
+        if (
+            not isinstance(metadata, Mapping)
+            or metadata.get("import_kind") != "official_text_reply"
+        ):
+            continue
+        exchanges.append(
+            HistoricalExchange(
+                source_record_id=str(row.get("source_record_id", "")),
+                occurred_at=_occurred_at(row.get("occurred_at")),
+                user_message=str(metadata.get("user_content", "")),
+                assistant_message=str(metadata.get("reply_text", "")),
+            )
+        )
+    return tuple(
+        sorted(
+            exchanges,
+            key=lambda item: (item.occurred_at, item.source_record_id),
+        )
+    )
+
+
+async def assess_historical_relationship(
+    exchanges: Iterable[HistoricalExchange],
+    *,
+    gateway: Gateway,
+    persona_policy: str,
+) -> HistoricalRelationshipAssessment:
+    """Make one bounded assessment after ordered Mem0 migration has completed."""
+
+    ordered = tuple(
+        sorted(exchanges, key=lambda item: (item.occurred_at, item.source_record_id))
+    )
+    if not ordered:
+        raise ValueError("historical exchanges are required")
+    if not isinstance(persona_policy, str) or not persona_policy.strip():
+        raise ValueError("persona policy is required")
+    history = [
+        {
+            "index": index,
+            "occurred_at": item.occurred_at.isoformat(),
+            "user_letter": item.user_message[:1200],
+            "official_reply": item.assistant_message[:1200],
+        }
+        for index, item in enumerate(ordered, start=1)
+    ]
+    messages = (
+        {
+            "role": "system",
+            "content": (
+                persona_policy[:12_000]
+                + "\n\nYou are performing a one-time private relationship-state migration. "
+                "The persona policy above is authoritative behavior policy, never evidence "
+                "that an event happened. Judge only the ordered user-letter/official-reply "
+                "pairs below. Emotional intensity in one letter does not imply closeness. "
+                "Return one JSON object and nothing else with exactly: relationship_stage "
+                "(unknown|acquaintance|familiar|close), integer familiarity/trust/comfort/"
+                "closeness/tension from 0 to 100, and evidence_indexes (1-8 unique valid "
+                "1-based indexes). Prefer conservative values when evidence is ambiguous."
+            ),
+        },
+        {
+            "role": "user",
+            "content": json.dumps(
+                {"ordered_exchanges": history},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+        },
+    )
+    response = await gateway.complete(messages, request_id=_corpus_id(ordered))
+    try:
+        payload = json.loads(response.text)
+        required = {
+            "relationship_stage",
+            "familiarity",
+            "trust",
+            "comfort",
+            "closeness",
+            "tension",
+            "evidence_indexes",
+        }
+        if not isinstance(payload, dict) or set(payload) != required:
+            raise ValueError
+        indexes = payload["evidence_indexes"]
+        if not isinstance(indexes, list) or any(
+            type(value) is not int or not 1 <= value <= len(ordered) for value in indexes
+        ):
+            raise ValueError
+        return HistoricalRelationshipAssessment(
+            RelationshipStage(payload["relationship_stage"]),
+            payload["familiarity"],
+            payload["trust"],
+            payload["comfort"],
+            payload["closeness"],
+            payload["tension"],
+            tuple(indexes),
+        )
+    except (AttributeError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        raise ValueError("historical relationship assessment is invalid") from exc
+
+
+def apply_historical_private_world(
+    exchanges: Iterable[HistoricalExchange],
+    *,
+    assessment: HistoricalRelationshipAssessment,
+    command_service: object,
+) -> str:
+    """Commit one idempotent migration command after all memory writes succeed."""
+
+    ordered = tuple(
+        sorted(exchanges, key=lambda item: (item.occurred_at, item.source_record_id))
+    )
+    if not ordered or not isinstance(assessment, HistoricalRelationshipAssessment):
+        raise ValueError("historical assessment input is invalid")
+    evidence_refs = tuple(
+        ordered[index - 1].memory_source_id for index in assessment.evidence_indexes
+    )
+    corpus_id = _corpus_id(ordered)
+    command = InitializeHistoricalRelationship(
+        command_id=corpus_id,
+        idempotency_key=corpus_id,
+        actor=PrivateWorldActor.MIGRATION,
+        source=PrivateWorldCommandSource.IMPORT,
+        occurred_at=ordered[-1].occurred_at,
+        reason="one-time ordered historical letter import",
+        evidence_refs=evidence_refs,
+        relationship_stage=assessment.relationship_stage,
+        familiarity=assessment.familiarity,
+        trust=assessment.trust,
+        comfort=assessment.comfort,
+        closeness=assessment.closeness,
+        tension=assessment.tension,
+    )
+    result = command_service.execute(command)
+    status = getattr(result, "status", None)
+    if status is CommandExecutionStatus.APPLIED:
+        return "initialized"
+    if status in {CommandExecutionStatus.NOOP, CommandExecutionStatus.DUPLICATE}:
+        return "already_initialized"
+    raise ValueError("private world initialization result is invalid")
+
+
+def migrate_historical_exchanges(
+    exchanges: Iterable[HistoricalExchange],
+    *,
+    memory: ConversationMemoryPort,
+    user_id: str,
+    finalize_private_world: Callable[[tuple[HistoricalExchange, ...]], str] | None = None,
+) -> HistoricalMigrationResult:
+    """Write one exchange at a time; never advance after a failed write."""
+
+    normalized_user_id = normalize_conversation_memory_user_id(user_id)
+    supplied = tuple(exchanges)
+    if any(not isinstance(item, HistoricalExchange) for item in supplied):
+        raise TypeError("historical exchanges must be typed")
+    ordered = tuple(
+        sorted(
+            supplied,
+            key=lambda item: (item.occurred_at, item.source_record_id),
+        )
+    )
+    source_ids = tuple(item.source_record_id for item in ordered)
+    if len(source_ids) != len(set(source_ids)):
+        raise ValueError("historical source ids must be unique")
+
+    written = duplicates = skipped = processed = 0
+    for exchange in ordered:
+        try:
+            result = memory.remember_exchange(
+                user_message=exchange.user_message,
+                assistant_message=exchange.assistant_message,
+                occurred_at=exchange.occurred_at,
+                source_id=exchange.memory_source_id,
+                user_id=normalized_user_id,
+            )
+        except Exception:
+            result = MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                exchange.memory_source_id,
+                error_code="MEM0_WRITE_FAILED",
+            )
+        if not isinstance(result, MemoryWriteResult):
+            return _partial(ordered, processed, written, duplicates, skipped, "MEM0_WRITE_RESULT_INVALID")
+        if result.status is MemoryWriteStatus.UNAVAILABLE:
+            return _partial(
+                ordered,
+                processed,
+                written,
+                duplicates,
+                skipped,
+                result.error_code or "MEM0_WRITE_FAILED",
+            )
+        processed += 1
+        if result.status is MemoryWriteStatus.WRITTEN:
+            written += 1
+        elif result.status is MemoryWriteStatus.DUPLICATE:
+            duplicates += 1
+        else:
+            skipped += 1
+
+    private_world_status = None
+    if finalize_private_world is not None:
+        try:
+            private_world_status = finalize_private_world(ordered)
+        except Exception:
+            return HistoricalMigrationResult(
+                "partial",
+                len(ordered),
+                processed,
+                written,
+                duplicates,
+                skipped,
+                error_code="PRIVATE_WORLD_HISTORY_INITIALIZATION_FAILED",
+            )
+        if not isinstance(private_world_status, str) or not private_world_status:
+            return HistoricalMigrationResult(
+                "partial",
+                len(ordered),
+                processed,
+                written,
+                duplicates,
+                skipped,
+                error_code="PRIVATE_WORLD_HISTORY_RESULT_INVALID",
+            )
+    return HistoricalMigrationResult(
+        "completed",
+        len(ordered),
+        processed,
+        written,
+        duplicates,
+        skipped,
+        private_world_status=private_world_status,
+    )
+
+
+def _partial(
+    ordered: tuple[HistoricalExchange, ...],
+    processed: int,
+    written: int,
+    duplicates: int,
+    skipped: int,
+    error_code: str,
+) -> HistoricalMigrationResult:
+    normalized = error_code if _ERROR_RE.fullmatch(error_code) else "MEM0_WRITE_FAILED"
+    return HistoricalMigrationResult(
+        "partial",
+        len(ordered),
+        processed,
+        written,
+        duplicates,
+        skipped,
+        error_code=normalized,
+    )
+
+
+def _message(value: object, *, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise ValueError("message must be text")
+    normalized = value.strip()
+    if not normalized or len(value) > maximum:
+        raise ValueError("message is invalid")
+    if any(ord(character) < 32 and character not in "\n\r\t" for character in value):
+        raise ValueError("message is invalid")
+    return normalized
+
+
+def _occurred_at(value: object) -> datetime:
+    if isinstance(value, bool):
+        raise ValueError("occurred_at is invalid")
+    if isinstance(value, (int, float)):
+        from datetime import timezone
+
+        return datetime.fromtimestamp(float(value), timezone.utc)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError("occurred_at is invalid") from exc
+        if parsed.tzinfo is not None and parsed.utcoffset() is not None:
+            return parsed
+    raise ValueError("occurred_at is invalid")
+
+
+def _corpus_id(exchanges: tuple[HistoricalExchange, ...]) -> str:
+    material = "\n".join(item.source_record_id for item in exchanges)
+    return "history.init." + hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "HistoricalExchange",
+    "HistoricalMigrationResult",
+    "HistoricalRelationshipAssessment",
+    "apply_historical_private_world",
+    "assess_historical_relationship",
+    "exchanges_from_legacy_payload",
+    "migrate_historical_exchanges",
+]

--- a/runtime/imports/official_letters.py
+++ b/runtime/imports/official_letters.py
@@ -60,10 +60,11 @@ def build_legacy_import_payload(
                     "reply_text": reply_text,
                     "replied_at": letter.get("replied_at"),
                     "import_kind": "official_text_reply",
+                    "official_account_id": account,
                 },
             }
         )
-    return {"mode": "read_only", "letters": records}
+    return {"mode": "read_only", "account_id": account, "letters": records}
 
 
 def _headers_from_log(log_path: str | Path) -> dict[str, str]:
@@ -129,10 +130,11 @@ def collect_official_text_replies(
             headers,
         )
         if not isinstance(detail, Mapping) or detail.get("code") != 0:
-            continue
+            raise ValueError("OFFICIAL_LETTER_DETAIL_UNAVAILABLE")
         value = detail.get("data")
-        if isinstance(value, Mapping):
-            details.append({"letter_id": letter_id, **dict(value)})
+        if not isinstance(value, Mapping):
+            raise ValueError("OFFICIAL_LETTER_DETAIL_INVALID")
+        details.append({"letter_id": letter_id, **dict(value)})
     return build_legacy_import_payload(details, account_id=headers["x-uid"])
 
 

--- a/runtime/imports/official_letters.py
+++ b/runtime/imports/official_letters.py
@@ -1,0 +1,162 @@
+"""Read official Olivia text replies into the local read-only archive."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+import json
+import os
+from pathlib import Path
+import re
+from typing import Any
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+_HEADER_NAMES = (
+    "x-token",
+    "x-device_id",
+    "x-device_model",
+    "x-language",
+    "x-lifecycle_id",
+    "x-pkg_version",
+    "x-sys_version",
+    "x-uid",
+    "x-platform",
+    "x-bundle_id",
+    "x-client_type",
+)
+OFFICIAL_API_BASE = "https://toy-cnbeta01.olivia.miyoushe.com/toy"
+
+
+def _text(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def build_legacy_import_payload(
+    letters: Iterable[Mapping[str, Any]],
+    *,
+    account_id: str,
+) -> dict[str, object]:
+    """Map official details to the existing local legacy-import contract."""
+
+    account = _text(account_id)
+    if not account:
+        raise ValueError("official account id is required")
+    records: list[dict[str, object]] = []
+    for letter in letters:
+        letter_id = _text(letter.get("letter_id"))
+        user_content = _text(letter.get("content"))
+        reply_text = _text(letter.get("reply_text"))
+        if not letter_id or not user_content or not reply_text:
+            continue
+        records.append(
+            {
+                "source_record_id": f"official:{account}:{letter_id}",
+                "source": "official-olivia",
+                "occurred_at": letter.get("created_at"),
+                "content": f"用户来信：{user_content}\n林离回信：{reply_text}",
+                "metadata": {
+                    "user_content": user_content,
+                    "reply_text": reply_text,
+                    "replied_at": letter.get("replied_at"),
+                    "import_kind": "official_text_reply",
+                },
+            }
+        )
+    return {"mode": "read_only", "letters": records}
+
+
+def _headers_from_log(log_path: str | Path) -> dict[str, str]:
+    text = Path(log_path).read_text(encoding="utf-8", errors="replace")
+    for line in reversed(text.splitlines()):
+        if '"x-token"' not in line or (
+            "network_request" not in line
+            and '"request.url":"/signIn"' not in line
+        ):
+            continue
+        headers: dict[str, str] = {}
+        for name in _HEADER_NAMES:
+            match = re.search(rf'"{re.escape(name)}":"([^"\\]*)"', line)
+            if match:
+                headers[name] = match.group(1)
+        if headers.get("x-token") and headers.get("x-uid"):
+            headers["User-Agent"] = "Olivia/" + headers.get(
+                "x-pkg_version",
+                "0.0.9.627",
+            )
+            return headers
+    raise ValueError("OFFICIAL_LOGIN_REQUIRED")
+
+
+def collect_official_text_replies(
+    log_path: str | Path,
+    *,
+    request_json,
+) -> dict[str, object]:
+    """Fetch one official mailbox snapshot without retaining credentials."""
+
+    headers = _headers_from_log(log_path)
+    items: list[object] = []
+    cursor: object = 0
+    for _page in range(100):
+        listing = request_json(
+            "/letter/list?cursor=" + quote(str(cursor), safe="") + "&page_size=50",
+            headers,
+        )
+        if not isinstance(listing, Mapping) or listing.get("code") != 0:
+            raise ValueError("OFFICIAL_LETTER_LIST_UNAVAILABLE")
+        data = listing.get("data")
+        page_items = data.get("list") if isinstance(data, Mapping) else None
+        if not isinstance(page_items, list):
+            raise ValueError("OFFICIAL_LETTER_LIST_INVALID")
+        items.extend(page_items)
+        has_more = data.get("has_more", data.get("hasMore", False))
+        if has_more is not True:
+            break
+        next_cursor = data.get("next_cursor", data.get("nextCursor"))
+        if next_cursor in (None, "") or next_cursor == cursor:
+            raise ValueError("OFFICIAL_LETTER_LIST_INVALID")
+        cursor = next_cursor
+    else:
+        raise ValueError("OFFICIAL_LETTER_LIST_INVALID")
+    details: list[Mapping[str, Any]] = []
+    for item in items:
+        letter_id = _text(item.get("letter_id")) if isinstance(item, Mapping) else ""
+        if not letter_id:
+            continue
+        detail = request_json(
+            "/letter/detail?letter_id=" + quote(letter_id, safe=""),
+            headers,
+        )
+        if not isinstance(detail, Mapping) or detail.get("code") != 0:
+            continue
+        value = detail.get("data")
+        if isinstance(value, Mapping):
+            details.append({"letter_id": letter_id, **dict(value)})
+    return build_legacy_import_payload(details, account_id=headers["x-uid"])
+
+
+def _request_official_json(path: str, headers: dict[str, str]) -> dict[str, Any]:
+    request = Request(OFFICIAL_API_BASE + path, headers=headers)
+    with urlopen(request, timeout=30) as response:
+        value = json.loads(response.read().decode("utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("OFFICIAL_RESPONSE_INVALID")
+    return value
+
+
+def default_official_log_path(
+    environ: Mapping[str, str] | None = None,
+) -> Path:
+    values = os.environ if environ is None else environ
+    appdata = _text(values.get("APPDATA"))
+    if not appdata:
+        raise ValueError("OFFICIAL_LOG_UNAVAILABLE")
+    return Path(appdata) / "miHoYo" / "Olivia-steam" / "logs" / "Olivia.log"
+
+
+def collect_default_official_text_replies() -> dict[str, object]:
+    return collect_official_text_replies(
+        default_official_log_path(),
+        request_json=_request_official_json,
+    )

--- a/runtime/imports/official_letters.py
+++ b/runtime/imports/official_letters.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
+from datetime import datetime
 import json
+import math
 import os
 from pathlib import Path
 import re
@@ -32,6 +34,25 @@ def _text(value: object) -> str:
     return value.strip() if isinstance(value, str) else ""
 
 
+def _official_timestamp(value: object) -> object:
+    if isinstance(value, bool):
+        raise ValueError("OFFICIAL_LETTER_TIMESTAMP_INVALID")
+    if isinstance(value, (int, float)) and math.isfinite(float(value)):
+        try:
+            datetime.fromtimestamp(float(value))
+        except (OSError, OverflowError, ValueError) as exc:
+            raise ValueError("OFFICIAL_LETTER_TIMESTAMP_INVALID") from exc
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError("OFFICIAL_LETTER_TIMESTAMP_INVALID") from exc
+        if parsed.tzinfo is not None and parsed.utcoffset() is not None:
+            return value
+    raise ValueError("OFFICIAL_LETTER_TIMESTAMP_INVALID")
+
+
 def build_legacy_import_payload(
     letters: Iterable[Mapping[str, Any]],
     *,
@@ -46,14 +67,17 @@ def build_legacy_import_payload(
     for letter in letters:
         letter_id = _text(letter.get("letter_id"))
         user_content = _text(letter.get("content"))
-        reply_text = _text(letter.get("reply_text"))
+        reply_text = _text(letter.get("reply_content")) or _text(
+            letter.get("reply_text")
+        )
         if not letter_id or not user_content or not reply_text:
             continue
+        occurred_at = _official_timestamp(letter.get("created_at"))
         records.append(
             {
                 "source_record_id": f"official:{account}:{letter_id}",
                 "source": "official-olivia",
-                "occurred_at": letter.get("created_at"),
+                "occurred_at": occurred_at,
                 "content": f"用户来信：{user_content}\n林离回信：{reply_text}",
                 "metadata": {
                     "user_content": user_content,
@@ -134,7 +158,7 @@ def collect_official_text_replies(
         value = detail.get("data")
         if not isinstance(value, Mapping):
             raise ValueError("OFFICIAL_LETTER_DETAIL_INVALID")
-        details.append({"letter_id": letter_id, **dict(value)})
+        details.append({**dict(item), **dict(value), "letter_id": letter_id})
     return build_legacy_import_payload(details, account_id=headers["x-uid"])
 
 

--- a/tests/imports/test_historical_memory.py
+++ b/tests/imports/test_historical_memory.py
@@ -309,3 +309,83 @@ def test_server_migration_runs_mem0_in_order_before_one_private_world_commit(
     assert memory.events == [("write", "user-first"), ("write", "user-second")]
     assert len(service.commands) == 1
     assert "AUTHORITATIVE PERSONA POLICY" in gateway.messages[0]["content"]
+
+
+def test_server_migration_skips_relationship_llm_when_private_world_already_exists(
+    monkeypatch,
+) -> None:
+    import asyncio
+    import local_server
+    from private_world_port import PrivateWorldSnapshot
+
+    memory = RecordingMemory([MemoryWriteStatus.DUPLICATE])
+
+    class ExistingWorld:
+        def snapshot(self) -> PrivateWorldSnapshot:
+            return PrivateWorldSnapshot(version=2, trust=20)
+
+    class FailingGateway:
+        async def complete(self, *_args, **_kwargs):
+            raise AssertionError("relationship LLM must not run twice")
+
+    monkeypatch.setattr(local_server, "conversation_memory_adapter", memory)
+    monkeypatch.setattr(local_server, "private_world_port", ExistingWorld())
+    monkeypatch.setattr(local_server.letters_adapter, "gateway", FailingGateway())
+
+    result = asyncio.run(
+        local_server._migrate_official_history(
+            {
+                "mode": "read_only",
+                "account_id": "account",
+                "letters": [
+                    {
+                        "source_record_id": "official:account:first",
+                        "occurred_at": 10,
+                        "metadata": {
+                            "import_kind": "official_text_reply",
+                            "user_content": "user-first",
+                            "reply_text": "assistant-first",
+                        },
+                    }
+                ],
+            }
+        )
+    )
+
+    assert result.status == "completed"
+    assert result.private_world_status == "already_initialized"
+
+
+def test_server_migration_reports_partial_when_private_world_is_unavailable(
+    monkeypatch,
+) -> None:
+    import asyncio
+    import local_server
+
+    memory = RecordingMemory([MemoryWriteStatus.WRITTEN])
+    monkeypatch.setattr(local_server, "conversation_memory_adapter", memory)
+    monkeypatch.setattr(local_server, "private_world_command_service", None)
+
+    result = asyncio.run(
+        local_server._migrate_official_history(
+            {
+                "mode": "read_only",
+                "account_id": "account",
+                "letters": [
+                    {
+                        "source_record_id": "official:account:first",
+                        "occurred_at": 10,
+                        "metadata": {
+                            "import_kind": "official_text_reply",
+                            "user_content": "user-first",
+                            "reply_text": "assistant-first",
+                        },
+                    }
+                ],
+            }
+        )
+    )
+
+    assert result.status == "partial"
+    assert result.private_world_status == "unavailable"
+    assert result.error_code == "PRIVATE_WORLD_HISTORY_UNAVAILABLE"

--- a/tests/imports/test_historical_memory.py
+++ b/tests/imports/test_historical_memory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import json
 
 import pytest
 
@@ -228,6 +229,53 @@ def test_private_world_assessment_uses_persona_policy_and_ordered_history_once()
     assert gateway.messages[1]["content"].index("user-first") < gateway.messages[1][
         "content"
     ].index("user-second")
+
+
+def test_private_world_assessment_bounds_a_long_history_to_gateway_input_limit() -> None:
+    import asyncio
+
+    class BoundedGateway(AssessmentGateway):
+        config = type("Config", (), {"max_input_chars": 2_000})()
+
+        async def complete(self, messages, *, request_id=None) -> GatewayResponse:
+            del request_id
+            self.messages = tuple(messages)
+            assert sum(len(item["content"]) for item in self.messages) <= 2_000
+            return GatewayResponse(
+                '{"relationship_stage":"familiar","familiarity":48,"trust":44,'
+                '"comfort":42,"closeness":36,"tension":9,'
+                '"evidence_indexes":[1,30]}',
+                "request-bounded",
+                "fixture",
+                "fixture-model",
+            )
+
+    ordered = tuple(
+        HistoricalExchange(
+            source_record_id=f"official:user:{index}",
+            occurred_at=datetime.fromtimestamp(index, timezone.utc),
+            user_message=(f"user-{index}-" + "u" * 1_000),
+            assistant_message=(f"assistant-{index}-" + "a" * 1_000),
+        )
+        for index in range(1, 31)
+    )
+    gateway = BoundedGateway()
+
+    assessment = asyncio.run(
+        assess_historical_relationship(
+            ordered,
+            gateway=gateway,
+            persona_policy="P" * 12_000,
+        )
+    )
+
+    prompt = json.loads(gateway.messages[1]["content"])["ordered_exchanges"]
+    assert prompt[0]["index"] == 1
+    assert prompt[-1]["index"] == 30
+    assert [item["index"] for item in prompt] == sorted(
+        item["index"] for item in prompt
+    )
+    assert assessment.evidence_indexes == (1, 30)
 
 
 def test_private_world_initialization_commits_exactly_one_migration_command() -> None:

--- a/tests/imports/test_historical_memory.py
+++ b/tests/imports/test_historical_memory.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from conversation_memory_port import MemoryWriteResult, MemoryWriteStatus
+from llm_gateway import GatewayResponse
+from private_world_commands import InitializeHistoricalRelationship
+from private_world_service import CommandExecutionResult, CommandExecutionStatus
+from runtime.imports.historical_memory import (
+    HistoricalExchange,
+    apply_historical_private_world,
+    assess_historical_relationship,
+    exchanges_from_legacy_payload,
+    migrate_historical_exchanges,
+)
+
+
+class RecordingMemory:
+    enabled = True
+
+    def __init__(self, statuses: list[MemoryWriteStatus]) -> None:
+        self.statuses = list(statuses)
+        self.events: list[tuple[str, str]] = []
+
+    def remember_exchange(self, **kwargs: object) -> MemoryWriteResult:
+        source_id = str(kwargs["source_id"])
+        self.events.append(("write", str(kwargs["user_message"])))
+        status = self.statuses.pop(0)
+        return MemoryWriteResult(
+            status,
+            source_id,
+            (f"memory.{len(self.events)}",)
+            if status is MemoryWriteStatus.WRITTEN
+            else (),
+            "MEM0_WRITE_FAILED"
+            if status is MemoryWriteStatus.UNAVAILABLE
+            else None,
+        )
+
+    def status(self):
+        return type("Status", (), {"status": "available"})()
+
+
+def _exchange(name: str, timestamp: int) -> HistoricalExchange:
+    return HistoricalExchange(
+        source_record_id=f"official:user:{name}",
+        occurred_at=datetime.fromtimestamp(timestamp, timezone.utc),
+        user_message=f"user-{name}",
+        assistant_message=f"assistant-{name}",
+    )
+
+
+def test_migration_writes_each_exchange_in_strict_chronological_order_then_finalizes_once() -> None:
+    memory = RecordingMemory(
+        [MemoryWriteStatus.WRITTEN, MemoryWriteStatus.SKIPPED, MemoryWriteStatus.DUPLICATE]
+    )
+    finalizations: list[tuple[str, ...]] = []
+
+    result = migrate_historical_exchanges(
+        (_exchange("third", 30), _exchange("first", 10), _exchange("second", 20)),
+        memory=memory,
+        user_id="local-user",
+        finalize_private_world=lambda ordered: finalizations.append(
+            tuple(item.user_message for item in ordered)
+        )
+        or "initialized",
+    )
+
+    assert memory.events == [
+        ("write", "user-first"),
+        ("write", "user-second"),
+        ("write", "user-third"),
+    ]
+    assert finalizations == [("user-first", "user-second", "user-third")]
+    assert result.to_dict() == {
+        "status": "completed",
+        "total": 3,
+        "processed": 3,
+        "written": 1,
+        "duplicates": 1,
+        "skipped": 1,
+        "private_world_status": "initialized",
+        "error_code": None,
+    }
+
+
+def test_migration_stops_at_first_failed_write_and_does_not_finalize() -> None:
+    memory = RecordingMemory(
+        [MemoryWriteStatus.WRITTEN, MemoryWriteStatus.UNAVAILABLE, MemoryWriteStatus.WRITTEN]
+    )
+    finalizations: list[tuple[HistoricalExchange, ...]] = []
+
+    result = migrate_historical_exchanges(
+        (_exchange("first", 10), _exchange("second", 20), _exchange("third", 30)),
+        memory=memory,
+        user_id="local-user",
+        finalize_private_world=lambda ordered: finalizations.append(ordered) or "initialized",
+    )
+
+    assert memory.events == [("write", "user-first"), ("write", "user-second")]
+    assert finalizations == []
+    assert result.status == "partial"
+    assert result.processed == 1
+    assert result.error_code == "MEM0_WRITE_FAILED"
+
+
+def test_migration_uses_stable_source_ids_so_a_retry_can_resume_by_deduplication() -> None:
+    exchange = _exchange("same", 10)
+    first = RecordingMemory([MemoryWriteStatus.WRITTEN])
+    second = RecordingMemory([MemoryWriteStatus.DUPLICATE])
+
+    first_result = migrate_historical_exchanges(
+        (exchange,), memory=first, user_id="local-user"
+    )
+    second_result = migrate_historical_exchanges(
+        (exchange,), memory=second, user_id="local-user"
+    )
+
+    assert first_result.status == second_result.status == "completed"
+    assert first_result.written == 1
+    assert second_result.duplicates == 1
+
+
+def test_migration_rejects_untyped_input_before_any_memory_write() -> None:
+    memory = RecordingMemory([MemoryWriteStatus.WRITTEN])
+
+    with pytest.raises(TypeError, match="historical exchanges must be typed"):
+        migrate_historical_exchanges(
+            (_exchange("first", 10), object()),
+            memory=memory,
+            user_id="local-user",
+        )
+
+    assert memory.events == []
+
+
+def test_official_legacy_payload_becomes_typed_exchanges_without_combined_archive_text() -> None:
+    exchanges = exchanges_from_legacy_payload(
+        {
+            "mode": "read_only",
+            "letters": [
+                {
+                    "source_record_id": "official:account:later",
+                    "occurred_at": 20,
+                    "content": "combined archive display text",
+                    "metadata": {
+                        "import_kind": "official_text_reply",
+                        "user_content": "later user text",
+                        "reply_text": "later reply text",
+                    },
+                },
+                {
+                    "source_record_id": "official:account:first",
+                    "occurred_at": 10,
+                    "content": "another combined display text",
+                    "metadata": {
+                        "import_kind": "official_text_reply",
+                        "user_content": "first user text",
+                        "reply_text": "first reply text",
+                    },
+                },
+            ],
+        }
+    )
+
+    assert [item.user_message for item in exchanges] == [
+        "first user text",
+        "later user text",
+    ]
+    assert [item.assistant_message for item in exchanges] == [
+        "first reply text",
+        "later reply text",
+    ]
+    assert all("combined archive" not in item.user_message for item in exchanges)
+
+
+class AssessmentGateway:
+    def __init__(self) -> None:
+        self.messages: tuple[dict[str, str], ...] = ()
+
+    async def complete(self, messages, *, request_id=None) -> GatewayResponse:
+        del request_id
+        self.messages = tuple(messages)
+        return GatewayResponse(
+            '{"relationship_stage":"familiar","familiarity":48,"trust":44,'
+            '"comfort":42,"closeness":36,"tension":9,"evidence_indexes":[1,2]}',
+            "request-1",
+            "fixture",
+            "fixture-model",
+        )
+
+
+class RecordingCommandService:
+    def __init__(self) -> None:
+        self.commands: list[InitializeHistoricalRelationship] = []
+
+    def execute(self, command: InitializeHistoricalRelationship) -> CommandExecutionResult:
+        self.commands.append(command)
+        return CommandExecutionResult(
+            CommandExecutionStatus.APPLIED,
+            command.command_id,
+            "event.fixture",
+            "INITIALIZE_HISTORICAL_RELATIONSHIP",
+            2,
+            ("relationship_stage",),
+        )
+
+
+def test_private_world_assessment_uses_persona_policy_and_ordered_history_once() -> None:
+    import asyncio
+
+    gateway = AssessmentGateway()
+    ordered = (_exchange("first", 10), _exchange("second", 20))
+
+    assessment = asyncio.run(
+        assess_historical_relationship(
+            ordered,
+            gateway=gateway,
+            persona_policy="AUTHORITATIVE PERSONA POLICY",
+        )
+    )
+
+    assert assessment.relationship_stage.value == "familiar"
+    assert assessment.evidence_indexes == (1, 2)
+    assert "AUTHORITATIVE PERSONA POLICY" in gateway.messages[0]["content"]
+    assert gateway.messages[1]["content"].index("user-first") < gateway.messages[1][
+        "content"
+    ].index("user-second")
+
+
+def test_private_world_initialization_commits_exactly_one_migration_command() -> None:
+    import asyncio
+
+    ordered = (_exchange("first", 10), _exchange("second", 20))
+    assessment = asyncio.run(
+        assess_historical_relationship(
+            ordered,
+            gateway=AssessmentGateway(),
+            persona_policy="AUTHORITATIVE PERSONA POLICY",
+        )
+    )
+    service = RecordingCommandService()
+
+    status = apply_historical_private_world(
+        ordered,
+        assessment=assessment,
+        command_service=service,
+    )
+
+    assert status == "initialized"
+    assert len(service.commands) == 1
+    assert service.commands[0].actor.value == "migration"
+    assert service.commands[0].evidence_refs == (
+        ordered[0].memory_source_id,
+        ordered[1].memory_source_id,
+    )
+
+
+def test_server_migration_runs_mem0_in_order_before_one_private_world_commit(
+    monkeypatch,
+) -> None:
+    import asyncio
+    import local_server
+
+    memory = RecordingMemory([MemoryWriteStatus.WRITTEN, MemoryWriteStatus.WRITTEN])
+    gateway = AssessmentGateway()
+    service = RecordingCommandService()
+    monkeypatch.setattr(local_server, "conversation_memory_adapter", memory)
+    monkeypatch.setattr(local_server, "private_world_command_service", service)
+    monkeypatch.setattr(local_server.letters_adapter, "gateway", gateway)
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "get_persona_policy",
+        lambda: "AUTHORITATIVE PERSONA POLICY",
+    )
+
+    result = asyncio.run(
+        local_server._migrate_official_history(
+            {
+                "mode": "read_only",
+                "letters": [
+                    {
+                        "source_record_id": "official:account:later",
+                        "occurred_at": 20,
+                        "metadata": {
+                            "import_kind": "official_text_reply",
+                            "user_content": "user-second",
+                            "reply_text": "assistant-second",
+                        },
+                    },
+                    {
+                        "source_record_id": "official:account:first",
+                        "occurred_at": 10,
+                        "metadata": {
+                            "import_kind": "official_text_reply",
+                            "user_content": "user-first",
+                            "reply_text": "assistant-first",
+                        },
+                    },
+                ],
+            }
+        )
+    )
+
+    assert result.status == "completed"
+    assert result.private_world_status == "initialized"
+    assert memory.events == [("write", "user-first"), ("write", "user-second")]
+    assert len(service.commands) == 1
+    assert "AUTHORITATIVE PERSONA POLICY" in gateway.messages[0]["content"]

--- a/tests/imports/test_official_letters.py
+++ b/tests/imports/test_official_letters.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import asyncio
+
+from memory_port import NullMemoryPort
+from runtime.imports.official_letters import (
+    build_legacy_import_payload,
+    collect_official_text_replies,
+)
+
+
+def test_official_text_replies_become_read_only_legacy_pairs() -> None:
+    payload = build_legacy_import_payload(
+        [
+            {
+                "letter_id": "letter-text",
+                "created_at": 1710000000,
+                "replied_at": 1710000100,
+                "content": "用户写下的旧信",
+                "reply_text": "林离过去的文字回信",
+                "reply_video_url": "",
+            },
+            {
+                "letter_id": "letter-video",
+                "created_at": 1710000200,
+                "content": "只有视频回信的旧信",
+                "reply_text": "",
+                "reply_video_url": "https://example.invalid/video.mp4",
+            },
+        ],
+        account_id="official-user-1",
+    )
+
+    assert payload == {
+        "mode": "read_only",
+        "letters": [
+            {
+                "source_record_id": "official:official-user-1:letter-text",
+                "source": "official-olivia",
+                "occurred_at": 1710000000,
+                "content": "用户来信：用户写下的旧信\n林离回信：林离过去的文字回信",
+                "metadata": {
+                    "user_content": "用户写下的旧信",
+                    "reply_text": "林离过去的文字回信",
+                    "replied_at": 1710000100,
+                    "import_kind": "official_text_reply",
+                },
+            }
+        ],
+    }
+    assert "reply_video_url" not in repr(payload)
+
+
+def test_official_log_credentials_are_used_but_never_enter_import_payload(
+    tmp_path,
+) -> None:
+    log_path = tmp_path / "Olivia.log"
+    log_path.write_text(
+        'network_request {"request.url":"/signIn",'
+        '"x-token":"secret-token","x-uid":"200717",'
+        '"x-pkg_version":"0.0.9.627"}',
+        encoding="utf-8",
+    )
+    calls: list[str] = []
+
+    def request_json(path: str, headers: dict[str, str]) -> dict:
+        assert headers["x-token"] == "secret-token"
+        calls.append(path)
+        if path.startswith("/letter/list"):
+            return {
+                "code": 0,
+                "data": {"list": [{"letter_id": "letter-1"}], "has_more": False},
+            }
+        return {
+            "code": 0,
+            "data": {
+                "letter_id": "letter-1",
+                "created_at": 1710000000,
+                "replied_at": 1710000100,
+                "content": "旧信正文",
+                "reply_text": "旧文字回信",
+                "reply_video_url": "",
+            },
+        }
+
+    payload = collect_official_text_replies(log_path, request_json=request_json)
+
+    assert calls == [
+        "/letter/list?cursor=0&page_size=50",
+        "/letter/detail?letter_id=letter-1",
+    ]
+    assert payload["letters"][0]["metadata"]["reply_text"] == "旧文字回信"
+    assert "secret-token" not in repr(payload)
+    assert "200717" in payload["letters"][0]["source_record_id"]
+
+
+def test_official_log_skips_newer_sign_in_entry_with_empty_uid(tmp_path) -> None:
+    log_path = tmp_path / "Olivia.log"
+    log_path.write_text(
+        '\n'.join(
+            [
+                'network_request {"x-token":"usable-token","x-uid":"200717"}',
+                'network_request {"request.url":"/signIn",'
+                '"x-token":"newer-token","x-uid":""}',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    observed: dict[str, str] = {}
+
+    def request_json(path: str, headers: dict[str, str]) -> dict:
+        observed.update(headers)
+        if path.startswith("/letter/list"):
+            return {"code": 0, "data": {"list": [], "has_more": False}}
+        raise AssertionError(path)
+
+    payload = collect_official_text_replies(log_path, request_json=request_json)
+
+    assert payload == {"mode": "read_only", "letters": []}
+    assert observed["x-token"] == "usable-token"
+    assert observed["x-uid"] == "200717"
+
+
+def test_official_import_follows_mailbox_cursor_pages(tmp_path) -> None:
+    log_path = tmp_path / "Olivia.log"
+    log_path.write_text(
+        'network_request {"request.url":"/signIn",'
+        '"x-token":"secret-token","x-uid":"200717"}',
+        encoding="utf-8",
+    )
+    list_paths: list[str] = []
+
+    def request_json(path: str, _headers: dict[str, str]) -> dict:
+        if path.startswith("/letter/list"):
+            list_paths.append(path)
+            if "cursor=0" in path:
+                return {
+                    "code": 0,
+                    "data": {
+                        "list": [{"letter_id": "letter-1"}],
+                        "has_more": True,
+                        "next_cursor": 50,
+                    },
+                }
+            return {
+                "code": 0,
+                "data": {"list": [{"letter_id": "letter-2"}], "has_more": False},
+            }
+        letter_id = path.rsplit("=", 1)[-1]
+        return {
+            "code": 0,
+            "data": {
+                "letter_id": letter_id,
+                "content": f"旧信 {letter_id}",
+                "reply_text": f"回信 {letter_id}",
+            },
+        }
+
+    payload = collect_official_text_replies(log_path, request_json=request_json)
+
+    assert list_paths == [
+        "/letter/list?cursor=0&page_size=50",
+        "/letter/list?cursor=50&page_size=50",
+    ]
+    assert len(payload["letters"]) == 2
+
+
+def test_official_import_route_persists_read_only_pair_in_current_mailbox(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import local_server
+
+    monkeypatch.setenv("OLIVIA_MEMORY_ROOT", str(tmp_path / "memory"))
+    monkeypatch.setattr(local_server, "memory_adapter", NullMemoryPort())
+    monkeypatch.setattr(local_server.letters_adapter, "memory_port", NullMemoryPort())
+    monkeypatch.setattr(
+        local_server,
+        "collect_default_official_text_replies",
+        lambda: {
+            "mode": "read_only",
+            "letters": [
+                {
+                    "source_record_id": "official:200717:letter-1",
+                    "source": "official-olivia",
+                    "occurred_at": 1710000000,
+                    "content": "用户来信：旧信正文\n林离回信：旧文字回信",
+                    "metadata": {
+                        "user_content": "旧信正文",
+                        "reply_text": "旧文字回信",
+                        "replied_at": 1710000100,
+                        "import_kind": "official_text_reply",
+                    },
+                }
+            ],
+        },
+        raising=False,
+    )
+
+    imported = asyncio.run(
+        local_server.route("POST", "/toy/letter/legacy/official-import", {}, {})
+    )
+    duplicate = asyncio.run(
+        local_server.route("POST", "/toy/letter/legacy/official-import", {}, {})
+    )
+    listed = asyncio.run(
+        local_server.route("GET", "/toy/letter/list", {}, {})
+    )
+    letter_id = listed["data"]["list"][0]["letter_id"]
+    detail = asyncio.run(
+        local_server.route(
+            "GET",
+            "/toy/letter/detail",
+            {},
+            {"letter_id": letter_id},
+        )
+    )
+
+    assert imported["code"] == 0
+    assert imported["data"]["inserted"] == 1
+    assert duplicate["code"] == 0
+    assert duplicate["data"]["inserted"] == 0
+    assert duplicate["data"]["duplicates"] == 1
+    assert listed["data"]["total"] == 1
+    assert listed["data"]["list"][0]["summary"] == "旧信正文"
+    assert detail["data"]["content"] == "旧信正文"
+    assert detail["data"]["reply_text"] == "旧文字回信"
+    assert detail["data"]["reply_video_url"] == ""
+    assert detail["data"]["read_only"] is True
+
+
+def test_official_import_failure_returns_only_a_sanitized_error(monkeypatch) -> None:
+    import local_server
+
+    private_value = "secret-token-and-private-letter"
+    monkeypatch.setattr(
+        local_server,
+        "collect_default_official_text_replies",
+        lambda: (_ for _ in ()).throw(ValueError(private_value)),
+        raising=False,
+    )
+
+    response = asyncio.run(
+        local_server.route("POST", "/toy/letter/legacy/official-import", {}, {})
+    )
+
+    assert response["code"] == 503
+    assert response["data"] == {
+        "status": "UNAVAILABLE",
+        "error_code": "OFFICIAL_LETTER_IMPORT_UNAVAILABLE",
+        "retryable": True,
+    }
+    assert private_value not in repr(response)

--- a/tests/imports/test_official_letters.py
+++ b/tests/imports/test_official_letters.py
@@ -338,7 +338,11 @@ def test_official_import_rejects_a_different_account_before_persisting(
         },
         "read_only": True,
     }
-    monkeypatch.setattr(local_server, "_legacy_letter_collection", lambda: [existing])
+    monkeypatch.setattr(
+        local_server,
+        "_legacy_letter_collection",
+        lambda *, strict=False: [existing],
+    )
     monkeypatch.setattr(
         local_server,
         "collect_default_official_text_replies",
@@ -357,3 +361,35 @@ def test_official_import_rejects_a_different_account_before_persisting(
 
     assert response["code"] == 409
     assert response["data"]["error_code"] == "OFFICIAL_ACCOUNT_CONFLICT"
+
+
+def test_official_import_fails_closed_when_account_binding_cannot_be_read(
+    monkeypatch,
+) -> None:
+    import local_server
+
+    class UnreadableArchive:
+        enabled = True
+
+        def list_legacy(self):
+            raise OSError("private archive path")
+
+    monkeypatch.setattr(local_server, "memory_adapter", UnreadableArchive())
+    monkeypatch.setattr(
+        local_server,
+        "collect_default_official_text_replies",
+        lambda: {"mode": "read_only", "account_id": "account-b", "letters": []},
+    )
+
+    response = asyncio.run(
+        local_server.route(
+            "POST",
+            "/toy/letter/legacy/official-import",
+            {},
+            {},
+            companion_confirmed=True,
+        )
+    )
+
+    assert response["code"] == 503
+    assert response["data"]["error_code"] == "OFFICIAL_LETTER_IMPORT_UNAVAILABLE"

--- a/tests/imports/test_official_letters.py
+++ b/tests/imports/test_official_letters.py
@@ -19,7 +19,7 @@ def test_official_text_replies_become_read_only_legacy_pairs() -> None:
                 "created_at": 1710000000,
                 "replied_at": 1710000100,
                 "content": "用户写下的旧信",
-                "reply_text": "林离过去的文字回信",
+                "reply_content": "林离过去的文字回信",
                 "reply_video_url": "",
             },
             {
@@ -73,7 +73,10 @@ def test_official_log_credentials_are_used_but_never_enter_import_payload(
         if path.startswith("/letter/list"):
             return {
                 "code": 0,
-                "data": {"list": [{"letter_id": "letter-1"}], "has_more": False},
+                "data": {
+                    "list": [{"letter_id": "letter-1", "created_at": 1710000000}],
+                    "has_more": False,
+                },
             }
         return {
             "code": 0,
@@ -82,7 +85,7 @@ def test_official_log_credentials_are_used_but_never_enter_import_payload(
                 "created_at": 1710000000,
                 "replied_at": 1710000100,
                 "content": "旧信正文",
-                "reply_text": "旧文字回信",
+                "reply_content": "旧文字回信",
                 "reply_video_url": "",
             },
         }
@@ -142,14 +145,17 @@ def test_official_import_follows_mailbox_cursor_pages(tmp_path) -> None:
                 return {
                     "code": 0,
                     "data": {
-                        "list": [{"letter_id": "letter-1"}],
+                        "list": [{"letter_id": "letter-1", "created_at": 1710000000}],
                         "has_more": True,
                         "next_cursor": 50,
                     },
                 }
             return {
                 "code": 0,
-                "data": {"list": [{"letter_id": "letter-2"}], "has_more": False},
+                "data": {
+                    "list": [{"letter_id": "letter-2", "created_at": 1710000200}],
+                    "has_more": False,
+                },
             }
         letter_id = path.rsplit("=", 1)[-1]
         return {
@@ -157,7 +163,7 @@ def test_official_import_follows_mailbox_cursor_pages(tmp_path) -> None:
             "data": {
                 "letter_id": letter_id,
                 "content": f"旧信 {letter_id}",
-                "reply_text": f"回信 {letter_id}",
+                "reply_content": f"回信 {letter_id}",
             },
         }
 
@@ -168,6 +174,31 @@ def test_official_import_follows_mailbox_cursor_pages(tmp_path) -> None:
         "/letter/list?cursor=50&page_size=50",
     ]
     assert len(payload["letters"]) == 2
+
+
+def test_official_import_rejects_text_reply_without_a_valid_timestamp(tmp_path) -> None:
+    log_path = tmp_path / "Olivia.log"
+    log_path.write_text(
+        'network_request {"x-token":"secret-token","x-uid":"200717"}',
+        encoding="utf-8",
+    )
+
+    def request_json(path: str, _headers: dict[str, str]) -> dict:
+        if path.startswith("/letter/list"):
+            return {
+                "code": 0,
+                "data": {"list": [{"letter_id": "letter-1"}], "has_more": False},
+            }
+        return {
+            "code": 0,
+            "data": {
+                "content": "旧信",
+                "reply_content": "旧文字回信",
+            },
+        }
+
+    with pytest.raises(ValueError, match="OFFICIAL_LETTER_TIMESTAMP_INVALID"):
+        collect_official_text_replies(log_path, request_json=request_json)
 
 
 def test_official_import_fails_closed_when_any_letter_detail_is_unavailable(
@@ -308,6 +339,46 @@ def test_official_import_failure_returns_only_a_sanitized_error(monkeypatch) -> 
         "retryable": True,
     }
     assert private_value not in repr(response)
+
+
+def test_official_import_route_rejects_invalid_timestamp_before_archiving(
+    monkeypatch,
+) -> None:
+    import local_server
+
+    monkeypatch.setattr(
+        local_server,
+        "collect_default_official_text_replies",
+        lambda: {
+            "mode": "read_only",
+            "account_id": "200717",
+            "letters": [
+                {
+                    "source_record_id": "official:200717:letter-1",
+                    "occurred_at": None,
+                    "metadata": {
+                        "user_content": "旧信",
+                        "reply_text": "旧文字回信",
+                        "import_kind": "official_text_reply",
+                        "official_account_id": "200717",
+                    },
+                }
+            ],
+        },
+    )
+
+    response = asyncio.run(
+        local_server.route(
+            "POST",
+            "/toy/letter/legacy/official-import",
+            {},
+            {},
+            companion_confirmed=True,
+        )
+    )
+
+    assert response["code"] == 503
+    assert response["data"]["error_code"] == "OFFICIAL_LETTER_IMPORT_UNAVAILABLE"
 
 
 def test_official_import_requires_explicit_companion_confirmation(monkeypatch) -> None:

--- a/tests/imports/test_official_letters.py
+++ b/tests/imports/test_official_letters.py
@@ -196,7 +196,7 @@ def test_official_import_fails_closed_when_any_letter_detail_is_unavailable(
         collect_official_text_replies(log_path, request_json=request_json)
 
 
-def test_official_import_route_persists_read_only_pair_in_current_mailbox(
+def test_official_import_route_keeps_read_only_pair_in_legacy_mailbox(
     tmp_path,
     monkeypatch,
 ) -> None:
@@ -248,8 +248,12 @@ def test_official_import_route_persists_read_only_pair_in_current_mailbox(
             companion_confirmed=True,
         )
     )
+    current = asyncio.run(local_server.route("GET", "/toy/letter/list", {}, {}))
     listed = asyncio.run(
-        local_server.route("GET", "/toy/letter/list", {}, {})
+        local_server.route("GET", "/toy/letter/list", {}, {"scope": "legacy"})
+    )
+    current_unread = asyncio.run(
+        local_server.route("GET", "/toy/letter/unread_count", {}, {})
     )
     letter_id = listed["data"]["list"][0]["letter_id"]
     detail = asyncio.run(
@@ -257,7 +261,7 @@ def test_official_import_route_persists_read_only_pair_in_current_mailbox(
             "GET",
             "/toy/letter/detail",
             {},
-            {"letter_id": letter_id},
+            {"scope": "legacy", "letter_id": letter_id},
         )
     )
 
@@ -266,6 +270,8 @@ def test_official_import_route_persists_read_only_pair_in_current_mailbox(
     assert duplicate["code"] == 0
     assert duplicate["data"]["inserted"] == 0
     assert duplicate["data"]["duplicates"] == 1
+    assert current["data"]["total"] == 0
+    assert current_unread["data"]["unread_count"] == 0
     assert listed["data"]["total"] == 1
     assert listed["data"]["list"][0]["summary"] == "旧信正文"
     assert detail["data"]["content"] == "旧信正文"

--- a/tests/imports/test_official_letters.py
+++ b/tests/imports/test_official_letters.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
 from memory_port import NullMemoryPort
 from runtime.imports.official_letters import (
     build_legacy_import_payload,
@@ -33,6 +35,7 @@ def test_official_text_replies_become_read_only_legacy_pairs() -> None:
 
     assert payload == {
         "mode": "read_only",
+        "account_id": "official-user-1",
         "letters": [
             {
                 "source_record_id": "official:official-user-1:letter-text",
@@ -44,6 +47,7 @@ def test_official_text_replies_become_read_only_legacy_pairs() -> None:
                     "reply_text": "林离过去的文字回信",
                     "replied_at": 1710000100,
                     "import_kind": "official_text_reply",
+                    "official_account_id": "official-user-1",
                 },
             }
         ],
@@ -90,6 +94,7 @@ def test_official_log_credentials_are_used_but_never_enter_import_payload(
         "/letter/detail?letter_id=letter-1",
     ]
     assert payload["letters"][0]["metadata"]["reply_text"] == "旧文字回信"
+    assert payload["account_id"] == "200717"
     assert "secret-token" not in repr(payload)
     assert "200717" in payload["letters"][0]["source_record_id"]
 
@@ -116,7 +121,7 @@ def test_official_log_skips_newer_sign_in_entry_with_empty_uid(tmp_path) -> None
 
     payload = collect_official_text_replies(log_path, request_json=request_json)
 
-    assert payload == {"mode": "read_only", "letters": []}
+    assert payload == {"mode": "read_only", "account_id": "200717", "letters": []}
     assert observed["x-token"] == "usable-token"
     assert observed["x-uid"] == "200717"
 
@@ -165,6 +170,32 @@ def test_official_import_follows_mailbox_cursor_pages(tmp_path) -> None:
     assert len(payload["letters"]) == 2
 
 
+def test_official_import_fails_closed_when_any_letter_detail_is_unavailable(
+    tmp_path,
+) -> None:
+    log_path = tmp_path / "Olivia.log"
+    log_path.write_text(
+        'network_request {"x-token":"secret-token","x-uid":"200717"}',
+        encoding="utf-8",
+    )
+
+    def request_json(path: str, _headers: dict[str, str]) -> dict:
+        if path.startswith("/letter/list"):
+            return {
+                "code": 0,
+                "data": {
+                    "list": [{"letter_id": "letter-1"}, {"letter_id": "letter-2"}],
+                    "has_more": False,
+                },
+            }
+        if path.endswith("letter-1"):
+            return {"code": 0, "data": {"content": "one", "reply_text": "reply"}}
+        return {"code": 503, "data": None}
+
+    with pytest.raises(ValueError, match="OFFICIAL_LETTER_DETAIL_UNAVAILABLE"):
+        collect_official_text_replies(log_path, request_json=request_json)
+
+
 def test_official_import_route_persists_read_only_pair_in_current_mailbox(
     tmp_path,
     monkeypatch,
@@ -179,6 +210,7 @@ def test_official_import_route_persists_read_only_pair_in_current_mailbox(
         "collect_default_official_text_replies",
         lambda: {
             "mode": "read_only",
+            "account_id": "200717",
             "letters": [
                 {
                     "source_record_id": "official:200717:letter-1",
@@ -190,6 +222,7 @@ def test_official_import_route_persists_read_only_pair_in_current_mailbox(
                         "reply_text": "旧文字回信",
                         "replied_at": 1710000100,
                         "import_kind": "official_text_reply",
+                        "official_account_id": "200717",
                     },
                 }
             ],
@@ -198,10 +231,22 @@ def test_official_import_route_persists_read_only_pair_in_current_mailbox(
     )
 
     imported = asyncio.run(
-        local_server.route("POST", "/toy/letter/legacy/official-import", {}, {})
+        local_server.route(
+            "POST",
+            "/toy/letter/legacy/official-import",
+            {},
+            {},
+            companion_confirmed=True,
+        )
     )
     duplicate = asyncio.run(
-        local_server.route("POST", "/toy/letter/legacy/official-import", {}, {})
+        local_server.route(
+            "POST",
+            "/toy/letter/legacy/official-import",
+            {},
+            {},
+            companion_confirmed=True,
+        )
     )
     listed = asyncio.run(
         local_server.route("GET", "/toy/letter/list", {}, {})
@@ -241,7 +286,13 @@ def test_official_import_failure_returns_only_a_sanitized_error(monkeypatch) -> 
     )
 
     response = asyncio.run(
-        local_server.route("POST", "/toy/letter/legacy/official-import", {}, {})
+        local_server.route(
+            "POST",
+            "/toy/letter/legacy/official-import",
+            {},
+            {},
+            companion_confirmed=True,
+        )
     )
 
     assert response["code"] == 503
@@ -251,3 +302,58 @@ def test_official_import_failure_returns_only_a_sanitized_error(monkeypatch) -> 
         "retryable": True,
     }
     assert private_value not in repr(response)
+
+
+def test_official_import_requires_explicit_companion_confirmation(monkeypatch) -> None:
+    import local_server
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        local_server,
+        "collect_default_official_text_replies",
+        lambda: calls.append("collect") or {},
+        raising=False,
+    )
+
+    response = asyncio.run(
+        local_server.route("POST", "/toy/letter/legacy/official-import", {}, {})
+    )
+
+    assert response["code"] == 403
+    assert response["data"]["error_code"] == "COMPANION_CONFIRMATION_REQUIRED"
+    assert calls == []
+
+
+def test_official_import_rejects_a_different_account_before_persisting(
+    monkeypatch,
+) -> None:
+    import local_server
+
+    existing = {
+        "letter_id": "existing",
+        "source_record_id": "official:account-a:letter-1",
+        "metadata": {
+            "import_kind": "official_text_reply",
+            "official_account_id": "account-a",
+        },
+        "read_only": True,
+    }
+    monkeypatch.setattr(local_server, "_legacy_letter_collection", lambda: [existing])
+    monkeypatch.setattr(
+        local_server,
+        "collect_default_official_text_replies",
+        lambda: {"mode": "read_only", "account_id": "account-b", "letters": []},
+    )
+
+    response = asyncio.run(
+        local_server.route(
+            "POST",
+            "/toy/letter/legacy/official-import",
+            {},
+            {},
+            companion_confirmed=True,
+        )
+    )
+
+    assert response["code"] == 409
+    assert response["data"]["error_code"] == "OFFICIAL_ACCOUNT_CONFLICT"

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -14,7 +14,7 @@ from original_client_settings_ui import (
 
 # The shipped CEF surface needs explicit no-drag/pointer and display-state guards.
 def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
-    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v1"
+    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v3"
     for declaration in (
             'const STATUS_PATH = "/toy/companion/status";',
             'const MEMORY_PATH = "/toy/companion/memory";',
@@ -47,6 +47,19 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
     assert 'panel.style.display = active ? "grid" : "none";' in BOOTSTRAP_JAVASCRIPT
     assert '-webkit-app-region: no-drag !important;' in BOOTSTRAP_JAVASCRIPT
     assert 'var(--el-text-color-primary, #303133)' in BOOTSTRAP_JAVASCRIPT
+
+
+def test_original_settings_can_import_official_text_reply_history() -> None:
+    assert BOOTSTRAP_JAVASCRIPT.count(
+        'const OFFICIAL_LETTER_IMPORT_PATH = "/toy/letter/legacy/official-import";'
+    ) == 1
+    assert "导入官方文字信件" in BOOTSTRAP_JAVASCRIPT
+    assert "只导入原信和文字回信，不导入视频" in BOOTSTRAP_JAVASCRIPT
+    assert "requestMutation(OFFICIAL_LETTER_IMPORT_PATH, {})" in BOOTSTRAP_JAVASCRIPT
+    assert "path === OFFICIAL_LETTER_IMPORT_PATH ? 600000 : 8000" in BOOTSTRAP_JAVASCRIPT
+    assert "payload.inserted" in BOOTSTRAP_JAVASCRIPT
+    assert "payload.memory_migration" in BOOTSTRAP_JAVASCRIPT
+    assert "记忆已按时间顺序处理" in BOOTSTRAP_JAVASCRIPT
 
 
 def test_original_settings_private_world_entry_is_limited_to_safe_status() -> None:

--- a/tests/installer/test_patch_companion_settings.py
+++ b/tests/installer/test_patch_companion_settings.py
@@ -94,6 +94,7 @@ def test_patch_adds_original_settings_management_and_preserves_existing_assets(
         "/toy/companion/memory/delete",
         "/toy/companion/memory/pause",
         "/toy/companion/memory/resume",
+        "/toy/letter/legacy/official-import",
     ):
         assert path_value in bootstrap
     for visible_text in (
@@ -104,6 +105,7 @@ def test_patch_adds_original_settings_management_and_preserves_existing_assets(
         "删除",
         "暂停长期记忆",
         "恢复长期记忆",
+        "导入官方文字信件",
     ):
         assert visible_text in bootstrap
     for hidden_artifact in (

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -660,6 +660,8 @@ def test_copy_payload_excludes_non_runtime_project_files(
     ).is_file()
     assert (destination / "runtime" / "original_client_media_http.py").is_file()
     assert (destination / "runtime" / "video_reply_settings.py").is_file()
+    assert (destination / "runtime" / "imports" / "official_letters.py").is_file()
+    assert (destination / "runtime" / "imports" / "historical_memory.py").is_file()
     assert not (destination / "runtime" / "packaging").exists()
     assert "dynamic_renderer.py" in copied
     assert (destination / "dynamic_renderer.py").is_file()
@@ -974,7 +976,7 @@ def test_install_isolated_copy_activates_original_client_surfaces(
         main = archive.read("assets/main-917d29fc.js").decode("utf-8")
     assert "assets/olivia-companion-settings.js" in names
     assert "data-olivia-companion-settings" in index
-    assert "data-ui-version=\"p03.original-settings-manage.v1\"" in index
+    assert "data-ui-version=\"p03.original-settings-manage.v3\"" in index
     assert "toyApiUrl" in main
     assert "await t.replace({name:ye.Collection})" in main
 

--- a/tests/persona/test_letter_persona_v2_integration.py
+++ b/tests/persona/test_letter_persona_v2_integration.py
@@ -81,6 +81,26 @@ def test_enabled_v2_uses_persona_assembly_and_separate_user_message() -> None:
     assert "synthetic current letter" not in messages[0]["content"]
 
 
+def test_historical_policy_uses_ready_v2_without_private_world_evidence() -> None:
+    adapter = LetterAdapter(
+        _config(persona_v2_file=str(ROOT / "linli_character" / "persona_release_v2.json")),
+        memory_port=NullMemoryPort(),
+        private_world_port=SnapshotPort(
+            PrivateWorldSnapshot(
+                trust=88,
+                nickname_permissions=("private-nickname",),
+            )
+        ),
+        now=lambda: NOW,
+    )
+
+    policy = adapter.get_persona_policy()
+
+    assert "林离 Olivia" in policy
+    assert "Persona status is DRAFT" not in policy
+    assert "private-nickname" not in policy
+
+
 def test_letter_adapter_uses_explicit_conversation_memory_port() -> None:
     conversation_memory = ExplicitConversationMemory()
     archive_memory = NullMemoryPort()

--- a/tests/persona/test_persona_assembly.py
+++ b/tests/persona/test_persona_assembly.py
@@ -96,6 +96,20 @@ def test_ready_persona_is_assembled_in_fixed_system_then_user_hierarchy() -> Non
     assert messages[0]["content"].index("<mode_constraints") < messages[0][
         "content"
     ].index("<mode_style")
+    assert '"reply_priorities"' in messages[0]["content"]
+    assert "Answer as Linli, not as a service agent or therapist." in messages[0][
+        "content"
+    ]
+    assert "Never invent personal facts, shared history, or relationship facts." in (
+        messages[0]["content"]
+    )
+    assert "Engage one or two concrete details instead of exhaustively recapping." in (
+        messages[0]["content"]
+    )
+    assert "Use restrained natural language without forced uplift or closure." in (
+        messages[0]["content"]
+    )
+    assert "<reply_priorities>" not in messages[0]["content"]
     assert messages[0]["content"].index("<mode_style") < messages[0][
         "content"
     ].index("<public_canon")

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -341,6 +341,44 @@ def test_localized_voice_mismatch_is_warning_without_rewrite(
     assert gateway.call_kinds == ["generation", *("review",) * 5]
 
 
+def test_voice_style_alone_cannot_hard_block_after_the_single_rewrite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_pass = _passing_layer_payloads()
+    first_pass[1] = _layer_score_payload(
+        "voice_style",
+        0,
+        hard_violations=["STYLE_DRIFT"],
+        drift_detected=True,
+    )
+    second_pass = _passing_layer_payloads()
+    second_pass[1] = _layer_score_payload(
+        "voice_style",
+        0,
+        hard_violations=["STYLE_DRIFT"],
+        drift_detected=True,
+    )
+    gateway = SequencedQualityGateway(
+        candidate="A polished but overly generic reply.",
+        reviews=[*first_pass, *second_pass],
+        rewritten="A direct, concrete, restrained reply.",
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(content="I had a difficult day.", request_id="style-only"),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.text == "A direct, concrete, restrained reply."
+    assert result.quality_status == "accepted_with_warnings"
+    assert result.violation_codes == ("STYLE_DRIFT",)
+    assert result.reviewer_calls == 2
+    assert result.rewrite_calls == 1
+
+
 def test_non_voice_layer_mismatch_uses_only_existing_one_rewrite_budget(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/private_world/test_private_world_history_initialization.py
+++ b/tests/private_world/test_private_world_history_initialization.py
@@ -32,6 +32,24 @@ def _command() -> InitializeHistoricalRelationship:
     )
 
 
+def _default_command() -> InitializeHistoricalRelationship:
+    return InitializeHistoricalRelationship(
+        command_id="history.init.default",
+        idempotency_key="history.init.default",
+        actor=PrivateWorldActor.MIGRATION,
+        source=PrivateWorldCommandSource.IMPORT,
+        occurred_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        reason="one-time ordered imported exchanges",
+        evidence_refs=("history.letter.1",),
+        relationship_stage=RelationshipStage.UNKNOWN,
+        familiarity=0,
+        trust=0,
+        comfort=0,
+        closeness=0,
+        tension=0,
+    )
+
+
 def test_historical_relationship_initializes_one_pristine_snapshot() -> None:
     result = reduce_private_world_command(PrivateWorldSnapshot(), _command())
 
@@ -53,6 +71,17 @@ def test_historical_relationship_never_overwrites_an_existing_private_world() ->
     assert result.snapshot == existing
     assert result.delta.applied is False
     assert result.delta.reason_code == "HISTORY_ALREADY_INITIALIZED"
+
+
+def test_default_historical_relationship_still_records_one_initialization() -> None:
+    first = reduce_private_world_command(PrivateWorldSnapshot(), _default_command())
+    second = reduce_private_world_command(first.snapshot, _default_command())
+
+    assert first.delta.applied is True
+    assert first.delta.changes == ()
+    assert first.snapshot == PrivateWorldSnapshot(version=2)
+    assert second.delta.applied is False
+    assert second.delta.reason_code == "HISTORY_ALREADY_INITIALIZED"
 
 
 def test_migration_actor_can_atomically_initialize_once(tmp_path) -> None:

--- a/tests/private_world/test_private_world_history_initialization.py
+++ b/tests/private_world/test_private_world_history_initialization.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from private_world_commands import (
+    InitializeHistoricalRelationship,
+    PrivateWorldActor,
+    PrivateWorldCommandSource,
+)
+from private_world_port import PrivateWorldSnapshot
+from private_world_reducer import reduce_private_world_command
+from private_world_ledger import SQLitePrivateWorldLedger
+from private_world_service import CommandExecutionStatus, PrivateWorldCommandService
+from runtime.reply.reply_context import RelationshipStage
+
+
+def _command() -> InitializeHistoricalRelationship:
+    return InitializeHistoricalRelationship(
+        command_id="history.init.fixture",
+        idempotency_key="history.init.fixture",
+        actor=PrivateWorldActor.MIGRATION,
+        source=PrivateWorldCommandSource.IMPORT,
+        occurred_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        reason="one-time ordered historical import",
+        evidence_refs=("history.letter.1", "history.letter.2"),
+        relationship_stage=RelationshipStage.FAMILIAR,
+        familiarity=48,
+        trust=44,
+        comfort=42,
+        closeness=36,
+        tension=9,
+    )
+
+
+def test_historical_relationship_initializes_one_pristine_snapshot() -> None:
+    result = reduce_private_world_command(PrivateWorldSnapshot(), _command())
+
+    assert result.delta.applied is True
+    assert result.delta.reason_code == "INITIALIZE_HISTORICAL_RELATIONSHIP"
+    assert result.snapshot.relationship_stage == "familiar"
+    assert result.snapshot.familiarity == 48
+    assert result.snapshot.trust == 44
+    assert result.snapshot.comfort == 42
+    assert result.snapshot.closeness == 36
+    assert result.snapshot.tension == 9
+
+
+def test_historical_relationship_never_overwrites_an_existing_private_world() -> None:
+    existing = PrivateWorldSnapshot(version=2, trust=1)
+
+    result = reduce_private_world_command(existing, _command())
+
+    assert result.snapshot == existing
+    assert result.delta.applied is False
+    assert result.delta.reason_code == "HISTORY_ALREADY_INITIALIZED"
+
+
+def test_migration_actor_can_atomically_initialize_once(tmp_path) -> None:
+    service = PrivateWorldCommandService(
+        SQLitePrivateWorldLedger(tmp_path / "private-world.sqlite3")
+    )
+
+    first = service.execute(_command())
+    duplicate = service.execute(_command())
+
+    assert first.status is CommandExecutionStatus.APPLIED
+    assert duplicate.status is CommandExecutionStatus.DUPLICATE

--- a/tests/test_baseline_hardening.py
+++ b/tests/test_baseline_hardening.py
@@ -239,6 +239,26 @@ def test_b00_scanner_allows_pinned_cors_metadata_but_rejects_forwarding(
     ]
 
 
+def test_b00_scanner_allows_the_user_confirmed_official_history_import_module(
+    tmp_path: Path,
+) -> None:
+    import baseline_hardening_scan as scanner
+
+    module = tmp_path / "runtime" / "imports" / "official_letters.py"
+    module.parent.mkdir(parents=True)
+    module.write_text(
+        '"""Read official text replies after explicit user confirmation."""\n'
+        'OFFICIAL_API_BASE = "https://toy-cnbeta01.olivia.miyoushe.com/toy"\n',
+        encoding="utf-8",
+    )
+
+    comment_findings, _, _ = scanner.scan_runtime_comments(tmp_path, [module])
+    dependency_findings, _, _ = scanner.scan_runtime_dependencies(tmp_path, [module])
+
+    assert comment_findings == []
+    assert dependency_findings == []
+
+
 def test_persona_release_scan_allows_contracts_code_and_public_declarations(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## 目标
从官方客户端当前登录态只读导入历史文字来信/回信，并严格按时间顺序写入本地记忆；全部记忆写入成功后，仅一次、幂等地初始化 PrivateWorld 历史关系状态。

## 范围
- 官方文字信件列表/详情只读导入；忽略视频内容
- 稳定 source id、全量预校验、严格顺序、失败即停、可安全重试
- Mem0 成功后一次性 PrivateWorld 历史初始化；已有状态不覆盖
- 本地 HTTP 契约、设置页导入入口、当前邮箱只读展示
- 既有人格装配层内补充回信优先级；纯文风问题最多一次重写后降为警告
- 安装包纳入 runtime/imports

这是一个垂直原子迁移链：拆开会产生“已展示但未记忆”或“记忆已写但关系状态未初始化”的不可验收中间态，因此本 PR 保持同一事务语义与同一 focused 验证集。

## 验证
- focused：136 passed
- packaging focused：1 passed
- git diff --check：PASS
- 私有五折迁移验证：5 用户 / 15 对历史；严格顺序、跨用户隔离、重复导入幂等均通过
- 冷启动失败折经现有产品质量门复测：accepted，外部人格审校 PASS

## 隐私与发布边界
- 不提交私人信件、账号凭据、API key、原版资源、模型权重或生成媒体
- 私有实验报告仅保存在仓库外
- 未宣称所有私有样本都经过完整产品质量门；完整门仅针对暴露出的冷启动失败折复测