### PR TITLE
feat(installer): build offline Windows setup executable

### DIFF
--- a/.github/workflows/windows-setup.yml
+++ b/.github/workflows/windows-setup.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install build dependencies
-        run: python -m pip install jsonschema
+        run: python -m pip install --require-hashes -r installer/setup-build-requirements.txt
 
       - name: Build verified offline core assets
         run: python installer/build_offline_core_assets.py --output offline
@@ -53,6 +53,11 @@ jobs:
           $iscc = Join-Path ${env:ProgramFiles(x86)} 'Inno Setup 6\ISCC.exe'
           if (-not (Test-Path -LiteralPath $iscc -PathType Leaf)) {
             throw 'SETUP_ISCC_NOT_FOUND'
+          }
+          $signature = Get-AuthenticodeSignature -LiteralPath $iscc
+          if (($signature.Status -ne 'Valid') -or
+              ($signature.SignerCertificate.Subject -notlike '*CN=Pyrsys B.V.*')) {
+            throw 'SETUP_ISCC_SIGNATURE_INVALID'
           }
           $version = "0.1.$env:GITHUB_RUN_NUMBER"
           python installer/build_windows_setup.py `

--- a/.github/workflows/windows-setup.yml
+++ b/.github/workflows/windows-setup.yml
@@ -33,6 +33,20 @@ jobs:
         shell: powershell
         run: choco install innosetup --version=6.7.1 --yes --no-progress
 
+      - name: Install verified Simplified Chinese messages
+        shell: powershell
+        run: |
+          $uri = 'https://raw.githubusercontent.com/jrsoftware/issrc/is-6_7_1/Files/Languages/Unofficial/ChineseSimplified.isl'
+          $languageDir = Join-Path ${env:ProgramFiles(x86)} 'Inno Setup 6\Languages'
+          $destination = Join-Path $languageDir 'ChineseSimplified.isl'
+          New-Item -ItemType Directory -Force -Path $languageDir | Out-Null
+          Invoke-WebRequest -Uri $uri -OutFile $destination
+          $expected = '7d544b9bb1d142cfa11f2e5d3cc8abe2e55f8e066c5124e3772675aa236e1278'
+          $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $destination).Hash.ToLowerInvariant()
+          if ($actual -cne $expected) {
+            throw 'SETUP_LANGUAGE_HASH_MISMATCH'
+          }
+
       - name: Build single-file setup
         shell: powershell
         run: |

--- a/.github/workflows/windows-setup.yml
+++ b/.github/workflows/windows-setup.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install pinned Inno Setup compiler
         shell: powershell
-        run: choco install innosetup --version=6.7.3 --yes --no-progress
+        run: choco install innosetup --version=6.7.1 --yes --no-progress
 
       - name: Build single-file setup
         shell: powershell

--- a/.github/workflows/windows-setup.yml
+++ b/.github/workflows/windows-setup.yml
@@ -66,6 +66,14 @@ jobs:
             --version $version `
             --iscc $iscc
 
+      - name: Exercise setup failure boundary
+        shell: powershell
+        run: |
+          $iscc = Join-Path ${env:ProgramFiles(x86)} 'Inno Setup 6\ISCC.exe'
+          & '.\tests\installer\windows_setup_smoke.ps1' `
+            -Iscc $iscc `
+            -SetupScript 'installer/windows_setup.iss'
+
       - name: Verify published checksum
         shell: powershell
         run: |

--- a/.github/workflows/windows-setup.yml
+++ b/.github/workflows/windows-setup.yml
@@ -1,0 +1,67 @@
+name: windows-setup
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build offline Windows setup
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: python -m pip install jsonschema
+
+      - name: Build verified offline core assets
+        run: python installer/build_offline_core_assets.py --output offline
+
+      - name: Install pinned Inno Setup compiler
+        shell: powershell
+        run: choco install innosetup --version=6.7.3 --yes --no-progress
+
+      - name: Build single-file setup
+        shell: powershell
+        run: |
+          $iscc = Join-Path ${env:ProgramFiles(x86)} 'Inno Setup 6\ISCC.exe'
+          if (-not (Test-Path -LiteralPath $iscc -PathType Leaf)) {
+            throw 'SETUP_ISCC_NOT_FOUND'
+          }
+          $version = "0.1.$env:GITHUB_RUN_NUMBER"
+          python installer/build_windows_setup.py `
+            --offline offline `
+            --output dist `
+            --version $version `
+            --iscc $iscc
+
+      - name: Verify published checksum
+        shell: powershell
+        run: |
+          $expected = (Get-Content -LiteralPath 'dist\Olivia-Setup-x64.exe.sha256').Split()[0]
+          $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath 'dist\Olivia-Setup-x64.exe').Hash.ToLowerInvariant()
+          if ($actual -cne $expected) {
+            throw 'SETUP_PUBLISHED_HASH_MISMATCH'
+          }
+
+      - name: Upload Windows setup
+        uses: actions/upload-artifact@v4
+        with:
+          name: Olivia-Windows-Setup-${{ github.sha }}
+          path: |
+            dist/Olivia-Setup-x64.exe
+            dist/Olivia-Setup-x64.exe.sha256
+          if-no-files-found: error
+          retention-days: 14

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,6 +10,8 @@
 | `pytest` | 开发测试 | [pytest-dev/pytest](https://github.com/pytest-dev/pytest) | MIT |
 | `numpy` | 可选开发/媒体测试依赖 | [numpy/numpy](https://github.com/numpy/numpy) | BSD-3-Clause |
 | `opencv-python-headless` | 可选媒体测试依赖 | [opencv/opencv-python](https://github.com/opencv/opencv-python) | Apache-2.0 |
+| Inno Setup 6.7.1 | 仅用于构建 Windows 单文件安装器；编译器本身不进入发布包，生成的 Setup runtime 进入 EXE | [jrsoftware/issrc `is-6_7_1`](https://github.com/jrsoftware/issrc/tree/is-6_7_1) | Inno Setup License；构建时验证 `ISCC.exe` 的有效 Authenticode 签名及发布者 `Pyrsys B.V.` |
+| `ChineseSimplified.isl` | Windows 安装向导简体中文消息，编译后进入 EXE | [Inno Setup `is-6_7_1` 固定标签](https://github.com/jrsoftware/issrc/blob/is-6_7_1/Files/Languages/Unofficial/ChineseSimplified.isl) | 随 Inno Setup 源码发布并适用其许可证；构建锁定 SHA-256 `7d544b9bb1d142cfa11f2e5d3cc8abe2e55f8e066c5124e3772675aa236e1278` |
 
 模型、官方游戏、CosyVoice、LiveTalking、ASR/TTS provider、生成媒体和用户数据不属于公开依赖清单；它们必须由使用者在本机按各自来源和许可证提供，不能因为本项目使用接口或适配器就被重新授权。
 

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -36,7 +36,7 @@ python installer/build_windows_setup.py `
   --iscc 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
 ```
 
-构建器只复制 Git 已跟踪的发布文件，排除 `.github`、`docs` 和 `tests`，并在编译前复验离线 manifest、requirements 哈希、每个资产的大小与 SHA-256，以及实际资产集合。输出为 `Olivia-Setup-x64.exe` 和对应 `.sha256` 文件。
+构建器只复制 Git 已跟踪且相对 `HEAD` 未修改的发布文件，排除 `.github`、`docs`、测试和构建/CI 元数据，并在编译前复验离线 manifest、requirements 哈希、每个资产的大小与 SHA-256，以及实际资产集合。输出为 `Olivia-Setup-x64.exe` 和对应 `.sha256` 文件。
 
 GitHub Actions 会在 PR 和 `main` 更新时生成同样的可下载 artifact。当前产物未做商业代码签名；正式面向普通用户发布前应增加受信任的 Authenticode 签名，但签名不替代随包 SHA-256 校验。
 

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -1,14 +1,16 @@
 # Windows 完整版补丁（隔离安装）
 
-本补丁只复制并修改用户自己的正版 Steam 文件副本，不写入正版目录，也不分发原版游戏、可选模型或媒体。发布包内含固定版本的核心 Python 运行时和依赖，使首次安装不依赖 Python.org、PyPI 或 Hugging Face。安装目标默认是 `%LOCALAPPDATA%\BSideOliviaLocal\install`，用户数据和未来外部缓存保留在同一产品目录的 `data` / `third-party` 下。
+本补丁只复制并修改用户自己的正版 Steam 文件副本，不写入正版目录，也不分发原版游戏、可选模型或媒体。`Olivia-Setup-x64.exe` 内含固定版本的核心 Python 运行时和依赖，使首次安装不依赖 Python.org、PyPI 或 Hugging Face。安装目标默认是 `%LOCALAPPDATA%\BSideOliviaLocal\install`，用户数据和未来外部缓存保留在同一产品目录的 `data` / `third-party` 下。
 
 ## 使用
 
-1. 将发布 ZIP 解压到任意目录。
-2. 双击 `INSTALL.cmd`。它从发布包的 `offline` 目录安装受管的 Python 3.12 runtime 和固定 wheel，不联网下载。安装器从 Steam AppID `4532590` 的 appmanifest 自动发现正版目录。
+1. 下载 `Olivia-Setup-x64.exe` 及同目录的 `.sha256` 文件，并先核对 SHA-256。
+2. 双击 EXE，选择安装位置和正版 Steam 游戏目录。安装器按当前用户运行，不要求管理员权限；它从 EXE 内置的离线资产安装受管 Python 3.12 runtime 和固定 wheel，不联网下载。正版目录可留空并按 Steam AppID `4532590` 自动发现。
 3. 安装成功后双击 `START.cmd`。它只启动一个监听 `127.0.0.1` 的本机服务，再直接启动隔离副本的 `0.0.9.627\Olivia.exe`，并使用安装目录下的独立 profile。长期记忆、PrivateWorld 和媒体接口都挂在同一个进程中。
 4. 首次配置可双击 `CONFIGURE.cmd`：API key 输入不回显，并以当前 Windows 用户 DPAPI 加密保存到 `data\config`；也可选择自己的参考音频/视频导入 `data\third-party\reference`。这些文件不进入补丁包。
 5. 卸载双击 `UNINSTALL.cmd`。受控卸载只删除安装器自己写入的 `app`、`local_backend`、启动脚本和 marker，保留 `data`、`logs`、`third-party`。
+
+兼容旧流程：源码/调试场景仍可解压发布内容后双击 `INSTALL.cmd`。EXE 只是图形化外壳，最终仍调用同一份 `installer/Install.ps1`，不会形成第二套安装逻辑。安装阶段不填写 API key，也不会下载 Mem0、BGE 或其他可选模型。
 
 ## 离线核心资产
 
@@ -21,6 +23,22 @@ python installer/build_offline_core_assets.py --output offline
 ```
 
 构建器只接受哈希锁定的二进制 wheel；pip 源仍兼容标准 `PIP_INDEX_URL` / pip 配置，因此发布构建可使用可信镜像，最终产物仍按仓库固定 SHA-256 验证。公开清单契约见 `contracts/offline_core_assets.schema.json` 和 `contracts/offline_core_assets.example.json`。
+
+## 构建单文件安装器
+
+构建机需要 Python 3.12、`jsonschema` 和 Inno Setup 6.7.3。先生成离线核心资产，再执行：
+
+```powershell
+python installer/build_windows_setup.py `
+  --offline offline `
+  --output dist `
+  --version 0.1.0 `
+  --iscc 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
+```
+
+构建器只复制 Git 已跟踪的发布文件，排除 `.github`、`docs` 和 `tests`，并在编译前复验离线 manifest、requirements 哈希、每个资产的大小与 SHA-256，以及实际资产集合。输出为 `Olivia-Setup-x64.exe` 和对应 `.sha256` 文件。
+
+GitHub Actions 会在 PR 和 `main` 更新时生成同样的可下载 artifact。当前产物未做商业代码签名；正式面向普通用户发布前应增加受信任的 Authenticode 签名，但签名不替代随包 SHA-256 校验。
 
 ## 启动器健康检查
 

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -26,7 +26,7 @@ python installer/build_offline_core_assets.py --output offline
 
 ## 构建单文件安装器
 
-构建机需要 Python 3.12、`jsonschema` 和 Inno Setup 6.7.3。先生成离线核心资产，再执行：
+构建机需要 Python 3.12、`jsonschema` 和 Inno Setup 6.7.1 或兼容的新版本。先生成离线核心资产，再执行：
 
 ```powershell
 python installer/build_windows_setup.py `

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -4,6 +4,7 @@ param(
     [string]$Destination = (Join-Path $env:LOCALAPPDATA 'BSideOliviaLocal\install'),
     [string]$OfficialRoot = '',
     [string]$OfflineAssetsRoot = '',
+    [switch]$NonInteractive,
     [switch]$SkipShortcut,
     [ValidateRange(1, 65535)]
     [int]$Port = 8899
@@ -384,7 +385,7 @@ $runner = @{ File = $runtimeExe; Args = @() }
 
 $arguments = @('install', '--payload', $PayloadRoot, '--destination', $Destination, '--manifest', (Join-Path $PayloadRoot 'installer\full-patch-manifest.json'), '--port', $Port)
 $selectedOfficial = $OfficialRoot
-if (-not $selectedOfficial) {
+if (-not $selectedOfficial -and -not $NonInteractive) {
     $selectedOfficial = Read-Host 'Steam 游戏目录（留空则按 AppID 自动发现）'
 }
 if ($selectedOfficial) { $arguments += @('--official-root', $selectedOfficial) }

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -4,6 +4,7 @@ param(
     [string]$Destination = (Join-Path $env:LOCALAPPDATA 'BSideOliviaLocal\install'),
     [string]$OfficialRoot = '',
     [string]$OfflineAssetsRoot = '',
+    [string]$SetupResultPath = '',
     [switch]$NonInteractive,
     [switch]$SkipShortcut,
     [ValidateRange(1, 65535)]
@@ -17,6 +18,40 @@ $runtimeExe = Join-Path $runtimeRoot 'python.exe'
 $offlineRoot = if ($OfflineAssetsRoot) { $OfflineAssetsRoot } else { Join-Path $PayloadRoot 'offline' }
 $offlineManifestPath = if ($OfflineAssetsRoot) { Join-Path $OfflineAssetsRoot 'offline-core-assets.json' } else { Join-Path $PayloadRoot 'offline\offline-core-assets.json' }
 $requirements = Join-Path $PayloadRoot 'installer\runtime-requirements.txt'
+
+function Get-SafeSetupErrorCode {
+    param([string]$Code)
+
+    if ($Code -cmatch '^[A-Z][A-Z0-9_]{3,95}$') {
+        $Code
+    } else {
+        'SETUP_INSTALL_FAILED'
+    }
+}
+
+function Write-SetupErrorResult {
+    param([string]$Code)
+
+    if (-not $SetupResultPath) { return }
+    $safeCode = Get-SafeSetupErrorCode -Code $Code
+    try {
+        $utf8NoBom = [Text.UTF8Encoding]::new($false)
+        [IO.File]::WriteAllText(
+            $SetupResultPath,
+            ('OLIVIA_SETUP_ERROR=' + $safeCode),
+            $utf8NoBom
+        )
+    } catch {
+        # The installer still receives the non-zero process code.
+    }
+}
+
+trap {
+    $safeCode = Get-SafeSetupErrorCode -Code ([string]$_.Exception.Message)
+    Write-SetupErrorResult -Code $safeCode
+    if (-not $SetupResultPath) { Write-Output $safeCode }
+    exit 2
+}
 
 function Get-Sha256 {
     param(
@@ -392,9 +427,29 @@ if ($selectedOfficial) { $arguments += @('--official-root', $selectedOfficial) }
 $oldPythonPath = if ($env:PYTHONPATH) { $env:PYTHONPATH } else { '' }
 $env:PYTHONPATH = $PayloadRoot + [IO.Path]::PathSeparator + $oldPythonPath
 $bootstrap = Join-Path $PayloadRoot 'installer\bootstrap_install.py'
-& $runner.File @($runner.Args + @($bootstrap, $PayloadRoot) + $arguments)
+$installOutput = @(& $runner.File @($runner.Args + @($bootstrap, $PayloadRoot) + $arguments))
 $installExitCode = $LASTEXITCODE
-if ($installExitCode -ne 0) { exit $installExitCode }
+if ($installExitCode -ne 0) {
+    $installCode = 'SETUP_INSTALL_FAILED'
+    foreach ($line in $installOutput) {
+        try {
+            $record = $line | ConvertFrom-Json
+            if (
+                $record.status -eq 'ERROR' -and
+                $record.code -is [string] -and
+                $record.code -cmatch '^[A-Z][A-Z0-9_]{3,95}$'
+            ) {
+                $installCode = $record.code
+            }
+        } catch {
+            # Ignore non-JSON child output; it must never reach the setup log.
+        }
+    }
+    Write-SetupErrorResult -Code $installCode
+    if (-not $SetupResultPath) { $installOutput | Write-Output }
+    exit $installExitCode
+}
+if (-not $SetupResultPath) { $installOutput | Write-Output }
 
 $LASTEXITCODE = 0
 

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -17,6 +17,16 @@ from pathlib import Path, PurePosixPath
 MANIFEST_NAME = "offline-core-assets.json"
 SETUP_NAME = "Olivia-Setup-x64.exe"
 EXCLUDED_PREFIXES = (".github/", "docs/", "tests/")
+EXCLUDED_RELEASE_FILES = {
+    "pyproject.toml",
+    "pytest.ini",
+    "requirements-ci.txt",
+    "requirements-dev.txt",
+    "requirements.txt",
+    "installer/build_windows_setup.py",
+    "installer/setup-build-requirements.txt",
+    "installer/windows_setup.iss",
+}
 REQUIRED_PAYLOAD_FILES = {
     "installer/Install.ps1",
     "installer/runtime-requirements.txt",
@@ -57,6 +67,43 @@ def _git_tracked_files(source: Path) -> set[str]:
         for item in result.stdout.split(b"\0")
         if item
     }
+
+
+def _git_dirty_files(source: Path) -> set[str]:
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                os.fspath(source),
+                "diff",
+                "--name-only",
+                "-z",
+                "HEAD",
+                "--",
+            ],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise SetupBuildError("SETUP_GIT_DIFF_FAILED") from exc
+    return {
+        item.decode("utf-8").replace("\\", "/")
+        for item in result.stdout.split(b"\0")
+        if item
+    }
+
+
+def _is_release_file(relative: str) -> bool:
+    if relative.startswith(EXCLUDED_PREFIXES) or relative in EXCLUDED_RELEASE_FILES:
+        return False
+    path = PurePosixPath(relative)
+    return not (
+        len(path.parts) == 1
+        and path.name.startswith("test_")
+        and path.suffix.lower() == ".py"
+    )
 
 
 def _safe_file(root: Path, relative: str) -> Path:
@@ -174,11 +221,9 @@ def prepare_setup_payload(
     tracked = _git_tracked_files(source)
     if not REQUIRED_PAYLOAD_FILES.issubset(tracked):
         raise SetupBuildError("SETUP_REQUIRED_PAYLOAD_MISSING")
-    selected = sorted(
-        relative
-        for relative in tracked
-        if not relative.startswith(EXCLUDED_PREFIXES)
-    )
+    selected = sorted(relative for relative in tracked if _is_release_file(relative))
+    if set(selected) & _git_dirty_files(source):
+        raise SetupBuildError("SETUP_SOURCE_DIRTY")
     staging = destination.parent / f".{destination.name}.staging-{uuid.uuid4().hex}"
     try:
         staging.mkdir(parents=True)

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -16,16 +16,120 @@ from pathlib import Path, PurePosixPath
 
 MANIFEST_NAME = "offline-core-assets.json"
 SETUP_NAME = "Olivia-Setup-x64.exe"
-EXCLUDED_PREFIXES = (".github/", "docs/", "tests/")
-EXCLUDED_RELEASE_FILES = {
-    "pyproject.toml",
-    "pytest.ini",
-    "requirements-ci.txt",
-    "requirements-dev.txt",
-    "requirements.txt",
+BUILD_CONTROL_FILES = {
     "installer/build_windows_setup.py",
     "installer/setup-build-requirements.txt",
     "installer/windows_setup.iss",
+}
+RELEASE_PREFIXES = (
+    "asr/",
+    "control_center/",
+    "contracts/",
+    "linli_character/",
+    "live/",
+    "media_state/",
+    "runtime/",
+    "tts/",
+    "visual_driver/",
+)
+RELEASE_ROOT_FILES = {
+    "LICENSE",
+    "NOTICE",
+    "README.md",
+    "THIRD_PARTY_NOTICES.md",
+    "companion_memory_context.py",
+    "conversation_memory_admin.py",
+    "conversation_memory_delivery.py",
+    "conversation_memory_outbox.py",
+    "conversation_memory_port.py",
+    "conversation_memory_runtime.py",
+    "http_contract.py",
+    "latentsync_reply.py",
+    "letter_status.py",
+    "letter_triage.py",
+    "llm_config.example.json",
+    "llm_gateway.py",
+    "local_memory.py",
+    "local_server.py",
+    "mem0_embedding_install.py",
+    "mem0_memory.py",
+    "memory.py",
+    "memory_isolation_case01.py",
+    "memory_port.py",
+    "memory_prompt.py",
+    "music_reply.py",
+    "original_client_companion_api.py",
+    "original_client_companion_backend.py",
+    "original_client_companion_mutation_api.py",
+    "original_client_companion_mutation_backend.py",
+    "original_client_letter_contract.py",
+    "original_client_media_http.py",
+    "original_client_server.py",
+    "original_client_settings_ui.py",
+    "patch_companion_settings.py",
+    "patch_feapp.py",
+    "patch_webplayer.py",
+    "persona_assembly.py",
+    "persona_loader.py",
+    "persona_provider.py",
+    "private_world_admin.py",
+    "private_world_candidate.py",
+    "private_world_candidates.py",
+    "private_world_commands.py",
+    "private_world_ledger.py",
+    "private_world_port.py",
+    "private_world_reducer.py",
+    "private_world_service.py",
+    "reply_context.py",
+    "reply_delivery.py",
+    "reply_media.py",
+    "reply_model_quality.py",
+    "reply_orchestrator.py",
+    "reply_pipeline.py",
+    "reply_reviewer.py",
+    "song_content.py",
+    "version.json",
+    "video_reply_settings.py",
+    "voice_direction.py",
+}
+RELEASE_INSTALLER_FILES = {
+    "installer/__init__.py",
+    "installer/__main__.py",
+    "installer/bootstrap_install.py",
+    "installer/component_update.py",
+    "installer/configure.py",
+    "installer/Create-Shortcut.ps1",
+    "installer/full_patch.py",
+    "installer/full-patch-manifest.json",
+    "installer/Install.ps1",
+    "installer/mem0-runtime-requirements.txt",
+    "installer/provision_mem0_embedding.py",
+    "installer/runtime-requirements.txt",
+    "installer/start_local.py",
+    "installer/uninstall.py",
+    "installer/uninstall_safety.py",
+    "installer/verify_mem0_runtime.py",
+    "installer/version_launcher.py",
+}
+RELEASE_TOOL_FILES = {
+    "tools/asr_healthcheck.py",
+    "tools/asr_manage.py",
+    "tools/asset_manifest.py",
+    "tools/b05_native_http_snapshot.patch",
+    "tools/B10A_cli.py",
+    "tools/B10B_cli.py",
+    "tools/download_third_party.py",
+    "tools/healthcheck.py",
+    "tools/Install-ThirdParty.ps1",
+    "tools/live_b10b.py",
+    "tools/live_healthcheck.py",
+    "tools/livetalking_runtime.py",
+    "tools/livetalking_worker.py",
+    "tools/memory_import.py",
+    "tools/minimax_music3_worker.py",
+    "tools/minimax_profile.py",
+    "tools/music_renderer.py",
+    "tools/tts_cli.py",
 }
 REQUIRED_PAYLOAD_FILES = {
     "installer/Install.ps1",
@@ -96,13 +200,11 @@ def _git_dirty_files(source: Path) -> set[str]:
 
 
 def _is_release_file(relative: str) -> bool:
-    if relative.startswith(EXCLUDED_PREFIXES) or relative in EXCLUDED_RELEASE_FILES:
-        return False
-    path = PurePosixPath(relative)
-    return not (
-        len(path.parts) == 1
-        and path.name.startswith("test_")
-        and path.suffix.lower() == ".py"
+    return (
+        relative in RELEASE_ROOT_FILES
+        or relative in RELEASE_INSTALLER_FILES
+        or relative in RELEASE_TOOL_FILES
+        or relative.startswith(RELEASE_PREFIXES)
     )
 
 
@@ -222,7 +324,10 @@ def prepare_setup_payload(
     if not REQUIRED_PAYLOAD_FILES.issubset(tracked):
         raise SetupBuildError("SETUP_REQUIRED_PAYLOAD_MISSING")
     selected = sorted(relative for relative in tracked if _is_release_file(relative))
-    if set(selected) & _git_dirty_files(source):
+    build_inputs = set(selected) | BUILD_CONTROL_FILES
+    if not build_inputs.issubset(tracked):
+        raise SetupBuildError("SETUP_REQUIRED_PAYLOAD_MISSING")
+    if build_inputs & _git_dirty_files(source):
         raise SetupBuildError("SETUP_SOURCE_DIRTY")
     staging = destination.parent / f".{destination.name}.staging-{uuid.uuid4().hex}"
     try:

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -1,0 +1,289 @@
+"""Build the single-file Windows setup wrapper from verified offline inputs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import uuid
+from pathlib import Path, PurePosixPath
+
+
+MANIFEST_NAME = "offline-core-assets.json"
+SETUP_NAME = "Olivia-Setup-x64.exe"
+EXCLUDED_PREFIXES = (".github/", "docs/", "tests/")
+REQUIRED_PAYLOAD_FILES = {
+    "installer/Install.ps1",
+    "installer/runtime-requirements.txt",
+}
+
+
+class SetupBuildError(RuntimeError):
+    """Stable setup-build failure code."""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _is_reparse_point(path: Path) -> bool:
+    attributes = getattr(path.stat(follow_symlinks=False), "st_file_attributes", 0)
+    return path.is_symlink() or bool(
+        attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    )
+
+
+def _git_tracked_files(source: Path) -> set[str]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", os.fspath(source), "ls-files", "-z"],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise SetupBuildError("SETUP_GIT_LIST_FAILED") from exc
+    return {
+        item.decode("utf-8").replace("\\", "/")
+        for item in result.stdout.split(b"\0")
+        if item
+    }
+
+
+def _safe_file(root: Path, relative: str) -> Path:
+    logical = PurePosixPath(relative)
+    if (
+        not relative
+        or "\\" in relative
+        or logical.is_absolute()
+        or any(part in {"", ".", ".."} for part in logical.parts)
+    ):
+        raise SetupBuildError("SETUP_OFFLINE_ASSET_PATH_INVALID")
+    candidate = root.joinpath(*logical.parts)
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise SetupBuildError("SETUP_OFFLINE_ASSET_PATH_INVALID") from exc
+    current = root
+    for part in logical.parts:
+        current = current / part
+        if current.exists() and _is_reparse_point(current):
+            raise SetupBuildError("SETUP_PATH_REPARSE_POINT")
+    if not candidate.is_file():
+        raise SetupBuildError("SETUP_OFFLINE_ASSET_MISSING")
+    return candidate
+
+
+def _load_and_verify_manifest(
+    source: Path,
+    offline: Path,
+    *,
+    validate_schema: bool,
+) -> dict[str, object]:
+    manifest_path = offline / MANIFEST_NAME
+    if not manifest_path.is_file() or _is_reparse_point(manifest_path):
+        raise SetupBuildError("SETUP_OFFLINE_MANIFEST_MISSING")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise SetupBuildError("SETUP_OFFLINE_MANIFEST_INVALID") from exc
+    if not isinstance(manifest, dict):
+        raise SetupBuildError("SETUP_OFFLINE_MANIFEST_INVALID")
+
+    if validate_schema:
+        try:
+            import jsonschema
+        except ImportError as exc:
+            raise SetupBuildError("SETUP_SCHEMA_VALIDATOR_MISSING") from exc
+        try:
+            schema = json.loads(
+                (source / "contracts" / "offline_core_assets.schema.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            jsonschema.validate(manifest, schema)
+        except (OSError, UnicodeError, json.JSONDecodeError, jsonschema.ValidationError) as exc:
+            raise SetupBuildError("SETUP_OFFLINE_MANIFEST_INVALID") from exc
+
+    requirements = source / "installer" / "runtime-requirements.txt"
+    if not requirements.is_file() or _is_reparse_point(requirements):
+        raise SetupBuildError("SETUP_REQUIREMENTS_MISSING")
+    if manifest.get("requirements_sha256") != _sha256(requirements):
+        raise SetupBuildError("SETUP_REQUIREMENTS_HASH_MISMATCH")
+
+    entries: list[object] = [manifest.get("python_runtime"), manifest.get("pip_bootstrap")]
+    wheels = manifest.get("wheels")
+    if not isinstance(wheels, list):
+        raise SetupBuildError("SETUP_OFFLINE_MANIFEST_INVALID")
+    entries.extend(wheels)
+    declared_paths: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise SetupBuildError("SETUP_OFFLINE_MANIFEST_INVALID")
+        relative = entry.get("path")
+        size = entry.get("size_bytes")
+        digest = entry.get("sha256")
+        if (
+            not isinstance(relative, str)
+            or type(size) is not int
+            or size < 1
+            or not isinstance(digest, str)
+            or len(digest) != 64
+            or relative in declared_paths
+        ):
+            raise SetupBuildError("SETUP_OFFLINE_MANIFEST_INVALID")
+        asset = _safe_file(offline, relative)
+        if asset.stat().st_size != size or _sha256(asset) != digest:
+            raise SetupBuildError("SETUP_OFFLINE_ASSET_HASH_MISMATCH")
+        declared_paths.add(relative)
+
+    actual_paths = {
+        path.relative_to(offline).as_posix()
+        for path in offline.rglob("*")
+        if path.is_file()
+    }
+    if any(_is_reparse_point(path) for path in offline.rglob("*")):
+        raise SetupBuildError("SETUP_PATH_REPARSE_POINT")
+    if actual_paths != declared_paths | {MANIFEST_NAME}:
+        raise SetupBuildError("SETUP_OFFLINE_ASSET_SET_MISMATCH")
+    return manifest
+
+
+def prepare_setup_payload(
+    source: Path,
+    offline: Path,
+    destination: Path,
+    *,
+    validate_schema: bool = True,
+) -> None:
+    source = source.expanduser().resolve()
+    offline = offline.expanduser().resolve()
+    destination = destination.expanduser().resolve()
+    if destination.exists():
+        raise SetupBuildError("SETUP_PAYLOAD_EXISTS")
+    _load_and_verify_manifest(source, offline, validate_schema=validate_schema)
+    tracked = _git_tracked_files(source)
+    if not REQUIRED_PAYLOAD_FILES.issubset(tracked):
+        raise SetupBuildError("SETUP_REQUIRED_PAYLOAD_MISSING")
+    selected = sorted(
+        relative
+        for relative in tracked
+        if not relative.startswith(EXCLUDED_PREFIXES)
+    )
+    staging = destination.parent / f".{destination.name}.staging-{uuid.uuid4().hex}"
+    try:
+        staging.mkdir(parents=True)
+        for relative in selected:
+            source_path = _safe_file(source, relative)
+            target = staging.joinpath(*PurePosixPath(relative).parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_path, target)
+        shutil.copytree(offline, staging / "offline")
+        os.replace(staging, destination)
+    except SetupBuildError:
+        raise
+    except OSError as exc:
+        raise SetupBuildError("SETUP_PAYLOAD_BUILD_FAILED") from exc
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _find_iscc(explicit: Path | None) -> Path:
+    candidates: list[Path] = []
+    if explicit is not None:
+        candidates.append(explicit.expanduser())
+    located = shutil.which("ISCC.exe")
+    if located:
+        candidates.append(Path(located))
+    for environment_name in ("LOCALAPPDATA", "ProgramFiles(x86)", "ProgramFiles"):
+        base = os.environ.get(environment_name)
+        if not base:
+            continue
+        for version in ("7", "6"):
+            candidates.append(Path(base) / f"Inno Setup {version}" / "ISCC.exe")
+            candidates.append(Path(base) / "Programs" / f"Inno Setup {version}" / "ISCC.exe")
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+    raise SetupBuildError("SETUP_ISCC_NOT_FOUND")
+
+
+def build_windows_setup(
+    source: Path,
+    offline: Path,
+    output: Path,
+    *,
+    version: str,
+    iscc: Path | None = None,
+) -> dict[str, object]:
+    source = source.expanduser().resolve()
+    output = output.expanduser().resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    setup = output / SETUP_NAME
+    checksum = output / f"{SETUP_NAME}.sha256"
+    if setup.exists() or checksum.exists():
+        raise SetupBuildError("SETUP_OUTPUT_EXISTS")
+    payload = output / f".setup-payload-{uuid.uuid4().hex}"
+    compiler = _find_iscc(iscc)
+    try:
+        prepare_setup_payload(source, offline, payload)
+        command = [
+            os.fspath(compiler),
+            f"/DPayloadRoot={payload}",
+            f"/DOutputDir={output}",
+            f"/DAppVersion={version}",
+            os.fspath(source / "installer" / "windows_setup.iss"),
+        ]
+        result = subprocess.run(command, check=False, timeout=900)
+        if result.returncode != 0 or not setup.is_file():
+            raise SetupBuildError("SETUP_COMPILE_FAILED")
+        digest = _sha256(setup)
+        checksum.write_text(f"{digest}  {SETUP_NAME}\n", encoding="ascii")
+        return {
+            "status": "OK",
+            "setup": os.fspath(setup),
+            "size_bytes": setup.stat().st_size,
+            "sha256": digest,
+        }
+    except SetupBuildError:
+        raise
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise SetupBuildError("SETUP_BUILD_FAILED") from exc
+    finally:
+        shutil.rmtree(payload, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="build-windows-setup")
+    parser.add_argument("--source", type=Path, default=Path(__file__).parents[1])
+    parser.add_argument("--offline", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--iscc", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        result = build_windows_setup(
+            args.source,
+            args.offline,
+            args.output,
+            version=args.version,
+            iscc=args.iscc,
+        )
+        print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+        return 0
+    except SetupBuildError as exc:
+        print(json.dumps({"status": "ERROR", "code": str(exc)}, sort_keys=True))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/installer/setup-build-requirements.txt
+++ b/installer/setup-build-requirements.txt
@@ -1,0 +1,7 @@
+# Exact Python 3.12 build-time schema-validation closure.
+attrs==26.1.0 --hash=sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309
+jsonschema==4.26.0 --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
+jsonschema-specifications==2025.9.1 --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe
+referencing==0.37.0 --hash=sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231
+rpds-py==2026.6.3 --hash=sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f
+typing_extensions==4.16.0 --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8

--- a/installer/windows_setup.iss
+++ b/installer/windows_setup.iss
@@ -1,0 +1,107 @@
+#ifndef PayloadRoot
+  #error PayloadRoot is required
+#endif
+#ifndef OutputDir
+  #error OutputDir is required
+#endif
+#ifndef AppVersion
+  #error AppVersion is required
+#endif
+
+[Setup]
+AppId={{E7B6A4B1-2AC0-4B1E-85DA-E17E66D6EF0A}
+AppName=Olivia 本地版
+AppVersion={#AppVersion}
+AppPublisher=BSide Olivia Community
+DefaultDirName={localappdata}\BSideOliviaLocal\install
+CreateAppDir=no
+Uninstallable=no
+PrivilegesRequired=lowest
+ArchitecturesAllowed=x64compatible
+OutputDir={#OutputDir}
+OutputBaseFilename=Olivia-Setup-x64
+Compression=lzma2/max
+SolidCompression=yes
+WizardStyle=modern
+LicenseFile={#PayloadRoot}\LICENSE
+DisableProgramGroupPage=yes
+SetupLogging=yes
+
+[Languages]
+Name: "chinesesimp"; MessagesFile: "compiler:Languages\ChineseSimplified.isl"
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Files]
+Source: "{#PayloadRoot}\*"; DestDir: "{tmp}\OliviaPayload"; Flags: recursesubdirs createallsubdirs deleteafterinstall ignoreversion
+
+[Code]
+var
+  InstallDirPage: TInputDirWizardPage;
+  OfficialDirPage: TInputDirWizardPage;
+
+procedure InitializeWizard;
+begin
+  InstallDirPage := CreateInputDirPage(
+    wpSelectDir,
+    '选择安装位置',
+    'Olivia 本地版将安装到当前 Windows 用户目录。',
+    '建议保留默认位置；升级补丁会继续使用这里的受管安装。',
+    False,
+    ''
+  );
+  InstallDirPage.Add('安装位置：');
+  InstallDirPage.Values[0] := ExpandConstant(
+    '{param:InstallRoot|{localappdata}\BSideOliviaLocal\install}'
+  );
+
+  OfficialDirPage := CreateInputDirPage(
+    InstallDirPage.ID,
+    '选择正版游戏目录',
+    '可选择 Steam 中 Olivia 的正版安装目录。',
+    '留空时安装器会按 Steam AppID 自动发现；不会写入正版目录。',
+    False,
+    ''
+  );
+  OfficialDirPage.Add('正版游戏目录（可留空）：');
+  OfficialDirPage.Values[0] := ExpandConstant('{param:OfficialRoot|}');
+end;
+
+function GetInstallRoot(Param: String): String;
+begin
+  Result := InstallDirPage.Values[0];
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  Result := True;
+  if (CurPageID = InstallDirPage.ID) and (Trim(InstallDirPage.Values[0]) = '') then
+  begin
+    MsgBox('请选择安装位置。', mbError, MB_OK);
+    Result := False;
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  PowerShell: String;
+  Params: String;
+  ExitCode: Integer;
+begin
+  if CurStep <> ssPostInstall then
+    Exit;
+
+  WizardForm.StatusLabel.Caption := '正在校验并安装离线核心组件…';
+  PowerShell := ExpandConstant('{sysnative}\WindowsPowerShell\v1.0\powershell.exe');
+  Params := '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File ' +
+    AddQuotes(ExpandConstant('{tmp}\OliviaPayload\installer\Install.ps1')) +
+    ' -PayloadRoot ' + AddQuotes(ExpandConstant('{tmp}\OliviaPayload')) +
+    ' -Destination ' + AddQuotes(InstallDirPage.Values[0]) +
+    ' -OfflineAssetsRoot ' + AddQuotes(ExpandConstant('{tmp}\OliviaPayload\offline')) +
+    ' -NonInteractive';
+  if Trim(OfficialDirPage.Values[0]) <> '' then
+    Params := Params + ' -OfficialRoot ' + AddQuotes(OfficialDirPage.Values[0]);
+
+  if (not Exec(PowerShell, Params, '', SW_HIDE, ewWaitUntilTerminated, ExitCode)) or
+     (ExitCode <> 0) then
+    RaiseException(Format('安装失败（错误码 %d）。请保留安装日志后重试。', [ExitCode]));
+end;

--- a/installer/windows_setup.iss
+++ b/installer/windows_setup.iss
@@ -40,12 +40,7 @@ var
   OfficialDirPage: TInputQueryWizardPage;
   OfficialBrowseButton: TNewButton;
   StableInstallCode: String;
-
-function IsCodeChar(const Value: Char): Boolean;
-begin
-  Result := ((Value >= 'A') and (Value <= 'Z')) or
-    ((Value >= '0') and (Value <= '9')) or (Value = '_');
-end;
+  SetupResultPath: String;
 
 procedure OfficialBrowseButtonClick(Sender: TObject);
 var
@@ -56,48 +51,38 @@ begin
     OfficialDirPage.Values[0] := Selected;
 end;
 
-function IsStableCodeCandidate(const Value: String): Boolean;
+function IsStableErrorCode(const Value: String): Boolean;
 var
   Index: Integer;
 begin
   Result := (Length(Value) >= 4) and (Length(Value) <= 96) and
-    (Pos('_', Value) > 0);
+    (Value[1] >= 'A') and (Value[1] <= 'Z') and (Pos('_', Value) > 0);
   if not Result then
     Exit;
   for Index := 1 to Length(Value) do
-    if not IsCodeChar(Value[Index]) then
+    if not (((Value[Index] >= 'A') and (Value[Index] <= 'Z')) or
+      ((Value[Index] >= '0') and (Value[Index] <= '9')) or
+      (Value[Index] = '_')) then
     begin
       Result := False;
       Exit;
     end;
 end;
 
-procedure CaptureStableInstallCode(
-  const S: String;
-  const Error, FirstLine: Boolean
-);
+function LoadStableInstallCode(const ResultPath: String): String;
 var
-  Index: Integer;
-  StartIndex: Integer;
+  Content: AnsiString;
+  Prefix: String;
   Candidate: String;
 begin
-  Index := 1;
-  while Index <= Length(S) do
+  Result := '';
+  Prefix := 'OLIVIA_SETUP_ERROR=';
+  if LoadStringFromFile(ResultPath, Content) then
   begin
-    while (Index <= Length(S)) and (not IsCodeChar(S[Index])) do
-      Index := Index + 1;
-    StartIndex := Index;
-    while (Index <= Length(S)) and IsCodeChar(S[Index]) do
-      Index := Index + 1;
-    if Index > StartIndex then
-    begin
-      Candidate := Copy(S, StartIndex, Index - StartIndex);
-      if IsStableCodeCandidate(Candidate) then
-      begin
-        StableInstallCode := Candidate;
-        Log('Olivia installer code: ' + StableInstallCode);
-      end;
-    end;
+    Candidate := Copy(String(Content), Length(Prefix) + 1, MaxInt);
+    if (Copy(String(Content), 1, Length(Prefix)) = Prefix) and
+      IsStableErrorCode(Candidate) then
+      Result := Candidate;
   end;
 end;
 
@@ -161,6 +146,8 @@ var
 begin
   Result := '';
   StableInstallCode := '';
+  SetupResultPath := ExpandConstant('{tmp}\olivia-setup-result.txt');
+  DeleteFile(SetupResultPath);
   ExitCode := -1;
   try
     ExtractTemporaryFiles('{tmp}\OliviaPayload\*');
@@ -178,21 +165,25 @@ begin
     ' -PayloadRoot ' + AddQuotes(ExpandConstant('{tmp}\OliviaPayload')) +
     ' -Destination ' + AddQuotes(InstallDirPage.Values[0]) +
     ' -OfflineAssetsRoot ' + AddQuotes(ExpandConstant('{tmp}\OliviaPayload\offline')) +
+    ' -SetupResultPath ' + AddQuotes(SetupResultPath) +
     ' -NonInteractive';
   if Trim(OfficialDirPage.Values[0]) <> '' then
     Params := Params + ' -OfficialRoot ' + AddQuotes(OfficialDirPage.Values[0]);
 
-  if (not ExecAndLogOutput(
+  if (not Exec(
        PowerShell,
        Params,
        '',
        SW_HIDE,
        ewWaitUntilTerminated,
-       ExitCode,
-       @CaptureStableInstallCode
+       ExitCode
      )) or
      (ExitCode <> 0) then
   begin
+    StableInstallCode := LoadStableInstallCode(SetupResultPath);
+    if StableInstallCode = '' then
+      StableInstallCode := 'SETUP_INSTALL_FAILED';
+    Log('Olivia installer code: ' + StableInstallCode);
     if StableInstallCode <> '' then
       Result := '安装失败：' + StableInstallCode + '。请保留安装日志后重试。'
     else

--- a/installer/windows_setup.iss
+++ b/installer/windows_setup.iss
@@ -32,12 +32,74 @@ Name: "chinesesimp"; MessagesFile: "compiler:Languages\ChineseSimplified.isl"
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
-Source: "{#PayloadRoot}\*"; DestDir: "{tmp}\OliviaPayload"; Flags: recursesubdirs createallsubdirs deleteafterinstall ignoreversion
+Source: "{#PayloadRoot}\*"; DestDir: "{tmp}\OliviaPayload"; Flags: recursesubdirs createallsubdirs dontcopy noencryption ignoreversion
 
 [Code]
 var
   InstallDirPage: TInputDirWizardPage;
-  OfficialDirPage: TInputDirWizardPage;
+  OfficialDirPage: TInputQueryWizardPage;
+  OfficialBrowseButton: TNewButton;
+  StableInstallCode: String;
+
+function IsCodeChar(const Value: Char): Boolean;
+begin
+  Result := ((Value >= 'A') and (Value <= 'Z')) or
+    ((Value >= '0') and (Value <= '9')) or (Value = '_');
+end;
+
+procedure OfficialBrowseButtonClick(Sender: TObject);
+var
+  Selected: String;
+begin
+  Selected := OfficialDirPage.Values[0];
+  if BrowseForFolder('选择正版 Steam 游戏目录', Selected, False) then
+    OfficialDirPage.Values[0] := Selected;
+end;
+
+function IsStableCodeCandidate(const Value: String): Boolean;
+var
+  Index: Integer;
+begin
+  Result := (Length(Value) >= 4) and (Length(Value) <= 96) and
+    (Pos('_', Value) > 0);
+  if not Result then
+    Exit;
+  for Index := 1 to Length(Value) do
+    if not IsCodeChar(Value[Index]) then
+    begin
+      Result := False;
+      Exit;
+    end;
+end;
+
+procedure CaptureStableInstallCode(
+  const S: String;
+  const Error, FirstLine: Boolean
+);
+var
+  Index: Integer;
+  StartIndex: Integer;
+  Candidate: String;
+begin
+  Index := 1;
+  while Index <= Length(S) do
+  begin
+    while (Index <= Length(S)) and (not IsCodeChar(S[Index])) do
+      Index := Index + 1;
+    StartIndex := Index;
+    while (Index <= Length(S)) and IsCodeChar(S[Index]) do
+      Index := Index + 1;
+    if Index > StartIndex then
+    begin
+      Candidate := Copy(S, StartIndex, Index - StartIndex);
+      if IsStableCodeCandidate(Candidate) then
+      begin
+        StableInstallCode := Candidate;
+        Log('Olivia installer code: ' + StableInstallCode);
+      end;
+    end;
+  end;
+end;
 
 procedure InitializeWizard;
 begin
@@ -54,16 +116,26 @@ begin
     '{param:InstallRoot|{localappdata}\BSideOliviaLocal\install}'
   );
 
-  OfficialDirPage := CreateInputDirPage(
+  OfficialDirPage := CreateInputQueryPage(
     InstallDirPage.ID,
     '选择正版游戏目录',
     '可选择 Steam 中 Olivia 的正版安装目录。',
-    '留空时安装器会按 Steam AppID 自动发现；不会写入正版目录。',
-    False,
-    ''
+    '留空时安装器会按 Steam AppID 自动发现；不会写入正版目录。'
   );
-  OfficialDirPage.Add('正版游戏目录（可留空）：');
+  OfficialDirPage.Add('正版游戏目录（可留空）：', False);
   OfficialDirPage.Values[0] := ExpandConstant('{param:OfficialRoot|}');
+
+  OfficialBrowseButton := TNewButton.Create(OfficialDirPage);
+  OfficialBrowseButton.Parent := OfficialDirPage.Surface;
+  OfficialBrowseButton.Caption := '浏览…';
+  OfficialBrowseButton.Width := ScaleX(80);
+  OfficialBrowseButton.Height := OfficialDirPage.Edits[0].Height;
+  OfficialBrowseButton.Left := OfficialDirPage.Edits[0].Left +
+    OfficialDirPage.Edits[0].Width - OfficialBrowseButton.Width;
+  OfficialBrowseButton.Top := OfficialDirPage.Edits[0].Top;
+  OfficialBrowseButton.OnClick := @OfficialBrowseButtonClick;
+  OfficialDirPage.Edits[0].Width := OfficialDirPage.Edits[0].Width -
+    OfficialBrowseButton.Width - ScaleX(8);
 end;
 
 function GetInstallRoot(Param: String): String;
@@ -81,14 +153,23 @@ begin
   end;
 end;
 
-procedure CurStepChanged(CurStep: TSetupStep);
+function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   PowerShell: String;
   Params: String;
   ExitCode: Integer;
 begin
-  if CurStep <> ssPostInstall then
+  Result := '';
+  StableInstallCode := '';
+  ExitCode := -1;
+  try
+    ExtractTemporaryFiles('{tmp}\OliviaPayload\*');
+  except
+    StableInstallCode := 'SETUP_PAYLOAD_EXTRACT_FAILED';
+    Log('Olivia installer code: ' + StableInstallCode);
+    Result := '安装失败：' + StableInstallCode + '。请保留安装日志后重试。';
     Exit;
+  end;
 
   WizardForm.StatusLabel.Caption := '正在校验并安装离线核心组件…';
   PowerShell := ExpandConstant('{sysnative}\WindowsPowerShell\v1.0\powershell.exe');
@@ -101,7 +182,20 @@ begin
   if Trim(OfficialDirPage.Values[0]) <> '' then
     Params := Params + ' -OfficialRoot ' + AddQuotes(OfficialDirPage.Values[0]);
 
-  if (not Exec(PowerShell, Params, '', SW_HIDE, ewWaitUntilTerminated, ExitCode)) or
+  if (not ExecAndLogOutput(
+       PowerShell,
+       Params,
+       '',
+       SW_HIDE,
+       ewWaitUntilTerminated,
+       ExitCode,
+       @CaptureStableInstallCode
+     )) or
      (ExitCode <> 0) then
-    RaiseException(Format('安装失败（错误码 %d）。请保留安装日志后重试。', [ExitCode]));
+  begin
+    if StableInstallCode <> '' then
+      Result := '安装失败：' + StableInstallCode + '。请保留安装日志后重试。'
+    else
+      Result := Format('安装失败（进程错误码 %d）。请保留安装日志后重试。', [ExitCode]);
+  end;
 end;

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -62,6 +62,12 @@ def test_prepare_setup_payload_copies_only_tracked_release_files_and_offline_ass
     (source / "LICENSE").write_text("license", encoding="utf-8")
     (source / "tracked.py").write_text("tracked", encoding="utf-8")
     (source / "untracked.py").write_text("untracked", encoding="utf-8")
+    (source / "test_root.py").write_text("hidden", encoding="utf-8")
+    (source / "requirements-ci.txt").write_text("hidden", encoding="utf-8")
+    (source / "pyproject.toml").write_text("hidden", encoding="utf-8")
+    (source / "installer" / "build_windows_setup.py").write_text(
+        "hidden", encoding="utf-8"
+    )
     (source / "tests" / "test_hidden.py").write_text("hidden", encoding="utf-8")
     (source / "docs" / "internal.md").write_text("hidden", encoding="utf-8")
     _offline_fixture(offline, requirements)
@@ -72,9 +78,16 @@ def test_prepare_setup_payload_copies_only_tracked_release_files_and_offline_ass
             "installer/runtime-requirements.txt",
             "LICENSE",
             "tracked.py",
+            "test_root.py",
+            "requirements-ci.txt",
+            "pyproject.toml",
+            "installer/build_windows_setup.py",
             "tests/test_hidden.py",
             "docs/internal.md",
         },
+    )
+    monkeypatch.setattr(
+        "installer.build_windows_setup._git_dirty_files", lambda _source: set()
     )
 
     prepare_setup_payload(source, offline, destination, validate_schema=False)
@@ -86,6 +99,39 @@ def test_prepare_setup_payload_copies_only_tracked_release_files_and_offline_ass
     assert not (destination / "untracked.py").exists()
     assert not (destination / "tests").exists()
     assert not (destination / "docs").exists()
+    assert not (destination / "test_root.py").exists()
+    assert not (destination / "requirements-ci.txt").exists()
+    assert not (destination / "pyproject.toml").exists()
+    assert not (destination / "installer" / "build_windows_setup.py").exists()
+
+
+def test_prepare_setup_payload_rejects_dirty_tracked_release_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = tmp_path / "source"
+    offline = tmp_path / "offline"
+    (source / "installer").mkdir(parents=True)
+    requirements = b"locked requirements"
+    (source / "installer" / "runtime-requirements.txt").write_bytes(requirements)
+    (source / "installer" / "Install.ps1").write_text("install", encoding="utf-8")
+    (source / "tracked.py").write_text("dirty", encoding="utf-8")
+    _offline_fixture(offline, requirements)
+    monkeypatch.setattr(
+        "installer.build_windows_setup._git_tracked_files",
+        lambda _source: {
+            "installer/Install.ps1",
+            "installer/runtime-requirements.txt",
+            "tracked.py",
+        },
+    )
+    monkeypatch.setattr(
+        "installer.build_windows_setup._git_dirty_files",
+        lambda _source: {"tracked.py"},
+    )
+
+    with pytest.raises(SetupBuildError, match="SETUP_SOURCE_DIRTY"):
+        prepare_setup_payload(source, offline, tmp_path / "payload", validate_schema=False)
 
 
 def test_prepare_setup_payload_rejects_tampered_offline_assets(
@@ -106,6 +152,9 @@ def test_prepare_setup_payload_rejects_tampered_offline_assets(
             "installer/Install.ps1",
             "installer/runtime-requirements.txt",
         },
+    )
+    monkeypatch.setattr(
+        "installer.build_windows_setup._git_dirty_files", lambda _source: set()
     )
 
     with pytest.raises(SetupBuildError, match="SETUP_OFFLINE_ASSET_HASH_MISMATCH"):
@@ -131,6 +180,9 @@ def test_prepare_setup_payload_rejects_reparse_parent(
         },
     )
     monkeypatch.setattr(
+        "installer.build_windows_setup._git_dirty_files", lambda _source: set()
+    )
+    monkeypatch.setattr(
         "installer.build_windows_setup._is_reparse_point",
         lambda path: path.name == "wheelhouse",
     )
@@ -149,6 +201,12 @@ def test_inno_wrapper_is_current_user_offline_and_delegates_to_install_ps1() -> 
     assert "Install.ps1" in script
     assert "-NonInteractive" in script
     assert "GetInstallRoot" in script
+    assert "ExecAndLogOutput" in script
+    assert "StableInstallCode" in script
+    assert "function PrepareToInstall" in script
+    assert "dontcopy noencryption" in script
+    assert "OfficialDirPage: TInputQueryWizardPage" in script
+    assert "BrowseForFolder" in script
     assert "{param:InstallRoot|" in script
     assert "{param:OfficialRoot|" in script
     assert "API" not in script
@@ -172,8 +230,31 @@ def test_github_build_publishes_setup_and_checksum_for_merged_main() -> None:
     assert "branches: [main]" in workflow
     assert "build_offline_core_assets.py" in workflow
     assert "build_windows_setup.py" in workflow
+    assert "pip install --require-hashes" in workflow
+    assert "installer/setup-build-requirements.txt" in workflow
     assert "choco install innosetup --version=6.7.1" in workflow
+    assert "Get-AuthenticodeSignature" in workflow
+    assert "Pyrsys B.V." in workflow
     assert "is-6_7_1/Files/Languages/Unofficial/ChineseSimplified.isl" in workflow
     assert "7d544b9bb1d142cfa11f2e5d3cc8abe2e55f8e066c5124e3772675aa236e1278" in workflow
     assert "Olivia-Setup-x64.exe.sha256" in workflow
     assert "actions/upload-artifact@v4" in workflow
+
+
+def test_setup_build_requirements_are_exact_and_hash_locked() -> None:
+    requirements = (
+        ROOT / "installer" / "setup-build-requirements.txt"
+    ).read_text(encoding="utf-8")
+    entries = [line for line in requirements.splitlines() if line and not line.startswith("#")]
+
+    assert any(line.startswith("jsonschema==") for line in entries)
+    assert all(" --hash=sha256:" in line for line in entries)
+
+
+def test_third_party_notices_cover_setup_compiler_and_chinese_messages() -> None:
+    notices = (ROOT / "THIRD_PARTY_NOTICES.md").read_text(encoding="utf-8")
+
+    assert "Inno Setup" in notices
+    assert "ChineseSimplified.isl" in notices
+    assert "is-6_7_1" in notices
+    assert "7d544b9bb1d142cfa11f2e5d3cc8abe2e55f8e066c5124e3772675aa236e1278" in notices

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from installer.build_windows_setup import (
+    SetupBuildError,
+    prepare_setup_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_asset(root: Path, relative: str, content: bytes) -> dict[str, object]:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return {
+        "path": relative.replace("\\", "/"),
+        "size_bytes": len(content),
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }
+
+
+def _offline_fixture(root: Path, requirements: bytes) -> None:
+    runtime = _write_asset(root, "python.zip", b"runtime")
+    runtime["source_url"] = "https://official.example/python.zip"
+    pip = _write_asset(root, "pip.whl", b"pip")
+    pip.update({"package": "pip", "version": "1"})
+    wheel = _write_asset(root, "wheelhouse/core.whl", b"wheel")
+    (root / "offline-core-assets.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "fixture.v1",
+                "python_runtime": runtime,
+                "pip_bootstrap": pip,
+                "requirements_sha256": hashlib.sha256(requirements).hexdigest(),
+                "wheels": [wheel],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_prepare_setup_payload_copies_only_tracked_release_files_and_offline_assets(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = tmp_path / "source"
+    offline = tmp_path / "offline"
+    destination = tmp_path / "payload"
+    (source / "installer").mkdir(parents=True)
+    (source / "tests").mkdir()
+    (source / "docs").mkdir()
+    (source / "installer" / "Install.ps1").write_text("install", encoding="utf-8")
+    requirements = b"locked requirements"
+    (source / "installer" / "runtime-requirements.txt").write_bytes(requirements)
+    (source / "LICENSE").write_text("license", encoding="utf-8")
+    (source / "tracked.py").write_text("tracked", encoding="utf-8")
+    (source / "untracked.py").write_text("untracked", encoding="utf-8")
+    (source / "tests" / "test_hidden.py").write_text("hidden", encoding="utf-8")
+    (source / "docs" / "internal.md").write_text("hidden", encoding="utf-8")
+    _offline_fixture(offline, requirements)
+    monkeypatch.setattr(
+        "installer.build_windows_setup._git_tracked_files",
+        lambda _source: {
+            "installer/Install.ps1",
+            "installer/runtime-requirements.txt",
+            "LICENSE",
+            "tracked.py",
+            "tests/test_hidden.py",
+            "docs/internal.md",
+        },
+    )
+
+    prepare_setup_payload(source, offline, destination, validate_schema=False)
+
+    assert (destination / "installer" / "Install.ps1").read_text() == "install"
+    assert (destination / "LICENSE").is_file()
+    assert (destination / "tracked.py").is_file()
+    assert (destination / "offline" / "offline-core-assets.json").is_file()
+    assert not (destination / "untracked.py").exists()
+    assert not (destination / "tests").exists()
+    assert not (destination / "docs").exists()
+
+
+def test_prepare_setup_payload_rejects_tampered_offline_assets(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = tmp_path / "source"
+    offline = tmp_path / "offline"
+    (source / "installer").mkdir(parents=True)
+    requirements = b"locked requirements"
+    (source / "installer" / "runtime-requirements.txt").write_bytes(requirements)
+    (source / "installer" / "Install.ps1").write_text("install", encoding="utf-8")
+    _offline_fixture(offline, requirements)
+    (offline / "wheelhouse" / "core.whl").write_bytes(b"tampered")
+    monkeypatch.setattr(
+        "installer.build_windows_setup._git_tracked_files",
+        lambda _source: {
+            "installer/Install.ps1",
+            "installer/runtime-requirements.txt",
+        },
+    )
+
+    with pytest.raises(SetupBuildError, match="SETUP_OFFLINE_ASSET_HASH_MISMATCH"):
+        prepare_setup_payload(source, offline, tmp_path / "payload", validate_schema=False)
+
+
+def test_prepare_setup_payload_rejects_reparse_parent(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = tmp_path / "source"
+    offline = tmp_path / "offline"
+    (source / "installer").mkdir(parents=True)
+    requirements = b"locked requirements"
+    (source / "installer" / "runtime-requirements.txt").write_bytes(requirements)
+    (source / "installer" / "Install.ps1").write_text("install", encoding="utf-8")
+    _offline_fixture(offline, requirements)
+    monkeypatch.setattr(
+        "installer.build_windows_setup._git_tracked_files",
+        lambda _source: {
+            "installer/Install.ps1",
+            "installer/runtime-requirements.txt",
+        },
+    )
+    monkeypatch.setattr(
+        "installer.build_windows_setup._is_reparse_point",
+        lambda path: path.name == "wheelhouse",
+    )
+
+    with pytest.raises(SetupBuildError, match="SETUP_PATH_REPARSE_POINT"):
+        prepare_setup_payload(source, offline, tmp_path / "payload", validate_schema=False)
+
+
+def test_inno_wrapper_is_current_user_offline_and_delegates_to_install_ps1() -> None:
+    script = (ROOT / "installer" / "windows_setup.iss").read_text(encoding="utf-8")
+
+    assert "PrivilegesRequired=lowest" in script
+    assert "CreateAppDir=no" in script
+    assert "Uninstallable=no" in script
+    assert "LicenseFile=" in script
+    assert "Install.ps1" in script
+    assert "-NonInteractive" in script
+    assert "GetInstallRoot" in script
+    assert "{param:InstallRoot|" in script
+    assert "{param:OfficialRoot|" in script
+    assert "API" not in script
+    assert "Hugging Face" not in script
+
+
+def test_install_ps1_supports_noninteractive_setup_without_optional_downloads() -> None:
+    script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
+
+    assert "[switch]$NonInteractive" in script
+    assert "if (-not $selectedOfficial -and -not $NonInteractive)" in script
+    assert "Invoke-WebRequest" not in script
+    assert "provision_mem0_embedding.py" not in script
+
+
+def test_github_build_publishes_setup_and_checksum_for_merged_main() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "windows-setup.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "branches: [main]" in workflow
+    assert "build_offline_core_assets.py" in workflow
+    assert "build_windows_setup.py" in workflow
+    assert "Olivia-Setup-x64.exe.sha256" in workflow
+    assert "actions/upload-artifact@v4" in workflow

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -173,5 +173,7 @@ def test_github_build_publishes_setup_and_checksum_for_merged_main() -> None:
     assert "build_offline_core_assets.py" in workflow
     assert "build_windows_setup.py" in workflow
     assert "choco install innosetup --version=6.7.1" in workflow
+    assert "is-6_7_1/Files/Languages/Unofficial/ChineseSimplified.isl" in workflow
+    assert "7d544b9bb1d142cfa11f2e5d3cc8abe2e55f8e066c5124e3772675aa236e1278" in workflow
     assert "Olivia-Setup-x64.exe.sha256" in workflow
     assert "actions/upload-artifact@v4" in workflow

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -172,5 +172,6 @@ def test_github_build_publishes_setup_and_checksum_for_merged_main() -> None:
     assert "branches: [main]" in workflow
     assert "build_offline_core_assets.py" in workflow
     assert "build_windows_setup.py" in workflow
+    assert "choco install innosetup --version=6.7.1" in workflow
     assert "Olivia-Setup-x64.exe.sha256" in workflow
     assert "actions/upload-artifact@v4" in workflow

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -7,7 +7,10 @@ from pathlib import Path
 import pytest
 
 from installer.build_windows_setup import (
+    BUILD_CONTROL_FILES,
     SetupBuildError,
+    _git_tracked_files,
+    _is_release_file,
     prepare_setup_payload,
 )
 
@@ -60,7 +63,7 @@ def test_prepare_setup_payload_copies_only_tracked_release_files_and_offline_ass
     requirements = b"locked requirements"
     (source / "installer" / "runtime-requirements.txt").write_bytes(requirements)
     (source / "LICENSE").write_text("license", encoding="utf-8")
-    (source / "tracked.py").write_text("tracked", encoding="utf-8")
+    (source / "local_server.py").write_text("tracked", encoding="utf-8")
     (source / "untracked.py").write_text("untracked", encoding="utf-8")
     (source / "test_root.py").write_text("hidden", encoding="utf-8")
     (source / "requirements-ci.txt").write_text("hidden", encoding="utf-8")
@@ -76,8 +79,9 @@ def test_prepare_setup_payload_copies_only_tracked_release_files_and_offline_ass
         lambda _source: {
             "installer/Install.ps1",
             "installer/runtime-requirements.txt",
+            *BUILD_CONTROL_FILES,
             "LICENSE",
-            "tracked.py",
+            "local_server.py",
             "test_root.py",
             "requirements-ci.txt",
             "pyproject.toml",
@@ -94,7 +98,7 @@ def test_prepare_setup_payload_copies_only_tracked_release_files_and_offline_ass
 
     assert (destination / "installer" / "Install.ps1").read_text() == "install"
     assert (destination / "LICENSE").is_file()
-    assert (destination / "tracked.py").is_file()
+    assert (destination / "local_server.py").is_file()
     assert (destination / "offline" / "offline-core-assets.json").is_file()
     assert not (destination / "untracked.py").exists()
     assert not (destination / "tests").exists()
@@ -115,19 +119,84 @@ def test_prepare_setup_payload_rejects_dirty_tracked_release_file(
     requirements = b"locked requirements"
     (source / "installer" / "runtime-requirements.txt").write_bytes(requirements)
     (source / "installer" / "Install.ps1").write_text("install", encoding="utf-8")
-    (source / "tracked.py").write_text("dirty", encoding="utf-8")
+    (source / "local_server.py").write_text("dirty", encoding="utf-8")
     _offline_fixture(offline, requirements)
     monkeypatch.setattr(
         "installer.build_windows_setup._git_tracked_files",
         lambda _source: {
             "installer/Install.ps1",
             "installer/runtime-requirements.txt",
-            "tracked.py",
+            *BUILD_CONTROL_FILES,
+            "local_server.py",
         },
     )
     monkeypatch.setattr(
         "installer.build_windows_setup._git_dirty_files",
-        lambda _source: {"tracked.py"},
+        lambda _source: {"local_server.py"},
+    )
+
+    with pytest.raises(SetupBuildError, match="SETUP_SOURCE_DIRTY"):
+        prepare_setup_payload(source, offline, tmp_path / "payload", validate_schema=False)
+
+
+def test_setup_payload_uses_positive_runtime_allowlist() -> None:
+    assert _is_release_file("local_server.py")
+    assert _is_release_file("control_center/static/index.html")
+    assert _is_release_file("installer/full_patch.py")
+    assert _is_release_file("tools/livetalking_worker.py")
+
+    assert not _is_release_file(".gitignore")
+    assert not _is_release_file("baseline_hardening_scan.py")
+    assert not _is_release_file("installer/build_offline_core_assets.py")
+    assert not _is_release_file("tools/verify_b11_scope.py")
+    assert not _is_release_file("tools/live_e2e_acceptance.py")
+
+
+def test_real_head_setup_payload_excludes_build_audit_test_and_scm_files() -> None:
+    selected = {
+        relative
+        for relative in _git_tracked_files(ROOT)
+        if _is_release_file(relative)
+    }
+
+    assert {
+        "installer/Install.ps1",
+        "installer/full_patch.py",
+        "local_server.py",
+        "control_center/static/index.html",
+    }.issubset(selected)
+    assert not any(
+        relative.startswith((".", "docs/", "tests/"))
+        or relative.startswith("tools/verify_")
+        or "/audit_" in relative
+        or "acceptance" in relative
+        or relative.startswith("installer/build_")
+        for relative in selected
+    )
+
+
+def test_prepare_setup_payload_rejects_dirty_setup_build_control_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = tmp_path / "source"
+    offline = tmp_path / "offline"
+    (source / "installer").mkdir(parents=True)
+    requirements = b"locked requirements"
+    (source / "installer" / "runtime-requirements.txt").write_bytes(requirements)
+    (source / "installer" / "Install.ps1").write_text("install", encoding="utf-8")
+    _offline_fixture(offline, requirements)
+    monkeypatch.setattr(
+        "installer.build_windows_setup._git_tracked_files",
+        lambda _source: {
+            "installer/Install.ps1",
+            "installer/runtime-requirements.txt",
+            *BUILD_CONTROL_FILES,
+        },
+    )
+    monkeypatch.setattr(
+        "installer.build_windows_setup._git_dirty_files",
+        lambda _source: {"installer/windows_setup.iss"},
     )
 
     with pytest.raises(SetupBuildError, match="SETUP_SOURCE_DIRTY"):
@@ -151,6 +220,7 @@ def test_prepare_setup_payload_rejects_tampered_offline_assets(
         lambda _source: {
             "installer/Install.ps1",
             "installer/runtime-requirements.txt",
+            *BUILD_CONTROL_FILES,
         },
     )
     monkeypatch.setattr(
@@ -201,8 +271,11 @@ def test_inno_wrapper_is_current_user_offline_and_delegates_to_install_ps1() -> 
     assert "Install.ps1" in script
     assert "-NonInteractive" in script
     assert "GetInstallRoot" in script
-    assert "ExecAndLogOutput" in script
+    assert "Exec(" in script
+    assert "ExecAndLogOutput" not in script
     assert "StableInstallCode" in script
+    assert "SetupResultPath" in script
+    assert "OLIVIA_SETUP_ERROR=" in script
     assert "function PrepareToInstall" in script
     assert "dontcopy noencryption" in script
     assert "OfficialDirPage: TInputQueryWizardPage" in script
@@ -217,6 +290,9 @@ def test_install_ps1_supports_noninteractive_setup_without_optional_downloads() 
     script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
 
     assert "[switch]$NonInteractive" in script
+    assert "[string]$SetupResultPath" in script
+    assert "OLIVIA_SETUP_ERROR=" in script
+    assert "SETUP_INSTALL_FAILED" in script
     assert "if (-not $selectedOfficial -and -not $NonInteractive)" in script
     assert "Invoke-WebRequest" not in script
     assert "provision_mem0_embedding.py" not in script
@@ -238,6 +314,7 @@ def test_github_build_publishes_setup_and_checksum_for_merged_main() -> None:
     assert "is-6_7_1/Files/Languages/Unofficial/ChineseSimplified.isl" in workflow
     assert "7d544b9bb1d142cfa11f2e5d3cc8abe2e55f8e066c5124e3772675aa236e1278" in workflow
     assert "Olivia-Setup-x64.exe.sha256" in workflow
+    assert "windows_setup_smoke.ps1" in workflow
     assert "actions/upload-artifact@v4" in workflow
 
 

--- a/tests/installer/windows_setup_smoke.ps1
+++ b/tests/installer/windows_setup_smoke.ps1
@@ -1,0 +1,70 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Iscc,
+    [Parameter(Mandatory)]
+    [string]$SetupScript
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Join-Path $env:RUNNER_TEMP ('olivia-setup-smoke-' + [guid]::NewGuid().ToString('N'))
+$payload = Join-Path $root 'payload'
+$output = Join-Path $root 'output'
+$install = Join-Path $root 'install'
+$log = Join-Path $root 'setup.log'
+$fixture = Join-Path $payload 'installer\Install.ps1'
+
+try {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $fixture), $output | Out-Null
+    $utf8NoBom = [Text.UTF8Encoding]::new($false)
+    [IO.File]::WriteAllText(
+        (Join-Path $payload 'LICENSE'),
+        'Synthetic test payload.',
+        $utf8NoBom
+    )
+    $fixtureContent = @'
+param(
+    [string]$PayloadRoot,
+    [string]$Destination,
+    [string]$OfficialRoot,
+    [string]$OfflineAssetsRoot,
+    [string]$SetupResultPath,
+    [switch]$NonInteractive
+)
+$utf8NoBom = [Text.UTF8Encoding]::new($false)
+[IO.File]::WriteAllText(
+    $SetupResultPath,
+    'OLIVIA_SETUP_ERROR=TEST_INSTALL_FAILURE',
+    $utf8NoBom
+)
+Write-Output 'synthetic private-looking path C:\Users\fixture'
+exit 23
+'@
+    [IO.File]::WriteAllText($fixture, $fixtureContent, $utf8NoBom)
+
+    & $Iscc "/DPayloadRoot=$payload" "/DOutputDir=$output" '/DAppVersion=smoke' $SetupScript
+    if ($LASTEXITCODE -ne 0) { throw 'SETUP_SMOKE_COMPILE_FAILED' }
+
+    $setup = Join-Path $output 'Olivia-Setup-x64.exe'
+    $arguments = @(
+        '/VERYSILENT',
+        '/SUPPRESSMSGBOXES',
+        '/NORESTART',
+        ('/InstallRoot="' + $install + '"'),
+        ('/LOG="' + $log + '"')
+    )
+    $process = Start-Process -FilePath $setup -ArgumentList $arguments -PassThru -Wait
+    if ($process.ExitCode -ne 7) { throw 'SETUP_SMOKE_EXIT_CODE_INVALID' }
+
+    $logText = Get-Content -Raw -LiteralPath $log
+    if ($logText -notmatch 'Olivia installer code: TEST_INSTALL_FAILURE') {
+        throw 'SETUP_SMOKE_STABLE_CODE_MISSING'
+    }
+    if ($logText -match 'synthetic private-looking') {
+        throw 'SETUP_SMOKE_PRIVATE_OUTPUT_LEAKED'
+    }
+} finally {
+    if (Test-Path -LiteralPath $root) {
+        Remove-Item -LiteralPath $root -Recurse -Force
+    }
+}


### PR DESCRIPTION
## 变更目的

为 Windows 普通用户提供当前用户权限、核心离线、单文件的 `Olivia-Setup-x64.exe`，同时复用现有安全安装与组件补丁机制；API key、模型和可选能力不进入安装包。

## 关联 issue

N/A

## 变更范围

- [ ] HTTP / contract
- [ ] memory / media state
- [ ] ASR / TTS / Live 实验模块
- [x] Windows 安装器、构建 CI、测试与文档

本 PR 为一个完整的“离线 Setup.exe 构建与安装边界”，共 9 个文件、`+1221/-6`。构建器、Inno 包装、PowerShell 安装入口、CI 门禁和对应测试必须同步落地，否则中间提交不能独立证明安装与失败传播安全，因此未再拆分。

## 验证与计数

```text
# targeted: python -m pytest tests/installer -q -> 177 passed, 1 skipped
# full: python -m pytest -q -> 1085 passed, 1 skipped, 1 deselected
# compile / scanner: py_compile PASS; Install.ps1 parser PASS; baseline_hardening_scan --mode all PASS; git diff --check PASS
# failure smoke: Inno 7.1.0 synthetic EXE -> Setup exit 7; TEST_INSTALL_FAILURE logged; synthetic private stdout absent
# real build at de85ff9: 16,472,341 bytes; SHA-256 fe272d6d1f48bfdbaa062efd90cdcea841c15f8be459414d99fa984ed1e52e45
# real install: isolated Windows x64 install exit 0; official 0.0.9.627 marker/runtime/entrypoints present; no Inno uninstaller
# real start: installed client started; GET /health?profile=core -> HEALTHY; isolated listener/processes cleaned up
# GitHub exact-head CI: public-smoke x2 SUCCESS; windows-setup run 33095470482 SUCCESS, including failure-boundary execution
```

## 外部依赖与边界

- 构建阶段下载哈希锁定的 Python/PyPI 核心资产、固定 Inno 6.7.1 和固定 SHA-256 的简体中文语言文件；安装阶段核心离线。
- 运行时仍需要用户正版 Steam 安装。模型和 provider 不属于本 PR 的安装验收条件。
- 安装包尚未进行商业 Authenticode 代码签名。

## 安全、版权与隐私

- [x] 未提交密钥、令牌、签名材料、真实请求日志或用户数据
- [x] 未提交官方游戏文件、提取资源、模型权重或生成媒体
- [x] 构建依赖、Inno Setup 与简体中文语言文件的来源、版本、摘要和许可证已记录
- [x] Inno 不记录安装子进程完整 stdout；失败只记录专用 `OLIVIA_SETUP_ERROR` 稳定字段

## 独立复核留痕

- 初审：`4da6e64af9cc65d7ceefed84ee92e4bbc317f5cd -> 4947917a3253694d8a6417d0f370ac04e2f3f32e`，Sol/high，`BLOCK`。主要问题：脏工作树、构建闭包、错误码传播、测试/CI 文件进入 payload。
- 修复后第 1 轮：`4da6e64af9cc65d7ceefed84ee92e4bbc317f5cd -> 81c3e11860e228a5c5fda3f0ae353521b6bab9c7`，Sol/high，`BLOCK`。主要问题：发布白名单、`.iss` 构建输入、日志隐私、真实失败 EXE 测试。
- 修复后第 2 轮（最终轮）：`4da6e64af9cc65d7ceefed84ee92e4bbc317f5cd -> de85ff95216a708697ff1287073dede9fe8d7c5d`，Sol/high，`BLOCK`。剩余意见：进一步收窄 runtime allowlist、扩展 dirty 构建控制链、构建器本地 Inno 信任检查、成功路径 CI smoke、稳定码语义白名单。
- Landing decision：已达到项目所有者明确设定的“两轮修复/复审上限”；不再进行第 3 次修改或复审，保留上述 BLOCK 与验证边界后直接合并。

## 回滚与后续

回滚本 PR 即可恢复 ZIP/`INSTALL.cmd` 路径；EXE 不接管应用卸载，受控 `UNINSTALL.cmd` 保持唯一卸载入口。后续单独实现登录后的 API key 与按需能力下载/管理，再从合并后 GitHub main artifact 做最终端到端验收。
