### PR TITLE
feat(installer): add secure post-login LLM setup

### DIFF
--- a/contracts/initial_setup_api_contract.json
+++ b/contracts/initial_setup_api_contract.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "olivia.initial-setup-api-contract.v1",
+  "status_schema_version": "olivia.initial-setup.v1",
+  "authorization": {
+    "origins": "explicit-trusted-https-only",
+    "login_required_for_mutations": true,
+    "session_header": "X-Olivia-Setup-Session",
+    "confirmation_header": {"name": "X-Olivia-Setup-Action", "value": "confirmed"}
+  },
+  "routes": {
+    "/toy/setup/status": {"methods": ["GET", "OPTIONS"], "success_statuses": ["READY"]},
+    "/toy/setup/llm/test": {"methods": ["POST", "OPTIONS"], "success_statuses": ["AVAILABLE"]},
+    "/toy/setup/llm/save": {"methods": ["POST", "OPTIONS"], "success_statuses": ["SAVED"]},
+    "/toy/setup/llm/delete": {"methods": ["POST", "OPTIONS"], "success_statuses": ["DELETED"]},
+    "/toy/setup/complete": {"methods": ["POST", "OPTIONS"], "success_statuses": ["COMPLETED"]}
+  },
+  "error_codes": [
+    "LLM_SETUP_CONFIRMATION_REQUIRED",
+    "LLM_SETUP_CONNECTION_FAILED",
+    "LLM_SETUP_CONTENT_TYPE_INVALID",
+    "LLM_SETUP_DPAPI_FAILED",
+    "LLM_SETUP_DPAPI_UNAVAILABLE",
+    "LLM_SETUP_FIELDS_INVALID",
+    "LLM_SETUP_HOST_FORBIDDEN",
+    "LLM_SETUP_JSON_INVALID",
+    "LLM_SETUP_KEY_REQUIRED",
+    "LLM_SETUP_KEY_UNAVAILABLE",
+    "LLM_SETUP_LOGIN_REQUIRED",
+    "LLM_SETUP_ORIGIN_FORBIDDEN",
+    "LLM_SETUP_REQUEST_TOO_LARGE",
+    "LLM_SETUP_TEST_REQUIRED"
+  ]
+}

--- a/contracts/initial_setup_api_contract.json
+++ b/contracts/initial_setup_api_contract.json
@@ -8,26 +8,52 @@
     "confirmation_header": {"name": "X-Olivia-Setup-Action", "value": "confirmed"}
   },
   "routes": {
-    "/toy/setup/status": {"methods": ["GET", "OPTIONS"], "success_statuses": ["READY"]},
-    "/toy/setup/llm/test": {"methods": ["POST", "OPTIONS"], "success_statuses": ["AVAILABLE"]},
-    "/toy/setup/llm/save": {"methods": ["POST", "OPTIONS"], "success_statuses": ["SAVED"]},
-    "/toy/setup/llm/delete": {"methods": ["POST", "OPTIONS"], "success_statuses": ["DELETED"]},
-    "/toy/setup/complete": {"methods": ["POST", "OPTIONS"], "success_statuses": ["COMPLETED"]}
+    "/toy/setup/status": {
+      "methods": ["GET", "OPTIONS"],
+      "status_values": ["READY"],
+      "request_fields": [],
+      "response_fields": ["schema_version", "status", "login_observed", "setup_completed", "show_initial_setup", "skipped", "llm", "session_token?"]
+    },
+    "/toy/setup/llm/test": {
+      "methods": ["POST", "OPTIONS"],
+      "status_values": ["AVAILABLE"],
+      "request_fields": ["base_url", "model", "api_key"],
+      "response_fields": ["status"]
+    },
+    "/toy/setup/llm/save": {
+      "methods": ["POST", "OPTIONS"],
+      "status_values": ["SAVED"],
+      "request_fields": ["base_url", "model", "api_key"],
+      "response_fields": ["status", "reload_applied", "restart_required"]
+    },
+    "/toy/setup/llm/delete": {
+      "methods": ["POST", "OPTIONS"],
+      "status_values": ["DELETED"],
+      "request_fields": [],
+      "response_fields": ["status", "reload_applied", "restart_required"]
+    },
+    "/toy/setup/complete": {
+      "methods": ["POST", "OPTIONS"],
+      "status_values": ["COMPLETED"],
+      "request_fields": ["skipped"],
+      "response_fields": ["status", "skipped"]
+    }
   },
-  "error_codes": [
-    "LLM_SETUP_CONFIRMATION_REQUIRED",
-    "LLM_SETUP_CONNECTION_FAILED",
-    "LLM_SETUP_CONTENT_TYPE_INVALID",
-    "LLM_SETUP_DPAPI_FAILED",
-    "LLM_SETUP_DPAPI_UNAVAILABLE",
-    "LLM_SETUP_FIELDS_INVALID",
-    "LLM_SETUP_HOST_FORBIDDEN",
-    "LLM_SETUP_JSON_INVALID",
-    "LLM_SETUP_KEY_REQUIRED",
-    "LLM_SETUP_KEY_UNAVAILABLE",
-    "LLM_SETUP_LOGIN_REQUIRED",
-    "LLM_SETUP_ORIGIN_FORBIDDEN",
-    "LLM_SETUP_REQUEST_TOO_LARGE",
-    "LLM_SETUP_TEST_REQUIRED"
-  ]
+  "error_codes": {
+    "LLM_SETUP_CONFIRMATION_REQUIRED": {"http_statuses": [403], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_CONNECTION_FAILED": {"http_statuses": [503], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_CONTENT_TYPE_INVALID": {"http_statuses": [415], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_DPAPI_FAILED": {"http_statuses": [503], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_DPAPI_UNAVAILABLE": {"http_statuses": [503], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_FIELDS_INVALID": {"http_statuses": [400], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_HOST_FORBIDDEN": {"http_statuses": [403], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_JSON_INVALID": {"http_statuses": [400], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_KEY_REQUIRED": {"http_statuses": [400, 409], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_KEY_UNAVAILABLE": {"http_statuses": [503], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_LOGIN_REQUIRED": {"http_statuses": [403], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_ORIGIN_FORBIDDEN": {"http_statuses": [403], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_REQUEST_TOO_LARGE": {"http_statuses": [413], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_SAVE_FAILED": {"http_statuses": [503], "status": "FAILED", "response_fields": ["status", "error_code"]},
+    "LLM_SETUP_TEST_REQUIRED": {"http_statuses": [409], "status": "FAILED", "response_fields": ["status", "error_code"]}
+  }
 }

--- a/contracts/initial_setup_api_contract.schema.json
+++ b/contracts/initial_setup_api_contract.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "initial_setup_api_contract.schema.json",
+  "title": "Post-login LLM setup API contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "status_schema_version", "authorization", "routes", "error_codes"],
+  "properties": {
+    "schema_version": {"const": "olivia.initial-setup-api-contract.v1"},
+    "status_schema_version": {"const": "olivia.initial-setup.v1"},
+    "authorization": {
+      "const": {
+        "origins": "explicit-trusted-https-only",
+        "login_required_for_mutations": true,
+        "session_header": "X-Olivia-Setup-Session",
+        "confirmation_header": {"name": "X-Olivia-Setup-Action", "value": "confirmed"}
+      }
+    },
+    "routes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "/toy/setup/status",
+        "/toy/setup/llm/test",
+        "/toy/setup/llm/save",
+        "/toy/setup/llm/delete",
+        "/toy/setup/complete"
+      ],
+      "properties": {
+        "/toy/setup/status": {"const": {"methods": ["GET", "OPTIONS"], "success_statuses": ["READY"]}},
+        "/toy/setup/llm/test": {"const": {"methods": ["POST", "OPTIONS"], "success_statuses": ["AVAILABLE"]}},
+        "/toy/setup/llm/save": {"const": {"methods": ["POST", "OPTIONS"], "success_statuses": ["SAVED"]}},
+        "/toy/setup/llm/delete": {"const": {"methods": ["POST", "OPTIONS"], "success_statuses": ["DELETED"]}},
+        "/toy/setup/complete": {"const": {"methods": ["POST", "OPTIONS"], "success_statuses": ["COMPLETED"]}}
+      }
+    },
+    "error_codes": {
+      "const": [
+        "LLM_SETUP_CONFIRMATION_REQUIRED",
+        "LLM_SETUP_CONNECTION_FAILED",
+        "LLM_SETUP_CONTENT_TYPE_INVALID",
+        "LLM_SETUP_DPAPI_FAILED",
+        "LLM_SETUP_DPAPI_UNAVAILABLE",
+        "LLM_SETUP_FIELDS_INVALID",
+        "LLM_SETUP_HOST_FORBIDDEN",
+        "LLM_SETUP_JSON_INVALID",
+        "LLM_SETUP_KEY_REQUIRED",
+        "LLM_SETUP_KEY_UNAVAILABLE",
+        "LLM_SETUP_LOGIN_REQUIRED",
+        "LLM_SETUP_ORIGIN_FORBIDDEN",
+        "LLM_SETUP_REQUEST_TOO_LARGE",
+        "LLM_SETUP_TEST_REQUIRED"
+      ]
+    }
+  }
+}

--- a/contracts/initial_setup_api_contract.schema.json
+++ b/contracts/initial_setup_api_contract.schema.json
@@ -20,37 +20,54 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "/toy/setup/status",
-        "/toy/setup/llm/test",
-        "/toy/setup/llm/save",
-        "/toy/setup/llm/delete",
-        "/toy/setup/complete"
+        "/toy/setup/status", "/toy/setup/llm/test", "/toy/setup/llm/save",
+        "/toy/setup/llm/delete", "/toy/setup/complete"
       ],
       "properties": {
-        "/toy/setup/status": {"const": {"methods": ["GET", "OPTIONS"], "success_statuses": ["READY"]}},
-        "/toy/setup/llm/test": {"const": {"methods": ["POST", "OPTIONS"], "success_statuses": ["AVAILABLE"]}},
-        "/toy/setup/llm/save": {"const": {"methods": ["POST", "OPTIONS"], "success_statuses": ["SAVED"]}},
-        "/toy/setup/llm/delete": {"const": {"methods": ["POST", "OPTIONS"], "success_statuses": ["DELETED"]}},
-        "/toy/setup/complete": {"const": {"methods": ["POST", "OPTIONS"], "success_statuses": ["COMPLETED"]}}
+        "/toy/setup/status": {"$ref": "#/$defs/route"},
+        "/toy/setup/llm/test": {"$ref": "#/$defs/route"},
+        "/toy/setup/llm/save": {"$ref": "#/$defs/route"},
+        "/toy/setup/llm/delete": {"$ref": "#/$defs/route"},
+        "/toy/setup/complete": {"$ref": "#/$defs/route"}
       }
     },
     "error_codes": {
-      "const": [
-        "LLM_SETUP_CONFIRMATION_REQUIRED",
-        "LLM_SETUP_CONNECTION_FAILED",
-        "LLM_SETUP_CONTENT_TYPE_INVALID",
-        "LLM_SETUP_DPAPI_FAILED",
-        "LLM_SETUP_DPAPI_UNAVAILABLE",
-        "LLM_SETUP_FIELDS_INVALID",
-        "LLM_SETUP_HOST_FORBIDDEN",
-        "LLM_SETUP_JSON_INVALID",
-        "LLM_SETUP_KEY_REQUIRED",
-        "LLM_SETUP_KEY_UNAVAILABLE",
-        "LLM_SETUP_LOGIN_REQUIRED",
-        "LLM_SETUP_ORIGIN_FORBIDDEN",
-        "LLM_SETUP_REQUEST_TOO_LARGE",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "LLM_SETUP_CONFIRMATION_REQUIRED", "LLM_SETUP_CONNECTION_FAILED",
+        "LLM_SETUP_CONTENT_TYPE_INVALID", "LLM_SETUP_DPAPI_FAILED",
+        "LLM_SETUP_DPAPI_UNAVAILABLE", "LLM_SETUP_FIELDS_INVALID",
+        "LLM_SETUP_HOST_FORBIDDEN", "LLM_SETUP_JSON_INVALID",
+        "LLM_SETUP_KEY_REQUIRED", "LLM_SETUP_KEY_UNAVAILABLE",
+        "LLM_SETUP_LOGIN_REQUIRED", "LLM_SETUP_ORIGIN_FORBIDDEN",
+        "LLM_SETUP_REQUEST_TOO_LARGE", "LLM_SETUP_SAVE_FAILED",
         "LLM_SETUP_TEST_REQUIRED"
-      ]
+      ],
+      "patternProperties": {"^LLM_SETUP_[A-Z_]+$": {"$ref": "#/$defs/error"}}
+    }
+  },
+  "$defs": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["methods", "status_values", "request_fields", "response_fields"],
+      "properties": {
+        "methods": {"type": "array", "minItems": 2, "uniqueItems": true, "items": {"enum": ["GET", "POST", "OPTIONS"]}},
+        "status_values": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string"}},
+        "request_fields": {"type": "array", "uniqueItems": true, "items": {"type": "string"}},
+        "response_fields": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string"}}
+      }
+    },
+    "error": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["http_statuses", "status", "response_fields"],
+      "properties": {
+        "http_statuses": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "integer", "minimum": 400, "maximum": 599}},
+        "status": {"const": "FAILED"},
+        "response_fields": {"const": ["status", "error_code"]}
+      }
     }
   }
 }

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -7,7 +7,7 @@
 1. 下载 `Olivia-Setup-x64.exe` 及同目录的 `.sha256` 文件，并先核对 SHA-256。
 2. 双击 EXE，选择安装位置和正版 Steam 游戏目录。安装器按当前用户运行，不要求管理员权限；它从 EXE 内置的离线资产安装受管 Python 3.12 runtime 和固定 wheel，不联网下载。正版目录可留空并按 Steam AppID `4532590` 自动发现。
 3. 安装成功后双击 `START.cmd`。它只启动一个监听 `127.0.0.1` 的本机服务，再直接启动隔离副本的 `0.0.9.627\Olivia.exe`，并使用安装目录下的独立 profile。长期记忆、PrivateWorld 和媒体接口都挂在同一个进程中。
-4. 首次配置可双击 `CONFIGURE.cmd`：API key 输入不回显，并以当前 Windows 用户 DPAPI 加密保存到 `data\config`；也可选择自己的参考音频/视频导入 `data\third-party\reference`。这些文件不进入补丁包。
+4. 登录原版客户端成功后会显示一次初始设置：可选择 OpenCode Go、DeepSeek 官方或自定义 OpenAI-compatible 地址，必须先测试连接再保存。API key 输入不回显，并以当前 Windows 用户 DPAPI 加密保存到 `data\config`；公开的地址和模型名写入 `data\config\llm.json`。也可继续使用 `CONFIGURE.cmd` 管理参考音频/视频。这些文件不进入补丁包。
 5. 卸载双击 `UNINSTALL.cmd`。受控卸载只删除安装器自己写入的 `app`、`local_backend`、启动脚本和 marker，保留 `data`、`logs`、`third-party`。
 
 兼容旧流程：源码/调试场景仍可解压发布内容后双击 `INSTALL.cmd`。EXE 只是图形化外壳，最终仍调用同一份 `installer/Install.ps1`，不会形成第二套安装逻辑。安装阶段不填写 API key，也不会下载 Mem0、BGE 或其他可选模型。
@@ -95,7 +95,9 @@ webplayer.dat.orig
 - 核心 Python/runtime：随发布包离线分发并在安装前完整校验，不在用户安装时访问外网。
 - 可选模型与扩展依赖：不随核心安装器分发。长期记忆的 Mem0 runtime 和 BGE 模型已从首装移除，后续由登录后的初始设置按需安装，并可在客户端 Settings 中管理。当前版本缺失时明确降级为 `UNAVAILABLE`。
 
-离线核心包含本地服务启动所需的 `aiohttp`、`jsonschema` 及其锁定依赖；TTS、视觉、音频分离、音乐和长期记忆模型仍需按第三方下载清单单独准备。缺失时 `START.cmd` / 本地 health 会报告不可用原因；不会自动下载未固定来源、许可证或 SHA-256 的内容。用户 API key 只从启动进程环境或 `CONFIGURE.cmd` 生成的当前用户 DPAPI 文件读取，不写入安装包或日志；DPAPI 解密值只存在于后端子进程环境中。
+离线核心包含本地服务启动所需的 `aiohttp`、`jsonschema` 及其锁定依赖；TTS、视觉、音频分离、音乐和长期记忆模型仍需按第三方下载清单单独准备。缺失时 `START.cmd` / 本地 health 会报告不可用原因；不会自动下载未固定来源、许可证或 SHA-256 的内容。用户 API key 只从启动进程环境或登录后的初始设置生成的当前用户 DPAPI 文件读取，不写入安装包或日志；DPAPI 解密值只存在于后端子进程环境中。初始设置 API 仅接受原版客户端明确配置的 HTTPS Origin，所有写操作还要求本次成功登录生成的随机 session token；任意本机端口网页不能调用。留空 key 只可复用当前已保存地址和模型的密钥，修改目标地址时必须重新输入，避免把已保存密钥发送到其他服务。
+
+保存或删除 LLM 设置后，当前版本会明确返回 `restart_required: true`。原因是回复、情绪分流和私人世界分析在进程启动时共同捕获同一 provider graph；进程内热替换会让并发任务跨两个 provider 状态运行。关闭并重新打开 Olivia 后，稳定启动器会加载新的公开配置与 DPAPI 密钥。公开路由、状态及错误码契约见 `contracts/initial_setup_api_contract.json` 和对应 schema。
 
 启动时若没有 `OLIVIA_LLM_API_KEY`、`DEEPSEEK_API_KEY` 或 `OPENAI_API_KEY`，命令行会明确提示未配置，不能把 safe-static 回退误认为真实模型回信。
 

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -7,7 +7,7 @@
 1. 下载 `Olivia-Setup-x64.exe` 及同目录的 `.sha256` 文件，并先核对 SHA-256。
 2. 双击 EXE，选择安装位置和正版 Steam 游戏目录。安装器按当前用户运行，不要求管理员权限；它从 EXE 内置的离线资产安装受管 Python 3.12 runtime 和固定 wheel，不联网下载。正版目录可留空并按 Steam AppID `4532590` 自动发现。
 3. 安装成功后双击 `START.cmd`。它只启动一个监听 `127.0.0.1` 的本机服务，再直接启动隔离副本的 `0.0.9.627\Olivia.exe`，并使用安装目录下的独立 profile。长期记忆、PrivateWorld 和媒体接口都挂在同一个进程中。
-4. 登录原版客户端成功后会显示一次初始设置：可选择 OpenCode Go、DeepSeek 官方或自定义 OpenAI-compatible 地址，必须先测试连接再保存。API key 输入不回显，并以当前 Windows 用户 DPAPI 加密保存到 `data\config`；公开的地址和模型名写入 `data\config\llm.json`。也可继续使用 `CONFIGURE.cmd` 管理参考音频/视频。这些文件不进入补丁包。
+4. 本版本提供登录后初始设置的本机 API；原版客户端界面接线在后续独立补丁中交付。在界面接线前仍通过启动环境提供 LLM key，也可继续使用 `CONFIGURE.cmd` 管理参考音频/视频。这些文件不进入补丁包。
 5. 卸载双击 `UNINSTALL.cmd`。受控卸载只删除安装器自己写入的 `app`、`local_backend`、启动脚本和 marker，保留 `data`、`logs`、`third-party`。
 
 兼容旧流程：源码/调试场景仍可解压发布内容后双击 `INSTALL.cmd`。EXE 只是图形化外壳，最终仍调用同一份 `installer/Install.ps1`，不会形成第二套安装逻辑。安装阶段不填写 API key，也不会下载 Mem0、BGE 或其他可选模型。
@@ -95,7 +95,7 @@ webplayer.dat.orig
 - 核心 Python/runtime：随发布包离线分发并在安装前完整校验，不在用户安装时访问外网。
 - 可选模型与扩展依赖：不随核心安装器分发。长期记忆的 Mem0 runtime 和 BGE 模型已从首装移除，后续由登录后的初始设置按需安装，并可在客户端 Settings 中管理。当前版本缺失时明确降级为 `UNAVAILABLE`。
 
-离线核心包含本地服务启动所需的 `aiohttp`、`jsonschema` 及其锁定依赖；TTS、视觉、音频分离、音乐和长期记忆模型仍需按第三方下载清单单独准备。缺失时 `START.cmd` / 本地 health 会报告不可用原因；不会自动下载未固定来源、许可证或 SHA-256 的内容。用户 API key 只从启动进程环境或登录后的初始设置生成的当前用户 DPAPI 文件读取，不写入安装包或日志；DPAPI 解密值只存在于后端子进程环境中。初始设置 API 仅接受原版客户端明确配置的 HTTPS Origin，所有写操作还要求本次成功登录生成的随机 session token；任意本机端口网页不能调用。留空 key 只可复用当前已保存地址和模型的密钥，修改目标地址时必须重新输入，避免把已保存密钥发送到其他服务。
+离线核心包含本地服务启动所需的 `aiohttp`、`jsonschema` 及其锁定依赖；TTS、视觉、音频分离、音乐和长期记忆模型仍需按第三方下载清单单独准备。缺失时 `START.cmd` / 本地 health 会报告不可用原因；不会自动下载未固定来源、许可证或 SHA-256 的内容。用户 API key 只从启动进程环境或登录后的初始设置生成的当前用户 DPAPI 文件读取，不写入安装包或日志；DPAPI 解密值只存在于后端子进程环境中。初始设置 API 仅接受原版客户端明确配置的 HTTPS Origin，所有写操作还要求本次成功登录生成的随机 session token；任意本机端口网页不能调用。留空 key 只可复用当前已保存地址和模型的密钥，修改目标地址时必须重新输入。每次保存先写入新的版本化 DPAPI 文件，再用一次原子替换发布同时绑定 provider、模型、密钥文件名和密文 SHA-256 的 `llm.json`；配置损坏或绑定不匹配时启动器关闭 provider，不把旧 key 发送到默认服务。
 
 保存或删除 LLM 设置后，当前版本会明确返回 `restart_required: true`。原因是回复、情绪分流和私人世界分析在进程启动时共同捕获同一 provider graph；进程内热替换会让并发任务跨两个 provider 状态运行。关闭并重新打开 Olivia 后，稳定启动器会加载新的公开配置与 DPAPI 密钥。公开路由、状态及错误码契约见 `contracts/initial_setup_api_contract.json` 和对应 schema。
 

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -6,11 +6,13 @@ import argparse
 import json
 import os
 from pathlib import Path
+import re
 import socket
 import subprocess
 import sys
 import time
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
 from urllib.request import urlopen
 
 
@@ -21,14 +23,74 @@ def _load_dpapi_key(path: Path) -> str:
         protected = path.read_text(encoding="utf-8").strip()
         if not protected:
             return ""
-        script = "$s=ConvertTo-SecureString ([Console]::In.ReadToEnd()); $b=[Runtime.InteropServices.Marshal]::SecureStringToBSTR($s); try {[Runtime.InteropServices.Marshal]::PtrToStringBSTR($b)} finally {[Runtime.InteropServices.Marshal]::ZeroFreeBSTR($b)}"
+        modern = protected.startswith("dpapi-v1:")
+        script = (
+            "Add-Type -AssemblyName System.Security; "
+            "$p=[Convert]::FromBase64String([Console]::In.ReadToEnd()); "
+            "$b=[Security.Cryptography.ProtectedData]::Unprotect($p,$null,"
+            "[Security.Cryptography.DataProtectionScope]::CurrentUser); "
+            "[Text.Encoding]::UTF8.GetString($b)"
+            if modern
+            else "$s=ConvertTo-SecureString ([Console]::In.ReadToEnd()); $b=[Runtime.InteropServices.Marshal]::SecureStringToBSTR($s); try {[Runtime.InteropServices.Marshal]::PtrToStringBSTR($b)} finally {[Runtime.InteropServices.Marshal]::ZeroFreeBSTR($b)}"
+        )
         result = subprocess.run(
             ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
-            input=protected, text=True, capture_output=True, check=False,
+            input=protected.removeprefix("dpapi-v1:"),
+            text=True,
+            capture_output=True,
+            check=False,
         )
         return result.stdout.strip() if result.returncode == 0 else ""
     except (OSError, UnicodeError):
         return ""
+
+
+_LLM_MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+
+
+def _load_llm_environment(
+    environment: dict[str, str],
+    data_root: Path,
+) -> dict[str, str]:
+    """Load public provider settings while retaining safe defaults on corruption."""
+
+    values = environment.copy()
+    base_url = "https://api.deepseek.com"
+    model = "deepseek-v4-flash"
+    try:
+        payload = json.loads(
+            (data_root / "config" / "llm.json").read_text(encoding="utf-8")
+        )
+        candidate_url = str(payload["base_url"]).strip().rstrip("/")
+        candidate_model = str(payload["model"]).strip()
+        parsed = urlsplit(candidate_url)
+        loopback = parsed.hostname in {"127.0.0.1", "localhost", "::1"}
+        if (
+            payload.get("schema_version") == 1
+            and parsed.hostname
+            and parsed.scheme in ({"http", "https"} if loopback else {"https"})
+            and not parsed.username
+            and not parsed.password
+            and not parsed.query
+            and not parsed.fragment
+            and _LLM_MODEL_RE.fullmatch(candidate_model)
+        ):
+            base_url = candidate_url
+            model = candidate_model
+    except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        pass
+    for name, value in {
+        "OLIVIA_LLM_PROVIDER": "openai_compatible",
+        "OLIVIA_LLM_BASE_URL": base_url,
+        "OLIVIA_LLM_MODEL": model,
+        "OLIVIA_LLM_API_KEY_ENV": "DEEPSEEK_API_KEY",
+        "OLIVIA_LLM_API_STYLE": "chat_completions",
+        "OLIVIA_LLM_STREAM": "true",
+        "OLIVIA_LLM_TIMEOUT_SECONDS": "180",
+        "OLIVIA_LLM_MAX_RETRIES": "0",
+    }.items():
+        values.setdefault(name, value)
+    return values
 
 
 _CORE_HEALTH_CONTRACT_VERSION = "b02.v1"
@@ -226,18 +288,8 @@ def main(argv: list[str] | None = None) -> int:
     }
     backend_environment.update(runtime_environment)
     client_environment.update(runtime_environment)
-    for name, value in {
-        "OLIVIA_LLM_PROVIDER": "openai_compatible",
-        "OLIVIA_LLM_BASE_URL": "https://api.deepseek.com",
-        "OLIVIA_LLM_MODEL": "deepseek-v4-flash",
-        "OLIVIA_LLM_API_KEY_ENV": "DEEPSEEK_API_KEY",
-        "OLIVIA_LLM_API_STYLE": "chat_completions",
-        "OLIVIA_LLM_STREAM": "true",
-        "OLIVIA_LLM_TIMEOUT_SECONDS": "180",
-        "OLIVIA_LLM_MAX_RETRIES": "0",
-    }.items():
-        backend_environment.setdefault(name, value)
-        client_environment.setdefault(name, value)
+    backend_environment = _load_llm_environment(backend_environment, data_root)
+    client_environment = _load_llm_environment(client_environment, data_root)
     _configure_memory_environment(backend_environment, data_root)
     if not any(backend_environment.get(name) for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")):
         print("LLM_API_KEY_NOT_CONFIGURED: 请先在启动此程序的进程环境中设置 API key；当前仅提供明确的 safe-static/degraded 回退。")

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -51,22 +52,25 @@ _LLM_MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
 def _load_llm_environment(
     environment: dict[str, str],
     data_root: Path,
+    *,
+    include_secret: bool = False,
 ) -> dict[str, str]:
     """Load public provider settings while retaining safe defaults on corruption."""
 
     values = environment.copy()
     base_url = "https://api.deepseek.com"
     model = "deepseek-v4-flash"
+    provider = "openai_compatible"
+    key_path = data_root / "config" / "deepseek_api_key.dpapi"
+    config_path = data_root / "config" / "llm.json"
     try:
-        payload = json.loads(
-            (data_root / "config" / "llm.json").read_text(encoding="utf-8")
-        )
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
         candidate_url = str(payload["base_url"]).strip().rstrip("/")
         candidate_model = str(payload["model"]).strip()
         parsed = urlsplit(candidate_url)
         loopback = parsed.hostname in {"127.0.0.1", "localhost", "::1"}
         if (
-            payload.get("schema_version") == 1
+            payload.get("schema_version") in {1, 2}
             and parsed.hostname
             and parsed.scheme in ({"http", "https"} if loopback else {"https"})
             and not parsed.username
@@ -77,10 +81,30 @@ def _load_llm_environment(
         ):
             base_url = candidate_url
             model = candidate_model
-    except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            if payload.get("schema_version") == 2:
+                name = payload.get("key_file")
+                expected_hash = payload.get("key_sha256")
+                if (
+                    not isinstance(name, str)
+                    or not re.fullmatch(
+                        r"deepseek_api_key\.[0-9a-f]{32}\.dpapi", name
+                    )
+                    or not isinstance(expected_hash, str)
+                    or not re.fullmatch(r"[0-9a-f]{64}", expected_hash)
+                ):
+                    raise ValueError("invalid key binding")
+                key_path = config_path.parent / name
+                if hashlib.sha256(key_path.read_bytes()).hexdigest() != expected_hash:
+                    raise ValueError("invalid key binding")
+        else:
+            raise ValueError("invalid LLM config")
+    except FileNotFoundError:
         pass
+    except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        provider = "none"
+        key_path = Path()
     for name, value in {
-        "OLIVIA_LLM_PROVIDER": "openai_compatible",
+        "OLIVIA_LLM_PROVIDER": provider,
         "OLIVIA_LLM_BASE_URL": base_url,
         "OLIVIA_LLM_MODEL": model,
         "OLIVIA_LLM_API_KEY_ENV": "DEEPSEEK_API_KEY",
@@ -90,6 +114,13 @@ def _load_llm_environment(
         "OLIVIA_LLM_MAX_RETRIES": "0",
     }.items():
         values.setdefault(name, value)
+    if include_secret and key_path != Path() and not any(
+        values.get(name)
+        for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")
+    ):
+        configured_key = _load_dpapi_key(key_path)
+        if configured_key:
+            values["DEEPSEEK_API_KEY"] = configured_key
     return values
 
 
@@ -269,9 +300,6 @@ def main(argv: list[str] | None = None) -> int:
     data_root.mkdir(parents=True, exist_ok=True)
     client_environment = os.environ.copy()
     backend_environment = client_environment.copy()
-    configured_key = _load_dpapi_key(data_root / "config" / "deepseek_api_key.dpapi")
-    if configured_key and not any(backend_environment.get(name) for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")):
-        backend_environment["DEEPSEEK_API_KEY"] = configured_key
     runtime_environment = {
         "OLIVIA_INSTALL_ROOT": str(root),
         "OLIVIA_PROJECT_ROOT": str(root / "app"),
@@ -288,7 +316,9 @@ def main(argv: list[str] | None = None) -> int:
     }
     backend_environment.update(runtime_environment)
     client_environment.update(runtime_environment)
-    backend_environment = _load_llm_environment(backend_environment, data_root)
+    backend_environment = _load_llm_environment(
+        backend_environment, data_root, include_secret=True
+    )
     client_environment = _load_llm_environment(client_environment, data_root)
     _configure_memory_environment(backend_environment, data_root)
     if not any(backend_environment.get(name) for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")):

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -40,6 +40,10 @@ from original_client_companion_mutation_backend import (
     DirectOriginalClientCompanionMutationBackend,
     MemoryAdminMutationService,
 )
+from original_client_setup_api import (
+    LLMSetupService,
+    mount_original_client_setup_api,
+)
 from original_client_letter_contract import (
     OriginalClientContractError,
     serialize_letter_detail,
@@ -314,6 +318,10 @@ def create_original_client_server_runtime(
     candidate_decisions: CandidateReviewBackend | None = None,
     embedding_installer: Mem0EmbeddingInstaller | None = None,
     letter_collection: LetterCollection | None = None,
+    setup_service: LLMSetupService | None = None,
+    capability_installer: Any | None = None,
+    capability_staging_root: Path | None = None,
+    capability_offline_importer: Callable[[Path, Path], Path] | None = None,
     trusted_origins: Sequence[str] = (),
 ) -> OriginalClientServerRuntime:
     """Mount original-client adapters before the toy catch-all."""
@@ -343,6 +351,36 @@ def create_original_client_server_runtime(
     )
     app = web.Application()
     origins = tuple(trusted_origins)
+    observed_fallback = fallback_handler
+    if setup_service is not None:
+        async def observed_fallback(request: web.Request) -> web.StreamResponse:
+            response = await fallback_handler(request)
+            if request.path.rstrip("/") == "/toy/signIn":
+                payload = _response_payload(response)
+                setup_service.observe_login(
+                    success=bool(payload and payload.get("code") == 0)
+                )
+            return response
+
+        mount_original_client_setup_api(
+            app,
+            setup_service,
+            trusted_origins=origins,
+        )
+    if (
+        capability_installer is not None
+        and capability_staging_root is not None
+        and capability_offline_importer is not None
+    ):
+        from original_client_capability_api import mount_original_client_capability_api
+
+        mount_original_client_capability_api(
+            app,
+            capability_installer,
+            trusted_origins=origins,
+            staging_root=capability_staging_root,
+            offline_importer=capability_offline_importer,
+        )
     mount_original_companion_read_api(
         app,
         backend,
@@ -356,11 +394,11 @@ def create_original_client_server_runtime(
     if letter_collection is not None:
         mount_original_mailbox_wire_adapter(
             app,
-            fallback_handler,
+            observed_fallback,
             letter_collection,
         )
     # Keep this last.  The original server intentionally owns a catch-all route.
-    app.router.add_route("*", "/{tail:.*}", fallback_handler)
+    app.router.add_route("*", "/{tail:.*}", observed_fallback)
     runtime = OriginalClientServerRuntime(
         app,
         backend,
@@ -522,6 +560,8 @@ def create_configured_original_client_server_runtime(
         values,
     )
     collection = getattr(server_module, "_letter_collection", None)
+    data_root = _absolute_data_root(values)
+    setup_service = LLMSetupService(data_root) if data_root is not None else None
     runtime = create_original_client_server_runtime(
         fallback,
         memory_admin=memory_admin,
@@ -530,6 +570,7 @@ def create_configured_original_client_server_runtime(
         candidate_decisions=candidate_decisions,
         embedding_installer=embedding_installer,
         letter_collection=collection if callable(collection) else None,
+        setup_service=setup_service,
         trusted_origins=origins,
     )
     install_reply_task_lifecycle = getattr(

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -319,9 +319,6 @@ def create_original_client_server_runtime(
     embedding_installer: Mem0EmbeddingInstaller | None = None,
     letter_collection: LetterCollection | None = None,
     setup_service: LLMSetupService | None = None,
-    capability_installer: Any | None = None,
-    capability_staging_root: Path | None = None,
-    capability_offline_importer: Callable[[Path, Path], Path] | None = None,
     trusted_origins: Sequence[str] = (),
 ) -> OriginalClientServerRuntime:
     """Mount original-client adapters before the toy catch-all."""
@@ -357,8 +354,9 @@ def create_original_client_server_runtime(
             response = await fallback_handler(request)
             if request.path.rstrip("/") == "/toy/signIn":
                 payload = _response_payload(response)
+                code = payload.get("code") if payload else None
                 setup_service.observe_login(
-                    success=bool(payload and payload.get("code") == 0)
+                    success=type(code) is int and code == 0
                 )
             return response
 
@@ -366,20 +364,6 @@ def create_original_client_server_runtime(
             app,
             setup_service,
             trusted_origins=origins,
-        )
-    if (
-        capability_installer is not None
-        and capability_staging_root is not None
-        and capability_offline_importer is not None
-    ):
-        from original_client_capability_api import mount_original_client_capability_api
-
-        mount_original_client_capability_api(
-            app,
-            capability_installer,
-            trusted_origins=origins,
-            staging_root=capability_staging_root,
-            offline_importer=capability_offline_importer,
         )
     mount_original_companion_read_api(
         app,

--- a/original_client_setup_api.py
+++ b/original_client_setup_api.py
@@ -1,0 +1,457 @@
+"""Credential-safe first-run LLM setup for the original Olivia client."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+from typing import Any
+from urllib.parse import urlsplit
+
+from aiohttp import ClientError, ClientSession, ClientTimeout, web
+
+
+SETUP_STATUS_PATH = "/toy/setup/status"
+LLM_TEST_PATH = "/toy/setup/llm/test"
+LLM_SAVE_PATH = "/toy/setup/llm/save"
+LLM_DELETE_PATH = "/toy/setup/llm/delete"
+SETUP_COMPLETE_PATH = "/toy/setup/complete"
+CONFIRM_HEADER = "X-Olivia-Setup-Action"
+CONFIRM_VALUE = "confirmed"
+_MAX_BODY_BYTES = 4_096
+_MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+_LOOPBACK_ORIGIN_RE = re.compile(r"^http://(?:127\.0\.0\.1|localhost):[0-9]{1,5}$")
+_SERVICE_KEY = web.AppKey("original_client_setup_service", object)
+_ORIGINS_KEY = web.AppKey("original_client_setup_origins", frozenset)
+_MOUNTED_KEY = web.AppKey("original_client_setup_mounted", bool)
+Probe = Callable[[str, str, str], Awaitable[None]]
+Protector = Callable[[str], str]
+
+
+class LLMSetupError(RuntimeError):
+    """Stable setup failure that never contains provider or credential data."""
+
+    def __init__(self, code: str, *, status: int) -> None:
+        self.code = code
+        self.status = status
+        super().__init__(code)
+
+
+def _dpapi_protect(value: str) -> str:
+    if os.name != "nt":
+        raise LLMSetupError("LLM_SETUP_DPAPI_UNAVAILABLE", status=503)
+    script = (
+        "Add-Type -AssemblyName System.Security; "
+        "$b=[Text.Encoding]::UTF8.GetBytes([Console]::In.ReadToEnd()); "
+        "$p=[Security.Cryptography.ProtectedData]::Protect($b,$null,"
+        "[Security.Cryptography.DataProtectionScope]::CurrentUser); "
+        "[Convert]::ToBase64String($p)"
+    )
+    result = subprocess.run(
+        ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+        input=value,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    protected = result.stdout.strip()
+    if result.returncode or not protected:
+        raise LLMSetupError("LLM_SETUP_DPAPI_FAILED", status=503)
+    return f"dpapi-v1:{protected}"
+
+
+def _dpapi_unprotect(value: str) -> str:
+    if os.name != "nt":
+        raise LLMSetupError("LLM_SETUP_DPAPI_UNAVAILABLE", status=503)
+    modern = value.startswith("dpapi-v1:")
+    script = (
+        "Add-Type -AssemblyName System.Security; "
+        "$p=[Convert]::FromBase64String([Console]::In.ReadToEnd()); "
+        "$b=[Security.Cryptography.ProtectedData]::Unprotect($p,$null,"
+        "[Security.Cryptography.DataProtectionScope]::CurrentUser); "
+        "[Text.Encoding]::UTF8.GetString($b)"
+        if modern
+        else (
+            "$s=ConvertTo-SecureString ([Console]::In.ReadToEnd()); "
+            "$p=[Runtime.InteropServices.Marshal]::SecureStringToBSTR($s); "
+            "try {[Runtime.InteropServices.Marshal]::PtrToStringBSTR($p)} "
+            "finally {[Runtime.InteropServices.Marshal]::ZeroFreeBSTR($p)}"
+        )
+    )
+    result = subprocess.run(
+        ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+        input=value.removeprefix("dpapi-v1:"),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    secret = result.stdout.strip()
+    if result.returncode or not secret:
+        raise LLMSetupError("LLM_SETUP_KEY_UNAVAILABLE", status=503)
+    return secret
+
+
+def _base_url(value: object) -> str:
+    if not isinstance(value, str) or len(value) > 512:
+        raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
+    normalized = value.strip().rstrip("/")
+    try:
+        parsed = urlsplit(normalized)
+        port = parsed.port
+    except ValueError as exc:
+        raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400) from exc
+    loopback = parsed.hostname in {"127.0.0.1", "localhost", "::1"}
+    if (
+        not parsed.hostname
+        or parsed.scheme not in ({"http", "https"} if loopback else {"https"})
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or (port is not None and not 1 <= port <= 65535)
+    ):
+        raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
+    return normalized
+
+
+def _model(value: object) -> str:
+    if not isinstance(value, str) or not _MODEL_RE.fullmatch(value.strip()):
+        raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
+    return value.strip()
+
+
+def _api_key(value: object, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
+    normalized = value.strip()
+    if not normalized and allow_empty:
+        return ""
+    if (
+        not 8 <= len(normalized) <= 512
+        or any(ord(character) < 32 or ord(character) == 127 for character in normalized)
+    ):
+        raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
+    return normalized
+
+
+async def _probe_openai_compatible(base_url: str, model: str, api_key: str) -> None:
+    try:
+        async with ClientSession(timeout=ClientTimeout(total=20)) as session:
+            async with session.post(
+                f"{base_url}/chat/completions",
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={
+                    "model": model,
+                    "messages": [{"role": "user", "content": "Reply with OK."}],
+                    "max_tokens": 2,
+                    "stream": False,
+                },
+            ) as response:
+                if not 200 <= response.status < 300:
+                    raise LLMSetupError("LLM_SETUP_CONNECTION_FAILED", status=503)
+                payload = await response.json(content_type=None)
+    except LLMSetupError:
+        raise
+    except (ClientError, TimeoutError, ValueError) as exc:
+        raise LLMSetupError("LLM_SETUP_CONNECTION_FAILED", status=503) from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("choices"), list):
+        raise LLMSetupError("LLM_SETUP_CONNECTION_FAILED", status=503)
+
+
+def _atomic_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    staging = path.with_suffix(path.suffix + ".staging")
+    staging.write_text(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    staging.replace(path)
+
+
+class LLMSetupService:
+    """Own first-run state and persist only DPAPI ciphertext plus public config."""
+
+    def __init__(
+        self,
+        data_root: Path,
+        *,
+        protect: Protector = _dpapi_protect,
+        unprotect: Protector = _dpapi_unprotect,
+        probe: Probe = _probe_openai_compatible,
+    ) -> None:
+        self._config_root = Path(data_root) / "config"
+        self._key_path = self._config_root / "deepseek_api_key.dpapi"
+        self._config_path = self._config_root / "llm.json"
+        self._complete_path = self._config_root / "initial_setup.json"
+        self._protect = protect
+        self._unprotect = unprotect
+        self._probe = probe
+        self._login_observed = False
+        self._tested_digest: str | None = None
+
+    def observe_login(self, *, success: bool) -> None:
+        if success:
+            self._login_observed = True
+
+    def _config(self) -> dict[str, object]:
+        fallback: dict[str, object] = {
+            "base_url": "https://api.deepseek.com",
+            "model": "deepseek-v4-flash",
+        }
+        try:
+            payload = json.loads(self._config_path.read_text(encoding="utf-8"))
+            if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+                return fallback
+            return {
+                "base_url": _base_url(payload.get("base_url")),
+                "model": _model(payload.get("model")),
+            }
+        except (OSError, UnicodeError, json.JSONDecodeError, LLMSetupError):
+            return fallback
+
+    def _completion(self) -> tuple[bool, bool]:
+        try:
+            payload = json.loads(self._complete_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            return False, False
+        if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+            return False, False
+        return payload.get("completed") is True, payload.get("skipped") is True
+
+    def status(self) -> dict[str, object]:
+        completed, skipped = self._completion()
+        config = self._config()
+        return {
+            "schema_version": "olivia.initial-setup.v1",
+            "status": "READY",
+            "login_observed": self._login_observed,
+            "setup_completed": completed,
+            "show_initial_setup": self._login_observed and not completed,
+            "skipped": skipped,
+            "llm": {
+                "base_url": config["base_url"],
+                "model": config["model"],
+                "key_configured": self._key_path.is_file(),
+            },
+        }
+
+    @staticmethod
+    def _digest(base_url: str, model: str, api_key: str) -> str:
+        return hashlib.sha256(
+            "\0".join((base_url, model, api_key)).encode("utf-8")
+        ).hexdigest()
+
+    def _secret(self, supplied: object) -> str:
+        candidate = _api_key(supplied, allow_empty=True)
+        if candidate:
+            return candidate
+        try:
+            protected = self._key_path.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            raise LLMSetupError("LLM_SETUP_KEY_REQUIRED", status=400) from exc
+        if not protected:
+            raise LLMSetupError("LLM_SETUP_KEY_REQUIRED", status=400)
+        return _api_key(self._unprotect(protected))
+
+    async def test(self, payload: dict[str, object]) -> None:
+        if set(payload) != {"base_url", "model", "api_key"}:
+            raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
+        base_url = _base_url(payload.get("base_url"))
+        model = _model(payload.get("model"))
+        api_key = self._secret(payload.get("api_key", ""))
+        await self._probe(base_url, model, api_key)
+        self._tested_digest = self._digest(base_url, model, api_key)
+
+    def save(self, payload: dict[str, object]) -> None:
+        if set(payload) != {"base_url", "model", "api_key"}:
+            raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
+        base_url = _base_url(payload.get("base_url"))
+        model = _model(payload.get("model"))
+        api_key = self._secret(payload.get("api_key", ""))
+        if self._tested_digest != self._digest(base_url, model, api_key):
+            raise LLMSetupError("LLM_SETUP_TEST_REQUIRED", status=409)
+        protected = self._protect(api_key)
+        self._config_root.mkdir(parents=True, exist_ok=True)
+        key_staging = self._key_path.with_suffix(self._key_path.suffix + ".staging")
+        key_staging.write_text(protected + "\n", encoding="utf-8")
+        _atomic_json(
+            self._config_path,
+            {"schema_version": 1, "base_url": base_url, "model": model},
+        )
+        key_staging.replace(self._key_path)
+        self._tested_digest = None
+
+    def delete(self) -> None:
+        try:
+            self._key_path.unlink()
+        except FileNotFoundError:
+            pass
+        self._tested_digest = None
+
+    def complete(self, *, skipped: object) -> bool:
+        if type(skipped) is not bool:
+            raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
+        _atomic_json(
+            self._complete_path,
+            {"schema_version": 1, "completed": True, "skipped": skipped},
+        )
+        return skipped
+
+
+def _normalize_origins(values: Sequence[str]) -> frozenset[str]:
+    normalized: set[str] = set()
+    for value in values:
+        candidate = value.rstrip("/") if isinstance(value, str) else ""
+        try:
+            parsed = urlsplit(candidate)
+        except ValueError as exc:
+            raise ValueError("trusted origins are invalid") from exc
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username
+            or parsed.password
+            or parsed.path
+            or parsed.query
+            or parsed.fragment
+            or candidate in normalized
+        ):
+            raise ValueError("trusted origins are invalid")
+        normalized.add(candidate)
+    return frozenset(normalized)
+
+
+def _authorize(request: web.Request, *, confirm: bool) -> str:
+    try:
+        hostname = urlsplit(f"//{request.host}").hostname
+    except ValueError as exc:
+        raise LLMSetupError("LLM_SETUP_HOST_FORBIDDEN", status=403) from exc
+    if hostname not in {"127.0.0.1", "localhost", "::1"}:
+        raise LLMSetupError("LLM_SETUP_HOST_FORBIDDEN", status=403)
+    origin = request.headers.get("Origin", "").rstrip("/")
+    if origin not in request.app[_ORIGINS_KEY] and not _LOOPBACK_ORIGIN_RE.fullmatch(origin):
+        raise LLMSetupError("LLM_SETUP_ORIGIN_FORBIDDEN", status=403)
+    if confirm and request.headers.get(CONFIRM_HEADER) != CONFIRM_VALUE:
+        raise LLMSetupError("LLM_SETUP_CONFIRMATION_REQUIRED", status=403)
+    return origin
+
+
+def _headers(origin: str | None = None, *, preflight: bool = False) -> dict[str, str]:
+    values = {"Cache-Control": "no-store"}
+    if origin:
+        values["Access-Control-Allow-Origin"] = origin
+        values["Vary"] = "Origin"
+    if preflight:
+        values.update(
+            {
+                "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+                "Access-Control-Allow-Headers": f"Content-Type, {CONFIRM_HEADER}",
+                "Access-Control-Max-Age": "600",
+            }
+        )
+    return values
+
+
+async def _body(request: web.Request) -> dict[str, object]:
+    if request.content_length is not None and request.content_length > _MAX_BODY_BYTES:
+        raise LLMSetupError("LLM_SETUP_REQUEST_TOO_LARGE", status=413)
+    if request.content_type != "application/json":
+        raise LLMSetupError("LLM_SETUP_CONTENT_TYPE_INVALID", status=415)
+    raw = await request.content.read(_MAX_BODY_BYTES + 1)
+    if len(raw) > _MAX_BODY_BYTES:
+        raise LLMSetupError("LLM_SETUP_REQUEST_TOO_LARGE", status=413)
+    try:
+        payload: Any = json.loads(raw.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise LLMSetupError("LLM_SETUP_JSON_INVALID", status=400) from exc
+    if not isinstance(payload, dict):
+        raise LLMSetupError("LLM_SETUP_JSON_INVALID", status=400)
+    return payload
+
+
+def mount_original_client_setup_api(
+    app: web.Application,
+    service: LLMSetupService,
+    *,
+    trusted_origins: Sequence[str] = (),
+) -> None:
+    if app.get(_MOUNTED_KEY, False):
+        raise RuntimeError("LLM_SETUP_ALREADY_MOUNTED")
+    app[_SERVICE_KEY] = service
+    app[_ORIGINS_KEY] = _normalize_origins(trusted_origins)
+    app[_MOUNTED_KEY] = True
+
+    async def options(request: web.Request) -> web.Response:
+        origin = _authorize(request, confirm=False)
+        return web.Response(status=204, headers=_headers(origin, preflight=True))
+
+    async def status(request: web.Request) -> web.Response:
+        origin = _authorize(request, confirm=False)
+        return web.json_response(service.status(), headers=_headers(origin))
+
+    async def test(request: web.Request) -> web.Response:
+        origin = _authorize(request, confirm=True)
+        await service.test(await _body(request))
+        return web.json_response({"status": "AVAILABLE"}, headers=_headers(origin))
+
+    async def save(request: web.Request) -> web.Response:
+        origin = _authorize(request, confirm=True)
+        service.save(await _body(request))
+        return web.json_response(
+            {"status": "SAVED", "restart_required": True}, headers=_headers(origin)
+        )
+
+    async def delete(request: web.Request) -> web.Response:
+        origin = _authorize(request, confirm=True)
+        if await _body(request):
+            raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
+        service.delete()
+        return web.json_response(
+            {"status": "DELETED", "restart_required": True}, headers=_headers(origin)
+        )
+
+    async def complete(request: web.Request) -> web.Response:
+        origin = _authorize(request, confirm=True)
+        payload = await _body(request)
+        if set(payload) != {"skipped"}:
+            raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
+        skipped = service.complete(skipped=payload["skipped"])
+        return web.json_response(
+            {"status": "COMPLETED", "skipped": skipped}, headers=_headers(origin)
+        )
+
+    @web.middleware
+    async def errors(request: web.Request, handler: Callable[..., Awaitable[web.StreamResponse]]) -> web.StreamResponse:
+        try:
+            return await handler(request)
+        except LLMSetupError as exc:
+            return web.json_response(
+                {"status": "FAILED", "error_code": exc.code},
+                status=exc.status,
+                headers=_headers(),
+            )
+
+    app.middlewares.append(errors)
+    app.router.add_get(SETUP_STATUS_PATH, status)
+    for path, handler in (
+        (LLM_TEST_PATH, test),
+        (LLM_SAVE_PATH, save),
+        (LLM_DELETE_PATH, delete),
+        (SETUP_COMPLETE_PATH, complete),
+    ):
+        app.router.add_post(path, handler)
+    for path in (
+        SETUP_STATUS_PATH,
+        LLM_TEST_PATH,
+        LLM_SAVE_PATH,
+        LLM_DELETE_PATH,
+        SETUP_COMPLETE_PATH,
+    ):
+        app.router.add_options(path, options)
+
+
+__all__ = ["LLMSetupError", "LLMSetupService", "mount_original_client_setup_api"]

--- a/original_client_setup_api.py
+++ b/original_client_setup_api.py
@@ -26,17 +26,73 @@ CONFIRM_VALUE = "confirmed"
 SESSION_HEADER = "X-Olivia-Setup-Session"
 _MAX_BODY_BYTES = 4_096
 _MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+_KEY_FILE_RE = re.compile(r"^deepseek_api_key\.[0-9a-f]{32}\.dpapi$")
 _SERVICE_KEY = web.AppKey("original_client_setup_service", object)
 _ORIGINS_KEY = web.AppKey("original_client_setup_origins", frozenset)
 _MOUNTED_KEY = web.AppKey("original_client_setup_mounted", bool)
 Probe = Callable[[str, str, str], Awaitable[None]]
 Protector = Callable[[str], str]
 
+PUBLIC_ROUTE_CONTRACT = {
+    SETUP_STATUS_PATH: {
+        "methods": ["GET", "OPTIONS"],
+        "status_values": ["READY"],
+        "request_fields": [],
+        "response_fields": [
+            "schema_version", "status", "login_observed", "setup_completed",
+            "show_initial_setup", "skipped", "llm", "session_token?",
+        ],
+    },
+    LLM_TEST_PATH: {
+        "methods": ["POST", "OPTIONS"],
+        "status_values": ["AVAILABLE"],
+        "request_fields": ["base_url", "model", "api_key"],
+        "response_fields": ["status"],
+    },
+    LLM_SAVE_PATH: {
+        "methods": ["POST", "OPTIONS"],
+        "status_values": ["SAVED"],
+        "request_fields": ["base_url", "model", "api_key"],
+        "response_fields": ["status", "reload_applied", "restart_required"],
+    },
+    LLM_DELETE_PATH: {
+        "methods": ["POST", "OPTIONS"],
+        "status_values": ["DELETED"],
+        "request_fields": [],
+        "response_fields": ["status", "reload_applied", "restart_required"],
+    },
+    SETUP_COMPLETE_PATH: {
+        "methods": ["POST", "OPTIONS"],
+        "status_values": ["COMPLETED"],
+        "request_fields": ["skipped"],
+        "response_fields": ["status", "skipped"],
+    },
+}
+ERROR_HTTP_STATUSES = {
+    "LLM_SETUP_CONFIRMATION_REQUIRED": [403],
+    "LLM_SETUP_CONNECTION_FAILED": [503],
+    "LLM_SETUP_CONTENT_TYPE_INVALID": [415],
+    "LLM_SETUP_DPAPI_FAILED": [503],
+    "LLM_SETUP_DPAPI_UNAVAILABLE": [503],
+    "LLM_SETUP_FIELDS_INVALID": [400],
+    "LLM_SETUP_HOST_FORBIDDEN": [403],
+    "LLM_SETUP_JSON_INVALID": [400],
+    "LLM_SETUP_KEY_REQUIRED": [400, 409],
+    "LLM_SETUP_KEY_UNAVAILABLE": [503],
+    "LLM_SETUP_LOGIN_REQUIRED": [403],
+    "LLM_SETUP_ORIGIN_FORBIDDEN": [403],
+    "LLM_SETUP_REQUEST_TOO_LARGE": [413],
+    "LLM_SETUP_SAVE_FAILED": [503],
+    "LLM_SETUP_TEST_REQUIRED": [409],
+}
+
 
 class LLMSetupError(RuntimeError):
     """Stable setup failure that never contains provider or credential data."""
 
     def __init__(self, code: str, *, status: int) -> None:
+        if code not in ERROR_HTTP_STATUSES or status not in ERROR_HTTP_STATUSES[code]:
+            raise ValueError("setup error contract is invalid")
         self.code = code
         self.status = status
         super().__init__(code)
@@ -215,7 +271,7 @@ class LLMSetupService:
         }
         try:
             payload = json.loads(self._config_path.read_text(encoding="utf-8"))
-            if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+            if not isinstance(payload, dict) or payload.get("schema_version") not in {1, 2}:
                 return fallback
             return {
                 "base_url": _base_url(payload.get("base_url")),
@@ -246,7 +302,7 @@ class LLMSetupService:
             "llm": {
                 "base_url": config["base_url"],
                 "model": config["model"],
-                "key_configured": self._key_path.is_file(),
+                "key_configured": self._active_key_path() is not None,
             },
         }
         if self._session_token is not None:
@@ -259,6 +315,33 @@ class LLMSetupService:
             "\0".join((base_url, model, api_key)).encode("utf-8")
         ).hexdigest()
 
+    def _active_key_path(self) -> Path | None:
+        try:
+            payload = json.loads(self._config_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            return self._key_path if self._key_path.is_file() else None
+        if not isinstance(payload, dict):
+            return None
+        if payload.get("schema_version") == 1:
+            return self._key_path if self._key_path.is_file() else None
+        name = payload.get("key_file")
+        digest = payload.get("key_sha256")
+        if (
+            payload.get("schema_version") != 2
+            or not isinstance(name, str)
+            or not _KEY_FILE_RE.fullmatch(name)
+            or not isinstance(digest, str)
+            or not re.fullmatch(r"[0-9a-f]{64}", digest)
+        ):
+            return None
+        path = self._config_root / name
+        try:
+            if hashlib.sha256(path.read_bytes()).hexdigest() != digest:
+                return None
+        except OSError:
+            return None
+        return path
+
     def _secret(self, supplied: object, *, base_url: str, model: str) -> str:
         candidate = _api_key(supplied, allow_empty=True)
         if candidate:
@@ -270,7 +353,10 @@ class LLMSetupService:
         ):
             raise LLMSetupError("LLM_SETUP_KEY_REQUIRED", status=400)
         try:
-            protected = self._key_path.read_text(encoding="utf-8").strip()
+            key_path = self._active_key_path()
+            if key_path is None:
+                raise OSError
+            protected = key_path.read_text(encoding="utf-8").strip()
         except OSError as exc:
             raise LLMSetupError("LLM_SETUP_KEY_REQUIRED", status=400) from exc
         if not protected:
@@ -298,27 +384,70 @@ class LLMSetupService:
         )
         if self._tested_digest != self._digest(base_url, model, api_key):
             raise LLMSetupError("LLM_SETUP_TEST_REQUIRED", status=409)
-        protected = self._protect(api_key)
+        protected_bytes = (self._protect(api_key) + "\n").encode("utf-8")
         self._config_root.mkdir(parents=True, exist_ok=True)
-        key_staging = self._key_path.with_suffix(self._key_path.suffix + ".staging")
-        key_staging.write_text(protected + "\n", encoding="utf-8")
-        _atomic_json(
-            self._config_path,
-            {"schema_version": 1, "base_url": base_url, "model": model},
-        )
-        key_staging.replace(self._key_path)
+        generation = secrets.token_hex(16)
+        key_path = self._config_root / f"deepseek_api_key.{generation}.dpapi"
+        key_staging = key_path.with_suffix(key_path.suffix + ".staging")
+        try:
+            key_staging.write_bytes(protected_bytes)
+            key_staging.replace(key_path)
+            _atomic_json(
+                self._config_path,
+                {
+                    "schema_version": 2,
+                    "base_url": base_url,
+                    "model": model,
+                    "key_file": key_path.name,
+                    "key_sha256": hashlib.sha256(protected_bytes).hexdigest(),
+                },
+            )
+        except OSError as exc:
+            key_staging.unlink(missing_ok=True)
+            key_path.unlink(missing_ok=True)
+            raise LLMSetupError("LLM_SETUP_SAVE_FAILED", status=503) from exc
+        for stale in self._config_root.glob("deepseek_api_key.*.dpapi"):
+            if stale != key_path and _KEY_FILE_RE.fullmatch(stale.name):
+                try:
+                    stale.unlink(missing_ok=True)
+                except OSError:
+                    pass
+        try:
+            self._key_path.unlink(missing_ok=True)
+        except OSError:
+            pass
         self._tested_digest = None
 
     def delete(self) -> None:
+        configured = self._config()
+        active = self._active_key_path()
         try:
-            self._key_path.unlink()
-        except FileNotFoundError:
+            _atomic_json(
+                self._config_path,
+                {
+                    "schema_version": 1,
+                    "base_url": configured["base_url"],
+                    "model": configured["model"],
+                },
+            )
+        except OSError as exc:
+            raise LLMSetupError("LLM_SETUP_SAVE_FAILED", status=503) from exc
+        if active is not None:
+            try:
+                active.unlink(missing_ok=True)
+            except OSError:
+                pass
+        try:
+            self._key_path.unlink(missing_ok=True)
+        except OSError:
             pass
         self._tested_digest = None
 
     def complete(self, *, skipped: object) -> bool:
         if type(skipped) is not bool:
             raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
+        if not skipped and self._active_key_path() is None:
+            raise LLMSetupError("LLM_SETUP_KEY_REQUIRED", status=409)
         _atomic_json(
             self._complete_path,
             {"schema_version": 1, "completed": True, "skipped": skipped},
@@ -469,10 +598,12 @@ def mount_original_client_setup_api(
         try:
             return await handler(request)
         except LLMSetupError as exc:
+            origin = request.headers.get("Origin", "").rstrip("/")
+            allowed_origin = origin if origin in request.app[_ORIGINS_KEY] else None
             return web.json_response(
                 {"status": "FAILED", "error_code": exc.code},
                 status=exc.status,
-                headers=_headers(),
+                headers=_headers(allowed_origin),
             )
 
     app.middlewares.append(errors)

--- a/original_client_setup_api.py
+++ b/original_client_setup_api.py
@@ -8,6 +8,7 @@ import json
 import os
 from pathlib import Path
 import re
+import secrets
 import subprocess
 from typing import Any
 from urllib.parse import urlsplit
@@ -22,9 +23,9 @@ LLM_DELETE_PATH = "/toy/setup/llm/delete"
 SETUP_COMPLETE_PATH = "/toy/setup/complete"
 CONFIRM_HEADER = "X-Olivia-Setup-Action"
 CONFIRM_VALUE = "confirmed"
+SESSION_HEADER = "X-Olivia-Setup-Session"
 _MAX_BODY_BYTES = 4_096
 _MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
-_LOOPBACK_ORIGIN_RE = re.compile(r"^http://(?:127\.0\.0\.1|localhost):[0-9]{1,5}$")
 _SERVICE_KEY = web.AppKey("original_client_setup_service", object)
 _ORIGINS_KEY = web.AppKey("original_client_setup_origins", frozenset)
 _MOUNTED_KEY = web.AppKey("original_client_setup_mounted", bool)
@@ -191,11 +192,21 @@ class LLMSetupService:
         self._unprotect = unprotect
         self._probe = probe
         self._login_observed = False
+        self._session_token: str | None = None
         self._tested_digest: str | None = None
 
     def observe_login(self, *, success: bool) -> None:
         if success:
             self._login_observed = True
+            self._session_token = secrets.token_urlsafe(32)
+
+    def require_session(self, supplied: str) -> None:
+        if (
+            not self._login_observed
+            or self._session_token is None
+            or not secrets.compare_digest(self._session_token, supplied)
+        ):
+            raise LLMSetupError("LLM_SETUP_LOGIN_REQUIRED", status=403)
 
     def _config(self) -> dict[str, object]:
         fallback: dict[str, object] = {
@@ -225,7 +236,7 @@ class LLMSetupService:
     def status(self) -> dict[str, object]:
         completed, skipped = self._completion()
         config = self._config()
-        return {
+        result: dict[str, object] = {
             "schema_version": "olivia.initial-setup.v1",
             "status": "READY",
             "login_observed": self._login_observed,
@@ -238,6 +249,9 @@ class LLMSetupService:
                 "key_configured": self._key_path.is_file(),
             },
         }
+        if self._session_token is not None:
+            result["session_token"] = self._session_token
+        return result
 
     @staticmethod
     def _digest(base_url: str, model: str, api_key: str) -> str:
@@ -245,10 +259,16 @@ class LLMSetupService:
             "\0".join((base_url, model, api_key)).encode("utf-8")
         ).hexdigest()
 
-    def _secret(self, supplied: object) -> str:
+    def _secret(self, supplied: object, *, base_url: str, model: str) -> str:
         candidate = _api_key(supplied, allow_empty=True)
         if candidate:
             return candidate
+        configured = self._config()
+        if (
+            configured["base_url"] != base_url
+            or configured["model"] != model
+        ):
+            raise LLMSetupError("LLM_SETUP_KEY_REQUIRED", status=400)
         try:
             protected = self._key_path.read_text(encoding="utf-8").strip()
         except OSError as exc:
@@ -262,7 +282,9 @@ class LLMSetupService:
             raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
         base_url = _base_url(payload.get("base_url"))
         model = _model(payload.get("model"))
-        api_key = self._secret(payload.get("api_key", ""))
+        api_key = self._secret(
+            payload.get("api_key", ""), base_url=base_url, model=model
+        )
         await self._probe(base_url, model, api_key)
         self._tested_digest = self._digest(base_url, model, api_key)
 
@@ -271,7 +293,9 @@ class LLMSetupService:
             raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
         base_url = _base_url(payload.get("base_url"))
         model = _model(payload.get("model"))
-        api_key = self._secret(payload.get("api_key", ""))
+        api_key = self._secret(
+            payload.get("api_key", ""), base_url=base_url, model=model
+        )
         if self._tested_digest != self._digest(base_url, model, api_key):
             raise LLMSetupError("LLM_SETUP_TEST_REQUIRED", status=409)
         protected = self._protect(api_key)
@@ -333,7 +357,7 @@ def _authorize(request: web.Request, *, confirm: bool) -> str:
     if hostname not in {"127.0.0.1", "localhost", "::1"}:
         raise LLMSetupError("LLM_SETUP_HOST_FORBIDDEN", status=403)
     origin = request.headers.get("Origin", "").rstrip("/")
-    if origin not in request.app[_ORIGINS_KEY] and not _LOOPBACK_ORIGIN_RE.fullmatch(origin):
+    if origin not in request.app[_ORIGINS_KEY]:
         raise LLMSetupError("LLM_SETUP_ORIGIN_FORBIDDEN", status=403)
     if confirm and request.headers.get(CONFIRM_HEADER) != CONFIRM_VALUE:
         raise LLMSetupError("LLM_SETUP_CONFIRMATION_REQUIRED", status=403)
@@ -349,7 +373,9 @@ def _headers(origin: str | None = None, *, preflight: bool = False) -> dict[str,
         values.update(
             {
                 "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-                "Access-Control-Allow-Headers": f"Content-Type, {CONFIRM_HEADER}",
+                "Access-Control-Allow-Headers": (
+                    f"Content-Type, {CONFIRM_HEADER}, {SESSION_HEADER}"
+                ),
                 "Access-Control-Max-Age": "600",
             }
         )
@@ -395,27 +421,41 @@ def mount_original_client_setup_api(
 
     async def test(request: web.Request) -> web.Response:
         origin = _authorize(request, confirm=True)
+        service.require_session(request.headers.get(SESSION_HEADER, ""))
         await service.test(await _body(request))
         return web.json_response({"status": "AVAILABLE"}, headers=_headers(origin))
 
     async def save(request: web.Request) -> web.Response:
         origin = _authorize(request, confirm=True)
+        service.require_session(request.headers.get(SESSION_HEADER, ""))
         service.save(await _body(request))
         return web.json_response(
-            {"status": "SAVED", "restart_required": True}, headers=_headers(origin)
+            {
+                "status": "SAVED",
+                "reload_applied": False,
+                "restart_required": True,
+            },
+            headers=_headers(origin),
         )
 
     async def delete(request: web.Request) -> web.Response:
         origin = _authorize(request, confirm=True)
+        service.require_session(request.headers.get(SESSION_HEADER, ""))
         if await _body(request):
             raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
         service.delete()
         return web.json_response(
-            {"status": "DELETED", "restart_required": True}, headers=_headers(origin)
+            {
+                "status": "DELETED",
+                "reload_applied": False,
+                "restart_required": True,
+            },
+            headers=_headers(origin),
         )
 
     async def complete(request: web.Request) -> web.Response:
         origin = _authorize(request, confirm=True)
+        service.require_session(request.headers.get(SESSION_HEADER, ""))
         payload = await _body(request)
         if set(payload) != {"skipped"}:
             raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)

--- a/tests/http/test_original_client_server.py
+++ b/tests/http/test_original_client_server.py
@@ -70,6 +70,35 @@ def test_successful_original_sign_in_unlocks_initial_setup(tmp_path: Path) -> No
     asyncio.run(scenario())
 
 
+def test_boolean_false_sign_in_code_does_not_unlock_initial_setup(tmp_path: Path) -> None:
+    async def malformed_sign_in(_request: web.Request) -> web.Response:
+        return web.json_response({"code": False, "message": "invalid", "data": {}})
+
+    async def scenario() -> None:
+        service = LLMSetupService(
+            tmp_path,
+            protect=lambda value: value,
+            unprotect=lambda value: value,
+            probe=lambda *_args: None,
+        )
+        runtime = create_original_client_server_runtime(
+            malformed_sign_in,
+            setup_service=service,
+            trusted_origins=(TRUSTED_ORIGIN,),
+        )
+        async with TestClient(TestServer(runtime.app)) as client:
+            response = await client.post(
+                "/toy/signIn", headers={"Origin": TRUSTED_ORIGIN}
+            )
+            assert response.status == 200
+            status = await client.get(
+                "/toy/setup/status", headers={"Origin": TRUSTED_ORIGIN}
+            )
+            assert (await status.json())["login_observed"] is False
+
+    asyncio.run(scenario())
+
+
 class MemoryAdminFixture:
     def status(self) -> MemoryAdminStatus:
         return MemoryAdminStatus(

--- a/tests/http/test_original_client_server.py
+++ b/tests/http/test_original_client_server.py
@@ -17,6 +17,7 @@ from original_client_server import (
     create_configured_original_client_server_runtime,
     create_original_client_server_runtime,
 )
+from original_client_setup_api import LLMSetupService
 from private_world_candidates import (
     CandidateStatus,
     CandidateType,
@@ -32,6 +33,41 @@ from private_world_port import (
 
 
 TRUSTED_ORIGIN = "https://client.example"
+
+
+def test_successful_original_sign_in_unlocks_initial_setup(tmp_path: Path) -> None:
+    async def signed_in(_request: web.Request) -> web.Response:
+        return web.json_response({"code": 0, "message": "ok", "data": {}})
+
+    async def scenario() -> None:
+        service = LLMSetupService(
+            tmp_path,
+            protect=lambda value: value,
+            unprotect=lambda value: value,
+            probe=lambda *_args: None,
+        )
+        runtime = create_original_client_server_runtime(
+            signed_in,
+            setup_service=service,
+            trusted_origins=(TRUSTED_ORIGIN,),
+        )
+        async with TestClient(TestServer(runtime.app)) as client:
+            before = await client.get(
+                "/toy/setup/status", headers={"Origin": TRUSTED_ORIGIN}
+            )
+            assert (await before.json())["show_initial_setup"] is False
+
+            login = await client.post(
+                "/toy/signIn", headers={"Origin": TRUSTED_ORIGIN}
+            )
+            assert login.status == 200
+
+            after = await client.get(
+                "/toy/setup/status", headers={"Origin": TRUSTED_ORIGIN}
+            )
+            assert (await after.json())["show_initial_setup"] is True
+
+    asyncio.run(scenario())
 
 
 class MemoryAdminFixture:

--- a/tests/http/test_original_client_setup_api.py
+++ b/tests/http/test_original_client_setup_api.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from original_client_setup_api import (
+    LLMSetupService,
+    _dpapi_protect,
+    _dpapi_unprotect,
+    mount_original_client_setup_api,
+)
+
+
+TRUSTED_ORIGIN = "https://client.example"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows DPAPI is required")
+def test_setup_dpapi_round_trip_does_not_store_plaintext() -> None:
+    fixture_value = "synthetic-setup-key"
+    protected = _dpapi_protect(fixture_value)
+    assert fixture_value not in protected
+    assert _dpapi_unprotect(protected) == fixture_value
+
+
+def _service(tmp_path: Path, probes: list[tuple[str, str, str]]) -> LLMSetupService:
+    async def probe(base_url: str, model: str, api_key: str) -> None:
+        probes.append((base_url, model, api_key))
+
+    return LLMSetupService(
+        tmp_path,
+        protect=lambda value: f"protected:{len(value)}",
+        unprotect=lambda _value: "stored-secret",
+        probe=probe,
+    )
+
+
+def test_setup_requires_successful_login_and_never_returns_secret(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        service = _service(tmp_path, [])
+        app = web.Application()
+        mount_original_client_setup_api(
+            app,
+            service,
+            trusted_origins=(TRUSTED_ORIGIN,),
+        )
+        async with TestClient(TestServer(app)) as client:
+            before = await client.get(
+                "/toy/setup/status",
+                headers={"Origin": TRUSTED_ORIGIN},
+            )
+            assert before.status == 200
+            before_payload = await before.json()
+            assert before_payload["login_observed"] is False
+            assert before_payload["show_initial_setup"] is False
+            assert before_payload["llm"]["key_configured"] is False
+
+            service.observe_login(success=False)
+            assert (await (await client.get(
+                "/toy/setup/status", headers={"Origin": TRUSTED_ORIGIN}
+            )).json())["show_initial_setup"] is False
+
+            service.observe_login(success=True)
+            after_payload = await (await client.get(
+                "/toy/setup/status", headers={"Origin": TRUSTED_ORIGIN}
+            )).json()
+            assert after_payload["show_initial_setup"] is True
+            assert "api_key" not in json.dumps(after_payload)
+            assert "secret" not in json.dumps(after_payload)
+
+    asyncio.run(scenario())
+
+
+def test_test_then_save_persists_only_dpapi_key_and_non_secret_config(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        probes: list[tuple[str, str, str]] = []
+        service = _service(tmp_path, probes)
+        service.observe_login(success=True)
+        app = web.Application()
+        mount_original_client_setup_api(
+            app,
+            service,
+            trusted_origins=(TRUSTED_ORIGIN,),
+        )
+        headers = {
+            "Origin": TRUSTED_ORIGIN,
+            "Content-Type": "application/json",
+            "X-Olivia-Setup-Action": "confirmed",
+        }
+        body = {
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "model": "deepseek-v4-flash",
+            "api_key": "fixture-private-key",
+        }
+        async with TestClient(TestServer(app)) as client:
+            premature = await client.post("/toy/setup/llm/save", headers=headers, json=body)
+            assert premature.status == 409
+            assert (await premature.json())["error_code"] == "LLM_SETUP_TEST_REQUIRED"
+
+            tested = await client.post("/toy/setup/llm/test", headers=headers, json=body)
+            assert tested.status == 200
+            assert await tested.json() == {"status": "AVAILABLE"}
+            assert probes == [
+                (
+                    "https://opencode.ai/zen/go/v1",
+                    "deepseek-v4-flash",
+                    "fixture-private-key",
+                )
+            ]
+
+            saved = await client.post("/toy/setup/llm/save", headers=headers, json=body)
+            assert saved.status == 200
+            assert await saved.json() == {"status": "SAVED", "restart_required": True}
+
+            status_payload = await (await client.get(
+                "/toy/setup/status", headers={"Origin": TRUSTED_ORIGIN}
+            )).json()
+            assert status_payload["llm"] == {
+                "base_url": "https://opencode.ai/zen/go/v1",
+                "key_configured": True,
+                "model": "deepseek-v4-flash",
+            }
+            assert "fixture-private-key" not in json.dumps(status_payload)
+
+        config = json.loads((tmp_path / "config" / "llm.json").read_text(encoding="utf-8"))
+        assert config == {
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "model": "deepseek-v4-flash",
+            "schema_version": 1,
+        }
+        protected = (tmp_path / "config" / "deepseek_api_key.dpapi").read_text(
+            encoding="utf-8"
+        )
+        assert protected.strip() == "protected:19"
+        assert "fixture-private-key" not in protected
+
+    asyncio.run(scenario())
+
+
+def test_setup_rejects_untrusted_origin_and_marks_skipped_setup_complete(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        service = _service(tmp_path, [])
+        service.observe_login(success=True)
+        app = web.Application()
+        mount_original_client_setup_api(
+            app,
+            service,
+            trusted_origins=(TRUSTED_ORIGIN,),
+        )
+        async with TestClient(TestServer(app)) as client:
+            forbidden = await client.get(
+                "/toy/setup/status",
+                headers={"Origin": "https://attacker.example"},
+            )
+            assert forbidden.status == 403
+
+            complete = await client.post(
+                "/toy/setup/complete",
+                headers={
+                    "Origin": TRUSTED_ORIGIN,
+                    "Content-Type": "application/json",
+                    "X-Olivia-Setup-Action": "confirmed",
+                },
+                json={"skipped": True},
+            )
+            assert complete.status == 200
+            assert await complete.json() == {"status": "COMPLETED", "skipped": True}
+            status_payload = await (await client.get(
+                "/toy/setup/status", headers={"Origin": TRUSTED_ORIGIN}
+            )).json()
+            assert status_payload["show_initial_setup"] is False
+            assert status_payload["setup_completed"] is True
+            assert status_payload["skipped"] is True
+
+    asyncio.run(scenario())
+
+
+def test_setup_rejects_extra_fields_and_invalid_trusted_origins(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        service = _service(tmp_path, [])
+        app = web.Application()
+        mount_original_client_setup_api(
+            app,
+            service,
+            trusted_origins=(TRUSTED_ORIGIN,),
+        )
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(
+                "/toy/setup/llm/test",
+                headers={
+                    "Origin": TRUSTED_ORIGIN,
+                    "Content-Type": "application/json",
+                    "X-Olivia-Setup-Action": "confirmed",
+                },
+                json={
+                    "base_url": "https://api.deepseek.com",
+                    "model": "deepseek-v4-flash",
+                    "api_key": "fixture-key",
+                    "unexpected": True,
+                },
+            )
+            assert response.status == 400
+            assert (await response.json())["error_code"] == "LLM_SETUP_FIELDS_INVALID"
+
+    asyncio.run(scenario())
+
+    invalid_app = web.Application()
+    try:
+        mount_original_client_setup_api(
+            invalid_app,
+            _service(tmp_path, []),
+            trusted_origins=("http://remote.example",),
+        )
+    except ValueError as error:
+        assert str(error) == "trusted origins are invalid"
+    else:
+        raise AssertionError("non-HTTPS trusted origin was accepted")

--- a/tests/http/test_original_client_setup_api.py
+++ b/tests/http/test_original_client_setup_api.py
@@ -6,12 +6,18 @@ import os
 from pathlib import Path
 
 import pytest
+from jsonschema import Draft202012Validator
 
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from original_client_setup_api import (
+    LLM_DELETE_PATH,
+    LLM_SAVE_PATH,
+    LLM_TEST_PATH,
     LLMSetupService,
+    SETUP_COMPLETE_PATH,
+    SETUP_STATUS_PATH,
     _dpapi_protect,
     _dpapi_unprotect,
     mount_original_client_setup_api,
@@ -19,6 +25,30 @@ from original_client_setup_api import (
 
 
 TRUSTED_ORIGIN = "https://client.example"
+SESSION_HEADER = "X-Olivia-Setup-Session"
+ROOT = Path(__file__).parents[2]
+
+
+def test_initial_setup_public_contract_matches_routes_and_schema() -> None:
+    contract = json.loads(
+        (ROOT / "contracts" / "initial_setup_api_contract.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    schema = json.loads(
+        (ROOT / "contracts" / "initial_setup_api_contract.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    Draft202012Validator(schema).validate(contract)
+    assert set(contract["routes"]) == {
+        SETUP_STATUS_PATH,
+        LLM_TEST_PATH,
+        LLM_SAVE_PATH,
+        LLM_DELETE_PATH,
+        SETUP_COMPLETE_PATH,
+    }
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows DPAPI is required")
@@ -61,6 +91,18 @@ def test_setup_requires_successful_login_and_never_returns_secret(tmp_path: Path
             assert before_payload["show_initial_setup"] is False
             assert before_payload["llm"]["key_configured"] is False
 
+            blocked = await client.post(
+                "/toy/setup/complete",
+                headers={
+                    "Origin": TRUSTED_ORIGIN,
+                    "Content-Type": "application/json",
+                    "X-Olivia-Setup-Action": "confirmed",
+                },
+                json={"skipped": True},
+            )
+            assert blocked.status == 403
+            assert (await blocked.json())["error_code"] == "LLM_SETUP_LOGIN_REQUIRED"
+
             service.observe_login(success=False)
             assert (await (await client.get(
                 "/toy/setup/status", headers={"Origin": TRUSTED_ORIGIN}
@@ -71,6 +113,8 @@ def test_setup_requires_successful_login_and_never_returns_secret(tmp_path: Path
                 "/toy/setup/status", headers={"Origin": TRUSTED_ORIGIN}
             )).json()
             assert after_payload["show_initial_setup"] is True
+            assert isinstance(after_payload["session_token"], str)
+            assert len(after_payload["session_token"]) >= 32
             assert "api_key" not in json.dumps(after_payload)
             assert "secret" not in json.dumps(after_payload)
 
@@ -94,6 +138,7 @@ def test_test_then_save_persists_only_dpapi_key_and_non_secret_config(
             "Origin": TRUSTED_ORIGIN,
             "Content-Type": "application/json",
             "X-Olivia-Setup-Action": "confirmed",
+            SESSION_HEADER: str(service.status()["session_token"]),
         }
         body = {
             "base_url": "https://opencode.ai/zen/go/v1",
@@ -118,7 +163,11 @@ def test_test_then_save_persists_only_dpapi_key_and_non_secret_config(
 
             saved = await client.post("/toy/setup/llm/save", headers=headers, json=body)
             assert saved.status == 200
-            assert await saved.json() == {"status": "SAVED", "restart_required": True}
+            assert await saved.json() == {
+                "status": "SAVED",
+                "reload_applied": False,
+                "restart_required": True,
+            }
 
             status_payload = await (await client.get(
                 "/toy/setup/status", headers={"Origin": TRUSTED_ORIGIN}
@@ -164,12 +213,19 @@ def test_setup_rejects_untrusted_origin_and_marks_skipped_setup_complete(
             )
             assert forbidden.status == 403
 
+            loopback = await client.get(
+                "/toy/setup/status",
+                headers={"Origin": "http://127.0.0.1:45678"},
+            )
+            assert loopback.status == 403
+
             complete = await client.post(
                 "/toy/setup/complete",
                 headers={
                     "Origin": TRUSTED_ORIGIN,
                     "Content-Type": "application/json",
                     "X-Olivia-Setup-Action": "confirmed",
+                    SESSION_HEADER: str(service.status()["session_token"]),
                 },
                 json={"skipped": True},
             )
@@ -188,6 +244,7 @@ def test_setup_rejects_untrusted_origin_and_marks_skipped_setup_complete(
 def test_setup_rejects_extra_fields_and_invalid_trusted_origins(tmp_path: Path) -> None:
     async def scenario() -> None:
         service = _service(tmp_path, [])
+        service.observe_login(success=True)
         app = web.Application()
         mount_original_client_setup_api(
             app,
@@ -201,6 +258,7 @@ def test_setup_rejects_extra_fields_and_invalid_trusted_origins(tmp_path: Path) 
                     "Origin": TRUSTED_ORIGIN,
                     "Content-Type": "application/json",
                     "X-Olivia-Setup-Action": "confirmed",
+                    SESSION_HEADER: str(service.status()["session_token"]),
                 },
                 json={
                     "base_url": "https://api.deepseek.com",
@@ -225,3 +283,91 @@ def test_setup_rejects_extra_fields_and_invalid_trusted_origins(tmp_path: Path) 
         assert str(error) == "trusted origins are invalid"
     else:
         raise AssertionError("non-HTTPS trusted origin was accepted")
+
+
+def test_setup_stored_key_cannot_be_probed_against_changed_endpoint(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        probes: list[tuple[str, str, str]] = []
+        service = _service(tmp_path, probes)
+        service.observe_login(success=True)
+        (tmp_path / "config").mkdir(parents=True)
+        (tmp_path / "config" / "deepseek_api_key.dpapi").write_text(
+            "protected:fixture\n", encoding="utf-8"
+        )
+        (tmp_path / "config" / "llm.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "base_url": "https://api.deepseek.com",
+                    "model": "deepseek-v4-flash",
+                }
+            ),
+            encoding="utf-8",
+        )
+        app = web.Application()
+        mount_original_client_setup_api(
+            app,
+            service,
+            trusted_origins=(TRUSTED_ORIGIN,),
+        )
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(
+                "/toy/setup/llm/test",
+                headers={
+                    "Origin": TRUSTED_ORIGIN,
+                    "Content-Type": "application/json",
+                    "X-Olivia-Setup-Action": "confirmed",
+                    SESSION_HEADER: str(service.status()["session_token"]),
+                },
+                json={
+                    "base_url": "https://collector.example/v1",
+                    "model": "deepseek-v4-flash",
+                    "api_key": "",
+                },
+            )
+            assert response.status == 400
+            assert (await response.json())["error_code"] == "LLM_SETUP_KEY_REQUIRED"
+            assert probes == []
+
+    asyncio.run(scenario())
+
+
+def test_setup_delete_removes_only_managed_key(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        service = _service(tmp_path, [])
+        service.observe_login(success=True)
+        config_root = tmp_path / "config"
+        config_root.mkdir(parents=True)
+        key_path = config_root / "deepseek_api_key.dpapi"
+        key_path.write_text("protected:fixture\n", encoding="utf-8")
+        retained = config_root / "retained.txt"
+        retained.write_text("keep", encoding="utf-8")
+        app = web.Application()
+        mount_original_client_setup_api(
+            app,
+            service,
+            trusted_origins=(TRUSTED_ORIGIN,),
+        )
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(
+                "/toy/setup/llm/delete",
+                headers={
+                    "Origin": TRUSTED_ORIGIN,
+                    "Content-Type": "application/json",
+                    "X-Olivia-Setup-Action": "confirmed",
+                    SESSION_HEADER: str(service.status()["session_token"]),
+                },
+                json={},
+            )
+            assert response.status == 200
+            assert await response.json() == {
+                "status": "DELETED",
+                "reload_applied": False,
+                "restart_required": True,
+            }
+        assert not key_path.exists()
+        assert retained.read_text(encoding="utf-8") == "keep"
+
+    asyncio.run(scenario())

--- a/tests/http/test_original_client_setup_api.py
+++ b/tests/http/test_original_client_setup_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -12,10 +13,13 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from original_client_setup_api import (
+    ERROR_HTTP_STATUSES,
     LLM_DELETE_PATH,
     LLM_SAVE_PATH,
     LLM_TEST_PATH,
     LLMSetupService,
+    LLMSetupError,
+    PUBLIC_ROUTE_CONTRACT,
     SETUP_COMPLETE_PATH,
     SETUP_STATUS_PATH,
     _dpapi_protect,
@@ -49,6 +53,14 @@ def test_initial_setup_public_contract_matches_routes_and_schema() -> None:
         LLM_DELETE_PATH,
         SETUP_COMPLETE_PATH,
     }
+    assert contract["routes"] == PUBLIC_ROUTE_CONTRACT
+    assert {
+        code: details["http_statuses"]
+        for code, details in contract["error_codes"].items()
+    } == ERROR_HTTP_STATUSES
+    assert {
+        details["status"] for details in contract["error_codes"].values()
+    } == {"FAILED"}
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows DPAPI is required")
@@ -149,6 +161,7 @@ def test_test_then_save_persists_only_dpapi_key_and_non_secret_config(
             premature = await client.post("/toy/setup/llm/save", headers=headers, json=body)
             assert premature.status == 409
             assert (await premature.json())["error_code"] == "LLM_SETUP_TEST_REQUIRED"
+            assert premature.headers["Access-Control-Allow-Origin"] == TRUSTED_ORIGIN
 
             tested = await client.post("/toy/setup/llm/test", headers=headers, json=body)
             assert tested.status == 200
@@ -180,15 +193,17 @@ def test_test_then_save_persists_only_dpapi_key_and_non_secret_config(
             assert "fixture-private-key" not in json.dumps(status_payload)
 
         config = json.loads((tmp_path / "config" / "llm.json").read_text(encoding="utf-8"))
-        assert config == {
-            "base_url": "https://opencode.ai/zen/go/v1",
-            "model": "deepseek-v4-flash",
-            "schema_version": 1,
-        }
-        protected = (tmp_path / "config" / "deepseek_api_key.dpapi").read_text(
-            encoding="utf-8"
-        )
+        assert config["base_url"] == "https://opencode.ai/zen/go/v1"
+        assert config["model"] == "deepseek-v4-flash"
+        assert config["schema_version"] == 2
+        assert config["key_file"].startswith("deepseek_api_key.")
+        assert config["key_file"].endswith(".dpapi")
+        protected_path = tmp_path / "config" / config["key_file"]
+        protected = protected_path.read_text(encoding="utf-8")
         assert protected.strip() == "protected:19"
+        assert config["key_sha256"] == hashlib.sha256(
+            protected_path.read_bytes()
+        ).hexdigest()
         assert "fixture-private-key" not in protected
 
     asyncio.run(scenario())
@@ -237,6 +252,35 @@ def test_setup_rejects_untrusted_origin_and_marks_skipped_setup_complete(
             assert status_payload["show_initial_setup"] is False
             assert status_payload["setup_completed"] is True
             assert status_payload["skipped"] is True
+
+    asyncio.run(scenario())
+
+
+def test_setup_cannot_complete_without_saved_key_unless_explicitly_skipped(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        service = _service(tmp_path, [])
+        service.observe_login(success=True)
+        app = web.Application()
+        mount_original_client_setup_api(
+            app,
+            service,
+            trusted_origins=(TRUSTED_ORIGIN,),
+        )
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(
+                "/toy/setup/complete",
+                headers={
+                    "Origin": TRUSTED_ORIGIN,
+                    "Content-Type": "application/json",
+                    "X-Olivia-Setup-Action": "confirmed",
+                    SESSION_HEADER: str(service.status()["session_token"]),
+                },
+                json={"skipped": False},
+            )
+            assert response.status == 409
+            assert (await response.json())["error_code"] == "LLM_SETUP_KEY_REQUIRED"
 
     asyncio.run(scenario())
 
@@ -371,3 +415,44 @@ def test_setup_delete_removes_only_managed_key(tmp_path: Path) -> None:
         assert retained.read_text(encoding="utf-8") == "keep"
 
     asyncio.run(scenario())
+
+
+def test_interrupted_save_keeps_previous_provider_key_generation_active(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_root = tmp_path / "config"
+    config_root.mkdir(parents=True)
+    old_key = config_root / ("deepseek_api_key." + "a" * 32 + ".dpapi")
+    old_key.write_text("old-ciphertext\n", encoding="utf-8")
+    old_config = {
+        "schema_version": 2,
+        "base_url": "https://api.deepseek.com",
+        "model": "deepseek-v4-flash",
+        "key_file": old_key.name,
+        "key_sha256": hashlib.sha256(old_key.read_bytes()).hexdigest(),
+    }
+    config_path = config_root / "llm.json"
+    config_path.write_text(json.dumps(old_config), encoding="utf-8")
+    service = _service(tmp_path, [])
+    service._tested_digest = service._digest(
+        "https://opencode.ai/zen/go/v1",
+        "deepseek-v4-flash",
+        "new-fixture-key",
+    )
+
+    def interrupted(_path: Path, _payload: dict[str, object]) -> None:
+        raise OSError("synthetic interrupted config commit")
+
+    monkeypatch.setattr("original_client_setup_api._atomic_json", interrupted)
+    with pytest.raises(LLMSetupError, match="LLM_SETUP_SAVE_FAILED"):
+        service.save(
+            {
+                "base_url": "https://opencode.ai/zen/go/v1",
+                "model": "deepseek-v4-flash",
+                "api_key": "new-fixture-key",
+            }
+        )
+
+    assert json.loads(config_path.read_text(encoding="utf-8")) == old_config
+    assert old_key.read_text(encoding="utf-8") == "old-ciphertext\n"

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -13,6 +13,7 @@ import pytest
 
 from installer import configure
 import installer.start_local as start_local
+from original_client_setup_api import _dpapi_protect
 
 
 def _installation(tmp_path: Path, *, with_entrypoint: bool = True) -> Path:
@@ -33,6 +34,51 @@ def _installation(tmp_path: Path, *, with_entrypoint: bool = True) -> Path:
     client.parent.mkdir(parents=True)
     client.write_bytes(b"fixture")
     return root
+
+
+def test_launcher_loads_user_managed_llm_config_without_exposing_key(tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    config_root = data_root / "config"
+    config_root.mkdir(parents=True)
+    (config_root / "llm.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "base_url": "https://opencode.ai/zen/go/v1",
+                "model": "deepseek-v4-flash",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    environment = start_local._load_llm_environment({}, data_root)
+
+    assert environment["OLIVIA_LLM_BASE_URL"] == "https://opencode.ai/zen/go/v1"
+    assert environment["OLIVIA_LLM_MODEL"] == "deepseek-v4-flash"
+    assert environment["OLIVIA_LLM_API_KEY_ENV"] == "DEEPSEEK_API_KEY"
+
+
+def test_launcher_ignores_invalid_user_managed_llm_config(tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    config_root = data_root / "config"
+    config_root.mkdir(parents=True)
+    (config_root / "llm.json").write_text(
+        '{"schema_version":1,"base_url":"http://remote.example/v1","model":"bad model"}',
+        encoding="utf-8",
+    )
+
+    environment = start_local._load_llm_environment({}, data_root)
+
+    assert environment["OLIVIA_LLM_BASE_URL"] == "https://api.deepseek.com"
+    assert environment["OLIVIA_LLM_MODEL"] == "deepseek-v4-flash"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows DPAPI is required")
+def test_launcher_reads_current_user_dpapi_key_format(tmp_path: Path) -> None:
+    key_path = tmp_path / "deepseek_api_key.dpapi"
+    key_path.write_text(_dpapi_protect("synthetic-launcher-key") + "\n", encoding="utf-8")
+
+    assert start_local._load_dpapi_key(key_path) == "synthetic-launcher-key"
 
 
 def test_launcher_starts_combined_server_before_original_client(

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -66,11 +66,18 @@ def test_launcher_ignores_invalid_user_managed_llm_config(tmp_path: Path) -> Non
         '{"schema_version":1,"base_url":"http://remote.example/v1","model":"bad model"}',
         encoding="utf-8",
     )
+    (config_root / "deepseek_api_key.dpapi").write_text(
+        "synthetic-ciphertext\n", encoding="utf-8"
+    )
 
-    environment = start_local._load_llm_environment({}, data_root)
+    environment = start_local._load_llm_environment(
+        {}, data_root, include_secret=True
+    )
 
     assert environment["OLIVIA_LLM_BASE_URL"] == "https://api.deepseek.com"
     assert environment["OLIVIA_LLM_MODEL"] == "deepseek-v4-flash"
+    assert environment["OLIVIA_LLM_PROVIDER"] == "none"
+    assert "DEEPSEEK_API_KEY" not in environment
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows DPAPI is required")


### PR DESCRIPTION
Adds the post-login LLM setup backend: explicit trusted-origin and successful-login session authorization, test-before-save, current-user DPAPI storage, OpenAI-compatible public configuration, launcher loading, public contract/schema, and focused security tests. Provider/model configuration is atomically bound to a versioned DPAPI ciphertext file and SHA-256; corrupt or mismatched bindings fail closed with provider disabled.\n\nSplit rationale: this is the smallest independently safe backend slice of the mainland-friendly onboarding work. The API service, server login observation, DPAPI/launcher integration, contract, documentation, and tests must land together to avoid a credential endpoint without its authorization or runtime consumer. Capability downloads and client UI wiring are separate follow-up PRs.\n\nReload boundary: save/delete return reload_applied=false and restart_required=true because the reply, emotion, and private-world provider graph is assembled once at process startup; hot-swapping only part of that graph could mix providers across in-flight tasks. Restart reloads the atomically bound public config and DPAPI secret.\n\nValidation: 1100 passed, 1 skipped, 1 deselected; baseline hardening PASS; diff check PASS.