### PR TITLE
fix(installer): preserve verified Mem0 readiness

### DIFF
--- a/mem0_capability_install.py
+++ b/mem0_capability_install.py
@@ -361,18 +361,29 @@ class ResumableModelDownloader:
         artifact = self.files[relative_path]
         cached = self.download_root.joinpath(*relative_path.split("/"))
         partial = cached.with_suffix(cached.suffix + ".part")
+        partial_source = partial.with_name(partial.name + ".source")
         cached.parent.mkdir(parents=True, exist_ok=True)
         if not self._valid(cached, artifact):
             cached.unlink(missing_ok=True)
             if partial.is_file() and partial.stat().st_size > artifact.size_bytes:
                 partial.unlink()
+                partial_source.unlink(missing_ok=True)
             last_error: Exception | None = None
             for source in self.sources:
                 try:
+                    try:
+                        recorded_source = partial_source.read_text(encoding="utf-8")
+                    except OSError:
+                        recorded_source = ""
+                    if partial.is_file() and recorded_source != source:
+                        partial.unlink()
+                        partial_source.unlink(missing_ok=True)
+                    partial_source.write_text(source, encoding="utf-8")
                     self.last_source = source
                     self._transfer(source, relative_path, partial, artifact)
                     if not self._valid(partial, artifact):
                         partial.unlink(missing_ok=True)
+                        partial_source.unlink(missing_ok=True)
                         raise RuntimeError("MEM0_MODEL_HASH_MISMATCH")
                     last_error = None
                     break
@@ -383,6 +394,7 @@ class ResumableModelDownloader:
             if last_error is not None:
                 raise RuntimeError("MEM0_MODEL_DOWNLOAD_FAILED") from last_error
             partial.replace(cached)
+            partial_source.unlink(missing_ok=True)
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(cached, destination)
         if relative_path not in self._completed:
@@ -767,20 +779,53 @@ class ManagedEmbeddingModel:
         )
         self.last_source: str | None = None
 
+    @property
+    def _source_marker(self) -> Path:
+        return self.config.model_cache / "olivia-mem0-capability-source.json"
+
+    def _read_source(self) -> str | None:
+        try:
+            payload = json.loads(self._source_marker.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        accepted = {*self.bom.sources, "verified-existing-cache", "verified-download-cache"}
+        source = payload.get("source")
+        if (
+            set(payload) != {"repo_id", "revision", "source"}
+            or payload.get("repo_id") != self.bom.repo_id
+            or payload.get("revision") != self.bom.revision
+            or source not in accepted
+        ):
+            return None
+        return str(source)
+
+    def _write_source(self, source: str) -> None:
+        self._source_marker.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self._source_marker.with_suffix(".tmp")
+        temporary.write_text(
+            json.dumps(
+                {
+                    "repo_id": self.bom.repo_id,
+                    "revision": self.bom.revision,
+                    "source": source,
+                },
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        temporary.replace(self._source_marker)
+
     def ready(self) -> bool:
         from mem0_memory import verified_embedding_cache
 
         if not verified_embedding_cache(self.config):
             return False
-        manifest_path = self.config.model_cache / "olivia-mem0-embedding-manifest.json"
-        try:
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeError, json.JSONDecodeError):
+        source = self._read_source()
+        if source is None:
             return False
-        expected = {name: artifact.sha256 for name, artifact in self.bom.files.items()}
-        if manifest.get("files") != expected or manifest.get("source") not in self.bom.sources:
-            return False
-        self.last_source = manifest["source"]
+        self.last_source = source
         return True
 
     def install(
@@ -797,6 +842,10 @@ class ManagedEmbeddingModel:
             return
         if offline_root is not None:
             raise ValueError("offline capability packs are not enabled")
+        from mem0_memory import verified_embedding_cache
+
+        cache_was_verified = verified_embedding_cache(self.config)
+        previous_source = self._read_source()
         downloader: ResumableModelDownloader
 
         def report(downloaded: int, total: int, current: str) -> None:
@@ -820,22 +869,26 @@ class ManagedEmbeddingModel:
                 name: artifact.sha256 for name, artifact in self.bom.files.items()
             },
         ).install()
-        self.last_source = downloader.last_source
-        manifest_path = self.config.model_cache / "olivia-mem0-embedding-manifest.json"
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        manifest["source"] = self.last_source
-        temporary = manifest_path.with_suffix(".tmp")
-        temporary.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
-        temporary.replace(manifest_path)
+        if result.status not in {"APPLIED", "NOOP"} or not verified_embedding_cache(
+            self.config
+        ):
+            if pause_requested.is_set():
+                raise _DownloadPaused
+            raise RuntimeError(result.reason_code or "MEM0_MODEL_INSTALL_FAILED")
+        self.last_source = (
+            downloader.last_source
+            or previous_source
+            or ("verified-existing-cache" if cache_was_verified else "verified-download-cache")
+        )
+        self._write_source(self.last_source)
         owner = self.download_root / ".olivia-mem0-downloads.json"
+        owner.parent.mkdir(parents=True, exist_ok=True)
         owner.write_text(
             json.dumps({"repo_id": self.bom.repo_id, "revision": self.bom.revision}),
             encoding="utf-8",
         )
-        if result.status not in {"APPLIED", "NOOP"} or not self.ready():
-            if pause_requested.is_set():
-                raise _DownloadPaused
-            raise RuntimeError(result.reason_code or "MEM0_MODEL_INSTALL_FAILED")
+        if not self.ready():
+            raise RuntimeError("MEM0_MODEL_INSTALL_FAILED")
 
     def uninstall(self) -> None:
         snapshot = self.config.embedding_snapshot
@@ -853,6 +906,8 @@ class ManagedEmbeddingModel:
             "files"
         ) != expected:
             raise RuntimeError("MEM0_MODEL_OWNERSHIP_INVALID")
+        if snapshot.exists() and self._read_source() is None:
+            raise RuntimeError("MEM0_MODEL_OWNERSHIP_INVALID")
         if self.download_root.exists() and json.loads(
             download_marker.read_text(encoding="utf-8")
         ) != {"repo_id": self.bom.repo_id, "revision": self.bom.revision}:
@@ -860,6 +915,7 @@ class ManagedEmbeddingModel:
         if snapshot.exists():
             shutil.rmtree(snapshot)
         manifest.unlink(missing_ok=True)
+        self._source_marker.unlink(missing_ok=True)
         if self.download_root.exists():
             shutil.rmtree(self.download_root)
         if snapshot.exists() or manifest.exists() or self.download_root.exists():

--- a/mem0_capability_install.py
+++ b/mem0_capability_install.py
@@ -1152,12 +1152,7 @@ class Mem0CapabilityInstaller:
                 CapabilityState.MISSING,
                 CapabilityState.READY,
             }:
-                self._status = self._new_status(
-                    CapabilityState.READY,
-                    "complete",
-                    self.total,
-                    source=self._actual_source(None),
-                )
+                self._set_ready(None)
                 return self._status
             if not ready and self._status.state is CapabilityState.READY:
                 self._status = self._new_status(
@@ -1171,6 +1166,12 @@ class Mem0CapabilityInstaller:
     def _actual_source(self, fallback: str | None) -> str | None:
         values = [getattr(layer, "last_source", None) for layer in (self.runtime, self.model)]
         return ";".join(dict.fromkeys(value for value in values if value)) or fallback
+
+    def _set_ready(self, source: str | None) -> None:
+        self._status = self._new_status(
+            CapabilityState.READY, "complete", self.total,
+            source=self._actual_source(source),
+        )
 
     def _has_space(self) -> bool:
         try:
@@ -1212,12 +1213,7 @@ class Mem0CapabilityInstaller:
             raise ValueError("capability source mode is invalid")
         if self._ready_after_migration():
             with self._lock:
-                self._status = self._new_status(
-                    CapabilityState.READY,
-                    "complete",
-                    self.total,
-                    source=self._actual_source(source_mode),
-                )
+                self._set_ready(source_mode)
             return "NOOP"
         if not self._has_space():
             with self._lock:
@@ -1288,12 +1284,7 @@ class Mem0CapabilityInstaller:
                 )
             return "REJECTED"
         with self._lock:
-            self._status = self._new_status(
-                CapabilityState.READY,
-                "complete",
-                self.total,
-                source=self._actual_source(source_mode),
-            )
+            self._set_ready(source_mode)
         return "APPLIED"
 
     def start(
@@ -1308,6 +1299,7 @@ class Mem0CapabilityInstaller:
             if self._thread is not None and self._thread.is_alive():
                 return "NOOP"
             if self._ready_after_migration():
+                self._set_ready(source_mode)
                 return "NOOP"
             if not self._has_space():
                 self._status = self._new_status(

--- a/mem0_capability_install.py
+++ b/mem0_capability_install.py
@@ -348,6 +348,12 @@ class ResumableModelDownloader:
         self.completed_bytes = 0
         self._completed: set[str] = set()
         self.last_source: str | None = None
+        self._source_history: list[str] = []
+
+    def _record_source(self, source: str) -> None:
+        if source not in self._source_history:
+            self._source_history.append(source)
+        self.last_source = ";".join(self._source_history)
 
     def download(
         self,
@@ -360,6 +366,7 @@ class ResumableModelDownloader:
             raise RuntimeError("MEM0_EMBEDDING_IDENTITY_MISMATCH")
         artifact = self.files[relative_path]
         cached = self.download_root.joinpath(*relative_path.split("/"))
+        cached_source = cached.with_name(cached.name + ".source")
         partial = cached.with_suffix(cached.suffix + ".part")
         partial_source = partial.with_name(partial.name + ".source")
         cached.parent.mkdir(parents=True, exist_ok=True)
@@ -395,6 +402,16 @@ class ResumableModelDownloader:
                 raise RuntimeError("MEM0_MODEL_DOWNLOAD_FAILED") from last_error
             partial.replace(cached)
             partial_source.unlink(missing_ok=True)
+            cached_source.write_text(str(self.last_source), encoding="utf-8")
+            self._record_source(str(self.last_source))
+        else:
+            try:
+                source = cached_source.read_text(encoding="utf-8")
+            except OSError:
+                source = "verified-legacy-download-cache"
+            self._record_source(
+                source if source in self.sources else "verified-legacy-download-cache"
+            )
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(cached, destination)
         if relative_path not in self._completed:
@@ -790,16 +807,36 @@ class ManagedEmbeddingModel:
             return None
         if not isinstance(payload, dict):
             return None
-        accepted = {*self.bom.sources, "verified-existing-cache", "verified-download-cache"}
+        accepted = {
+            *self.bom.sources,
+            "verified-existing-cache",
+            "verified-download-cache",
+            "verified-legacy-download-cache",
+        }
         source = payload.get("source")
         if (
             set(payload) != {"repo_id", "revision", "source"}
             or payload.get("repo_id") != self.bom.repo_id
             or payload.get("revision") != self.bom.revision
-            or source not in accepted
+            or not isinstance(source, str)
+            or not source
+            or any(value not in accepted for value in source.split(";"))
         ):
             return None
         return str(source)
+
+    def _bom_cache_ready(self) -> bool:
+        from mem0_memory import verified_embedding_cache
+
+        if not verified_embedding_cache(self.config):
+            return False
+        manifest_path = self.config.model_cache / "olivia-mem0-embedding-manifest.json"
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            return False
+        expected = {name: artifact.sha256 for name, artifact in self.bom.files.items()}
+        return manifest.get("files") == expected
 
     def _write_source(self, source: str) -> None:
         self._source_marker.parent.mkdir(parents=True, exist_ok=True)
@@ -818,15 +855,71 @@ class ManagedEmbeddingModel:
         temporary.replace(self._source_marker)
 
     def ready(self) -> bool:
-        from mem0_memory import verified_embedding_cache
-
-        if not verified_embedding_cache(self.config):
+        if not self._bom_cache_ready():
             return False
         source = self._read_source()
         if source is None:
             return False
         self.last_source = source
         return True
+
+    def migrate_verified_cache(self) -> bool:
+        if self.ready():
+            return True
+        if not self._bom_cache_ready():
+            return False
+        self.last_source = "verified-existing-cache"
+        self._write_source(self.last_source)
+        return self.ready()
+
+    def _ensure_download_ownership(self) -> None:
+        self.install_root.mkdir(parents=True, exist_ok=True)
+        safe_managed_target(
+            self.install_owner_root,
+            self.download_root.relative_to(self.install_root).as_posix(),
+        )
+        owner = self.download_root / ".olivia-mem0-downloads.json"
+        expected_owner = {"repo_id": self.bom.repo_id, "revision": self.bom.revision}
+        if owner.is_file():
+            try:
+                if json.loads(owner.read_text(encoding="utf-8")) != expected_owner:
+                    raise RuntimeError("MEM0_MODEL_OWNERSHIP_INVALID")
+            except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+                raise RuntimeError("MEM0_MODEL_OWNERSHIP_INVALID") from exc
+            return
+        allowed: set[str] = set()
+        for relative_path in self.bom.files:
+            allowed.update(
+                {
+                    relative_path,
+                    relative_path + ".source",
+                    relative_path + ".part",
+                    relative_path + ".part.source",
+                }
+            )
+        allowed_directories = {
+            parent.as_posix()
+            for name in allowed
+            for parent in Path(name).parents
+            if parent != Path(".")
+        }
+        if self.download_root.exists():
+            for candidate in self.download_root.rglob("*"):
+                relative = candidate.relative_to(self.download_root).as_posix()
+                safe_managed_target(self.download_root, relative)
+                if (
+                    candidate.is_file()
+                    and relative not in allowed
+                    or candidate.is_dir()
+                    and relative not in allowed_directories
+                    or not candidate.is_file()
+                    and not candidate.is_dir()
+                ):
+                    raise RuntimeError("MEM0_MODEL_OWNERSHIP_INVALID")
+        self.download_root.mkdir(parents=True, exist_ok=True)
+        temporary = owner.with_suffix(".tmp")
+        temporary.write_text(json.dumps(expected_owner, sort_keys=True), encoding="utf-8")
+        temporary.replace(owner)
 
     def install(
         self,
@@ -842,10 +935,9 @@ class ManagedEmbeddingModel:
             return
         if offline_root is not None:
             raise ValueError("offline capability packs are not enabled")
-        from mem0_memory import verified_embedding_cache
-
-        cache_was_verified = verified_embedding_cache(self.config)
+        cache_was_verified = self._bom_cache_ready()
         previous_source = self._read_source()
+        self._ensure_download_ownership()
         downloader: ResumableModelDownloader
 
         def report(downloaded: int, total: int, current: str) -> None:
@@ -869,9 +961,7 @@ class ManagedEmbeddingModel:
                 name: artifact.sha256 for name, artifact in self.bom.files.items()
             },
         ).install()
-        if result.status not in {"APPLIED", "NOOP"} or not verified_embedding_cache(
-            self.config
-        ):
+        if result.status not in {"APPLIED", "NOOP"} or not self._bom_cache_ready():
             if pause_requested.is_set():
                 raise _DownloadPaused
             raise RuntimeError(result.reason_code or "MEM0_MODEL_INSTALL_FAILED")
@@ -881,12 +971,6 @@ class ManagedEmbeddingModel:
             or ("verified-existing-cache" if cache_was_verified else "verified-download-cache")
         )
         self._write_source(self.last_source)
-        owner = self.download_root / ".olivia-mem0-downloads.json"
-        owner.parent.mkdir(parents=True, exist_ok=True)
-        owner.write_text(
-            json.dumps({"repo_id": self.bom.repo_id, "revision": self.bom.revision}),
-            encoding="utf-8",
-        )
         if not self.ready():
             raise RuntimeError("MEM0_MODEL_INSTALL_FAILED")
 
@@ -894,13 +978,15 @@ class ManagedEmbeddingModel:
         snapshot = self.config.embedding_snapshot
         manifest = self.config.model_cache / "olivia-mem0-embedding-manifest.json"
         download_marker = self.download_root / ".olivia-mem0-downloads.json"
-        safe_managed_target(
-            self.data_owner_root, snapshot.relative_to(self.data_root).as_posix()
-        )
-        safe_managed_target(
-            self.install_owner_root,
-            self.download_root.relative_to(self.install_root).as_posix(),
-        )
+        if snapshot.exists() or manifest.exists() or self._source_marker.exists():
+            safe_managed_target(
+                self.data_owner_root, snapshot.relative_to(self.data_root).as_posix()
+            )
+        if self.download_root.exists():
+            safe_managed_target(
+                self.install_owner_root,
+                self.download_root.relative_to(self.install_root).as_posix(),
+            )
         expected = {name: item.sha256 for name, item in self.bom.files.items()}
         if snapshot.exists() and json.loads(manifest.read_text(encoding="utf-8")).get(
             "files"
@@ -1092,6 +1178,14 @@ class Mem0CapabilityInstaller:
         except OSError:
             return False
 
+    def _ready_after_migration(self) -> bool:
+        if not self.runtime.ready():
+            return False
+        if self.model.ready():
+            return True
+        migrate = getattr(self.model, "migrate_verified_cache", None)
+        return bool(callable(migrate) and migrate())
+
     def _progress(self, phase: str, layer: CapabilityLayer, source: str) -> Progress:
         def update(downloaded: int, total: int, current: str) -> None:
             ratio = 0 if total <= 0 else min(1.0, downloaded / total)
@@ -1116,6 +1210,15 @@ class Mem0CapabilityInstaller:
     ) -> str:
         if source_mode not in {"auto", "official"} or offline_root is not None:
             raise ValueError("capability source mode is invalid")
+        if self._ready_after_migration():
+            with self._lock:
+                self._status = self._new_status(
+                    CapabilityState.READY,
+                    "complete",
+                    self.total,
+                    source=self._actual_source(source_mode),
+                )
+            return "NOOP"
         if not self._has_space():
             with self._lock:
                 self._status = self._new_status(
@@ -1127,8 +1230,6 @@ class Mem0CapabilityInstaller:
                 )
             return "REJECTED"
         with self._lock:
-            if self.runtime.ready() and self.model.ready():
-                return "NOOP"
             if self._pause.is_set():
                 self._status = self._new_status(
                     CapabilityState.PAUSED, "queued", 0, source=source_mode
@@ -1206,7 +1307,7 @@ class Mem0CapabilityInstaller:
         with self._lock:
             if self._thread is not None and self._thread.is_alive():
                 return "NOOP"
-            if self.runtime.ready() and self.model.ready():
+            if self._ready_after_migration():
                 return "NOOP"
             if not self._has_space():
                 self._status = self._new_status(

--- a/tests/installer/test_mem0_capability_install.py
+++ b/tests/installer/test_mem0_capability_install.py
@@ -179,6 +179,11 @@ def test_model_download_retries_official_when_mirror_payload_hash_is_wrong(
 
     assert len(observed) == 2
     assert downloader.last_source == "https://official.example"
+    downloader.last_source = None
+    downloader._source_history.clear()
+    downloader.opener = lambda *_args, **_kwargs: pytest.fail("network must not be used")
+    downloader.download(revision="a" * 40, relative_path="weights.bin", destination=tmp_path / "cached" / "weights.bin")
+    assert downloader.last_source == "https://official.example"
 
 
 def test_model_download_discards_partial_when_falling_back_to_another_source(
@@ -226,36 +231,6 @@ def test_model_download_discards_partial_when_falling_back_to_another_source(
 
     assert observed[1][1] is None
     assert (tmp_path / "stage" / "weights.bin").read_bytes() == trusted
-
-
-def test_model_download_restores_transport_source_from_verified_complete_cache(
-    tmp_path: Path,
-) -> None:
-    trusted = b"trusted model bytes"
-    artifact = ModelArtifact(len(trusted), hashlib.sha256(trusted).hexdigest())
-    cached = tmp_path / "downloads" / "weights.bin"
-    cached.parent.mkdir(parents=True)
-    cached.write_bytes(trusted)
-    cached.with_name(cached.name + ".source").write_text(
-        "https://official.example", encoding="utf-8"
-    )
-    downloader = ResumableModelDownloader(
-        repo_id="owner/model",
-        revision="a" * 40,
-        files={"weights.bin": artifact},
-        sources=("https://mirror.example", "https://official.example"),
-        download_root=tmp_path / "downloads",
-        source_mode="auto",
-        pause_requested=threading.Event(),
-        progress=lambda *_args: None,
-        opener=lambda *_args, **_kwargs: pytest.fail("network must not be used"),
-    )
-    downloader.download(
-        revision="a" * 40,
-        relative_path="weights.bin",
-        destination=tmp_path / "stage" / "weights.bin",
-    )
-    assert downloader.last_source == "https://official.example"
 
 
 class _Layer:
@@ -790,7 +765,11 @@ def test_managed_embedding_marks_download_root_before_installer_can_fail(
 
 def test_capability_migrates_verified_model_before_download_space_preflight() -> None:
     class MigratingLayer(_Layer):
+        migration_enabled = False
+
         def migrate_verified_cache(self) -> bool:
+            if not self.migration_enabled:
+                return False
             self.is_ready = True
             self.last_source = "verified-existing-cache"
             return True
@@ -807,7 +786,10 @@ def test_capability_migrates_verified_model_before_download_space_preflight() ->
         space_checks=((lambda: 0, 100),),
     )
 
-    assert installer.install(source_mode="auto") == "NOOP"
+    assert installer.install(source_mode="auto") == "REJECTED"
+    assert installer.status().state is CapabilityState.REPAIR
+    model.migration_enabled = True
+    assert installer.start(source_mode="auto") == "NOOP"
     assert installer.status().state is CapabilityState.READY
 
 

--- a/tests/installer/test_mem0_capability_install.py
+++ b/tests/installer/test_mem0_capability_install.py
@@ -28,6 +28,13 @@ REQUIREMENTS = Path(__file__).parents[2] / "installer" / "mem0-runtime-requireme
 CONTRACTS = Path(__file__).parents[2] / "contracts"
 
 
+def _managed_model(tmp_path: Path, bom) -> ManagedEmbeddingModel:
+    return ManagedEmbeddingModel(
+        data_root=tmp_path / "data", install_root=tmp_path / "install", bom=bom.model,
+        download_root=tmp_path / "install" / "downloads" / "mem0-model",
+    )
+
+
 def test_mem0_bom_closes_runtime_model_hashes_sources_and_license() -> None:
     bom = load_mem0_capability_bom(MANIFEST, REQUIREMENTS)
 
@@ -219,6 +226,36 @@ def test_model_download_discards_partial_when_falling_back_to_another_source(
 
     assert observed[1][1] is None
     assert (tmp_path / "stage" / "weights.bin").read_bytes() == trusted
+
+
+def test_model_download_restores_transport_source_from_verified_complete_cache(
+    tmp_path: Path,
+) -> None:
+    trusted = b"trusted model bytes"
+    artifact = ModelArtifact(len(trusted), hashlib.sha256(trusted).hexdigest())
+    cached = tmp_path / "downloads" / "weights.bin"
+    cached.parent.mkdir(parents=True)
+    cached.write_bytes(trusted)
+    cached.with_name(cached.name + ".source").write_text(
+        "https://official.example", encoding="utf-8"
+    )
+    downloader = ResumableModelDownloader(
+        repo_id="owner/model",
+        revision="a" * 40,
+        files={"weights.bin": artifact},
+        sources=("https://mirror.example", "https://official.example"),
+        download_root=tmp_path / "downloads",
+        source_mode="auto",
+        pause_requested=threading.Event(),
+        progress=lambda *_args: None,
+        opener=lambda *_args, **_kwargs: pytest.fail("network must not be used"),
+    )
+    downloader.download(
+        revision="a" * 40,
+        relative_path="weights.bin",
+        destination=tmp_path / "stage" / "weights.bin",
+    )
+    assert downloader.last_source == "https://official.example"
 
 
 class _Layer:
@@ -565,12 +602,7 @@ def test_managed_embedding_uninstall_removes_model_and_transport_cache(
     tmp_path: Path,
 ) -> None:
     bom = load_mem0_capability_bom(MANIFEST, REQUIREMENTS)
-    layer = ManagedEmbeddingModel(
-        data_root=tmp_path / "data",
-        install_root=tmp_path / "install",
-        bom=bom.model,
-        download_root=tmp_path / "install" / "downloads" / "mem0-model",
-    )
+    layer = _managed_model(tmp_path, bom)
     layer.config.embedding_snapshot.mkdir(parents=True)
     manifest = layer.config.model_cache / "olivia-mem0-embedding-manifest.json"
     manifest.write_text(
@@ -601,12 +633,7 @@ def test_managed_embedding_keeps_canonical_manifest_and_persists_source_separate
     monkeypatch,
 ) -> None:
     bom = load_mem0_capability_bom(MANIFEST, REQUIREMENTS)
-    layer = ManagedEmbeddingModel(
-        data_root=tmp_path / "data",
-        install_root=tmp_path / "install",
-        bom=bom.model,
-        download_root=tmp_path / "install" / "downloads" / "mem0-model",
-    )
+    layer = _managed_model(tmp_path, bom)
     expected = {name: item.sha256 for name, item in bom.model.files.items()}
 
     def verified(config) -> bool:
@@ -662,18 +689,47 @@ def test_managed_embedding_keeps_canonical_manifest_and_persists_source_separate
     assert layer.last_source == bom.model.sources[0]
 
 
+def test_managed_embedding_ready_binds_canonical_manifest_to_capability_bom(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    bom = load_mem0_capability_bom(MANIFEST, REQUIREMENTS)
+    layer = _managed_model(tmp_path, bom)
+    manifest = layer.config.model_cache / "olivia-mem0-embedding-manifest.json"
+    manifest.parent.mkdir(parents=True)
+    files = {name: item.sha256 for name, item in bom.model.files.items()}
+    files["model.safetensors"] = "0" * 64
+    manifest.write_text(
+        json.dumps({"model": bom.model.repo_id, "revision": bom.model.revision, "files": files}),
+        encoding="utf-8",
+    )
+    layer._write_source(bom.model.sources[0])
+    monkeypatch.setattr(mem0_memory, "verified_embedding_cache", lambda _config: True)
+
+    assert layer.ready() is False
+
+
 def test_managed_embedding_migrates_verified_cache_without_source_to_owned_marker(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     bom = load_mem0_capability_bom(MANIFEST, REQUIREMENTS)
-    layer = ManagedEmbeddingModel(
-        data_root=tmp_path / "data",
-        install_root=tmp_path / "install",
-        bom=bom.model,
-        download_root=tmp_path / "install" / "downloads" / "mem0-model",
-    )
+    layer = _managed_model(tmp_path, bom)
     monkeypatch.setattr(mem0_memory, "verified_embedding_cache", lambda _config: True)
+    manifest = layer.config.model_cache / "olivia-mem0-embedding-manifest.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        json.dumps(
+            {
+                "model": bom.model.repo_id,
+                "revision": bom.model.revision,
+                "files": {
+                    name: item.sha256 for name, item in bom.model.files.items()
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
 
     class ExistingCacheInstaller:
         def __init__(self, _config, *, downloader, expected_hashes) -> None:
@@ -698,6 +754,61 @@ def test_managed_embedding_migrates_verified_cache_without_source_to_owned_marke
 
     assert layer.ready() is True
     assert layer.last_source == "verified-existing-cache"
+
+
+def test_managed_embedding_marks_download_root_before_installer_can_fail(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    bom = load_mem0_capability_bom(MANIFEST, REQUIREMENTS)
+    layer = _managed_model(tmp_path, bom)
+    class FailingInstaller:
+        def __init__(self, _config, *, downloader, expected_hashes) -> None:
+            self.downloader = downloader
+            assert expected_hashes == {
+                name: item.sha256 for name, item in bom.model.files.items()
+            }
+
+        def install(self):
+            owner = self.downloader.download_root / ".olivia-mem0-downloads.json"
+            assert owner.is_file()
+            (self.downloader.download_root / "model.safetensors.part").write_bytes(b"partial")
+            return SimpleNamespace(status="REJECTED", reason_code="SYNTHETIC_FAILURE")
+
+    monkeypatch.setattr(mem0_embedding_install, "Mem0EmbeddingInstaller", FailingInstaller)
+
+    with pytest.raises(RuntimeError, match="SYNTHETIC_FAILURE"):
+        layer.install(
+            source_mode="auto",
+            offline_root=None,
+            pause_requested=threading.Event(),
+            progress=lambda *_args: None,
+        )
+    layer.uninstall()
+    assert not layer.download_root.exists()
+
+
+def test_capability_migrates_verified_model_before_download_space_preflight() -> None:
+    class MigratingLayer(_Layer):
+        def migrate_verified_cache(self) -> bool:
+            self.is_ready = True
+            self.last_source = "verified-existing-cache"
+            return True
+
+    runtime = _Layer(ready=True)
+    model = MigratingLayer()
+    installer = Mem0CapabilityInstaller(
+        runtime=runtime,
+        model=model,
+        version="fixture-v1",
+        estimated_download_bytes=20,
+        license_summary="fixture licenses",
+        requires_gpu=False,
+        space_checks=((lambda: 0, 100),),
+    )
+
+    assert installer.install(source_mode="auto") == "NOOP"
+    assert installer.status().state is CapabilityState.READY
 
 
 def test_capability_rejects_start_before_thread_when_disk_space_is_low() -> None:

--- a/tests/installer/test_mem0_capability_install.py
+++ b/tests/installer/test_mem0_capability_install.py
@@ -9,6 +9,8 @@ import threading
 
 from jsonschema import Draft202012Validator
 import pytest
+import mem0_embedding_install
+import mem0_memory
 
 from mem0_capability_install import (
     CapabilityState,
@@ -88,6 +90,9 @@ def test_model_download_resumes_partial_file_and_uses_official_fallback(
     partial = tmp_path / "downloads" / "weights.bin.part"
     partial.parent.mkdir(parents=True)
     partial.write_bytes(content[:8])
+    partial.with_name(partial.name + ".source").write_text(
+        "https://mirror.example", encoding="utf-8"
+    )
     observed: list[tuple[str, str | None]] = []
 
     def opener(request, *, timeout: float):
@@ -95,7 +100,7 @@ def test_model_download_resumes_partial_file_and_uses_official_fallback(
         observed.append((request.full_url, request.headers.get("Range")))
         if request.full_url.startswith("https://mirror.example"):
             raise OSError("synthetic mirror outage")
-        return _Response(content[8:], status=206)
+        return _Response(content, status=200)
 
     progress: list[tuple[int, int, str]] = []
     downloader = ResumableModelDownloader(
@@ -126,7 +131,7 @@ def test_model_download_resumes_partial_file_and_uses_official_fallback(
         ),
         (
             "https://official.example/owner/model/resolve/" + "a" * 40 + "/weights.bin",
-            "bytes=8-",
+            None,
         ),
     ]
     assert destination.read_bytes() == content
@@ -167,6 +172,53 @@ def test_model_download_retries_official_when_mirror_payload_hash_is_wrong(
 
     assert len(observed) == 2
     assert downloader.last_source == "https://official.example"
+
+
+def test_model_download_discards_partial_when_falling_back_to_another_source(
+    tmp_path: Path,
+) -> None:
+    trusted = b"trusted model bytes"
+    artifact = ModelArtifact(len(trusted), hashlib.sha256(trusted).hexdigest())
+    observed: list[tuple[str, str | None]] = []
+
+    class InterruptedResponse(_Response):
+        def __init__(self) -> None:
+            super().__init__(b"bad", status=200)
+            self._reads = 0
+
+        def read(self, size: int = -1) -> bytes:
+            self._reads += 1
+            if self._reads == 1:
+                return super().read(3)
+            raise OSError("synthetic interrupted mirror")
+
+    def opener(request, *, timeout: float):
+        assert timeout == 30
+        observed.append((request.full_url, request.headers.get("Range")))
+        if "mirror.example" in request.full_url:
+            return InterruptedResponse()
+        return _Response(trusted, status=200)
+
+    downloader = ResumableModelDownloader(
+        repo_id="owner/model",
+        revision="a" * 40,
+        files={"weights.bin": artifact},
+        sources=("https://mirror.example", "https://official.example"),
+        download_root=tmp_path / "downloads",
+        source_mode="auto",
+        pause_requested=threading.Event(),
+        progress=lambda *_args: None,
+        opener=opener,
+    )
+
+    downloader.download(
+        revision="a" * 40,
+        relative_path="weights.bin",
+        destination=tmp_path / "stage" / "weights.bin",
+    )
+
+    assert observed[1][1] is None
+    assert (tmp_path / "stage" / "weights.bin").read_bytes() == trusted
 
 
 class _Layer:
@@ -522,9 +574,14 @@ def test_managed_embedding_uninstall_removes_model_and_transport_cache(
     layer.config.embedding_snapshot.mkdir(parents=True)
     manifest = layer.config.model_cache / "olivia-mem0-embedding-manifest.json"
     manifest.write_text(
-        json.dumps({"files": {name: item.sha256 for name, item in bom.model.files.items()}, "source": bom.model.sources[0]}),
+        json.dumps({
+            "model": bom.model.repo_id,
+            "revision": bom.model.revision,
+            "files": {name: item.sha256 for name, item in bom.model.files.items()},
+        }),
         encoding="utf-8",
     )
+    layer._write_source(bom.model.sources[0])
     layer.download_root.mkdir(parents=True)
     (layer.download_root / "model.safetensors.part").write_bytes(b"partial")
     (layer.download_root / ".olivia-mem0-downloads.json").write_text(
@@ -537,6 +594,110 @@ def test_managed_embedding_uninstall_removes_model_and_transport_cache(
     assert not layer.config.embedding_snapshot.exists()
     assert not manifest.exists()
     assert not layer.download_root.exists()
+
+
+def test_managed_embedding_keeps_canonical_manifest_and_persists_source_separately(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    bom = load_mem0_capability_bom(MANIFEST, REQUIREMENTS)
+    layer = ManagedEmbeddingModel(
+        data_root=tmp_path / "data",
+        install_root=tmp_path / "install",
+        bom=bom.model,
+        download_root=tmp_path / "install" / "downloads" / "mem0-model",
+    )
+    expected = {name: item.sha256 for name, item in bom.model.files.items()}
+
+    def verified(config) -> bool:
+        try:
+            payload = json.loads(
+                (config.model_cache / "olivia-mem0-embedding-manifest.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+        except OSError:
+            return False
+        return set(payload) == {"model", "revision", "files"} and payload["files"] == expected
+
+    class FakeInstaller:
+        def __init__(self, config, *, downloader, expected_hashes) -> None:
+            self.config = config
+            self.downloader = downloader
+            assert expected_hashes == expected
+
+        def install(self):
+            self.downloader.last_source = bom.model.sources[0]
+            self.config.model_cache.mkdir(parents=True, exist_ok=True)
+            manifest = self.config.model_cache / "olivia-mem0-embedding-manifest.json"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "model": bom.model.repo_id,
+                        "revision": bom.model.revision,
+                        "files": expected,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            return SimpleNamespace(status="APPLIED", reason_code=None)
+
+    monkeypatch.setattr(mem0_memory, "verified_embedding_cache", verified)
+    monkeypatch.setattr(mem0_embedding_install, "Mem0EmbeddingInstaller", FakeInstaller)
+
+    layer.install(
+        source_mode="auto",
+        offline_root=None,
+        pause_requested=threading.Event(),
+        progress=lambda *_args: None,
+    )
+
+    manifest = json.loads(
+        (layer.config.model_cache / "olivia-mem0-embedding-manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert set(manifest) == {"model", "revision", "files"}
+    assert layer.ready() is True
+    assert layer.last_source == bom.model.sources[0]
+
+
+def test_managed_embedding_migrates_verified_cache_without_source_to_owned_marker(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    bom = load_mem0_capability_bom(MANIFEST, REQUIREMENTS)
+    layer = ManagedEmbeddingModel(
+        data_root=tmp_path / "data",
+        install_root=tmp_path / "install",
+        bom=bom.model,
+        download_root=tmp_path / "install" / "downloads" / "mem0-model",
+    )
+    monkeypatch.setattr(mem0_memory, "verified_embedding_cache", lambda _config: True)
+
+    class ExistingCacheInstaller:
+        def __init__(self, _config, *, downloader, expected_hashes) -> None:
+            del downloader
+            assert expected_hashes == {
+                name: item.sha256 for name, item in bom.model.files.items()
+            }
+
+        def install(self):
+            return SimpleNamespace(status="NOOP", reason_code=None)
+
+    monkeypatch.setattr(
+        mem0_embedding_install, "Mem0EmbeddingInstaller", ExistingCacheInstaller
+    )
+
+    layer.install(
+        source_mode="auto",
+        offline_root=None,
+        pause_requested=threading.Event(),
+        progress=lambda *_args: None,
+    )
+
+    assert layer.ready() is True
+    assert layer.last_source == "verified-existing-cache"
 
 
 def test_capability_rejects_start_before_thread_when_disk_space_is_low() -> None:


### PR DESCRIPTION
Post-merge hotfix for the exact-pair findings recorded on PR #194.\n\n- Keeps the canonical embedding manifest byte-contract intact and separately binds it to the immutable capability BOM.\n- Persists per-file transport provenance for verified complete-cache hits; legacy provenance is labeled explicitly.\n- Persists partial-file source identity and discards a partial before switching mirror origins.\n- Establishes and validates the download-root ownership marker before any cache write, including interrupted-install uninstall.\n- Migrates a verified existing cache before full-download disk preflight and publishes READY consistently for synchronous/background recovery.\n- Keeps offline import unavailable.\n\nValidation: 21 focused tests; full suite 1,121 passed, 1 skipped, 1 deselected; baseline hardening PASS; compile and diff checks PASS. Scope: 2 files, 497 changed lines.