### PR TITLE
fix(installer): isolate runtime with selected install

### DIFF
--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -5,7 +5,7 @@
 ## 使用
 
 1. 下载 `Olivia-Setup-x64.exe` 及同目录的 `.sha256` 文件，并先核对 SHA-256。
-2. 双击 EXE，选择安装位置和正版 Steam 游戏目录。安装器按当前用户运行，不要求管理员权限；它从 EXE 内置的离线资产安装受管 Python 3.12 runtime 和固定 wheel，不联网下载。正版目录可留空并按 Steam AppID `4532590` 自动发现。
+2. 双击 EXE，选择产品目录和正版 Steam 游戏目录。安装器按当前用户运行，不要求管理员权限；它在产品目录内分别创建 `install` 与 `runtime`，从 EXE 内置的离线资产安装受管 Python 3.12 runtime 和固定 wheel，不联网下载。正版目录可留空并按 Steam AppID `4532590` 自动发现。
 3. 安装成功后双击 `START.cmd`。它只启动一个监听 `127.0.0.1` 的本机服务，再直接启动隔离副本的 `0.0.9.627\Olivia.exe`，并使用安装目录下的独立 profile。长期记忆、PrivateWorld 和媒体接口都挂在同一个进程中。
 4. 本版本提供登录后初始设置的本机 API；原版客户端界面接线在后续独立补丁中交付。在界面接线前仍通过启动环境提供 LLM key，也可继续使用 `CONFIGURE.cmd` 管理参考音频/视频。这些文件不进入补丁包。
 5. 卸载双击 `UNINSTALL.cmd`。受控卸载只删除安装器自己写入的 `app`、`local_backend`、启动脚本和 marker，保留 `data`、`logs`、`third-party`。

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -1,7 +1,7 @@
 ﻿[CmdletBinding()]
 param(
     [string]$PayloadRoot = (Split-Path -Parent $PSScriptRoot),
-    [string]$Destination = (Join-Path $env:LOCALAPPDATA 'BSideOliviaLocal\install'),
+    [string]$Destination = (Join-Path $env:LOCALAPPDATA 'BSideOliviaLocal'),
     [string]$OfficialRoot = '',
     [string]$OfflineAssetsRoot = '',
     [string]$SetupResultPath = '',
@@ -13,14 +13,6 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $env:MEM0_TELEMETRY = 'False'
-$destinationFull = [IO.Path]::GetFullPath($Destination)
-if (-not [string]::Equals([IO.Path]::GetFileName($destinationFull.TrimEnd('\')), 'install', [StringComparison]::OrdinalIgnoreCase)) {
-    $destinationFull = Join-Path $destinationFull 'install'
-}
-$Destination = $destinationFull
-$productRoot = Split-Path -Parent $destinationFull
-$runtimeRoot = Join-Path $productRoot 'runtime\python-3.12.10-embed-amd64'
-$runtimeExe = Join-Path $runtimeRoot 'python.exe'
 $offlineRoot = if ($OfflineAssetsRoot) { $OfflineAssetsRoot } else { Join-Path $PayloadRoot 'offline' }
 $offlineManifestPath = if ($OfflineAssetsRoot) { Join-Path $OfflineAssetsRoot 'offline-core-assets.json' } else { Join-Path $PayloadRoot 'offline\offline-core-assets.json' }
 $requirements = Join-Path $PayloadRoot 'installer\runtime-requirements.txt'
@@ -59,6 +51,15 @@ trap {
     exit 2
 }
 
+$productRoot = [IO.Path]::GetFullPath($Destination)
+$legacyDefaultInstall = [IO.Path]::GetFullPath((Join-Path $env:LOCALAPPDATA 'BSideOliviaLocal\install'))
+if ([string]::Equals($productRoot.TrimEnd('\'), $legacyDefaultInstall.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase)) {
+    $productRoot = Split-Path -Parent $productRoot
+}
+$Destination = Join-Path $productRoot 'install'
+$runtimeRoot = Join-Path $productRoot 'runtime\python-3.12.10-embed-amd64'
+$runtimeExe = Join-Path $runtimeRoot 'python.exe'
+
 function Get-Sha256 {
     param(
         [Parameter(Mandatory)]
@@ -72,6 +73,154 @@ function Get-Sha256 {
     } finally {
         $hasher.Dispose()
         $stream.Dispose()
+    }
+}
+
+function Assert-NoReparsePointsInPath {
+    param(
+        [Parameter(Mandatory)]
+        [string]$LiteralPath
+    )
+
+    $full = [IO.Path]::GetFullPath($LiteralPath)
+    $root = [IO.Path]::GetPathRoot($full)
+    if (-not $root) { throw 'OFFLINE_CORE_RUNTIME_PARENT_INVALID' }
+    if (
+        -not [IO.Directory]::Exists($root) -or
+        (([IO.File]::GetAttributes($root) -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+    ) {
+        throw 'OFFLINE_CORE_RUNTIME_PARENT_INVALID'
+    }
+    $current = $root
+    $parts = $full.Substring($root.Length).Split(
+        [char[]]@([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar),
+        [StringSplitOptions]::RemoveEmptyEntries
+    )
+    foreach ($part in $parts) {
+        $current = Join-Path $current $part
+        if (Test-Path -LiteralPath $current) {
+            if (
+                -not [IO.Directory]::Exists($current) -or
+                (([IO.File]::GetAttributes($current) -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+            ) {
+                throw 'OFFLINE_CORE_RUNTIME_PARENT_INVALID'
+            }
+        }
+    }
+}
+
+function Test-PathsOverlap {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Left,
+        [Parameter(Mandatory)]
+        [string]$Right
+    )
+
+    $leftFull = [IO.Path]::GetFullPath($Left).TrimEnd('\')
+    $rightFull = [IO.Path]::GetFullPath($Right).TrimEnd('\')
+    if ([string]::Equals($leftFull, $rightFull, [StringComparison]::OrdinalIgnoreCase)) {
+        return $true
+    }
+    return (
+        $leftFull.StartsWith($rightFull + '\', [StringComparison]::OrdinalIgnoreCase) -or
+        $rightFull.StartsWith($leftFull + '\', [StringComparison]::OrdinalIgnoreCase)
+    )
+}
+
+function Resolve-OfficialInstall {
+    param([string]$RequestedRoot)
+
+    if ($RequestedRoot) {
+        return [IO.Path]::GetFullPath($RequestedRoot)
+    }
+    $steamRoots = [Collections.Generic.List[string]]::new()
+    try {
+        $steamPath = (Get-ItemProperty -LiteralPath 'HKCU:\Software\Valve\Steam' -Name SteamPath).SteamPath
+        if ($steamPath) { $steamRoots.Add([string]$steamPath) }
+    } catch {
+        # Continue with conventional Steam roots.
+    }
+    foreach ($drive in 'CDEFGHIJKLMNOPQRSTUVWXYZ'.ToCharArray()) {
+        $candidate = $drive + ':\steam'
+        if ([IO.Directory]::Exists($candidate)) { $steamRoots.Add($candidate) }
+    }
+    $libraryRoots = [Collections.Generic.List[string]]::new()
+    foreach ($steamRoot in $steamRoots) {
+        try {
+            $steamFull = [IO.Path]::GetFullPath($steamRoot)
+            $libraryRoots.Add($steamFull)
+            $vdf = Join-Path $steamFull 'steamapps\libraryfolders.vdf'
+            if ([IO.File]::Exists($vdf)) {
+                $text = [IO.File]::ReadAllText($vdf)
+                foreach ($match in [regex]::Matches($text, '"path"\s+"([^"]+)"', [Text.RegularExpressions.RegexOptions]::IgnoreCase)) {
+                    $libraryRoots.Add($match.Groups[1].Value.Replace('\\', '\'))
+                }
+            }
+        } catch {
+            # Ignore malformed or inaccessible Steam library entries.
+        }
+    }
+    foreach ($libraryRoot in $libraryRoots) {
+        try {
+            $libraryFull = [IO.Path]::GetFullPath($libraryRoot)
+            $appManifest = Join-Path $libraryFull 'steamapps\appmanifest_4532590.acf'
+            if (-not [IO.File]::Exists($appManifest)) { continue }
+            $match = [regex]::Match(
+                [IO.File]::ReadAllText($appManifest),
+                '"installdir"\s+"([^"]+)"',
+                [Text.RegularExpressions.RegexOptions]::IgnoreCase
+            )
+            if (-not $match.Success) { continue }
+            $candidate = Join-Path $libraryFull ('steamapps\common\' + $match.Groups[1].Value)
+            if ([IO.Directory]::Exists($candidate)) {
+                return [IO.Path]::GetFullPath($candidate)
+            }
+        } catch {
+            # Continue to the next Steam library.
+        }
+    }
+    throw 'OFFICIAL_INSTALL_NOT_FOUND'
+}
+
+function Assert-OfficialSource {
+    param(
+        [Parameter(Mandatory)]
+        [string]$SourceRoot,
+        [Parameter(Mandatory)]
+        [string]$ManifestPath
+    )
+
+    try {
+        $manifest = [IO.File]::ReadAllText($ManifestPath) | ConvertFrom-Json
+        if (
+            $manifest.schema_version -ne 'olivia.full-patch.v2' -or
+            $manifest.steam_app_id -ne '4532590' -or
+            $manifest.patch_mode -ne 'isolated-copy' -or
+            $manifest.client_version -isnot [string] -or
+            $manifest.feapp_sha256 -cnotmatch '^[0-9a-fA-F]{64}$' -or
+            $manifest.webplayer_sha256 -cnotmatch '^[0-9a-fA-F]{64}$'
+        ) {
+            throw 'PATCH_MANIFEST_INVALID'
+        }
+    } catch {
+        if ([string]$_.Exception.Message -eq 'PATCH_MANIFEST_INVALID') { throw }
+        throw 'PATCH_MANIFEST_INVALID'
+    }
+    $versionRoot = Join-Path $SourceRoot $manifest.client_version
+    $resources = Join-Path $versionRoot 'resources'
+    $launcher = Join-Path $SourceRoot 'launcher.exe'
+    $client = Join-Path $versionRoot 'Olivia.exe'
+    $feapp = Join-Path $resources 'feapp.dat'
+    $webplayer = Join-Path $resources 'webplayer.dat'
+    foreach ($required in @($launcher, $client, $feapp, $webplayer)) {
+        if (-not [IO.File]::Exists($required)) { throw 'OFFICIAL_INSTALL_NOT_FOUND' }
+    }
+    if (
+        (Get-Sha256 -LiteralPath $feapp) -cne ([string]$manifest.feapp_sha256).ToLowerInvariant() -or
+        (Get-Sha256 -LiteralPath $webplayer) -cne ([string]$manifest.webplayer_sha256).ToLowerInvariant()
+    ) {
+        throw 'UNSUPPORTED_OFFICIAL_VERSION'
     }
 }
 
@@ -121,21 +270,19 @@ function Assert-ManagedRuntimeParent {
 
     try {
         $productFull = [IO.Path]::GetFullPath($ProductRoot)
+        $volumeRoot = [IO.Path]::GetPathRoot($productFull)
+        if (
+            -not $volumeRoot -or
+            [string]::Equals($productFull.TrimEnd('\'), $volumeRoot.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase)
+        ) {
+            throw 'OFFLINE_CORE_RUNTIME_PARENT_INVALID'
+        }
         $runtimeParent = Join-Path $productFull 'runtime'
         $expectedRuntime = Join-Path $runtimeParent 'python-3.12.10-embed-amd64'
         if (-not [string]::Equals([IO.Path]::GetFullPath($RuntimePath), $expectedRuntime, [StringComparison]::OrdinalIgnoreCase)) {
             throw 'OFFLINE_CORE_RUNTIME_PARENT_INVALID'
         }
-        foreach ($path in @($productFull, $runtimeParent, $expectedRuntime)) {
-            if (Test-Path -LiteralPath $path) {
-                if (
-                    -not [IO.Directory]::Exists($path) -or
-                    (([IO.File]::GetAttributes($path) -band [IO.FileAttributes]::ReparsePoint) -ne 0)
-                ) {
-                    throw 'OFFLINE_CORE_RUNTIME_PARENT_INVALID'
-                }
-            }
-        }
+        Assert-NoReparsePointsInPath -LiteralPath $expectedRuntime
     } catch {
         throw 'OFFLINE_CORE_RUNTIME_PARENT_INVALID'
     }
@@ -367,6 +514,16 @@ function Test-ManagedServerDependencies {
 }
 
 Assert-ManagedRuntimeParent -ProductRoot $productRoot -RuntimePath $runtimeRoot
+$selectedOfficial = $OfficialRoot
+if (-not $selectedOfficial -and -not $NonInteractive) {
+    $selectedOfficial = Read-Host 'Steam 游戏目录（留空则按 AppID 自动发现）'
+}
+$selectedOfficial = Resolve-OfficialInstall -RequestedRoot $selectedOfficial
+if (Test-PathsOverlap -Left $productRoot -Right $selectedOfficial) {
+    throw 'INSTALL_ROOT_OVERLAPS_OFFICIAL'
+}
+$manifestPath = Join-Path $PayloadRoot 'installer\full-patch-manifest.json'
+Assert-OfficialSource -SourceRoot $selectedOfficial -ManifestPath $manifestPath
 $coreAssets = Get-OfflineCoreAssets -Root $offlineRoot -ManifestPath $offlineManifestPath -RequirementsPath $requirements
 $runtimeStaging = $runtimeRoot + '.staging.' + [guid]::NewGuid().ToString('N')
 $runtimeBackup = ''
@@ -423,12 +580,7 @@ try {
 }
 $runner = @{ File = $runtimeExe; Args = @() }
 
-$arguments = @('install', '--payload', $PayloadRoot, '--destination', $Destination, '--manifest', (Join-Path $PayloadRoot 'installer\full-patch-manifest.json'), '--port', $Port)
-$selectedOfficial = $OfficialRoot
-if (-not $selectedOfficial -and -not $NonInteractive) {
-    $selectedOfficial = Read-Host 'Steam 游戏目录（留空则按 AppID 自动发现）'
-}
-if ($selectedOfficial) { $arguments += @('--official-root', $selectedOfficial) }
+$arguments = @('install', '--payload', $PayloadRoot, '--destination', $Destination, '--manifest', $manifestPath, '--port', $Port, '--official-root', $selectedOfficial)
 $oldPythonPath = if ($env:PYTHONPATH) { $env:PYTHONPATH } else { '' }
 $env:PYTHONPATH = $PayloadRoot + [IO.Path]::PathSeparator + $oldPythonPath
 $bootstrap = Join-Path $PayloadRoot 'installer\bootstrap_install.py'

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -13,7 +13,13 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $env:MEM0_TELEMETRY = 'False'
-$runtimeRoot = Join-Path $env:LOCALAPPDATA 'BSideOliviaLocal\runtime\python-3.12.10-embed-amd64'
+$destinationFull = [IO.Path]::GetFullPath($Destination)
+if (-not [string]::Equals([IO.Path]::GetFileName($destinationFull.TrimEnd('\')), 'install', [StringComparison]::OrdinalIgnoreCase)) {
+    $destinationFull = Join-Path $destinationFull 'install'
+}
+$Destination = $destinationFull
+$productRoot = Split-Path -Parent $destinationFull
+$runtimeRoot = Join-Path $productRoot 'runtime\python-3.12.10-embed-amd64'
 $runtimeExe = Join-Path $runtimeRoot 'python.exe'
 $offlineRoot = if ($OfflineAssetsRoot) { $OfflineAssetsRoot } else { Join-Path $PayloadRoot 'offline' }
 $offlineManifestPath = if ($OfflineAssetsRoot) { Join-Path $OfflineAssetsRoot 'offline-core-assets.json' } else { Join-Path $PayloadRoot 'offline\offline-core-assets.json' }
@@ -108,20 +114,19 @@ function Get-ExpectedOfflineWheels {
 function Assert-ManagedRuntimeParent {
     param(
         [Parameter(Mandatory)]
-        [string]$LocalAppData,
+        [string]$ProductRoot,
         [Parameter(Mandatory)]
         [string]$RuntimePath
     )
 
     try {
-        $localFull = [IO.Path]::GetFullPath($LocalAppData)
-        $productRoot = Join-Path $localFull 'BSideOliviaLocal'
-        $runtimeParent = Join-Path $productRoot 'runtime'
+        $productFull = [IO.Path]::GetFullPath($ProductRoot)
+        $runtimeParent = Join-Path $productFull 'runtime'
         $expectedRuntime = Join-Path $runtimeParent 'python-3.12.10-embed-amd64'
         if (-not [string]::Equals([IO.Path]::GetFullPath($RuntimePath), $expectedRuntime, [StringComparison]::OrdinalIgnoreCase)) {
             throw 'OFFLINE_CORE_RUNTIME_PARENT_INVALID'
         }
-        foreach ($path in @($localFull, $productRoot, $runtimeParent, $expectedRuntime)) {
+        foreach ($path in @($productFull, $runtimeParent, $expectedRuntime)) {
             if (Test-Path -LiteralPath $path) {
                 if (
                     -not [IO.Directory]::Exists($path) -or
@@ -361,7 +366,7 @@ function Test-ManagedServerDependencies {
     }
 }
 
-Assert-ManagedRuntimeParent -LocalAppData $env:LOCALAPPDATA -RuntimePath $runtimeRoot
+Assert-ManagedRuntimeParent -ProductRoot $productRoot -RuntimePath $runtimeRoot
 $coreAssets = Get-OfflineCoreAssets -Root $offlineRoot -ManifestPath $offlineManifestPath -RequirementsPath $requirements
 $runtimeStaging = $runtimeRoot + '.staging.' + [guid]::NewGuid().ToString('N')
 $runtimeBackup = ''

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -79,17 +79,18 @@ function Get-Sha256 {
 function Assert-NoReparsePointsInPath {
     param(
         [Parameter(Mandatory)]
-        [string]$LiteralPath
+        [string]$LiteralPath,
+        [string]$ErrorCode = 'OFFLINE_CORE_RUNTIME_PARENT_INVALID'
     )
 
     $full = [IO.Path]::GetFullPath($LiteralPath)
     $root = [IO.Path]::GetPathRoot($full)
-    if (-not $root) { throw 'OFFLINE_CORE_RUNTIME_PARENT_INVALID' }
+    if (-not $root) { throw $ErrorCode }
     if (
         -not [IO.Directory]::Exists($root) -or
         (([IO.File]::GetAttributes($root) -band [IO.FileAttributes]::ReparsePoint) -ne 0)
     ) {
-        throw 'OFFLINE_CORE_RUNTIME_PARENT_INVALID'
+        throw $ErrorCode
     }
     $current = $root
     $parts = $full.Substring($root.Length).Split(
@@ -103,7 +104,7 @@ function Assert-NoReparsePointsInPath {
                 -not [IO.Directory]::Exists($current) -or
                 (([IO.File]::GetAttributes($current) -band [IO.FileAttributes]::ReparsePoint) -ne 0)
             ) {
-                throw 'OFFLINE_CORE_RUNTIME_PARENT_INVALID'
+                throw $ErrorCode
             }
         }
     }
@@ -519,6 +520,7 @@ if (-not $selectedOfficial -and -not $NonInteractive) {
     $selectedOfficial = Read-Host 'Steam 游戏目录（留空则按 AppID 自动发现）'
 }
 $selectedOfficial = Resolve-OfficialInstall -RequestedRoot $selectedOfficial
+Assert-NoReparsePointsInPath -LiteralPath $selectedOfficial -ErrorCode 'OFFICIAL_INSTALL_PATH_REPARSE_POINT'
 if (Test-PathsOverlap -Left $productRoot -Right $selectedOfficial) {
     throw 'INSTALL_ROOT_OVERLAPS_OFFICIAL'
 }

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -497,15 +497,15 @@ def _write_start_scripts(root: Path, port: int) -> None:
     launcher.parent.mkdir(parents=True, exist_ok=True)
     _copy_file(root / "local_backend" / "installer" / "version_launcher.py", launcher)
     (root / "START.cmd").write_text(
-        f"@echo off\nsetlocal\nset ROOT=%~dp0\nset OLIVIA_PORT={port}\nset PYTHON_EXE=%LOCALAPPDATA%\\BSideOliviaLocal\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" start --port %OLIVIA_PORT%\nexit /b %ERRORLEVEL%\n",
+        f"@echo off\nsetlocal\nset ROOT=%~dp0\nset OLIVIA_PORT={port}\nset PYTHON_EXE=%ROOT%..\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" start --port %OLIVIA_PORT%\nexit /b %ERRORLEVEL%\n",
         encoding="utf-8",
     )
     (root / "UNINSTALL.cmd").write_text(
-        "@echo off\nsetlocal\nset ROOT=%~dp0\nset PYTHON_EXE=%LOCALAPPDATA%\\BSideOliviaLocal\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" uninstall --apply\nexit /b %ERRORLEVEL%\n",
+        "@echo off\nsetlocal\nset ROOT=%~dp0\nset PYTHON_EXE=%ROOT%..\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" uninstall --apply\nexit /b %ERRORLEVEL%\n",
         encoding="utf-8",
     )
     (root / "CONFIGURE.cmd").write_text(
-        "@echo off\nsetlocal\nset ROOT=%~dp0\nset PYTHON_EXE=%LOCALAPPDATA%\\BSideOliviaLocal\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" configure\nexit /b %ERRORLEVEL%\n",
+        "@echo off\nsetlocal\nset ROOT=%~dp0\nset PYTHON_EXE=%ROOT%..\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" configure\nexit /b %ERRORLEVEL%\n",
         encoding="utf-8",
     )
 

--- a/installer/windows_setup.iss
+++ b/installer/windows_setup.iss
@@ -13,7 +13,7 @@ AppId={{E7B6A4B1-2AC0-4B1E-85DA-E17E66D6EF0A}
 AppName=Olivia 本地版
 AppVersion={#AppVersion}
 AppPublisher=BSide Olivia Community
-DefaultDirName={localappdata}\BSideOliviaLocal\install
+DefaultDirName={localappdata}\BSideOliviaLocal
 CreateAppDir=no
 Uninstallable=no
 PrivilegesRequired=lowest
@@ -90,15 +90,15 @@ procedure InitializeWizard;
 begin
   InstallDirPage := CreateInputDirPage(
     wpSelectDir,
-    '选择安装位置',
-    'Olivia 本地版将安装到当前 Windows 用户目录。',
+    '选择产品目录',
+    'Olivia 本地版将在产品目录内分别管理客户端与运行环境。',
     '建议保留默认位置；升级补丁会继续使用这里的受管安装。',
     False,
     ''
   );
-  InstallDirPage.Add('安装位置：');
+  InstallDirPage.Add('产品目录：');
   InstallDirPage.Values[0] := ExpandConstant(
-    '{param:InstallRoot|{localappdata}\BSideOliviaLocal\install}'
+    '{param:InstallRoot|{localappdata}\BSideOliviaLocal}'
   );
 
   OfficialDirPage := CreateInputQueryPage(
@@ -133,7 +133,7 @@ begin
   Result := True;
   if (CurPageID = InstallDirPage.ID) and (Trim(InstallDirPage.Values[0]) = '') then
   begin
-    MsgBox('请选择安装位置。', mbError, MB_OK);
+    MsgBox('请选择产品目录。', mbError, MB_OK);
     Result := False;
   end;
 end;

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -203,6 +203,37 @@ def test_first_install_rejects_a_reparse_point_in_an_existing_ancestor(
         os.rmdir(linked_ancestor)
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows junction contract")
+def test_first_install_rejects_an_official_junction_alias_before_writes(
+    tmp_path: Path,
+) -> None:
+    physical_official = tmp_path / "physical-official"
+    official_alias = tmp_path / "official-alias"
+    product_root = physical_official / "nested-product"
+    physical_official.mkdir()
+    linked = subprocess.run(
+        ["cmd", "/d", "/c", "mklink", "/J", str(official_alias), str(physical_official)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if linked.returncode != 0:
+        pytest.skip("junction creation is unavailable")
+    try:
+        result = _run_install_preflight(
+            product_root,
+            tmp_path,
+            "-OfficialRoot",
+            str(official_alias),
+        )
+
+        assert result.returncode != 0
+        assert "OFFICIAL_INSTALL_PATH_REPARSE_POINT" in result.stdout + result.stderr
+        assert not (product_root / "runtime").exists()
+    finally:
+        os.rmdir(official_alias)
+
+
 @pytest.mark.skipif(os.name != "nt", reason="Windows path contract")
 def test_first_install_rejects_a_volume_root_as_product_root(tmp_path: Path) -> None:
     result = _run_install_preflight(Path(tmp_path.anchor), tmp_path)

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -103,6 +103,12 @@ def test_first_install_rebuilds_and_atomically_replaces_any_existing_runtime() -
     script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
 
     assert "if (-not (Test-Path -LiteralPath $runtimeExe))" not in script
+    assert "$destinationFull = [IO.Path]::GetFullPath($Destination)" in script
+    assert "$destinationFull = Join-Path $destinationFull 'install'" in script
+    assert "$Destination = $destinationFull" in script
+    assert "$productRoot = Split-Path -Parent $destinationFull" in script
+    assert "$runtimeRoot = Join-Path $productRoot 'runtime\\python-3.12.10-embed-amd64'" in script
+    assert "Join-Path $env:LOCALAPPDATA 'BSideOliviaLocal\\runtime" not in script
     assert "Assert-OfflineObjectShape" in script
     assert "OFFLINE_CORE_WHEEL_SET_MISMATCH" in script
     assert "$lockedWheelHashes.SetEquals($manifestWheelHashes)" in script
@@ -114,10 +120,8 @@ def test_first_install_rebuilds_and_atomically_replaces_any_existing_runtime() -
 def test_first_install_rejects_a_reparse_point_in_the_runtime_parent_chain(
     tmp_path: Path,
 ) -> None:
-    local_app_data = tmp_path / "localappdata"
     outside = tmp_path / "outside"
-    product_root = local_app_data / "BSideOliviaLocal"
-    local_app_data.mkdir()
+    product_root = tmp_path / "isolated-product"
     outside.mkdir()
     linked = subprocess.run(
         ["cmd", "/d", "/c", "mklink", "/J", str(product_root), str(outside)],
@@ -128,8 +132,6 @@ def test_first_install_rejects_a_reparse_point_in_the_runtime_parent_chain(
     if linked.returncode != 0:
         pytest.skip("junction creation is unavailable")
     try:
-        environment = os.environ.copy()
-        environment["LOCALAPPDATA"] = str(local_app_data)
         result = subprocess.run(
             [
                 "powershell",
@@ -143,14 +145,13 @@ def test_first_install_rejects_a_reparse_point_in_the_runtime_parent_chain(
                 "-OfflineAssetsRoot",
                 str(tmp_path / "missing-offline-assets"),
                 "-Destination",
-                str(tmp_path / "install"),
+                str(product_root / "install"),
                 "-SkipShortcut",
             ],
             capture_output=True,
             text=True,
             encoding="utf-8",
             errors="replace",
-            env=environment,
             check=False,
         )
 

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -103,25 +103,62 @@ def test_first_install_rebuilds_and_atomically_replaces_any_existing_runtime() -
     script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
 
     assert "if (-not (Test-Path -LiteralPath $runtimeExe))" not in script
-    assert "$destinationFull = [IO.Path]::GetFullPath($Destination)" in script
-    assert "$destinationFull = Join-Path $destinationFull 'install'" in script
-    assert "$Destination = $destinationFull" in script
-    assert "$productRoot = Split-Path -Parent $destinationFull" in script
+    assert "$productRoot = [IO.Path]::GetFullPath($Destination)" in script
+    assert "$Destination = Join-Path $productRoot 'install'" in script
     assert "$runtimeRoot = Join-Path $productRoot 'runtime\\python-3.12.10-embed-amd64'" in script
+    assert "GetFileName($destinationFull" not in script
     assert "Join-Path $env:LOCALAPPDATA 'BSideOliviaLocal\\runtime" not in script
     assert "Assert-OfflineObjectShape" in script
     assert "OFFLINE_CORE_WHEEL_SET_MISMATCH" in script
     assert "$lockedWheelHashes.SetEquals($manifestWheelHashes)" in script
     assert "[IO.Directory]::Move($runtimeRoot, $runtimeBackup)" in script
     assert "[IO.Directory]::Move($runtimeBackup, $runtimeRoot)" in script
+    assert script.rindex(
+        "$selectedOfficial = Resolve-OfficialInstall"
+    ) < script.index("$coreAssets = Get-OfflineCoreAssets")
+    assert script.rindex("Assert-OfficialSource") < script.index(
+        "$coreAssets = Get-OfflineCoreAssets"
+    )
+
+
+def _run_install_preflight(
+    product_root: Path,
+    tmp_path: Path,
+    *extra: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(ROOT / "installer" / "Install.ps1"),
+            "-PayloadRoot",
+            str(ROOT),
+            "-OfflineAssetsRoot",
+            str(tmp_path / "missing-offline-assets"),
+            "-Destination",
+            str(product_root),
+            "-SkipShortcut",
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows junction contract")
-def test_first_install_rejects_a_reparse_point_in_the_runtime_parent_chain(
+@pytest.mark.parametrize("product_name", ["isolated-product", "install"])
+def test_first_install_rejects_a_reparse_point_at_the_selected_product_root(
     tmp_path: Path,
+    product_name: str,
 ) -> None:
     outside = tmp_path / "outside"
-    product_root = tmp_path / "isolated-product"
+    product_root = tmp_path / product_name
     outside.mkdir()
     linked = subprocess.run(
         ["cmd", "/d", "/c", "mklink", "/J", str(product_root), str(outside)],
@@ -132,34 +169,90 @@ def test_first_install_rejects_a_reparse_point_in_the_runtime_parent_chain(
     if linked.returncode != 0:
         pytest.skip("junction creation is unavailable")
     try:
-        result = subprocess.run(
-            [
-                "powershell",
-                "-NoProfile",
-                "-ExecutionPolicy",
-                "Bypass",
-                "-File",
-                str(ROOT / "installer" / "Install.ps1"),
-                "-PayloadRoot",
-                str(ROOT),
-                "-OfflineAssetsRoot",
-                str(tmp_path / "missing-offline-assets"),
-                "-Destination",
-                str(product_root / "install"),
-                "-SkipShortcut",
-            ],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            check=False,
-        )
+        result = _run_install_preflight(product_root, tmp_path)
 
         assert result.returncode != 0
         assert "OFFLINE_CORE_RUNTIME_PARENT_INVALID" in result.stdout + result.stderr
         assert not (outside / "runtime").exists()
     finally:
         os.rmdir(product_root)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows junction contract")
+def test_first_install_rejects_a_reparse_point_in_an_existing_ancestor(
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path / "outside"
+    linked_ancestor = tmp_path / "linked-ancestor"
+    outside.mkdir()
+    linked = subprocess.run(
+        ["cmd", "/d", "/c", "mklink", "/J", str(linked_ancestor), str(outside)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if linked.returncode != 0:
+        pytest.skip("junction creation is unavailable")
+    try:
+        result = _run_install_preflight(linked_ancestor / "Olivia", tmp_path)
+
+        assert result.returncode != 0
+        assert "OFFLINE_CORE_RUNTIME_PARENT_INVALID" in result.stdout + result.stderr
+        assert not (outside / "Olivia" / "runtime").exists()
+    finally:
+        os.rmdir(linked_ancestor)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows path contract")
+def test_first_install_rejects_a_volume_root_as_product_root(tmp_path: Path) -> None:
+    result = _run_install_preflight(Path(tmp_path.anchor), tmp_path)
+
+    assert result.returncode != 0
+    assert "OFFLINE_CORE_RUNTIME_PARENT_INVALID" in result.stdout + result.stderr
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows preflight contract")
+def test_first_install_rejects_official_overlap_before_runtime_writes(
+    tmp_path: Path,
+) -> None:
+    product_root = tmp_path / "official"
+    product_root.mkdir()
+
+    result = _run_install_preflight(
+        product_root,
+        tmp_path,
+        "-OfficialRoot",
+        str(product_root),
+    )
+
+    assert result.returncode != 0
+    assert "INSTALL_ROOT_OVERLAPS_OFFICIAL" in result.stdout + result.stderr
+    assert not (product_root / "runtime").exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows preflight contract")
+def test_first_install_validates_official_files_before_runtime_writes(
+    tmp_path: Path,
+) -> None:
+    product_root = tmp_path / "product"
+    official_root = tmp_path / "official"
+    resources = official_root / "0.0.9.627" / "resources"
+    resources.mkdir(parents=True)
+    (official_root / "launcher.exe").write_bytes(b"launcher")
+    (official_root / "0.0.9.627" / "Olivia.exe").write_bytes(b"client")
+    (resources / "feapp.dat").write_bytes(b"wrong feapp")
+    (resources / "webplayer.dat").write_bytes(b"wrong webplayer")
+
+    result = _run_install_preflight(
+        product_root,
+        tmp_path,
+        "-OfficialRoot",
+        str(official_root),
+    )
+
+    assert result.returncode != 0
+    assert "UNSUPPORTED_OFFICIAL_VERSION" in result.stdout + result.stderr
+    assert not (product_root / "runtime").exists()
 
 
 def test_offline_asset_builder_uses_the_hash_locked_windows_wheel_closure() -> None:

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1000,11 +1000,18 @@ def test_install_isolated_copy_activates_original_client_surfaces(
     start = (installed / "START.cmd").read_text(encoding="utf-8")
     assert "launcher\\version_launcher.py" in start
     assert "runtime\\python-3.12.10-embed-amd64\\python.exe" in start
+    assert "set PYTHON_EXE=%ROOT%..\\runtime\\python-3.12.10-embed-amd64\\python.exe" in start
     uninstall = (installed / "UNINSTALL.cmd").read_text(encoding="utf-8")
     assert "launcher\\version_launcher.py" in uninstall
     assert "installer_main" not in uninstall
-    for script in (installed / "START.cmd", installed / "UNINSTALL.cmd"):
+    for script in (
+        installed / "START.cmd",
+        installed / "CONFIGURE.cmd",
+        installed / "UNINSTALL.cmd",
+    ):
         value = script.read_text(encoding="utf-8").lower()
+        assert "%localappdata%" not in value
+        assert "%root%..\\runtime\\python-3.12.10-embed-amd64\\python.exe" in value
         assert "d:/" not in value
         assert "f:/" not in value
         assert "sk-" not in value

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -281,6 +281,8 @@ def test_inno_wrapper_is_current_user_offline_and_delegates_to_install_ps1() -> 
     assert "OfficialDirPage: TInputQueryWizardPage" in script
     assert "BrowseForFolder" in script
     assert "{param:InstallRoot|" in script
+    assert "{localappdata}\\BSideOliviaLocal\\install}" not in script
+    assert "产品目录" in script
     assert "{param:OfficialRoot|" in script
     assert "API" not in script
     assert "Hugging Face" not in script


### PR DESCRIPTION
E2E-discovered hotfix after PR #196.

- Derives the embedded Python runtime from the user-selected product root instead of the global `%LOCALAPPDATA%` path.
- Normalizes a selected product directory to its managed `install` child while preserving the existing default `.../BSideOliviaLocal/install` layout.
- Generates START/CONFIGURE/UNINSTALL launchers that resolve the sibling runtime through `%ROOT%..`.
- Preserves reparse-point validation on the selected product/runtime chain.

Evidence: the merged installer failed with exit 7 while three unrelated `pythonw` processes owned the old global runtime. The source-fixed installer completed successfully in an isolated F: product root without stopping or modifying those processes.

Validation: 43 focused passed, 1 skipped; full suite 1,132 passed, 1 skipped, 1 deselected; hardening PASS; diff-check PASS. Scope: 4 files, +31/-18.