### PR TITLE
fix(mem0): verify isolated runtime closure

### DIFF
--- a/installer/verify_mem0_runtime.py
+++ b/installer/verify_mem0_runtime.py
@@ -9,6 +9,7 @@ import json
 from pathlib import Path
 import re
 import sys
+from urllib.parse import urlsplit
 
 
 def verify_runtime(runtime: Path, requirements: Path) -> bool:
@@ -23,7 +24,24 @@ def verify_runtime(runtime: Path, requirements: Path) -> bool:
         expected_hash = hashlib.sha256(requirements.read_bytes()).hexdigest()
     except (OSError, UnicodeError, json.JSONDecodeError):
         return False
-    if manifest != {"requirements_sha256": expected_hash}:
+    if not isinstance(manifest, dict) or set(manifest) != {
+        "requirements_sha256",
+        "source",
+    }:
+        return False
+    source = manifest.get("source")
+    if not isinstance(source, str):
+        return False
+    parsed_source = urlsplit(source)
+    if (
+        manifest.get("requirements_sha256") != expected_hash
+        or parsed_source.scheme != "https"
+        or not parsed_source.hostname
+        or parsed_source.username
+        or parsed_source.password
+        or parsed_source.query
+        or parsed_source.fragment
+    ):
         return False
 
     sys.path[:0] = [

--- a/mem0_capability_install.py
+++ b/mem0_capability_install.py
@@ -666,6 +666,7 @@ class ManagedMem0Runtime:
             "--require-hashes",
             "--only-binary=:all:",
             "--no-compile",
+            "--ignore-installed",
             "--target",
             str(target),
             "-r",

--- a/tests/installer/test_mem0_capability_install.py
+++ b/tests/installer/test_mem0_capability_install.py
@@ -494,6 +494,7 @@ def test_managed_runtime_uses_mirror_then_official_and_registers_atomic_target(
     def runner(command, *, environment, pause_requested) -> int:
         assert environment["PIP_DISABLE_PIP_VERSION_CHECK"] == "1"
         assert not pause_requested.is_set()
+        assert "--ignore-installed" in command
         calls.append(list(command))
         target = Path(command[command.index("--target") + 1])
         target.mkdir(parents=True, exist_ok=True)

--- a/tests/installer/test_mem0_first_install_lifecycle.py
+++ b/tests/installer/test_mem0_first_install_lifecycle.py
@@ -171,7 +171,12 @@ def test_memory_runtime_probe_accepts_a_hash_locked_requirement_and_runtime(
     )
     (runtime / ".olivia-mem0-runtime-manifest.json").write_text(
         json.dumps(
-            {"requirements_sha256": hashlib.sha256(requirements.read_bytes()).hexdigest()}
+            {
+                "requirements_sha256": hashlib.sha256(
+                    requirements.read_bytes()
+                ).hexdigest(),
+                "source": "https://pypi.tuna.tsinghua.edu.cn/simple",
+            }
         ),
         encoding="utf-8",
     )
@@ -211,7 +216,12 @@ def test_windows_installer_runtime_probe_survives_native_argument_quoting(
     )
     (runtime / ".olivia-mem0-runtime-manifest.json").write_text(
         json.dumps(
-            {"requirements_sha256": hashlib.sha256(requirements.read_bytes()).hexdigest()}
+            {
+                "requirements_sha256": hashlib.sha256(
+                    requirements.read_bytes()
+                ).hexdigest(),
+                "source": "https://pypi.tuna.tsinghua.edu.cn/simple",
+            }
         ),
         encoding="utf-8",
     )


### PR DESCRIPTION
## Summary
- force pip to install the complete hash-locked Mem0 closure into the managed target
- validate the runtime marker schema actually emitted by the installer, including its HTTPS source
- add regressions for both E2E failure causes

## Evidence
- RED: managed command omitted --ignore-installed; real marker was rejected by verify_mem0_runtime.py
- GREEN: 35 focused tests passed
- Full: 1138 passed, 1 skipped, 1 deselected
- baseline hardening: PASS
- git diff --check: PASS

## Boundary
The real merged installer reached the runtime download phase against the Tsinghua mirror, but returned MEM0_CAPABILITY_INSTALL_FAILED before model download. A same-runtime pip dry-run resolved all 69 pinned artifacts from the mirror; no key, model, media, or private data is included in this PR.