### PR TITLE
fix(installer): allow Mem0 cold startup

### DIFF
--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -132,6 +132,7 @@ _CORE_HEALTH_REQUIRED_CHECKS = (
     "music.catalog",
 )
 _CORE_HEALTH_CHECK_STATES = frozenset({"available", "degraded", "unavailable"})
+_BACKEND_START_TIMEOUT_SECONDS = 120
 
 
 def _port_is_bindable(port: int) -> bool:
@@ -340,7 +341,7 @@ def main(argv: list[str] | None = None) -> int:
             stderr=subprocess.DEVNULL,
             creationflags=detached,
         )
-        deadline = time.monotonic() + 20
+        deadline = time.monotonic() + _BACKEND_START_TIMEOUT_SECONDS
         while time.monotonic() < deadline and server.poll() is None:
             if _health(args.port) == "READY":
                 break

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -134,6 +134,40 @@ def test_launcher_starts_combined_server_before_original_client(
     assert not backend_command[-1].endswith("local_server.py")
 
 
+def test_launcher_allows_mem0_cold_start_before_opening_client(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    root = _installation(tmp_path)
+    clock = [0.0]
+    client_commands: list[list[str]] = []
+
+    class Process:
+        @staticmethod
+        def poll():
+            return None
+
+    def health(_port: int) -> str:
+        return "READY" if clock[0] >= 45 else "UNAVAILABLE"
+
+    def sleep(seconds: float) -> None:
+        clock[0] += seconds
+
+    def call(command, **_kwargs):
+        client_commands.append([str(value) for value in command])
+        return 0
+
+    monkeypatch.setattr(start_local, "_health", health)
+    monkeypatch.setattr(start_local.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(start_local.time, "sleep", sleep)
+    monkeypatch.setattr(start_local.subprocess, "Popen", lambda *_args, **_kwargs: Process())
+    monkeypatch.setattr(start_local.subprocess, "call", call)
+
+    assert start_local.main(["--install-root", str(root), "--port", "8899"]) == 0
+    assert clock[0] >= 45
+    assert len(client_commands) == 1
+
+
 def test_launcher_loads_configured_dpapi_key_without_environment_or_key_output(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- allow up to 120 seconds for the installed backend to become healthy
- cover a 45-second Mem0 cold start before opening the original client

## Evidence
- focused launcher tests: 25 passed
- full suite: 1139 passed, 1 skipped, 1 deselected
- baseline hardening: PASS
- git diff check: PASS

## Scope
Two files only. No model manifest, download source, UI, or secret changes.