### PR TITLE
fix(installer): preserve Mem0 across patch upgrades

### DIFF
--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -550,6 +550,24 @@ try {
             throw 'OFFLINE_CORE_DEPENDENCY_VERIFY_FAILED'
         }
     }
+    $existingMemoryRuntime = Join-Path $productRoot 'runtime\mem0-site-packages'
+    $memoryRuntimeRequirements = Join-Path $PayloadRoot 'installer\mem0-runtime-requirements.txt'
+    $memoryRuntimeVerifier = Join-Path $PayloadRoot 'installer\verify_mem0_runtime.py'
+    if (
+        [IO.Directory]::Exists($existingMemoryRuntime) -and
+        [IO.File]::Exists($memoryRuntimeRequirements) -and
+        [IO.File]::Exists($memoryRuntimeVerifier)
+    ) {
+        try {
+            Assert-NoReparsePointsInPath -LiteralPath $existingMemoryRuntime
+            & $candidateExe $memoryRuntimeVerifier $existingMemoryRuntime $memoryRuntimeRequirements *> $null
+            if ($LASTEXITCODE -eq 0) {
+                Update-ManagedPythonPath -PthPath $pth.FullName -MemoryRuntimePath $existingMemoryRuntime
+            }
+        } catch {
+            # An invalid optional Mem0 runtime stays unregistered after core upgrade.
+        }
+    }
     if (Test-Path -LiteralPath $runtimeRoot) {
         if (
             -not [IO.Directory]::Exists($runtimeRoot) -or

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -110,6 +110,35 @@ function Assert-NoReparsePointsInPath {
     }
 }
 
+function Test-NoReparsePointsInTree {
+    param(
+        [Parameter(Mandatory)]
+        [string]$LiteralPath
+    )
+
+    try {
+        $root = [IO.Path]::GetFullPath($LiteralPath)
+        if (-not [IO.Directory]::Exists($root)) { return $false }
+        $pending = [Collections.Generic.Stack[string]]::new()
+        $pending.Push($root)
+        while ($pending.Count -gt 0) {
+            $current = $pending.Pop()
+            foreach ($entry in [IO.Directory]::EnumerateFileSystemEntries($current)) {
+                $attributes = [IO.File]::GetAttributes($entry)
+                if (($attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+                    return $false
+                }
+                if (($attributes -band [IO.FileAttributes]::Directory) -ne 0) {
+                    $pending.Push($entry)
+                }
+            }
+        }
+        return $true
+    } catch {
+        return $false
+    }
+}
+
 function Test-PathsOverlap {
     param(
         [Parameter(Mandatory)]
@@ -499,6 +528,43 @@ function Update-ManagedPythonPath {
     }
 }
 
+function Register-VerifiedMemoryRuntime {
+    param(
+        [Parameter(Mandatory)]
+        [string]$CandidateExe,
+        [Parameter(Mandatory)]
+        [string]$PthPath,
+        [Parameter(Mandatory)]
+        [string]$MemoryRuntimePath,
+        [Parameter(Mandatory)]
+        [string]$RequirementsPath,
+        [Parameter(Mandatory)]
+        [string]$VerifierPath
+    )
+
+    if (
+        -not [IO.File]::Exists($CandidateExe) -or
+        -not [IO.File]::Exists($PthPath) -or
+        -not [IO.Directory]::Exists($MemoryRuntimePath) -or
+        -not [IO.File]::Exists($RequirementsPath) -or
+        -not [IO.File]::Exists($VerifierPath)
+    ) {
+        return $false
+    }
+    try {
+        Assert-NoReparsePointsInPath -LiteralPath $MemoryRuntimePath
+        if (-not (Test-NoReparsePointsInTree -LiteralPath $MemoryRuntimePath)) {
+            return $false
+        }
+        & $CandidateExe $VerifierPath $MemoryRuntimePath $RequirementsPath *> $null
+        if ($LASTEXITCODE -ne 0) { return $false }
+        Update-ManagedPythonPath -PthPath $PthPath -MemoryRuntimePath $MemoryRuntimePath
+        return $true
+    } catch {
+        return $false
+    }
+}
+
 function Test-ManagedServerDependencies {
     param(
         [Parameter(Mandatory)]
@@ -553,21 +619,7 @@ try {
     $existingMemoryRuntime = Join-Path $productRoot 'runtime\mem0-site-packages'
     $memoryRuntimeRequirements = Join-Path $PayloadRoot 'installer\mem0-runtime-requirements.txt'
     $memoryRuntimeVerifier = Join-Path $PayloadRoot 'installer\verify_mem0_runtime.py'
-    if (
-        [IO.Directory]::Exists($existingMemoryRuntime) -and
-        [IO.File]::Exists($memoryRuntimeRequirements) -and
-        [IO.File]::Exists($memoryRuntimeVerifier)
-    ) {
-        try {
-            Assert-NoReparsePointsInPath -LiteralPath $existingMemoryRuntime
-            & $candidateExe $memoryRuntimeVerifier $existingMemoryRuntime $memoryRuntimeRequirements *> $null
-            if ($LASTEXITCODE -eq 0) {
-                Update-ManagedPythonPath -PthPath $pth.FullName -MemoryRuntimePath $existingMemoryRuntime
-            }
-        } catch {
-            # An invalid optional Mem0 runtime stays unregistered after core upgrade.
-        }
-    }
+    [void](Register-VerifiedMemoryRuntime -CandidateExe $candidateExe -PthPath $pth.FullName -MemoryRuntimePath $existingMemoryRuntime -RequirementsPath $memoryRuntimeRequirements -VerifierPath $memoryRuntimeVerifier)
     if (Test-Path -LiteralPath $runtimeRoot) {
         if (
             -not [IO.Directory]::Exists($runtimeRoot) -or

--- a/installer/verify_mem0_runtime.py
+++ b/installer/verify_mem0_runtime.py
@@ -22,6 +22,11 @@ def verify_runtime(runtime: Path, requirements: Path) -> bool:
             )
         )
         expected_hash = hashlib.sha256(requirements.read_bytes()).hexdigest()
+        capability = json.loads(
+            (requirements.parent / "mem0-capability-manifest.json").read_text(
+                encoding="utf-8"
+            )
+        )
     except (OSError, UnicodeError, json.JSONDecodeError):
         return False
     if not isinstance(manifest, dict) or set(manifest) != {
@@ -30,7 +35,21 @@ def verify_runtime(runtime: Path, requirements: Path) -> bool:
     }:
         return False
     source = manifest.get("source")
-    if not isinstance(source, str):
+    runtime_bom = capability.get("runtime") if isinstance(capability, dict) else None
+    sources = runtime_bom.get("pypi_sources") if isinstance(runtime_bom, dict) else None
+    if (
+        not isinstance(capability, dict)
+        or capability.get("schema_version") != "olivia.capability-bom.v1"
+        or not isinstance(runtime_bom, dict)
+        or runtime_bom.get("requirements_sha256") != expected_hash
+        or runtime_bom.get("requirements")
+        != "installer/mem0-runtime-requirements.txt"
+        or not isinstance(sources, dict)
+        or set(sources) != {"mirror", "official"}
+        or any(not isinstance(item, str) for item in sources.values())
+        or not isinstance(source, str)
+        or source not in sources.values()
+    ):
         return False
     parsed_source = urlsplit(source)
     if (

--- a/tests/installer/test_mem0_first_install_lifecycle.py
+++ b/tests/installer/test_mem0_first_install_lifecycle.py
@@ -139,15 +139,36 @@ def test_memory_assets_remain_pinned_but_are_not_installed_during_first_setup() 
     ).read_text(encoding="utf-8")
 
     assert script.count("mem0-runtime-requirements.txt") == 1
-    assert "[IO.Directory]::Exists($existingMemoryRuntime)" in script
+    assert "[IO.Directory]::Exists($MemoryRuntimePath)" in script
     assert (
-        "& $candidateExe $memoryRuntimeVerifier $existingMemoryRuntime "
-        "$memoryRuntimeRequirements"
+        "& $CandidateExe $VerifierPath $MemoryRuntimePath "
+        "$RequirementsPath"
     ) in script
     assert "provision_mem0_embedding.py" not in script
     assert "mem0ai==2.0.18" in requirements
     assert "sentence-transformers==5.7.0" in requirements
     assert (root / "installer" / "provision_mem0_embedding.py").is_file()
+
+
+def _write_runtime_bom(requirements: Path) -> None:
+    (requirements.parent / "mem0-capability-manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.capability-bom.v1",
+                "runtime": {
+                    "requirements": "installer/mem0-runtime-requirements.txt",
+                    "requirements_sha256": hashlib.sha256(
+                        requirements.read_bytes()
+                    ).hexdigest(),
+                    "pypi_sources": {
+                        "mirror": "https://pypi.tuna.tsinghua.edu.cn/simple",
+                        "official": "https://pypi.org/simple",
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
 
 
 def test_memory_runtime_probe_accepts_a_hash_locked_requirement_and_runtime(
@@ -174,6 +195,7 @@ def test_memory_runtime_probe_accepts_a_hash_locked_requirement_and_runtime(
         "annotated-doc==0.0.5 --hash=sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101\n",
         encoding="utf-8",
     )
+    _write_runtime_bom(requirements)
     (runtime / ".olivia-mem0-runtime-manifest.json").write_text(
         json.dumps(
             {
@@ -194,6 +216,19 @@ def test_memory_runtime_probe_accepts_a_hash_locked_requirement_and_runtime(
     )
 
     assert result.returncode == 0, result.stderr
+
+    marker = runtime / ".olivia-mem0-runtime-manifest.json"
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    payload["source"] = "https://unapproved.example/simple"
+    marker.write_text(json.dumps(payload), encoding="utf-8")
+    rejected = subprocess.run(
+        [sys.executable, str(verifier), str(runtime), str(requirements)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert rejected.returncode == 2
 
 
 def test_windows_installer_runtime_probe_survives_native_argument_quoting(
@@ -219,6 +254,7 @@ def test_windows_installer_runtime_probe_survives_native_argument_quoting(
         "annotated-doc==0.0.5 --hash=sha256:fixture\n",
         encoding="utf-8",
     )
+    _write_runtime_bom(requirements)
     (runtime / ".olivia-mem0-runtime-manifest.json").write_text(
         json.dumps(
             {
@@ -247,7 +283,7 @@ def test_first_install_defers_memory_runtime_and_embedding_downloads() -> None:
     launcher = (root / "installer" / "start_local.py").read_text(encoding="utf-8")
 
     assert script.count("mem0-runtime-requirements.txt") == 1
-    assert "[IO.Directory]::Exists($existingMemoryRuntime)" in script
+    assert "[IO.Directory]::Exists($MemoryRuntimePath)" in script
     assert "provision_mem0_embedding.py" not in script
     assert "BAAI/bge-small-zh-v1.5" not in script
     assert "Read-Host 'Accept this optional" not in script

--- a/tests/installer/test_mem0_first_install_lifecycle.py
+++ b/tests/installer/test_mem0_first_install_lifecycle.py
@@ -138,7 +138,12 @@ def test_memory_assets_remain_pinned_but_are_not_installed_during_first_setup() 
         root / "installer" / "mem0-runtime-requirements.txt"
     ).read_text(encoding="utf-8")
 
-    assert "mem0-runtime-requirements.txt" not in script
+    assert script.count("mem0-runtime-requirements.txt") == 1
+    assert "[IO.Directory]::Exists($existingMemoryRuntime)" in script
+    assert (
+        "& $candidateExe $memoryRuntimeVerifier $existingMemoryRuntime "
+        "$memoryRuntimeRequirements"
+    ) in script
     assert "provision_mem0_embedding.py" not in script
     assert "mem0ai==2.0.18" in requirements
     assert "sentence-transformers==5.7.0" in requirements
@@ -241,7 +246,8 @@ def test_first_install_defers_memory_runtime_and_embedding_downloads() -> None:
     script = (root / "installer" / "Install.ps1").read_text(encoding="utf-8")
     launcher = (root / "installer" / "start_local.py").read_text(encoding="utf-8")
 
-    assert "mem0-runtime-requirements.txt" not in script
+    assert script.count("mem0-runtime-requirements.txt") == 1
+    assert "[IO.Directory]::Exists($existingMemoryRuntime)" in script
     assert "provision_mem0_embedding.py" not in script
     assert "BAAI/bge-small-zh-v1.5" not in script
     assert "Read-Host 'Accept this optional" not in script

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -25,7 +25,7 @@ def test_first_install_consumes_only_bundled_core_assets() -> None:
     assert "python.org" not in script
     assert "bootstrap.pypa.io" not in script
     assert script.count("mem0-runtime-requirements.txt") == 1
-    assert "[IO.Directory]::Exists($existingMemoryRuntime)" in script
+    assert "[IO.Directory]::Exists($MemoryRuntimePath)" in script
     assert "Update-ManagedPythonPath -PthPath $pth.FullName" in script
     assert "provision_mem0_embedding.py" not in script
     assert "BAAI/bge-small-zh-v1.5" not in script

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -24,7 +24,9 @@ def test_first_install_consumes_only_bundled_core_assets() -> None:
     assert "Invoke-WebRequest" not in script
     assert "python.org" not in script
     assert "bootstrap.pypa.io" not in script
-    assert "mem0-runtime-requirements.txt" not in script
+    assert script.count("mem0-runtime-requirements.txt") == 1
+    assert "[IO.Directory]::Exists($existingMemoryRuntime)" in script
+    assert "Update-ManagedPythonPath -PthPath $pth.FullName" in script
     assert "provision_mem0_embedding.py" not in script
     assert "BAAI/bge-small-zh-v1.5" not in script
 

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -281,7 +281,6 @@ def test_missing_managed_server_dependencies_are_a_nonfatal_probe_result() -> No
 def _run_managed_python_path_helper(
     *,
     pth_path: Path,
-    memory_runtime_path: Path | None = None,
     deny_replace: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     repo_root = Path(__file__).parents[2]
@@ -299,10 +298,7 @@ def _run_managed_python_path_helper(
         "if($env:BSIDE_DENY_REPLACE -eq '1'){"
         "$lock=[IO.File]::Open($env:BSIDE_PTH_PATH,[IO.FileMode]::Open,"
         "[IO.FileAccess]::Read,[IO.FileShare]::ReadWrite)};"
-        "$arguments=@{PthPath=$env:BSIDE_PTH_PATH};"
-        "if($env:BSIDE_MEMORY_RUNTIME_PATH){"
-        "$arguments.MemoryRuntimePath=$env:BSIDE_MEMORY_RUNTIME_PATH};"
-        "try{Update-ManagedPythonPath @arguments}"
+        "try{Update-ManagedPythonPath -PthPath $env:BSIDE_PTH_PATH}"
         "finally{if($lock){$lock.Dispose()}}"
     )
     env = os.environ.copy()
@@ -310,9 +306,6 @@ def _run_managed_python_path_helper(
         {
             "BSIDE_INSTALL_SCRIPT": str(repo_root / "installer" / "Install.ps1"),
             "BSIDE_PTH_PATH": str(pth_path),
-            "BSIDE_MEMORY_RUNTIME_PATH": (
-                str(memory_runtime_path) if memory_runtime_path else ""
-            ),
             "BSIDE_DENY_REPLACE": "1" if deny_replace else "0",
         }
     )
@@ -423,51 +416,200 @@ def test_managed_runtime_pth_never_writes_payload_and_preserves_existing_paths(
     ]
 
 
-def test_core_runtime_upgrade_reregisters_only_verified_mem0_runtime(
-    tmp_path: Path,
-) -> None:
-    if os.name != "nt":
-        pytest.skip("Windows PowerShell is only available on Windows")
+def _run_memory_runtime_registration(
+    *,
+    pth_path: Path,
+    memory_runtime: Path,
+    requirements: Path,
+    verifier: Path,
+) -> subprocess.CompletedProcess[str]:
+    repo_root = Path(__file__).parents[2]
+    command = (
+        "$tokens=$null;$errors=$null;"
+        "$ast=[System.Management.Automation.Language.Parser]::ParseFile("
+        "$env:BSIDE_INSTALL_SCRIPT,[ref]$tokens,[ref]$errors);"
+        "if($errors.Count){throw 'INSTALL_SCRIPT_PARSE_FAILED'};"
+        "$names=@('Assert-NoReparsePointsInPath','Test-NoReparsePointsInTree',"
+        "'Update-ManagedPythonPath','Register-VerifiedMemoryRuntime');"
+        "foreach($name in $names){"
+        "$function=$ast.Find({param($node)"
+        "$node -is [System.Management.Automation.Language.FunctionDefinitionAst]"
+        " -and $node.Name -eq $name},$true);"
+        "if(-not $function){throw ('FUNCTION_MISSING:'+$name)};"
+        ". ([scriptblock]::Create($function.Extent.Text))};"
+        "$registered=Register-VerifiedMemoryRuntime "
+        "-CandidateExe $env:BSIDE_PROBE_EXECUTABLE "
+        "-PthPath $env:BSIDE_PTH_PATH "
+        "-MemoryRuntimePath $env:BSIDE_MEMORY_RUNTIME_PATH "
+        "-RequirementsPath $env:BSIDE_MEMORY_REQUIREMENTS "
+        "-VerifierPath $env:BSIDE_MEMORY_VERIFIER;"
+        "if($registered){exit 0};exit 7"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "BSIDE_INSTALL_SCRIPT": str(repo_root / "installer" / "Install.ps1"),
+            "BSIDE_PROBE_EXECUTABLE": sys.executable,
+            "BSIDE_PTH_PATH": str(pth_path),
+            "BSIDE_MEMORY_RUNTIME_PATH": str(memory_runtime),
+            "BSIDE_MEMORY_REQUIREMENTS": str(requirements),
+            "BSIDE_MEMORY_VERIFIER": str(verifier),
+        }
+    )
+    return subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            command,
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
 
-    product_root = tmp_path / "product"
-    runtime_root = product_root / "runtime" / "python-3.12.10-embed-amd64"
-    runtime_root.mkdir(parents=True)
-    pth_path = runtime_root / "python312._pth"
+
+def _memory_registration_fixture(
+    tmp_path: Path,
+    verifier_source: str,
+) -> tuple[Path, Path, Path, Path, dict[Path, str]]:
+    product = tmp_path / "product"
+    python_root = product / "runtime" / "python-3.12.10-embed-amd64"
+    python_root.mkdir(parents=True)
+    pth_path = python_root / "python312._pth"
     pth_path.write_text(
         "python312.zip\n.\nsite-packages\nimport site\n",
         encoding="utf-8",
     )
-    memory_runtime = product_root / "runtime" / "mem0-site-packages"
+    memory_runtime = product / "runtime" / "mem0-site-packages"
     memory_runtime.mkdir()
+    runtime_marker = memory_runtime / ".olivia-mem0-runtime-manifest.json"
+    runtime_marker.write_text('{"synthetic":"owned"}', encoding="utf-8")
+    requirements = tmp_path / "mem0-runtime-requirements.txt"
+    requirements.write_text("synthetic==1\n", encoding="utf-8")
+    verifier = tmp_path / "verify.py"
+    verifier.write_text(verifier_source, encoding="utf-8")
+    data_file = product / "install" / "data" / "config" / "llm.json"
+    data_file.parent.mkdir(parents=True)
+    data_file.write_bytes(b"synthetic-user-data")
+    model_manifest = (
+        product
+        / "install"
+        / "data"
+        / "memory"
+        / "model-cache"
+        / "olivia-mem0-embedding-manifest.json"
+    )
+    model_manifest.parent.mkdir(parents=True)
+    model_manifest.write_bytes(b"synthetic-model-manifest")
+    preserved = {
+        path: _sha256(path)
+        for path in (runtime_marker, data_file, model_manifest)
+    }
+    return pth_path, memory_runtime, requirements, verifier, preserved
 
-    result = _run_managed_python_path_helper(
-        pth_path=pth_path,
-        memory_runtime_path=memory_runtime,
+
+def test_core_runtime_upgrade_registers_verified_mem0_without_touching_data(
+    tmp_path: Path,
+) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows PowerShell is only available on Windows")
+    pth, runtime, requirements, verifier, preserved = _memory_registration_fixture(
+        tmp_path,
+        "raise SystemExit(0)\n",
+    )
+
+    result = _run_memory_runtime_registration(
+        pth_path=pth,
+        memory_runtime=runtime,
+        requirements=requirements,
+        verifier=verifier,
     )
 
     assert result.returncode == 0, result.stderr or result.stdout
-    assert pth_path.read_text(encoding="utf-8").splitlines()[:3] == [
-        str(memory_runtime),
-        str(memory_runtime / "win32"),
-        str(memory_runtime / "win32" / "lib"),
+    assert pth.read_text(encoding="utf-8").splitlines()[:3] == [
+        str(runtime),
+        str(runtime / "win32"),
+        str(runtime / "win32" / "lib"),
     ]
-    script = (
-        Path(__file__).parents[2] / "installer" / "Install.ps1"
-    ).read_text(encoding="utf-8-sig")
-    verification = (
-        "& $candidateExe $memoryRuntimeVerifier $existingMemoryRuntime "
-        "$memoryRuntimeRequirements"
+    assert {path: _sha256(path) for path in preserved} == preserved
+
+
+@pytest.mark.parametrize(
+    "verifier_source",
+    ("raise SystemExit(2)\n", "raise RuntimeError('synthetic failure')\n"),
+)
+def test_core_runtime_upgrade_keeps_failed_mem0_unregistered_and_preserved(
+    tmp_path: Path,
+    verifier_source: str,
+) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows PowerShell is only available on Windows")
+    pth, runtime, requirements, verifier, preserved = _memory_registration_fixture(
+        tmp_path,
+        verifier_source,
     )
-    registration = (
-        "Update-ManagedPythonPath -PthPath $pth.FullName "
-        "-MemoryRuntimePath $existingMemoryRuntime"
+
+    result = _run_memory_runtime_registration(
+        pth_path=pth,
+        memory_runtime=runtime,
+        requirements=requirements,
+        verifier=verifier,
     )
-    core_probe = "if (-not (Test-ManagedServerDependencies -PythonExe $candidateExe))"
-    assert verification in script
-    assert registration in script
-    assert script.index(core_probe) < script.index(verification) < script.index(
-        registration
+
+    assert result.returncode == 7
+    assert all(
+        "mem0-site-packages" not in line
+        for line in pth.read_text(encoding="utf-8").splitlines()
     )
+    assert {path: _sha256(path) for path in preserved} == preserved
+
+
+@pytest.mark.parametrize("nested", (False, True))
+def test_core_runtime_upgrade_rejects_root_and_descendant_reparse_points(
+    tmp_path: Path,
+    nested: bool,
+) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows junction contract")
+    pth, runtime, requirements, verifier, _preserved = _memory_registration_fixture(
+        tmp_path,
+        "raise SystemExit(0)\n",
+    )
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    if nested:
+        link = runtime / "nested-runtime-link"
+    else:
+        (runtime / ".olivia-mem0-runtime-manifest.json").unlink()
+        runtime.rmdir()
+        link = runtime
+    linked = subprocess.run(
+        ["cmd", "/d", "/c", "mklink", "/J", str(link), str(outside)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if linked.returncode != 0:
+        pytest.skip("junction creation is unavailable")
+    try:
+        result = _run_memory_runtime_registration(
+            pth_path=pth,
+            memory_runtime=runtime,
+            requirements=requirements,
+            verifier=verifier,
+        )
+
+        assert result.returncode == 7
+        assert all(
+            "mem0-site-packages" not in line
+            for line in pth.read_text(encoding="utf-8").splitlines()
+        )
+    finally:
+        os.rmdir(link)
 
 
 def test_published_powershell_scripts_are_utf8_bom_safe() -> None:

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -281,6 +281,7 @@ def test_missing_managed_server_dependencies_are_a_nonfatal_probe_result() -> No
 def _run_managed_python_path_helper(
     *,
     pth_path: Path,
+    memory_runtime_path: Path | None = None,
     deny_replace: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     repo_root = Path(__file__).parents[2]
@@ -298,7 +299,10 @@ def _run_managed_python_path_helper(
         "if($env:BSIDE_DENY_REPLACE -eq '1'){"
         "$lock=[IO.File]::Open($env:BSIDE_PTH_PATH,[IO.FileMode]::Open,"
         "[IO.FileAccess]::Read,[IO.FileShare]::ReadWrite)};"
-        "try{Update-ManagedPythonPath -PthPath $env:BSIDE_PTH_PATH}"
+        "$arguments=@{PthPath=$env:BSIDE_PTH_PATH};"
+        "if($env:BSIDE_MEMORY_RUNTIME_PATH){"
+        "$arguments.MemoryRuntimePath=$env:BSIDE_MEMORY_RUNTIME_PATH};"
+        "try{Update-ManagedPythonPath @arguments}"
         "finally{if($lock){$lock.Dispose()}}"
     )
     env = os.environ.copy()
@@ -306,6 +310,9 @@ def _run_managed_python_path_helper(
         {
             "BSIDE_INSTALL_SCRIPT": str(repo_root / "installer" / "Install.ps1"),
             "BSIDE_PTH_PATH": str(pth_path),
+            "BSIDE_MEMORY_RUNTIME_PATH": (
+                str(memory_runtime_path) if memory_runtime_path else ""
+            ),
             "BSIDE_DENY_REPLACE": "1" if deny_replace else "0",
         }
     )
@@ -414,6 +421,53 @@ def test_managed_runtime_pth_never_writes_payload_and_preserves_existing_paths(
         "site-packages",
         "import site",
     ]
+
+
+def test_core_runtime_upgrade_reregisters_only_verified_mem0_runtime(
+    tmp_path: Path,
+) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows PowerShell is only available on Windows")
+
+    product_root = tmp_path / "product"
+    runtime_root = product_root / "runtime" / "python-3.12.10-embed-amd64"
+    runtime_root.mkdir(parents=True)
+    pth_path = runtime_root / "python312._pth"
+    pth_path.write_text(
+        "python312.zip\n.\nsite-packages\nimport site\n",
+        encoding="utf-8",
+    )
+    memory_runtime = product_root / "runtime" / "mem0-site-packages"
+    memory_runtime.mkdir()
+
+    result = _run_managed_python_path_helper(
+        pth_path=pth_path,
+        memory_runtime_path=memory_runtime,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert pth_path.read_text(encoding="utf-8").splitlines()[:3] == [
+        str(memory_runtime),
+        str(memory_runtime / "win32"),
+        str(memory_runtime / "win32" / "lib"),
+    ]
+    script = (
+        Path(__file__).parents[2] / "installer" / "Install.ps1"
+    ).read_text(encoding="utf-8-sig")
+    verification = (
+        "& $candidateExe $memoryRuntimeVerifier $existingMemoryRuntime "
+        "$memoryRuntimeRequirements"
+    )
+    registration = (
+        "Update-ManagedPythonPath -PthPath $pth.FullName "
+        "-MemoryRuntimePath $existingMemoryRuntime"
+    )
+    core_probe = "if (-not (Test-ManagedServerDependencies -PythonExe $candidateExe))"
+    assert verification in script
+    assert registration in script
+    assert script.index(core_probe) < script.index(verification) < script.index(
+        registration
+    )
 
 
 def test_published_powershell_scripts_are_utf8_bom_safe() -> None:


### PR DESCRIPTION
## Summary\n- re-verify an existing install-owned Mem0 runtime during core runtime replacement\n- re-register only a valid, non-reparse runtime after core dependencies are independently verified\n- keep first install download-free and preserve on-demand capability ownership\n\n## Validation\n- installer tests: 211 passed, 1 skipped\n- full suite: 1142 passed, 1 skipped, 1 deselected\n- baseline hardening: PASS\n- git diff --check: PASS\n- real retained Mem0 runtime verifier: exit 0\n\n## E2E trigger\nThe merged PR #200 setup upgraded the same isolated product root and preserved all Mem0 files byte-exact, but replaced python312._pth without the Mem0 registration. The formal launcher then reported MEM0_IMPORT_FAILED. This patch closes that upgrade-only gap.