### PR TITLE
fix: restore installed client interactions

### DIFF
--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -16,6 +16,11 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
 from urllib.request import urlopen
 
+from patch_companion_settings import (
+    CompanionSettingsPatchError,
+    patch_companion_settings,
+)
+
 
 def _load_dpapi_key(path: Path) -> str:
     if os.name != "nt" or not path.is_file():
@@ -194,6 +199,21 @@ def _client_executable(root: Path) -> Path:
     return root / "app" / version / "Olivia.exe"
 
 
+def _repair_client_frontend(root: Path, port: int) -> str:
+    """Upgrade repository-owned UI in an existing isolated client copy."""
+
+    client = _client_executable(root)
+    feapp = client.parent / "resources" / "feapp.dat"
+    if not feapp.is_file():
+        return "NOT_AVAILABLE"
+    result = patch_companion_settings(
+        feapp,
+        f"http://127.0.0.1:{port}/",
+        work_root=feapp.parent,
+    )
+    return result["status"]
+
+
 def _client_command(client: Path, local: Path) -> list[str]:
     """Match the first-party launcher's only client argument."""
 
@@ -356,6 +376,11 @@ def main(argv: list[str] | None = None) -> int:
     client = _client_executable(root)
     if not client.is_file():
         print("ISOLATED_CLIENT_NOT_FOUND")
+        return 2
+    try:
+        _repair_client_frontend(root, args.port)
+    except (CompanionSettingsPatchError, OSError):
+        print("CLIENT_FRONTEND_REPAIR_FAILED")
         return 2
     profile = root / "profile"
     roaming = profile / "Roaming"

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -205,7 +205,7 @@ def _repair_client_frontend(root: Path, port: int) -> str:
     client = _client_executable(root)
     feapp = client.parent / "resources" / "feapp.dat"
     if not feapp.is_file():
-        return "NOT_AVAILABLE"
+        raise CompanionSettingsPatchError("COMPANION_ARCHIVE_NOT_FOUND")
     result = patch_companion_settings(
         feapp,
         f"http://127.0.0.1:{port}/",

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-SETTINGS_UI_VERSION = "p03.original-settings-manage.v6"
+SETTINGS_UI_VERSION = "p03.original-settings-manage.v7"
 
 BOOTSTRAP_JAVASCRIPT = r'''(() => {
   "use strict";
@@ -1175,7 +1175,6 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
 
   const removeShell = () => {
     document.querySelector(`[${ROOT_ATTR}]`)?.remove();
-    document.querySelector(`[${DIALOG_ATTR}]`)?.remove();
   };
 
   const openDialog = (initialMode = false) => {

--- a/patch_companion_settings.py
+++ b/patch_companion_settings.py
@@ -21,6 +21,11 @@ from original_client_settings_ui import (
     BOOTSTRAP_JAVASCRIPT,
     SETTINGS_UI_VERSION,
 )
+from patch_feapp import (
+    MAILBOX_WRITE_ANCHOR_0627,
+    MAILBOX_WRITE_REPLACEMENT_0627,
+    MAIN_JS_0627,
+)
 
 
 INDEX_MEMBER = "index.html"
@@ -310,17 +315,42 @@ def _repack(root: Path, destination: Path) -> None:
             pass
 
 
+def _repair_mailbox_write_access(root: Path) -> str:
+    main = root / Path(*MAIN_JS_0627.split("/"))
+    if not main.is_file():
+        return "UNCHANGED"
+    source = _read_text(main, "COMPANION_MAIN_MODULE_UNREADABLE")
+    anchor_count = source.count(MAILBOX_WRITE_ANCHOR_0627)
+    replacement_count = source.count(MAILBOX_WRITE_REPLACEMENT_0627)
+    if anchor_count == 1 and replacement_count == 0:
+        _write_utf8(
+            main,
+            source.replace(
+                MAILBOX_WRITE_ANCHOR_0627,
+                MAILBOX_WRITE_REPLACEMENT_0627,
+                1,
+            ),
+        )
+        return "PATCHED"
+    if anchor_count == 0 and replacement_count == 1:
+        return "ALREADY_PATCHED"
+    return "UNCHANGED"
+
+
 def _verify_archive(
     path: Path,
     *,
     api_base: str,
     original_hashes: dict[str, str],
+    mailbox_write_changed: bool = False,
 ) -> None:
     patched_hashes = _member_hashes(path)
     if set(patched_hashes) != set(original_hashes) | {BOOTSTRAP_MEMBER}:
         raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED")
     for name, digest in original_hashes.items():
-        if name in {INDEX_MEMBER, BOOTSTRAP_MEMBER}:
+        if name in {INDEX_MEMBER, BOOTSTRAP_MEMBER} or (
+            mailbox_write_changed and name == MAIN_JS_0627
+        ):
             continue
         if patched_hashes.get(name) != digest:
             raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED")
@@ -328,6 +358,11 @@ def _verify_archive(
         with zipfile.ZipFile(path) as archive:
             index = archive.read(INDEX_MEMBER).decode("utf-8")
             bootstrap = archive.read(BOOTSTRAP_MEMBER).decode("utf-8")
+            main_0627 = (
+                archive.read(MAIN_JS_0627).decode("utf-8")
+                if mailbox_write_changed
+                else ""
+            )
     except (KeyError, OSError, UnicodeError, zipfile.BadZipFile) as exc:
         raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED") from exc
     required = (
@@ -387,6 +422,13 @@ def _verify_archive(
         or any(value in bootstrap for value in forbidden)
         or _normalize_newlines(bootstrap)
         != _normalize_newlines(BOOTSTRAP_JAVASCRIPT)
+        or (
+            mailbox_write_changed
+            and (
+                main_0627.count(MAILBOX_WRITE_REPLACEMENT_0627) != 1
+                or MAILBOX_WRITE_ANCHOR_0627 in main_0627
+            )
+        )
     ):
         raise CompanionSettingsPatchError("COMPANION_PATCH_VERIFICATION_FAILED")
 
@@ -397,7 +439,7 @@ def patch_companion_settings(
     *,
     work_root: str | os.PathLike[str] | None = None,
 ) -> dict[str, str]:
-    """Patch one staged client archive and preserve every existing asset."""
+    """Patch repository-owned UI and restore the supported mailbox entry."""
 
     feapp = Path(feapp_path).expanduser().resolve()
     normalized_api_base = validate_api_base(api_base)
@@ -423,7 +465,14 @@ def patch_companion_settings(
             unpacked = temporary_root / "unpacked"
             with zipfile.ZipFile(feapp) as archive:
                 _safe_extract(archive, unpacked)
-            status = _patch_index(unpacked, normalized_api_base)
+            ui_status = _patch_index(unpacked, normalized_api_base)
+            mailbox_status = _repair_mailbox_write_access(unpacked)
+            status = (
+                "PATCHED"
+                if "PATCHED" in {ui_status, mailbox_status}
+                else "ALREADY_PATCHED"
+            )
+            mailbox_write_changed = mailbox_status == "PATCHED"
             if status == "PATCHED":
                 output = temporary_root / "patched.dat"
                 _repack(unpacked, output)
@@ -432,6 +481,7 @@ def patch_companion_settings(
                 feapp,
                 api_base=normalized_api_base,
                 original_hashes=original_hashes,
+                mailbox_write_changed=mailbox_write_changed,
             )
         except Exception:
             _atomic_copy(rollback, feapp)

--- a/patch_companion_settings.py
+++ b/patch_companion_settings.py
@@ -1,8 +1,10 @@
 """Add a bounded companion panel to the supported Olivia settings view.
 
-The patch only changes a staged ``feapp.dat`` archive. It keeps the client main
-module byte-for-byte intact, inserts one repository-owned local script into
-``index.html``, and rolls the archive back if any validation step fails.
+The patch only changes a staged ``feapp.dat`` archive. It inserts one
+repository-owned local script into ``index.html`` and, for the supported
+0.0.9.627 bundle, replaces exactly one known mailbox write-visibility anchor.
+Every other existing member stays byte-for-byte intact, and any validation
+failure rolls the archive back.
 """
 
 from __future__ import annotations
@@ -334,7 +336,9 @@ def _repair_mailbox_write_access(root: Path) -> str:
         return "PATCHED"
     if anchor_count == 0 and replacement_count == 1:
         return "ALREADY_PATCHED"
-    return "UNCHANGED"
+    raise CompanionSettingsPatchError(
+        "COMPANION_MAILBOX_WRITE_ANCHOR_INVALID"
+    )
 
 
 def _verify_archive(

--- a/patch_feapp.py
+++ b/patch_feapp.py
@@ -44,6 +44,8 @@ MAILBOX_LOGIN_REPLACEMENT_0627 = (
     'await t.replace({name:ve.Collection}),'
     'await h(z.uid.toString(),z.modelGatewayToken||"",!1))'
 )
+MAILBOX_WRITE_ANCHOR_0627 = '"hide-write":o(p)||!o(N3)'
+MAILBOX_WRITE_REPLACEMENT_0627 = '"hide-write":!1'
 
 
 @dataclass(frozen=True)
@@ -55,6 +57,8 @@ class _PatchProfile:
     mailbox_anchor: str
     mailbox_replacement: str
     collection_route: str
+    mailbox_write_anchor: str | None
+    mailbox_write_replacement: str | None
 
 
 _PATCH_PROFILES = (
@@ -66,6 +70,8 @@ _PATCH_PROFILES = (
         MAILBOX_LOGIN_ANCHOR,
         MAILBOX_LOGIN_REPLACEMENT,
         "await t.replace({name:ye.Collection})",
+        None,
+        None,
     ),
     _PatchProfile(
         MAIN_JS_0627,
@@ -75,6 +81,8 @@ _PATCH_PROFILES = (
         MAILBOX_LOGIN_ANCHOR_0627,
         MAILBOX_LOGIN_REPLACEMENT_0627,
         "await t.replace({name:ve.Collection})",
+        MAILBOX_WRITE_ANCHOR_0627,
+        MAILBOX_WRITE_REPLACEMENT_0627,
     ),
 )
 
@@ -175,6 +183,21 @@ def _patch_mailbox_default_route(
     )
 
 
+def _patch_mailbox_write_access(
+    javascript: str,
+    profile: _PatchProfile,
+) -> str:
+    if profile.mailbox_write_anchor is None:
+        return javascript
+    if javascript.count(profile.mailbox_write_anchor) != 1:
+        raise ValueError("mailbox write visibility anchor is missing or not unique")
+    return javascript.replace(
+        profile.mailbox_write_anchor,
+        profile.mailbox_write_replacement,
+        1,
+    )
+
+
 def _ensure_backup(feapp: Path) -> Path:
     backup = Path(str(feapp) + ".orig")
     if backup.exists():
@@ -238,8 +261,12 @@ def patch_feapp(feapp_path: str | os.PathLike[str], new_ws: str | None,
             head_end = index + len(profile.inject_prefix)
             main_path.write_text(javascript[:head_end] + patch + ',' + javascript[head_end:], encoding="utf-8")
             patched_javascript = main_path.read_text(encoding="utf-8")
+            mailbox_javascript = _patch_mailbox_default_route(
+                patched_javascript,
+                profile,
+            )
             main_path.write_text(
-                _patch_mailbox_default_route(patched_javascript, profile),
+                _patch_mailbox_write_access(mailbox_javascript, profile),
                 encoding="utf-8",
             )
             output_archive = temporary_root / "patched.dat"
@@ -255,6 +282,10 @@ def patch_feapp(feapp_path: str | os.PathLike[str], new_ws: str | None,
                 or new_ws not in patched_js
                 or 'localStorage.setItem("appMode","lite")' not in patched_js
                 or profile.collection_route not in patched_js
+                or (
+                    profile.mailbox_write_replacement is not None
+                    and profile.mailbox_write_replacement not in patched_js
+                )
             ):
                 raise ValueError("patched archive verification failed")
         except Exception:

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -5,6 +5,7 @@ import json
 import os
 from pathlib import Path
 from urllib.error import HTTPError, URLError
+import zipfile
 
 import pytest
 from jsonschema import Draft202012Validator
@@ -16,7 +17,12 @@ import installer.start_local as start_local
 from original_client_setup_api import _dpapi_protect
 
 
-def _installation(tmp_path: Path, *, with_entrypoint: bool = True) -> Path:
+def _installation(
+    tmp_path: Path,
+    *,
+    with_entrypoint: bool = True,
+    client_version: str = "0.0.9.615",
+) -> Path:
     root = tmp_path / "installed"
     backend = root / "local_backend"
     (backend / "installer").mkdir(parents=True)
@@ -27,13 +33,49 @@ def _installation(tmp_path: Path, *, with_entrypoint: bool = True) -> Path:
             encoding="utf-8",
         )
     (backend / "installer" / "full-patch-manifest.json").write_text(
-        json.dumps({"client_version": "0.0.9.615"}),
+        json.dumps({"client_version": client_version}),
         encoding="utf-8",
     )
-    client = root / "app" / "0.0.9.615" / "Olivia.exe"
+    client = root / "app" / client_version / "Olivia.exe"
     client.parent.mkdir(parents=True)
     client.write_bytes(b"fixture")
     return root
+
+
+def test_launcher_repairs_existing_0627_frontend_before_start(
+    tmp_path: Path,
+) -> None:
+    root = _installation(tmp_path, client_version="0.0.9.627")
+    resources = root / "app" / "0.0.9.627" / "resources"
+    resources.mkdir()
+    index = """<!doctype html><html><head>
+<script type="module" src="./assets/main-31595bd3.js"></script>
+<script src="./assets/olivia-companion-settings.js" data-olivia-companion-settings="p03.original-settings-shell.v1" data-ui-version="p03.original-settings-manage.v6" data-api-base="http://127.0.0.1:8899/"></script>
+</head><body><div id="app"></div></body></html>"""
+    from original_client_settings_ui import BOOTSTRAP_JAVASCRIPT
+
+    old_bootstrap = BOOTSTRAP_JAVASCRIPT.replace(
+        '    document.querySelector(`[${ROOT_ATTR}]`)?.remove();\n',
+        '    document.querySelector(`[${ROOT_ATTR}]`)?.remove();\n'
+        '    document.querySelector(`[${DIALOG_ATTR}]`)?.remove();\n',
+        1,
+    )
+    feapp = resources / "feapp.dat"
+    with zipfile.ZipFile(feapp, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("index.html", index)
+        archive.writestr(
+            "assets/main-31595bd3.js",
+            b'prefix"hide-write":o(p)||!o(N3)suffix',
+        )
+        archive.writestr("assets/olivia-companion-settings.js", old_bootstrap)
+
+    assert start_local._repair_client_frontend(root, 8899) == "PATCHED"
+
+    with zipfile.ZipFile(feapp) as archive:
+        bootstrap = archive.read("assets/olivia-companion-settings.js").decode()
+        main = archive.read("assets/main-31595bd3.js").decode()
+    assert bootstrap == BOOTSTRAP_JAVASCRIPT
+    assert '"hide-write":!1' in main
 
 
 def test_launcher_loads_user_managed_llm_config_without_exposing_key(tmp_path: Path) -> None:
@@ -96,6 +138,7 @@ def test_launcher_starts_combined_server_before_original_client(
     health = iter(("UNAVAILABLE", "READY", "READY"))
     commands: list[list[str]] = []
     client_commands: list[list[str]] = []
+    frontend_repairs: list[tuple[Path, int]] = []
 
     class Process:
         @staticmethod
@@ -118,6 +161,12 @@ def test_launcher_starts_combined_server_before_original_client(
     )
     monkeypatch.setattr(start_local.subprocess, "Popen", popen)
     monkeypatch.setattr(start_local.subprocess, "call", call)
+    monkeypatch.setattr(
+        start_local,
+        "_repair_client_frontend",
+        lambda installation, port: frontend_repairs.append((installation, port))
+        or "PATCHED",
+    )
 
     result = start_local.main(["--install-root", str(root), "--port", "8899"])
 
@@ -132,6 +181,7 @@ def test_launcher_starts_combined_server_before_original_client(
     ]
     assert client_commands[0][0].endswith("Olivia.exe")
     assert not backend_command[-1].endswith("local_server.py")
+    assert frontend_repairs == [(root.resolve(), 8899)]
 
 
 def test_launcher_allows_mem0_cold_start_before_opening_client(
@@ -695,6 +745,7 @@ def test_health_treats_connection_refused_as_no_listener(monkeypatch) -> None:
         raise URLError(ConnectionRefusedError(errno.ECONNREFUSED, "connection refused"))
 
     monkeypatch.setattr(start_local, "urlopen", connection_refused)
+    monkeypatch.setattr(start_local, "_port_is_bindable", lambda _port: True)
 
     assert start_local._health(8899) == "UNAVAILABLE"
 
@@ -708,6 +759,7 @@ def test_health_treats_windows_connection_refused_as_no_listener(monkeypatch) ->
         raise URLError(WindowsConnectionRefused("connection refused"))
 
     monkeypatch.setattr(start_local, "urlopen", connection_refused)
+    monkeypatch.setattr(start_local, "_port_is_bindable", lambda _port: True)
 
     assert start_local._health(8899) == "UNAVAILABLE"
 

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -14,7 +14,9 @@ import pytest
 
 from installer import configure
 import installer.start_local as start_local
+from original_client_settings_ui import BOOTSTRAP_JAVASCRIPT, SETTINGS_UI_VERSION
 from original_client_setup_api import _dpapi_protect
+from patch_companion_settings import CompanionSettingsPatchError
 
 
 def _installation(
@@ -39,6 +41,31 @@ def _installation(
     client = root / "app" / client_version / "Olivia.exe"
     client.parent.mkdir(parents=True)
     client.write_bytes(b"fixture")
+    resources = client.parent / "resources"
+    resources.mkdir()
+    main_member = (
+        "assets/main-31595bd3.js"
+        if client_version == "0.0.9.627"
+        else "assets/main-917d29fc.js"
+    )
+    index = (
+        '<!doctype html><html><head>'
+        f'<script type="module" src="./{main_member}"></script>'
+        '<script src="./assets/olivia-companion-settings.js" '
+        'data-olivia-companion-settings="p03.original-settings-shell.v1" '
+        f'data-ui-version="{SETTINGS_UI_VERSION}" '
+        'data-api-base="http://127.0.0.1:8899/"></script>'
+        '</head><body><div id="app"></div></body></html>'
+    )
+    main = (
+        b'synthetic-main"hide-write":!1'
+        if client_version == "0.0.9.627"
+        else b"synthetic-main"
+    )
+    with zipfile.ZipFile(resources / "feapp.dat", "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("index.html", index)
+        archive.writestr(main_member, main)
+        archive.writestr("assets/olivia-companion-settings.js", BOOTSTRAP_JAVASCRIPT)
     return root
 
 
@@ -47,13 +74,10 @@ def test_launcher_repairs_existing_0627_frontend_before_start(
 ) -> None:
     root = _installation(tmp_path, client_version="0.0.9.627")
     resources = root / "app" / "0.0.9.627" / "resources"
-    resources.mkdir()
     index = """<!doctype html><html><head>
 <script type="module" src="./assets/main-31595bd3.js"></script>
 <script src="./assets/olivia-companion-settings.js" data-olivia-companion-settings="p03.original-settings-shell.v1" data-ui-version="p03.original-settings-manage.v6" data-api-base="http://127.0.0.1:8899/"></script>
 </head><body><div id="app"></div></body></html>"""
-    from original_client_settings_ui import BOOTSTRAP_JAVASCRIPT
-
     old_bootstrap = BOOTSTRAP_JAVASCRIPT.replace(
         '    document.querySelector(`[${ROOT_ATTR}]`)?.remove();\n',
         '    document.querySelector(`[${ROOT_ATTR}]`)?.remove();\n'
@@ -76,6 +100,16 @@ def test_launcher_repairs_existing_0627_frontend_before_start(
         main = archive.read("assets/main-31595bd3.js").decode()
     assert bootstrap == BOOTSTRAP_JAVASCRIPT
     assert '"hide-write":!1' in main
+
+
+def test_launcher_rejects_missing_frontend_archive(tmp_path: Path) -> None:
+    root = _installation(tmp_path, client_version="0.0.9.627")
+    (root / "app" / "0.0.9.627" / "resources" / "feapp.dat").unlink()
+
+    with pytest.raises(CompanionSettingsPatchError) as error:
+        start_local._repair_client_frontend(root, 8899)
+
+    assert error.value.code == "COMPANION_ARCHIVE_NOT_FOUND"
 
 
 def test_launcher_loads_user_managed_llm_config_without_exposing_key(tmp_path: Path) -> None:

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -14,7 +14,7 @@ from original_client_settings_ui import (
 
 # The shipped CEF surface needs explicit no-drag/pointer and display-state guards.
 def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
-    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v6"
+    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v7"
     for declaration in (
             'const STATUS_PATH = "/toy/companion/status";',
             'const MEMORY_PATH = "/toy/companion/memory";',

--- a/tests/installer/test_original_settings_javascript.py
+++ b/tests/installer/test_original_settings_javascript.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 import shutil
 import subprocess
 
@@ -76,3 +77,49 @@ def test_original_settings_reuses_llm_setup_after_login() -> None:
     assert 'local_data_root: "本地数据目录"' in source
     assert "|| isSettingsRoute()" not in source
     assert "innerHTML" not in source
+
+
+def test_initial_setup_dialog_survives_mailbox_route_cleanup() -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is unavailable for JavaScript behavior validation")
+    harness = r'''
+const fs = require("fs");
+const vm = require("vm");
+let source = fs.readFileSync(0, "utf8");
+source = source.replace(/\}\)\(\);\s*$/, `
+  globalThis.mountSettingsShell = mountShell;
+})();\n`);
+
+let dialogRemoved = false;
+const dialog = { remove: () => { dialogRemoved = true; } };
+const document = {
+  currentScript: { dataset: { apiBase: "http://127.0.0.1:8899/" } },
+  documentElement: {},
+  querySelector: (selector) => selector.includes("settings-dialog") ? dialog : null,
+  querySelectorAll: () => [],
+};
+const context = {
+  URL, AbortController, document,
+  MutationObserver: class { observe() {} },
+  window: {
+    location: { pathname: "/collection", hash: "" },
+    requestAnimationFrame: () => {},
+    addEventListener: () => {},
+    setInterval: () => 1,
+  },
+};
+vm.runInNewContext(source, context);
+context.mountSettingsShell();
+process.stdout.write(JSON.stringify({ dialogRemoved }));
+'''
+    completed = subprocess.run(
+        [node, "-e", harness],
+        input=BOOTSTRAP_JAVASCRIPT.encode("utf-8"),
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    output = (completed.stderr or completed.stdout).decode("utf-8", errors="replace")
+    assert completed.returncode == 0, output
+    assert json.loads(completed.stdout)["dialogRemoved"] is False

--- a/tests/installer/test_patch_companion_settings.py
+++ b/tests/installer/test_patch_companion_settings.py
@@ -219,6 +219,45 @@ def test_repository_owned_bootstrap_is_upgraded_without_touching_main_module(
     assert index.count(PATCH_MARKER) == 1
 
 
+def test_repository_owned_bootstrap_upgrade_restores_0627_mailbox_write_access(
+    tmp_path: Path,
+) -> None:
+    main_member = "assets/main-31595bd3.js"
+    old_bootstrap = BOOTSTRAP_JAVASCRIPT.replace(
+        '    document.querySelector(`[${ROOT_ATTR}]`)?.remove();\n',
+        '    document.querySelector(`[${ROOT_ATTR}]`)?.remove();\n'
+        '    document.querySelector(`[${DIALOG_ATTR}]`)?.remove();\n',
+        1,
+    )
+    legacy_tag = (
+        '<script src="./assets/olivia-companion-settings.js" '
+        'data-olivia-companion-settings="p03.original-settings-shell.v1" '
+        'data-ui-version="p03.original-settings-manage.v6" '
+        'data-api-base="http://127.0.0.1:8899/"></script>'
+    )
+    index = INDEX.replace("main-917d29fc.js", "main-31595bd3.js")
+    index = index.replace("</head>", legacy_tag + "</head>")
+    path = tmp_path / "feapp.dat"
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(INDEX_MEMBER, index)
+        archive.writestr(main_member, b'prefix"hide-write":o(p)||!o(N3)suffix')
+        archive.writestr(BOOTSTRAP_MEMBER, old_bootstrap)
+        archive.writestr("assets/index.css", b"body{display:block}")
+
+    result = patch_companion_settings(
+        path,
+        "http://127.0.0.1:8899",
+        work_root=tmp_path,
+    )
+
+    after = _members(path)
+    assert result["status"] == "PATCHED"
+    assert after[BOOTSTRAP_MEMBER].decode() == BOOTSTRAP_JAVASCRIPT
+    main = after[main_member].decode()
+    assert '"hide-write":!1' in main
+    assert '"hide-write":o(p)||!o(N3)' not in main
+
+
 def test_repatch_with_a_different_api_base_is_rejected_without_mutation(
     tmp_path: Path,
 ) -> None:

--- a/tests/installer/test_patch_companion_settings.py
+++ b/tests/installer/test_patch_companion_settings.py
@@ -150,7 +150,10 @@ def test_patch_supports_original_client_0_0_9_627_main_module(
     path = tmp_path / "feapp.dat"
     with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
         archive.writestr(INDEX_MEMBER, index)
-        archive.writestr(main_member, b"synthetic-0.0.9.627-main-module")
+        archive.writestr(
+            main_member,
+            b'synthetic-0.0.9.627-main-module"hide-write":!1',
+        )
         archive.writestr("assets/index.css", b"body{display:block}")
 
     result = patch_companion_settings(
@@ -161,7 +164,7 @@ def test_patch_supports_original_client_0_0_9_627_main_module(
 
     after = _members(path)
     assert result["status"] == "PATCHED"
-    assert after[main_member] == b"synthetic-0.0.9.627-main-module"
+    assert after[main_member] == b'synthetic-0.0.9.627-main-module"hide-write":!1'
     assert PATCH_MARKER in after[INDEX_MEMBER].decode()
     assert BOOTSTRAP_MEMBER in after
 
@@ -256,6 +259,29 @@ def test_repository_owned_bootstrap_upgrade_restores_0627_mailbox_write_access(
     main = after[main_member].decode()
     assert '"hide-write":!1' in main
     assert '"hide-write":o(p)||!o(N3)' not in main
+
+
+def test_0627_mailbox_write_repair_rejects_missing_anchor_without_mutation(
+    tmp_path: Path,
+) -> None:
+    main_member = "assets/main-31595bd3.js"
+    index = INDEX.replace("main-917d29fc.js", "main-31595bd3.js")
+    path = tmp_path / "feapp.dat"
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(INDEX_MEMBER, index)
+        archive.writestr(main_member, b"unsupported-main")
+        archive.writestr("assets/index.css", b"body{display:block}")
+    before = path.read_bytes()
+
+    with pytest.raises(CompanionSettingsPatchError) as error:
+        patch_companion_settings(
+            path,
+            "http://127.0.0.1:8899",
+            work_root=tmp_path,
+        )
+
+    assert error.value.code == "COMPANION_MAILBOX_WRITE_ANCHOR_INVALID"
+    assert path.read_bytes() == before
 
 
 def test_repatch_with_a_different_api_base_is_rejected_without_mutation(

--- a/tests/installer/test_private_world_default.py
+++ b/tests/installer/test_private_world_default.py
@@ -27,6 +27,11 @@ def test_start_local_configures_private_world_under_install_data(
     monkeypatch.setattr(start_local, "_health", lambda _port: "READY")
     monkeypatch.setattr(start_local, "_load_dpapi_key", lambda _path: "")
     monkeypatch.setattr(start_local, "_client_executable", lambda _root: client)
+    monkeypatch.setattr(
+        start_local,
+        "_repair_client_frontend",
+        lambda _root, _port: "ALREADY_PATCHED",
+    )
 
     def fake_call(command, *, cwd, env):
         observed.update({"command": command, "cwd": cwd, "env": env})

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1172,7 +1172,7 @@ def test_install_isolated_copy_activates_original_client_surfaces(
         main = archive.read("assets/main-917d29fc.js").decode("utf-8")
     assert "assets/olivia-companion-settings.js" in names
     assert "data-olivia-companion-settings" in index
-    assert "data-ui-version=\"p03.original-settings-manage.v6\"" in index
+    assert "data-ui-version=\"p03.original-settings-manage.v7\"" in index
     assert (installed / "local_backend" / "original_client_setup_api.py").is_file()
     assert (installed / "local_backend" / "original_client_capability_api.py").is_file()
     assert (installed / "local_backend" / "original_client_update_api.py").is_file()

--- a/tests/test_baseline_hardening.py
+++ b/tests/test_baseline_hardening.py
@@ -1083,6 +1083,7 @@ def test_patch_feapp_supports_original_client_0_0_9_627(
         '"query.response":io(a)}}),t(c)},onFailure:'
         '!z.isNew||$?(await t.replace({name:ve.Home}),'
         'await h(z.uid.toString(),z.modelGatewayToken||"",!1))'
+        '"hide-write":o(p)||!o(N3)'
     )
     with zipfile.ZipFile(feapp, "w", zipfile.ZIP_DEFLATED) as archive:
         archive.writestr(main_member, javascript)
@@ -1101,6 +1102,8 @@ def test_patch_feapp_supports_original_client_0_0_9_627(
     assert 'localStorage.setItem("appMode","lite")' in patched
     assert "await t.replace({name:ve.Collection})" in patched
     assert "await t.replace({name:ve.Home})" not in patched
+    assert '"hide-write":!1' in patched
+    assert '"hide-write":o(p)||!o(N3)' not in patched
 
 
 def test_patch_feapp_requires_explicit_local_ws_and_rolls_back_on_failure(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- stop mailbox route cleanup from removing the first-run setup dialog and triggering a render/fetch loop
- restore the existing 0.0.9.627 write-letter entry that official offline/feature gates hide
- upgrade repository-owned frontend assets from a local backend patch on the next launch, so existing users do not reinstall

## Verification
- full suite: 1159 passed, 1 skipped, 1 deselected
- focused installer/client tests: 140 passed, 1 skipped
- copied F:\game installed feapp upgrade: PATCHED, UI v7, write anchor restored
- git diff --check: passed
- Ruff: unavailable in the current environment

## Review pair
- base: ee61cc3fb835ece13d849f1b52c2c4a1c8c98fc5
- head: b4b589e

## Boundary
The live F:\game installation was not modified or stopped; real-install validation used a temporary copy.