### PR TITLE
Fix provider connection and component backend activation

### DIFF
--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -12,6 +12,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 
 - `contract_version`: `b02.v1`
 - `schema_version`: `1`
+- core health 的 `backend_id` 是组件版本与安装实例摘要组成的不透明标识；不包含安装路径、用户名或密钥。启动器只复用与当前安装实例和活动组件同时匹配的本机后端。
 - 正常响应：`{"code":0,"message":"ok","data":{...}}`
 - 错误响应：`{"code":<HTTP 状态>,"message":"<error_code>","data":{"status":"FAILED","error_code":"<error_code>"}}`
 - 真正未实现能力：HTTP `501`，`data.status=NOT_IMPLEMENTED`。

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -42,7 +42,7 @@ GitHub Actions 会在 PR 和 `main` 更新时生成同样的可下载 artifact�
 
 ## 启动器健康检查
 
-`installer/start_local.py --health-only` 输出一行符合 [`contracts/launcher_health.schema.json`](../contracts/launcher_health.schema.json) 的 JSON。`READY` 的退出码为 0；`UNAVAILABLE` 与 `PORT_CONFLICT` 的退出码为 2。`PORT_CONFLICT` 表示端口已有非本契约监听器或返回了无效健康契约，启动器不会尝试启动第二个后端。
+`installer/start_local.py --health-only` 输出一行符合 [`contracts/launcher_health.schema.json`](../contracts/launcher_health.schema.json) 的 JSON。`READY` 的退出码为 0；`UNAVAILABLE` 与 `PORT_CONFLICT` 的退出码为 2。`PORT_CONFLICT` 表示端口已有非本契约监听器或返回了无效健康契约，启动器不会尝试启动第二个后端。正常启动还会核对 health 中不含路径的 `backend_id`，它同时绑定活动组件与当前安装实例；版本或安装实例不匹配时不会复用该服务。首个组件补丁遇到旧版遗留服务时，只有在 Windows 确认监听进程是当前产品目录自带 runtime 的 Python 后才会终止并启动新版本；无法证明归属时以 `STALE_BACKEND_RUNNING` 停止，不会结束其他程序。启动器自己创建的后端随 Olivia 客户端退出而结束。
 
 ## 原版客户端补丁
 

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -248,6 +248,12 @@ def _backend_entrypoint(backend: Path) -> Path:
     return backend / "original_client_server.py"
 
 
+def _active_backend() -> Path:
+    """Resolve the complete backend tree that owns this launcher module."""
+
+    return Path(__file__).resolve().parents[1]
+
+
 _BACKEND_BOOTSTRAP = (
     "import runpy,sys; "
     "backend,entrypoint,*args=sys.argv[1:]; "
@@ -304,7 +310,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--health-only", action="store_true")
     args = parser.parse_args(argv)
     root = args.install_root.expanduser().resolve()
-    backend = root / "local_backend"
+    backend = _active_backend()
     entrypoint = _backend_entrypoint(backend)
     if not (backend / "local_server.py").is_file() or not entrypoint.is_file():
         print("PATCH_PAYLOAD_INCOMPLETE")

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -138,6 +138,7 @@ _CORE_HEALTH_REQUIRED_CHECKS = (
 )
 _CORE_HEALTH_CHECK_STATES = frozenset({"available", "degraded", "unavailable"})
 _BACKEND_START_TIMEOUT_SECONDS = 120
+_BACKEND_ID_RE = re.compile(r"[0-9A-Za-z.+-]{1,160}")
 
 
 def _port_is_bindable(port: int) -> bool:
@@ -185,6 +186,65 @@ def _health(port: int) -> str:
         return "PORT_CONFLICT"
     except Exception:
         return "UNAVAILABLE" if _port_is_bindable(port) else "PORT_CONFLICT"
+
+
+def _backend_id(backend: Path) -> str:
+    """Return a path-free identity for the selected backend tree."""
+
+    if backend.name == "local_backend":
+        return "legacy"
+    if (
+        backend.parent.name == "local_backend"
+        and backend.parent.parent.name == "versions"
+        and _BACKEND_ID_RE.fullmatch(backend.name)
+    ):
+        return backend.name
+    return "invalid"
+
+
+def _server_backend_id(port: int) -> str | None:
+    """Read the path-free identity published by the backend on this port."""
+
+    try:
+        with urlopen(
+            f"http://127.0.0.1:{port}/health?profile=core",
+            timeout=1.5,
+        ) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        data = payload.get("data") if isinstance(payload, dict) else None
+        backend_id = data.get("backend_id") if isinstance(data, dict) else None
+        if (
+            response.status == 200
+            and payload.get("code") == 0
+            and isinstance(backend_id, str)
+            and _BACKEND_ID_RE.fullmatch(backend_id)
+        ):
+            return backend_id
+    except Exception:
+        pass
+    return None
+
+
+def _stop_backend_server(server: object) -> None:
+    """Best-effort cleanup for the backend process owned by this launcher."""
+
+    terminate = getattr(server, "terminate", None)
+    wait = getattr(server, "wait", None)
+    if not callable(terminate) or not callable(wait):
+        return
+    try:
+        terminate()
+        wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        kill = getattr(server, "kill", None)
+        if callable(kill):
+            kill()
+            try:
+                wait(timeout=5)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+    except OSError:
+        pass
 
 
 def _client_executable(root: Path) -> Path:
@@ -323,6 +383,10 @@ def main(argv: list[str] | None = None) -> int:
     if health == "PORT_CONFLICT":
         print("PORT_CONFLICT")
         return 2
+    expected_backend_id = _backend_id(backend)
+    if health == "READY" and _server_backend_id(args.port) != expected_backend_id:
+        print("STALE_BACKEND_RUNNING")
+        return 2
     data_root = root / "data"
     data_root.mkdir(parents=True, exist_ok=True)
     client_environment = os.environ.copy()
@@ -342,6 +406,7 @@ def main(argv: list[str] | None = None) -> int:
         "OLIVIA_PORT": str(args.port),
     }
     backend_environment.update(runtime_environment)
+    backend_environment["OLIVIA_BACKEND_ID"] = expected_backend_id
     client_environment.update(runtime_environment)
     backend_environment = _load_llm_environment(
         backend_environment, data_root, include_secret=True
@@ -351,49 +416,57 @@ def main(argv: list[str] | None = None) -> int:
     if not any(backend_environment.get(name) for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")):
         print("LLM_API_KEY_NOT_CONFIGURED: 请先在启动此程序的进程环境中设置 API key；当前仅提供明确的 safe-static/degraded 回退。")
     server = None
-    if health != "READY":
-        detached = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) | getattr(subprocess, "DETACHED_PROCESS", 0)
-        server = subprocess.Popen(
-            [
-                str(_backend_executable()),
-                "-c",
-                _BACKEND_BOOTSTRAP,
-                str(backend),
-                str(entrypoint),
-            ],
-            cwd=backend,
-            env=backend_environment,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            creationflags=detached,
-        )
-        deadline = time.monotonic() + _BACKEND_START_TIMEOUT_SECONDS
-        while time.monotonic() < deadline and server.poll() is None:
-            if _health(args.port) == "READY":
-                break
-            time.sleep(0.25)
-        health = _health(args.port)
-        if health != "READY":
-            if health == "PORT_CONFLICT":
-                print("PORT_CONFLICT")
-                return 2
-            print("LOCAL_SERVER_UNAVAILABLE")
-            return 2
-    client = _client_executable(root)
-    if not client.is_file():
-        print("ISOLATED_CLIENT_NOT_FOUND")
-        return 2
     try:
-        _repair_client_frontend(root, args.port)
-    except (CompanionSettingsPatchError, OSError):
-        print("CLIENT_FRONTEND_REPAIR_FAILED")
-        return 2
-    profile = root / "profile"
-    roaming = profile / "Roaming"
-    local = profile / "Local"
-    roaming.mkdir(parents=True, exist_ok=True)
-    local.mkdir(parents=True, exist_ok=True)
-    return subprocess.call(_client_command(client, local), cwd=root / "app", env=_client_environment(client_environment, roaming, local))
+        if health != "READY":
+            creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            server = subprocess.Popen(
+                [
+                    str(_backend_executable()),
+                    "-c",
+                    _BACKEND_BOOTSTRAP,
+                    str(backend),
+                    str(entrypoint),
+                ],
+                cwd=backend,
+                env=backend_environment,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                creationflags=creationflags,
+            )
+            deadline = time.monotonic() + _BACKEND_START_TIMEOUT_SECONDS
+            while time.monotonic() < deadline and server.poll() is None:
+                if _health(args.port) == "READY":
+                    break
+                time.sleep(0.25)
+            health = _health(args.port)
+            if health != "READY":
+                if health == "PORT_CONFLICT":
+                    print("PORT_CONFLICT")
+                    return 2
+                print("LOCAL_SERVER_UNAVAILABLE")
+                return 2
+        client = _client_executable(root)
+        if not client.is_file():
+            print("ISOLATED_CLIENT_NOT_FOUND")
+            return 2
+        try:
+            _repair_client_frontend(root, args.port)
+        except (CompanionSettingsPatchError, OSError):
+            print("CLIENT_FRONTEND_REPAIR_FAILED")
+            return 2
+        profile = root / "profile"
+        roaming = profile / "Roaming"
+        local = profile / "Local"
+        roaming.mkdir(parents=True, exist_ok=True)
+        local.mkdir(parents=True, exist_ok=True)
+        return subprocess.call(
+            _client_command(client, local),
+            cwd=root / "app",
+            env=_client_environment(client_environment, roaming, local),
+        )
+    finally:
+        if server is not None:
+            _stop_backend_server(server)
 
 
 if __name__ == "__main__":

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -188,18 +188,23 @@ def _health(port: int) -> str:
         return "UNAVAILABLE" if _port_is_bindable(port) else "PORT_CONFLICT"
 
 
-def _backend_id(backend: Path) -> str:
+def _backend_id(backend: Path, root: Path) -> str:
     """Return a path-free identity for the selected backend tree."""
 
     if backend.name == "local_backend":
-        return "legacy"
-    if (
+        component_id = "legacy"
+    elif (
         backend.parent.name == "local_backend"
         and backend.parent.parent.name == "versions"
         and _BACKEND_ID_RE.fullmatch(backend.name)
     ):
-        return backend.name
-    return "invalid"
+        component_id = backend.name
+    else:
+        component_id = "invalid"
+    installation_id = hashlib.sha256(
+        os.path.normcase(os.fspath(root)).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"{component_id}.{installation_id}"
 
 
 def _server_backend_id(port: int) -> str | None:
@@ -245,6 +250,110 @@ def _stop_backend_server(server: object) -> None:
                 pass
     except OSError:
         pass
+
+
+def _listening_process_id(port: int) -> int | None:
+    """Resolve the Windows PID that owns one listening TCP port."""
+
+    if os.name != "nt":
+        return None
+    import ctypes
+    from ctypes import wintypes
+
+    class TcpRowOwnerPid(ctypes.Structure):
+        _fields_ = [
+            ("state", wintypes.DWORD),
+            ("local_address", wintypes.DWORD),
+            ("local_port", wintypes.DWORD),
+            ("remote_address", wintypes.DWORD),
+            ("remote_port", wintypes.DWORD),
+            ("process_id", wintypes.DWORD),
+        ]
+
+    size = wintypes.ULONG()
+    table = ctypes.WinDLL("iphlpapi", use_last_error=True).GetExtendedTcpTable
+    table(None, ctypes.byref(size), False, socket.AF_INET, 3, 0)
+    if not size.value:
+        return None
+    buffer = ctypes.create_string_buffer(size.value)
+    if table(buffer, ctypes.byref(size), False, socket.AF_INET, 3, 0) != 0:
+        return None
+    count = ctypes.cast(buffer, ctypes.POINTER(wintypes.DWORD)).contents.value
+    offset = ctypes.sizeof(wintypes.DWORD)
+    row_size = ctypes.sizeof(TcpRowOwnerPid)
+    for index in range(count):
+        row = TcpRowOwnerPid.from_buffer_copy(buffer, offset + index * row_size)
+        if socket.ntohs(row.local_port & 0xFFFF) == port:
+            return int(row.process_id)
+    return None
+
+
+def _runtime_owns_executable(executable: Path, root: Path) -> bool:
+    """Limit legacy migration to Python bundled beside this installation."""
+
+    if executable.name.casefold() not in {"python.exe", "pythonw.exe"}:
+        return False
+    candidate = os.path.normcase(os.fspath(executable.absolute()))
+    for runtime in (root.parent / "runtime", root / "runtime"):
+        boundary = os.path.normcase(os.fspath(runtime.absolute()))
+        try:
+            if os.path.commonpath((candidate, boundary)) == boundary:
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+def _terminate_runtime_process(process_id: int, root: Path) -> bool:
+    """Terminate a listener only when its executable belongs to this install."""
+
+    if os.name != "nt":
+        return False
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.QueryFullProcessImageNameW.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.LPWSTR,
+        ctypes.POINTER(wintypes.DWORD),
+    ]
+    kernel32.QueryFullProcessImageNameW.restype = wintypes.BOOL
+    kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
+    kernel32.TerminateProcess.restype = wintypes.BOOL
+    kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+
+    process_access = 0x0001 | 0x1000 | 0x00100000
+    handle = kernel32.OpenProcess(process_access, False, process_id)
+    if not handle:
+        return False
+    try:
+        buffer = ctypes.create_unicode_buffer(32768)
+        length = wintypes.DWORD(len(buffer))
+        if not kernel32.QueryFullProcessImageNameW(
+            handle,
+            0,
+            buffer,
+            ctypes.byref(length),
+        ) or not _runtime_owns_executable(Path(buffer.value), root):
+            return False
+        if not kernel32.TerminateProcess(handle, 0):
+            return False
+        return kernel32.WaitForSingleObject(handle, 5000) == 0
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def _stop_stale_backend(port: int, root: Path) -> bool:
+    """Stop a legacy listener only after proving it uses this install runtime."""
+
+    process_id = _listening_process_id(port)
+    return process_id is not None and _terminate_runtime_process(process_id, root)
 
 
 def _client_executable(root: Path) -> Path:
@@ -383,10 +492,20 @@ def main(argv: list[str] | None = None) -> int:
     if health == "PORT_CONFLICT":
         print("PORT_CONFLICT")
         return 2
-    expected_backend_id = _backend_id(backend)
+    expected_backend_id = _backend_id(backend, root)
     if health == "READY" and _server_backend_id(args.port) != expected_backend_id:
-        print("STALE_BACKEND_RUNNING")
-        return 2
+        if not _stop_stale_backend(args.port, root):
+            print("STALE_BACKEND_RUNNING")
+            return 2
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            health = _health(args.port)
+            if health == "UNAVAILABLE":
+                break
+            time.sleep(0.1)
+        if health != "UNAVAILABLE":
+            print("STALE_BACKEND_RUNNING")
+            return 2
     data_root = root / "data"
     data_root.mkdir(parents=True, exist_ok=True)
     client_environment = os.environ.copy()

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -19,6 +19,9 @@ from typing import Any, AsyncIterator, Callable, Mapping, Sequence
 import aiohttp
 
 
+PROVIDER_USER_AGENT = "Olivia-Community/0.1"
+
+
 ALLOWED_ROLES = frozenset({"system", "user", "assistant"})
 SUPPORTED_API_STYLES = frozenset({"chat_completions", "responses"})
 
@@ -540,7 +543,11 @@ class OpenAICompatibleAdapter(Gateway):
         return self.config.base_url.rstrip("/") + "/" + suffix
 
     def _headers(self, key: str | None, request_id: str) -> dict[str, str]:
-        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": PROVIDER_USER_AGENT,
+        }
         if key:
             headers["Authorization"] = "Bearer " + key
         if request_id.startswith("letter-reply:"):

--- a/local_server.py
+++ b/local_server.py
@@ -1384,10 +1384,17 @@ def _health_result(profile: str = contract.HEALTH_PROFILE_CORE) -> dict:
         profile_status = "HEALTHY" if native_asr_status.get("status") == "available" else "UNAVAILABLE"
     else:
         profile_status = "HEALTHY" if memory_status == "available" else "UNAVAILABLE"
+    raw_backend_id = _os.environ.get("OLIVIA_BACKEND_ID", "legacy")
+    backend_id = (
+        raw_backend_id
+        if _re.fullmatch(r"[0-9A-Za-z.+-]{1,160}", raw_backend_id)
+        else "invalid"
+    )
     return ok(
         {
             "schema_version": contract.SCHEMA_VERSION,
             "contract_version": contract.CONTRACT_VERSION,
+            "backend_id": backend_id,
             "profile": profile,
             "status": profile_status,
             "providers": {

--- a/original_client_setup_api.py
+++ b/original_client_setup_api.py
@@ -16,6 +16,7 @@ from urllib.parse import urlsplit
 from aiohttp import ClientError, ClientSession, ClientTimeout, web
 
 
+PROVIDER_USER_AGENT = "Olivia-Community/0.1"
 SETUP_STATUS_PATH = "/toy/setup/status"
 LLM_TEST_PATH = "/toy/setup/llm/test"
 LLM_SAVE_PATH = "/toy/setup/llm/save"
@@ -200,7 +201,10 @@ async def _probe_openai_compatible(base_url: str, model: str, api_key: str) -> N
         async with ClientSession(timeout=ClientTimeout(total=20)) as session:
             async with session.post(
                 f"{base_url}/chat/completions",
-                headers={"Authorization": f"Bearer {api_key}"},
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": PROVIDER_USER_AGENT,
+                },
                 json={
                     "model": model,
                     "messages": [{"role": "user", "content": "Reply with OK."}],

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -48,6 +48,7 @@ def test_core_health_is_versioned_and_reports_unavailable_optional_capabilities(
     assert data["status"] == "HEALTHY"
     assert data["contract_version"] == "b02.v1"
     assert data["schema_version"] == 1
+    assert data["backend_id"] == "legacy"
     assert data["privacy"]["logs_include_request_body"] is False
     assert data["privacy"]["logs_include_query_values"] is False
     for capability in ("native.websocket", "native.asr", "native.tts", "native.live"):

--- a/tests/http/test_original_client_setup_api.py
+++ b/tests/http/test_original_client_setup_api.py
@@ -209,6 +209,35 @@ def test_test_then_save_persists_only_dpapi_key_and_non_secret_config(
     asyncio.run(scenario())
 
 
+def test_setup_connection_probe_identifies_the_client_to_provider(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        seen: dict[str, str | None] = {}
+
+        async def completion(request: web.Request) -> web.Response:
+            seen["user_agent"] = request.headers.get("User-Agent")
+            return web.json_response(
+                {"choices": [{"message": {"role": "assistant", "content": "OK"}}]}
+            )
+
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", completion)
+        async with TestClient(TestServer(app)) as client:
+            service = LLMSetupService(tmp_path)
+            await service.test(
+                {
+                    "base_url": str(client.make_url("/v1")),
+                    "model": "deepseek-v4-flash",
+                    "api_key": "fixture-private-key",
+                }
+            )
+
+        assert seen["user_agent"] == "Olivia-Community/0.1"
+
+    asyncio.run(scenario())
+
+
 def test_setup_rejects_untrusted_origin_and_marks_skipped_setup_complete(
     tmp_path: Path,
 ) -> None:

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -259,6 +259,113 @@ def test_component_launcher_starts_the_backend_that_owns_start_local(
     assert commands[0][3:] == [str(active_backend), str(active_entrypoint)]
 
 
+def test_component_launcher_identifies_and_stops_its_backend(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    root = _installation(tmp_path)
+    active_backend = tmp_path / "versions" / "local_backend" / "0.1.2-digest"
+    (active_backend / "installer").mkdir(parents=True)
+    (active_backend / "local_server.py").write_text("# active", encoding="utf-8")
+    (active_backend / "original_client_server.py").write_text(
+        "# active",
+        encoding="utf-8",
+    )
+    health = iter(("UNAVAILABLE", "READY", "READY"))
+    backend_environments: list[dict[str, str]] = []
+    lifecycle: list[str] = []
+
+    class Process:
+        @staticmethod
+        def poll():
+            return None
+
+        @staticmethod
+        def terminate() -> None:
+            lifecycle.append("terminate")
+
+        @staticmethod
+        def wait(*, timeout: float) -> int:
+            lifecycle.append(f"wait:{timeout}")
+            return 0
+
+    def popen(_command, **kwargs):
+        backend_environments.append(kwargs["env"])
+        return Process()
+
+    monkeypatch.setattr(start_local, "_active_backend", lambda: active_backend)
+    monkeypatch.setattr(start_local, "_health", lambda _port: next(health))
+    monkeypatch.setattr(start_local.subprocess, "Popen", popen)
+    monkeypatch.setattr(start_local.subprocess, "call", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(start_local, "_repair_client_frontend", lambda *_args: "PATCHED")
+
+    assert start_local.main(["--install-root", str(root), "--port", "8899"]) == 0
+    assert backend_environments[0]["OLIVIA_BACKEND_ID"] == "0.1.2-digest"
+    assert lifecycle == ["terminate", "wait:5"]
+
+
+def test_launcher_refuses_to_reuse_a_ready_backend_with_another_identity(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    root = _installation(tmp_path)
+    active_backend = tmp_path / "versions" / "local_backend" / "0.1.2-digest"
+    (active_backend / "installer").mkdir(parents=True)
+    (active_backend / "local_server.py").write_text("# active", encoding="utf-8")
+    (active_backend / "original_client_server.py").write_text(
+        "# active",
+        encoding="utf-8",
+    )
+    client_calls: list[list[str]] = []
+
+    monkeypatch.setattr(start_local, "_active_backend", lambda: active_backend)
+    monkeypatch.setattr(start_local, "_health", lambda _port: "READY")
+    monkeypatch.setattr(start_local, "_server_backend_id", lambda _port: "legacy")
+    monkeypatch.setattr(
+        start_local.subprocess,
+        "call",
+        lambda command, **_kwargs: client_calls.append(command) or 0,
+    )
+
+    assert start_local.main(["--install-root", str(root), "--port", "8899"]) == 2
+    assert capsys.readouterr().out.strip() == "STALE_BACKEND_RUNNING"
+    assert client_calls == []
+
+
+def test_launcher_reads_backend_identity_from_health_response(monkeypatch) -> None:
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        @staticmethod
+        def read() -> bytes:
+            return json.dumps(
+                {
+                    "code": 0,
+                    "message": "ok",
+                    "data": {"backend_id": "0.1.2-digest"},
+                }
+            ).encode("utf-8")
+
+    monkeypatch.setattr(start_local, "urlopen", lambda *_args, **_kwargs: Response())
+
+    assert start_local._server_backend_id(8899) == "0.1.2-digest"
+
+
+def test_backend_identity_tracks_versioned_and_legacy_selection(tmp_path: Path) -> None:
+    legacy = tmp_path / "local_backend"
+    versioned = tmp_path / "versions" / "local_backend" / "0.1.2-digest"
+
+    assert start_local._backend_id(legacy) == "legacy"
+    assert start_local._backend_id(versioned) == "0.1.2-digest"
+
+
 def test_launcher_allows_mem0_cold_start_before_opening_client(
     tmp_path: Path,
     monkeypatch,

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -300,14 +300,16 @@ def test_component_launcher_identifies_and_stops_its_backend(
     monkeypatch.setattr(start_local, "_repair_client_frontend", lambda *_args: "PATCHED")
 
     assert start_local.main(["--install-root", str(root), "--port", "8899"]) == 0
-    assert backend_environments[0]["OLIVIA_BACKEND_ID"] == "0.1.2-digest"
+    assert backend_environments[0]["OLIVIA_BACKEND_ID"] == start_local._backend_id(
+        active_backend,
+        root.resolve(),
+    )
     assert lifecycle == ["terminate", "wait:5"]
 
 
-def test_launcher_refuses_to_reuse_a_ready_backend_with_another_identity(
+def test_launcher_replaces_a_verified_stale_backend_before_starting_active_version(
     tmp_path: Path,
     monkeypatch,
-    capsys,
 ) -> None:
     root = _installation(tmp_path)
     active_backend = tmp_path / "versions" / "local_backend" / "0.1.2-digest"
@@ -317,20 +319,34 @@ def test_launcher_refuses_to_reuse_a_ready_backend_with_another_identity(
         "# active",
         encoding="utf-8",
     )
-    client_calls: list[list[str]] = []
+    health = iter(("READY", "UNAVAILABLE", "READY", "READY"))
+    stale_stops: list[tuple[int, Path]] = []
+    backend_starts: list[list[str]] = []
+
+    class Process:
+        @staticmethod
+        def poll():
+            return None
 
     monkeypatch.setattr(start_local, "_active_backend", lambda: active_backend)
-    monkeypatch.setattr(start_local, "_health", lambda _port: "READY")
+    monkeypatch.setattr(start_local, "_health", lambda _port: next(health))
     monkeypatch.setattr(start_local, "_server_backend_id", lambda _port: "legacy")
     monkeypatch.setattr(
-        start_local.subprocess,
-        "call",
-        lambda command, **_kwargs: client_calls.append(command) or 0,
+        start_local,
+        "_stop_stale_backend",
+        lambda port, installation: stale_stops.append((port, installation)) or True,
     )
+    monkeypatch.setattr(
+        start_local.subprocess,
+        "Popen",
+        lambda command, **_kwargs: backend_starts.append(command) or Process(),
+    )
+    monkeypatch.setattr(start_local.subprocess, "call", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(start_local, "_repair_client_frontend", lambda *_args: "PATCHED")
 
-    assert start_local.main(["--install-root", str(root), "--port", "8899"]) == 2
-    assert capsys.readouterr().out.strip() == "STALE_BACKEND_RUNNING"
-    assert client_calls == []
+    assert start_local.main(["--install-root", str(root), "--port", "8899"]) == 0
+    assert stale_stops == [(8899, root.resolve())]
+    assert len(backend_starts) == 1
 
 
 def test_launcher_reads_backend_identity_from_health_response(monkeypatch) -> None:
@@ -358,12 +374,46 @@ def test_launcher_reads_backend_identity_from_health_response(monkeypatch) -> No
     assert start_local._server_backend_id(8899) == "0.1.2-digest"
 
 
-def test_backend_identity_tracks_versioned_and_legacy_selection(tmp_path: Path) -> None:
-    legacy = tmp_path / "local_backend"
+def test_backend_identity_tracks_version_and_installation(tmp_path: Path) -> None:
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    legacy = first_root / "local_backend"
     versioned = tmp_path / "versions" / "local_backend" / "0.1.2-digest"
 
-    assert start_local._backend_id(legacy) == "legacy"
-    assert start_local._backend_id(versioned) == "0.1.2-digest"
+    legacy_id = start_local._backend_id(legacy, first_root)
+    versioned_id = start_local._backend_id(versioned, first_root)
+
+    assert legacy_id.startswith("legacy.")
+    assert versioned_id.startswith("0.1.2-digest.")
+    assert start_local._backend_id(versioned, second_root) != versioned_id
+
+
+def test_stale_backend_stop_requires_runtime_owned_process(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    root = tmp_path / "installed"
+    calls: list[tuple[int, Path]] = []
+    monkeypatch.setattr(start_local, "_listening_process_id", lambda _port: 4321)
+    monkeypatch.setattr(
+        start_local,
+        "_terminate_runtime_process",
+        lambda pid, installation: calls.append((pid, installation)) or True,
+    )
+
+    assert start_local._stop_stale_backend(8899, root) is True
+    assert calls == [(4321, root)]
+
+
+def test_runtime_process_ownership_is_scoped_to_one_installation(tmp_path: Path) -> None:
+    root = tmp_path / "product" / "install"
+    owned = tmp_path / "product" / "runtime" / "python-3.12" / "pythonw.exe"
+    another = tmp_path / "other" / "runtime" / "python-3.12" / "pythonw.exe"
+    unrelated = tmp_path / "product" / "runtime" / "Olivia.exe"
+
+    assert start_local._runtime_owns_executable(owned, root) is True
+    assert start_local._runtime_owns_executable(another, root) is False
+    assert start_local._runtime_owns_executable(unrelated, root) is False
 
 
 def test_launcher_allows_mem0_cold_start_before_opening_client(

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -188,6 +188,7 @@ def test_launcher_starts_combined_server_before_original_client(
         return 0
 
     monkeypatch.setattr(start_local, "_health", lambda _port: next(health))
+    monkeypatch.setattr(start_local, "_active_backend", lambda: root / "local_backend")
     monkeypatch.setattr(
         start_local,
         "_backend_executable",
@@ -216,6 +217,46 @@ def test_launcher_starts_combined_server_before_original_client(
     assert client_commands[0][0].endswith("Olivia.exe")
     assert not backend_command[-1].endswith("local_server.py")
     assert frontend_repairs == [(root.resolve(), 8899)]
+
+
+def test_component_launcher_starts_the_backend_that_owns_start_local(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    root = _installation(tmp_path)
+    active_backend = tmp_path / "versions" / "local_backend" / "0.1.2-digest"
+    (active_backend / "installer").mkdir(parents=True)
+    (active_backend / "local_server.py").write_text("# active", encoding="utf-8")
+    active_entrypoint = active_backend / "original_client_server.py"
+    active_entrypoint.write_text("# active", encoding="utf-8")
+    health = iter(("UNAVAILABLE", "READY", "READY"))
+    commands: list[list[str]] = []
+
+    class Process:
+        @staticmethod
+        def poll():
+            return None
+
+    monkeypatch.setattr(start_local, "_active_backend", lambda: active_backend)
+    monkeypatch.setattr(start_local, "_health", lambda _port: next(health))
+    monkeypatch.setattr(start_local, "_backend_executable", lambda: Path("pythonw.exe"))
+    monkeypatch.setattr(
+        start_local.subprocess,
+        "Popen",
+        lambda command, **_kwargs: commands.append(
+            [str(value) for value in command]
+        )
+        or Process(),
+    )
+    monkeypatch.setattr(start_local.subprocess, "call", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(
+        start_local,
+        "_repair_client_frontend",
+        lambda *_args: "PATCHED",
+    )
+
+    assert start_local.main(["--install-root", str(root), "--port", "8899"]) == 0
+    assert commands[0][3:] == [str(active_backend), str(active_entrypoint)]
 
 
 def test_launcher_allows_mem0_cold_start_before_opening_client(
@@ -414,9 +455,11 @@ def test_launcher_supplies_deepseek_defaults_when_llm_overrides_are_absent(
 
 def test_launcher_refuses_payload_without_combined_entrypoint(
     tmp_path: Path,
+    monkeypatch,
     capsys,
 ) -> None:
     root = _installation(tmp_path, with_entrypoint=False)
+    monkeypatch.setattr(start_local, "_active_backend", lambda: root / "local_backend")
 
     assert start_local.main(["--install-root", str(root)]) == 2
     assert capsys.readouterr().out.strip() == "PATCH_PAYLOAD_INCOMPLETE"

--- a/tests/installer/test_private_world_default.py
+++ b/tests/installer/test_private_world_default.py
@@ -24,7 +24,13 @@ def test_start_local_configures_private_world_under_install_data(
     client.write_bytes(b"synthetic")
     observed: dict[str, object] = {}
 
+    monkeypatch.setattr(start_local, "_active_backend", lambda: backend)
     monkeypatch.setattr(start_local, "_health", lambda _port: "READY")
+    monkeypatch.setattr(
+        start_local,
+        "_server_backend_id",
+        lambda _port: start_local._backend_id(backend, root.resolve()),
+    )
     monkeypatch.setattr(start_local, "_load_dpapi_key", lambda _path: "")
     monkeypatch.setattr(start_local, "_client_executable", lambda _root: client)
     monkeypatch.setattr(

--- a/tests/llm/test_gateway.py
+++ b/tests/llm/test_gateway.py
@@ -109,6 +109,7 @@ def test_chat_completion_adapter_uses_local_mock_server_and_env_key(monkeypatch:
 
         async def handler(request: web.Request) -> web.Response:
             seen["auth"] = request.headers.get("Authorization")
+            seen["user_agent"] = request.headers.get("User-Agent")
             seen["idempotency_key"] = request.headers.get("Idempotency-Key")
             seen["request_id"] = request.headers.get("X-Request-ID")
             seen["body"] = await request.json()
@@ -129,6 +130,7 @@ def test_chat_completion_adapter_uses_local_mock_server_and_env_key(monkeypatch:
     assert response.text == "mock reply"
     assert response.request_id == "request-1"
     assert seen["auth"] == "Bearer TEST"
+    assert seen["user_agent"] == "Olivia-Community/0.1"
     assert seen["idempotency_key"] is None
     assert seen["request_id"] == "request-1"
     assert seen["body"]["model"] == "synthetic-model"


### PR DESCRIPTION
## Summary
- launch the backend tree that owns the active component launcher instead of the legacy installation directory
- send a stable Olivia User-Agent from both initial setup probes and runtime LLM requests
- cover active backend selection and provider request identity with focused regressions

## Validation
- python -m pytest -q tests/installer/test_original_client_server_launcher.py tests/http/test_original_client_setup_api.py tests/llm/test_gateway.py -> 54 passed
- OpenCode Go deepseek-v4-flash setup probe -> PASS with the user-authorized key
- OpenCode Go runtime gateway completion -> PASS with a non-empty response
- git diff --check -> PASS

## Root cause
The component launcher activated a versioned state pointer but start_local.py still launched install/local_backend. Separately, aiohttp's default Python User-Agent was rejected by OpenCode Go/Cloudflare with HTTP 403 error 1010.