### PR TITLE
fix(settings): make official letter import actionable

### DIFF
--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-SETTINGS_UI_VERSION = "p03.original-settings-manage.v8"
+SETTINGS_UI_VERSION = "p03.original-settings-manage.v7"
 
 BOOTSTRAP_JAVASCRIPT = r'''(() => {
   "use strict";

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-SETTINGS_UI_VERSION = "p03.original-settings-manage.v7"
+SETTINGS_UI_VERSION = "p03.original-settings-manage.v8"
 
 BOOTSTRAP_JAVASCRIPT = r'''(() => {
   "use strict";
@@ -16,6 +16,8 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const MEMORY_PATH = "/toy/companion/memory";
   const VIDEO_REPLY_SETTINGS_PATH = "/toy/settings/video-reply";
   const OFFICIAL_LETTER_IMPORT_PATH = "/toy/letter/legacy/official-import";
+  const OFFICIAL_LETTER_LIST_PATH = "/toy/letter/list";
+  const OFFICIAL_IMPORT_CONFIRM_ATTR = "data-olivia-companion-official-import-confirm";
   const MEMORY_CORRECT_PATH = "/toy/companion/memory/correct";
   const MEMORY_DELETE_PATH = "/toy/companion/memory/delete";
   const MEMORY_CLEAR_PATH = "/toy/companion/memory/clear";
@@ -96,6 +98,58 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       item.style.cursor = busy ? "default" : "pointer";
     }
   };
+
+  const confirmOfficialImport = (message) => new Promise((resolve) => {
+    document.querySelector(`[${OFFICIAL_IMPORT_CONFIRM_ATTR}]`)?.remove();
+    const backdrop = document.createElement("div");
+    backdrop.setAttribute(OFFICIAL_IMPORT_CONFIRM_ATTR, "");
+    backdrop.style.position = "fixed";
+    backdrop.style.inset = "0";
+    backdrop.style.zIndex = "2147483000";
+    backdrop.style.display = "grid";
+    backdrop.style.placeItems = "center";
+    backdrop.style.padding = "24px";
+    backdrop.style.backgroundColor = "rgba(0, 0, 0, 0.72)";
+    backdrop.style.pointerEvents = "auto";
+    backdrop.style.webkitAppRegion = "no-drag";
+
+    const dialog = document.createElement("section");
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("aria-modal", "true");
+    dialog.style.width = "min(520px, calc(100vw - 48px))";
+    dialog.style.padding = "24px";
+    dialog.style.borderRadius = "12px";
+    dialog.style.backgroundColor = "#ffffff";
+    dialog.style.color = "#1f2937";
+    dialog.style.boxShadow = "0 24px 80px rgba(0, 0, 0, 0.45)";
+    dialog.style.pointerEvents = "auto";
+    dialog.style.webkitAppRegion = "no-drag";
+
+    const finish = (accepted) => {
+      backdrop.remove();
+      resolve(accepted);
+    };
+    const messageNode = text("p", message, "text-text-body text-body-m font-regular");
+    messageNode.style.color = "#1f2937";
+    const actionsNode = actions();
+    actionsNode.style.justifyContent = "flex-end";
+    const cancel = button("取消", () => finish(false));
+    const confirm = button("确定", () => finish(true));
+    for (const item of [cancel, confirm]) {
+      item.style.color = "#1f2937";
+      item.style.backgroundColor = "#ffffff";
+      item.style.borderColor = "#9ca3af";
+      item.style.pointerEvents = "auto";
+      item.style.webkitAppRegion = "no-drag";
+    }
+    confirm.style.backgroundColor = "#2563eb";
+    confirm.style.color = "#ffffff";
+    actionsNode.append(cancel, confirm);
+    dialog.append(messageNode, actionsNode);
+    backdrop.append(dialog);
+    (document.body || document.documentElement).append(backdrop);
+    confirm.focus();
+  });
 
   const card = () => {
     const element = document.createElement("article");
@@ -209,6 +263,29 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         : payload && ["READY", "PAUSED", "UNAVAILABLE"].includes(payload.status);
       if (!response.ok || !valid) {
         throw new Error("unavailable");
+      }
+      return payload;
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  };
+
+  const requestLegacyLetterList = async () => {
+    const endpoint = new URL(`${OFFICIAL_LETTER_LIST_PATH}?scope=legacy`, apiBase);
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 8000);
+    try {
+      const response = await fetch(endpoint, {
+        method: "GET",
+        cache: "no-store",
+        credentials: "omit",
+        headers: { "Accept": "application/json" },
+        signal: controller.signal,
+      });
+      const responseBody = await response.json();
+      const payload = responseBody && responseBody.data;
+      if (!response.ok || !payload || payload.scope !== "legacy" || !Array.isArray(payload.list)) {
+        throw new Error("legacy-list-unavailable");
       }
       return payload;
     } finally {
@@ -1419,23 +1496,72 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   };
 
   const mountOfficialLetterImport = (section) => {
-    const row = document.createElement("div");
-    row.className = "flex items-center justify-between px-0 py-3 rounded-3";
-    const copy = document.createElement("div");
-    copy.className = "flex flex-col gap-0 flex-1 min-w-0";
-    const state = text("div", "", "text-text-secondary text-caption-m font-regular");
-    state.setAttribute("aria-live", "polite");
-    copy.append(
+    const legacyList = document.createElement("ul");
+    legacyList.style.display = "grid";
+    legacyList.style.gap = "8px";
+    legacyList.style.padding = "0";
+    legacyList.style.margin = "0";
+    legacyList.style.listStyle = "none";
+    const renderLegacyLetters = (payload) => {
+      legacyList.replaceChildren();
+      const letters = Array.isArray(payload.list) ? payload.list : [];
+      if (!letters.length) {
+        legacyList.append(text("li", "暂无已导入的历史信件。", "text-text-secondary text-body-m font-regular"));
+        return;
+      }
+      for (const letter of letters) {
+        const item = document.createElement("li");
+        item.style.display = "flex";
+        item.style.flexDirection = "column";
+        item.style.gap = "2px";
+        item.style.padding = "8px 10px";
+        item.style.borderRadius = "8px";
+        item.style.backgroundColor = "rgba(0, 0, 0, 0.035)";
+        const summary = typeof letter.summary === "string" && letter.summary.trim()
+          ? letter.summary.trim()
+          : "（无正文摘要）";
+        item.append(text("span", summary, "text-text-body text-body-m font-regular"));
+        const createdAt = formatTime(letter.created_at);
+        if (createdAt) {
+          item.append(text("span", createdAt, "text-text-secondary text-caption-m font-regular"));
+        }
+        legacyList.append(item);
+      }
+    };
+    const refreshLegacyLetters = async () => {
+      try {
+        const payload = await requestLegacyLetterList();
+        renderLegacyLetters(payload);
+        return true;
+      } catch (_error) {
+        legacyList.replaceChildren(text("li", "历史信件暂时无法读取，请稍后重试。", "text-text-secondary text-body-m font-regular"));
+        return false;
+      }
+    };
+    const history = stack();
+    history.style.marginTop = "12px";
+    history.append(
+      text("div", "已导入历史信件（只读）", "text-text-body text-label-l"),
+      text("div", "历史信件不会进入当前收件箱，也不会改变未读数。", "text-text-secondary text-body-m font-regular"),
+      legacyList
+    );
+    const importRow = document.createElement("div");
+    importRow.className = "flex items-center justify-between px-0 py-3 rounded-3";
+    const importCopy = document.createElement("div");
+    importCopy.className = "flex flex-col gap-0 flex-1 min-w-0";
+    const importState = text("div", "", "text-text-secondary text-caption-m font-regular");
+    importState.setAttribute("aria-live", "polite");
+    importCopy.append(
       text("div", "导入官方文字信件", "text-text-body text-label-l"),
       text("div", "只导入原信和文字回信，不导入视频。重复信件会自动跳过。", "text-text-secondary text-body-m font-regular"),
-      state
+      importState
     );
     const importButton = button("导入", async () => {
-      if (!window.confirm("确认从这台电脑上的官方 Olivia 账户导入文字信件？")) {
+      if (!await confirmOfficialImport("确认从这台电脑上的官方 Olivia 账户导入文字信件？")) {
         return;
       }
       setButtonsBusy([importButton], true);
-      state.textContent = "正在读取官方文字信件……";
+      importState.textContent = "正在读取官方文字信件……";
       try {
         const payload = await requestMutation(OFFICIAL_LETTER_IMPORT_PATH, {});
         const inserted = Number.isInteger(payload.inserted) ? payload.inserted : 0;
@@ -1444,15 +1570,23 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         const memoryText = migration && migration.status === "completed"
           ? `记忆已按时间顺序处理 ${migration.processed || 0} 封。`
           : "信件已保存；长期记忆尚未全部处理，可稍后重试。";
-        state.textContent = `已导入 ${inserted} 封，跳过 ${duplicates} 封重复信件。${memoryText}`;
+        importState.textContent = `已导入 ${inserted} 封，跳过 ${duplicates} 封重复信件。${memoryText}`;
+        await refreshLegacyLetters();
       } catch (_error) {
-        state.textContent = "导入失败。请先启动官方客户端并登录，再重试。";
+        importState.textContent = "导入失败。请先启动官方客户端并登录，再重试。";
       } finally {
         setButtonsBusy([importButton], false);
       }
     });
-    row.append(copy, importButton);
-    section.append(text("div", "历史信件", "text-text-body text-title-m"), row);
+    importRow.append(importCopy, importButton);
+    section.append(
+      text("div", "历史信件", "text-text-body text-title-m"),
+      importRow,
+      history
+    );
+    void refreshLegacyLetters();
+    return;
+
   };
 
   const mountShell = () => {

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -14,7 +14,7 @@ from original_client_settings_ui import (
 
 # The shipped CEF surface needs explicit no-drag/pointer and display-state guards.
 def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
-    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v8"
+    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v7"
     for declaration in (
             'const STATUS_PATH = "/toy/companion/status";',
             'const MEMORY_PATH = "/toy/companion/memory";',

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -14,7 +14,7 @@ from original_client_settings_ui import (
 
 # The shipped CEF surface needs explicit no-drag/pointer and display-state guards.
 def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
-    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v7"
+    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v8"
     for declaration in (
             'const STATUS_PATH = "/toy/companion/status";',
             'const MEMORY_PATH = "/toy/companion/memory";',
@@ -27,7 +27,7 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
         'const CONFIRM_VALUE = "confirmed";',
     ):
         assert BOOTSTRAP_JAVASCRIPT.count(declaration) == 1
-    assert BOOTSTRAP_JAVASCRIPT.count('method: "GET"') == 1
+    assert BOOTSTRAP_JAVASCRIPT.count('method: "GET"') == 2
     assert BOOTSTRAP_JAVASCRIPT.count('method: "POST"') == 2
     assert "limit: 50" in BOOTSTRAP_JAVASCRIPT
     assert "input.maxLength = 500" in BOOTSTRAP_JAVASCRIPT
@@ -77,6 +77,158 @@ def test_original_settings_can_import_official_text_reply_history() -> None:
     assert "payload.inserted" in BOOTSTRAP_JAVASCRIPT
     assert "payload.memory_migration" in BOOTSTRAP_JAVASCRIPT
     assert "记忆已按时间顺序处理" in BOOTSTRAP_JAVASCRIPT
+
+
+def test_official_import_uses_visible_confirmation_and_refreshes_legacy_list() -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is not installed")
+    harness = r'''
+const fs = require("fs");
+const vm = require("vm");
+const source = fs.readFileSync(0, "utf8");
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag;
+    this.children = [];
+    this.parentElement = null;
+    this.style = {};
+    this.attributes = {};
+    this.listeners = {};
+    this.textContent = "";
+    this.className = "";
+    this.disabled = false;
+  }
+  append(...items) {
+    for (const item of items) {
+      item.parentElement = this;
+      this.children.push(item);
+    }
+  }
+  replaceChildren(...items) {
+    this.children = [];
+    this.append(...items);
+  }
+  remove() {
+    if (!this.parentElement) return;
+    this.parentElement.children = this.parentElement.children.filter((item) => item !== this);
+    this.parentElement = null;
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  addEventListener(name, handler) { this.listeners[name] = handler; }
+  async click() { return this.listeners.click && this.listeners.click({ target: this }); }
+  focus() {}
+  matches(selector) {
+    if (selector.startsWith(".")) return this.className.split(/\s+/).includes(selector.slice(1));
+    if (selector.startsWith("[")) {
+      const match = selector.match(/^\[([^=\]]+)(?:="([^"]*)")?\]$/);
+      return Boolean(match) && Object.prototype.hasOwnProperty.call(this.attributes, match[1])
+        && (!match[2] || this.attributes[match[1]] === match[2]);
+    }
+    return this.tagName === selector;
+  }
+  querySelectorAll(selector) {
+    const selectors = selector.split(",").map((item) => item.trim());
+    const found = [];
+    const visit = (node) => {
+      for (const child of node.children) {
+        if (selectors.some((item) => child.matches(item))) found.push(child);
+        visit(child);
+      }
+    };
+    visit(this);
+    return found;
+  }
+  querySelector(selector) { return this.querySelectorAll(selector)[0] || null; }
+}
+
+const body = new Element("body");
+const main = new Element("main");
+const settings = new Element("section");
+settings.className = "tp-settings-item";
+const container = new Element("div");
+container.append(settings);
+main.append(container);
+body.append(main);
+const document = {
+  body,
+  documentElement: new Element("html"),
+  currentScript: { dataset: { apiBase: "http://127.0.0.1:8899" } },
+  createElement: (tag) => new Element(tag),
+  querySelectorAll: (selector) => body.querySelectorAll(selector),
+  querySelector: (selector) => body.querySelector(selector),
+};
+let nativeConfirmCalls = 0;
+const calls = [];
+const fetch = async (endpoint, options) => {
+  calls.push({ path: endpoint.pathname, method: options.method, headers: options.headers });
+  if (endpoint.pathname === "/toy/setup/status") {
+    return { ok: true, json: async () => ({ status: "READY", setup_completed: true, show_initial_setup: false }) };
+  }
+  if (endpoint.pathname === "/toy/settings/video-reply") {
+    return { ok: true, json: async () => ({ code: 0, data: { state: "available", enabled: false } }) };
+  }
+  if (endpoint.pathname === "/toy/letter/list") {
+    return { ok: true, json: async () => ({ code: 0, data: {
+      list: [{ letter_id: "legacy-1", summary: "legacy-summary", created_at: "2026-08-27T00:00:00Z" }],
+      total: 1, scope: "legacy", read_only: true,
+    } }) };
+  }
+  if (endpoint.pathname === "/toy/letter/legacy/official-import") {
+    return { ok: true, json: async () => ({ code: 0, data: {
+      status: "APPLIED", inserted: 1, duplicates: 0,
+      memory_migration: { status: "completed", processed: 1 },
+    } }) };
+  }
+  throw new Error(`unexpected request: ${endpoint.pathname}`);
+};
+const window = {
+  location: { pathname: "/collection", hash: "#/settings" },
+  requestAnimationFrame: (callback) => callback(),
+  addEventListener: () => {},
+  setTimeout: (callback) => { callback(); return 1; },
+  clearTimeout: () => {},
+  confirm: () => { nativeConfirmCalls += 1; throw new Error("native confirmation is unusable"); },
+};
+const context = {
+  URL, AbortController, document, window, fetch,
+  MutationObserver: class { constructor() {} observe() {} },
+};
+vm.runInNewContext(source, context);
+const flush = async () => { for (let index = 0; index < 8; index += 1) await Promise.resolve(); };
+(async () => {
+  await flush();
+  const buttons = body.querySelectorAll("button");
+  const importButton = buttons[buttons.length - 1];
+  if (!importButton) throw new Error("official import button missing");
+  if (!body.querySelectorAll("span").some((item) => item.textContent === "legacy-summary")) {
+    throw new Error("persisted legacy letter was not rendered");
+  }
+  const importPending = importButton.click();
+  const confirmDialog = body.querySelector("[data-olivia-companion-official-import-confirm]");
+  if (!confirmDialog) throw new Error("visible official import confirmation missing");
+  const confirmButton = confirmDialog.querySelectorAll("button")[1];
+  if (!confirmButton || confirmButton.style.pointerEvents !== "auto") throw new Error("confirmation button is not actionable");
+  await confirmButton.click();
+  await importPending;
+  await flush();
+  const importCall = calls.find((item) => item.path === "/toy/letter/legacy/official-import");
+  if (!importCall || importCall.headers["X-Olivia-Companion-Action"] !== "confirmed") throw new Error("official import confirmation header missing");
+  if (nativeConfirmCalls !== 0) throw new Error("native confirmation was used");
+  process.stdout.write(JSON.stringify({ legacyListRequests: calls.filter((item) => item.path === "/toy/letter/list").length }));
+})().catch((error) => { console.error(error.stack); process.exitCode = 1; });
+'''
+    result = subprocess.run(
+        [node, "-e", harness],
+        input=BOOTSTRAP_JAVASCRIPT.encode("utf-8"),
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    output = (result.stderr or result.stdout).decode("utf-8", errors="replace")
+    assert result.returncode == 0, output
+    assert json.loads(result.stdout.decode("utf-8")) == {"legacyListRequests": 2}
 
 
 def test_original_settings_private_world_entry_is_limited_to_safe_status() -> None:
@@ -375,7 +527,12 @@ const statusPayload = (status) => ({
           version: "fixture",
           license_summary: "fixture",
           requires_gpu: false,
-        }) };
+          }) };
+      }
+      if (endpoint.pathname === "/toy/letter/list") {
+        return { ok: true, json: async () => ({ code: 0, data: {
+          list: [], total: 0, scope: "legacy", read_only: true,
+        } }) };
       }
       if (endpoint.pathname === "/toy/settings/video-reply") {
     videoMethods.push(options.method);

--- a/tests/installer/test_original_settings_javascript.py
+++ b/tests/installer/test_original_settings_javascript.py
@@ -29,7 +29,7 @@ def test_original_settings_bootstrap_has_valid_javascript(tmp_path: Path) -> Non
 def test_original_settings_actions_remain_bounded_and_in_client() -> None:
     source = BOOTSTRAP_JAVASCRIPT
     assert source.count('method: "POST"') == 2
-    assert source.count('method: "GET"') == 1
+    assert source.count('method: "GET"') == 2
     assert '"Content-Type": "application/json"' in source
     assert 'const CONFIRM_VALUE = "confirmed"' in source
     assert "window.confirm" in source


### PR DESCRIPTION
## Summary
- replace the official text-letter import native confirm with an accessible in-page confirmation dialog
- refresh and render persisted read-only legacy letters after import and on settings load
- keep imported history isolated from the current mailbox and unread count

## Verification
- python -m pytest -q tests/imports/test_official_letters.py tests/http/test_original_client_setup_api.py tests/installer/test_original_client_settings_ui.py tests/installer/test_original_settings_javascript.py tests/http/test_original_client_letter_contract.py
- 49 passed
- git diff --check

## Scope
- Changed only the settings bootstrap UI and its focused UI assertions.
- No API keys or private account data were read or printed.
- Real-client rendering and human acceptance remain pending.