### PR TITLE
fix: make settings dialogs readable

### DIFF
--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -107,7 +107,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     }
   };
 
-  const confirmOfficialImport = (message) => new Promise((resolve) => {
+  const confirmAction = (message) => new Promise((resolve) => {
     document.querySelector(`[${OFFICIAL_IMPORT_CONFIRM_ATTR}]`)?.remove();
     const backdrop = document.createElement("div");
     backdrop.setAttribute(OFFICIAL_IMPORT_CONFIRM_ATTR, "");
@@ -121,40 +121,41 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     backdrop.style.pointerEvents = "auto";
     backdrop.style.webkitAppRegion = "no-drag";
 
-    const dialog = document.createElement("section");
-    dialog.setAttribute("role", "dialog");
-    dialog.setAttribute("aria-modal", "true");
-    dialog.style.width = "min(520px, calc(100vw - 48px))";
-    dialog.style.padding = "24px";
-    dialog.style.borderRadius = "12px";
-    dialog.style.backgroundColor = "#ffffff";
-    dialog.style.color = "#1f2937";
-    dialog.style.boxShadow = "0 24px 80px rgba(0, 0, 0, 0.45)";
-    dialog.style.pointerEvents = "auto";
-    dialog.style.webkitAppRegion = "no-drag";
+    const confirmation = document.createElement("section");
+    confirmation.setAttribute("role", "dialog");
+    confirmation.setAttribute("aria-modal", "true");
+    confirmation.style.width = "min(520px, calc(100vw - 48px))";
+    confirmation.style.padding = "24px";
+    confirmation.style.borderRadius = "12px";
+    confirmation.style.backgroundColor = "#18191c";
+    confirmation.style.color = "#f9fafb";
+    confirmation.style.colorScheme = "dark";
+    confirmation.style.boxShadow = "0 24px 80px rgba(0, 0, 0, 0.45)";
+    confirmation.style.pointerEvents = "auto";
+    confirmation.style.webkitAppRegion = "no-drag";
 
     const finish = (accepted) => {
       backdrop.remove();
       resolve(accepted);
     };
     const messageNode = text("p", message, "text-text-body text-body-m font-regular");
-    messageNode.style.color = "#1f2937";
+    messageNode.style.color = "#f9fafb";
     const actionsNode = actions();
     actionsNode.style.justifyContent = "flex-end";
     const cancel = button("取消", () => finish(false));
     const confirm = button("确定", () => finish(true));
     for (const item of [cancel, confirm]) {
-      item.style.color = "#1f2937";
-      item.style.backgroundColor = "#ffffff";
-      item.style.borderColor = "#9ca3af";
+      item.style.color = "#f9fafb";
+      item.style.backgroundColor = "#111827";
+      item.style.borderColor = "#6b7280";
       item.style.pointerEvents = "auto";
       item.style.webkitAppRegion = "no-drag";
     }
     confirm.style.backgroundColor = "#2563eb";
     confirm.style.color = "#ffffff";
     actionsNode.append(cancel, confirm);
-    dialog.append(messageNode, actionsNode);
-    backdrop.append(dialog);
+    confirmation.append(messageNode, actionsNode);
+    backdrop.append(confirmation);
     (document.body || document.documentElement).append(backdrop);
     confirm.focus();
   });
@@ -523,7 +524,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
               resultState.textContent = "内容没有变化。";
               return;
             }
-            if (!window.confirm("确认用新内容替换这条长期记忆？")) {
+            if (!await confirmAction("确认用新内容替换这条长期记忆？")) {
               return;
             }
             setButtonsBusy([save, cancel, correct, remove], true);
@@ -563,7 +564,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         });
 
         const remove = button("删除", async () => {
-          if (!window.confirm("确认删除这条长期记忆？原始信件不会被删除。")) {
+          if (!await confirmAction("确认删除这条长期记忆？原始信件不会被删除。")) {
             return;
           }
           setButtonsBusy([correct, remove], true);
@@ -596,15 +597,15 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
 
   const renderMemoryPanel = async (panel, capability) => {
     const state = capabilityState(capability);
-    const confirmClear = () => window.confirm("确认清空当前用户的 Mem0 长期记忆？")
-      && window.confirm("清空后无法恢复。原始信件和私人世界不会受影响，仍要继续吗？");
+    const confirmClear = async () => await confirmAction("确认清空当前用户的 Mem0 长期记忆？")
+      && await confirmAction("清空后无法恢复。原始信件和私人世界不会受影响，仍要继续吗？");
     if (state === "disabled" || state === "unavailable") {
       if (state === "unavailable" && capability && capability.reason_code === "MEMORY_ADMIN_CLEAR_PENDING") {
         const heading = text("h3", "长期记忆", "text-text-title text-title-m");
         const summary = text("p", "上次清空尚未完成。", "text-text-secondary text-body-m font-regular");
         const resultState = text("p", "", "text-text-secondary text-body-m font-regular");
         const resume = button("继续完成清空", async () => {
-          if (!confirmClear()) return;
+          if (!await confirmClear()) return;
           setButtonsBusy([resume], true);
           resultState.textContent = "正在继续清空当前用户记忆……";
           try {
@@ -671,7 +672,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
           return;
         }
         const install = button("安装 Embedding", async () => {
-          if (!window.confirm("确认下载本地 Embedding 模型？下载仅在此次确认后开始。")) {
+          if (!await confirmAction("确认下载本地 Embedding 模型？下载仅在此次确认后开始。")) {
             return;
           }
           setButtonsBusy([install], true);
@@ -762,7 +763,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     };
     const toggle = button(paused ? "恢复长期记忆" : "暂停长期记忆", async () => {
       const action = paused ? "恢复" : "暂停";
-      if (!window.confirm(`确认${action} Mem0 长期记忆？Archive 和私人世界不会受影响。`)) {
+      if (!await confirmAction(`确认${action} Mem0 长期记忆？Archive 和私人世界不会受影响。`)) {
         return;
       }
       setButtonsBusy([toggle, clear], true);
@@ -784,7 +785,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       }
     });
     const clear = button("清空当前用户记忆", async () => {
-      if (!confirmClear()) return;
+      if (!await confirmClear()) return;
       setButtonsBusy([toggle, clear], true);
       resultState.textContent = "正在清空当前用户记忆……";
       try {
@@ -950,7 +951,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     });
     save.disabled = true;
     const removeKey = button("删除 API key", async () => {
-      if (!window.confirm("确认删除这台电脑上保存的 API key？删除后需重启 Olivia。")) {
+      if (!await confirmAction("确认删除这台电脑上保存的 API key？删除后需重启 Olivia。")) {
         return;
       }
       setButtonsBusy([testConnection, save, removeKey], true);
@@ -1068,7 +1069,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         source.append(option);
       }
       const install = button(stateValue === "paused" ? "继续下载" : "下载并启用", async () => {
-        if (!window.confirm("确认下载长期记忆能力包？下载将在后台继续。")) return;
+        if (!await confirmAction("确认下载长期记忆能力包？下载将在后台继续。")) return;
         setButtonsBusy([install], true);
         result.textContent = "正在启动后台下载……";
         try {
@@ -1096,7 +1097,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       window.setTimeout(refresh, 1000);
     } else if (stateValue === "ready") {
       const uninstall = button("卸载运行依赖", async () => {
-        if (!window.confirm("确认卸载长期记忆运行依赖？已下载模型和个人记忆会保留。")) return;
+        if (!await confirmAction("确认卸载长期记忆运行依赖？已下载模型和个人记忆会保留。")) return;
         await requestCapability(MEM0_CAPABILITY_ACTION_PATH, {
           action: "uninstall",
           remove_model: false,
@@ -1104,8 +1105,8 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         await refresh();
       });
       const removeAll = button("卸载并删除模型", async () => {
-        if (!window.confirm("确认卸载长期记忆并删除已下载模型？个人记忆仍会保留。")) return;
-        if (!window.confirm("模型删除后重新启用需要再次下载，仍要继续吗？")) return;
+        if (!await confirmAction("确认卸载长期记忆并删除已下载模型？个人记忆仍会保留。")) return;
+        if (!await confirmAction("模型删除后重新启用需要再次下载，仍要继续吗？")) return;
         await requestCapability(MEM0_CAPABILITY_ACTION_PATH, {
           action: "uninstall",
           remove_model: true,
@@ -1276,7 +1277,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         result.textContent = "请输入发布页提供的 64 位 Manifest SHA-256。";
         return;
       }
-      if (!window.confirm("确认校验并安装这个本地补丁？")) return;
+      if (!await confirmAction("确认校验并安装这个本地补丁？")) return;
       setButtonsBusy([install, rollback], true);
       result.textContent = "正在校验并安装补丁……";
       try {
@@ -1293,7 +1294,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       }
     });
     const rollback = button("回滚上一版本", async () => {
-      if (!window.confirm("确认回滚到上一版本？关闭并重新打开 Olivia 后生效。")) return;
+      if (!await confirmAction("确认回滚到上一版本？关闭并重新打开 Olivia 后生效。")) return;
       setButtonsBusy([install, rollback], true);
       result.textContent = "正在切换到上一版本……";
       try {
@@ -1498,7 +1499,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       panel.setAttribute("role", "tabpanel");
       panel.style.padding = "18px";
       panel.style.borderRadius = "12px";
-      panel.style.background = "var(--el-fill-color-light, rgba(0,0,0,0.035))";
+      panel.style.background = "#23252a";
       panel.style.display = "grid";
       panel.style.gap = "14px";
       panel.append(
@@ -1660,7 +1661,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         importState.textContent = "无法确认长期记忆组件状态，请重启客户端后再试。";
         return;
       }
-      if (!await confirmOfficialImport("确认从这台电脑上的官方 Olivia 账户导入文字信件？")) {
+      if (!await confirmAction("确认从这台电脑上的官方 Olivia 账户导入文字信件？")) {
         return;
       }
       setButtonsBusy([importButton], true);

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -124,6 +124,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     const confirmation = document.createElement("section");
     confirmation.setAttribute("role", "dialog");
     confirmation.setAttribute("aria-modal", "true");
+    confirmation.setAttribute("aria-labelledby", "olivia-companion-confirm-message");
     confirmation.style.width = "min(520px, calc(100vw - 48px))";
     confirmation.style.padding = "24px";
     confirmation.style.borderRadius = "12px";
@@ -139,6 +140,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       resolve(accepted);
     };
     const messageNode = text("p", message, "text-text-body text-body-m font-regular");
+    messageNode.id = "olivia-companion-confirm-message";
     messageNode.style.color = "#f9fafb";
     const actionsNode = actions();
     actionsNode.style.justifyContent = "flex-end";
@@ -156,6 +158,18 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     actionsNode.append(cancel, confirm);
     confirmation.append(messageNode, actionsNode);
     backdrop.append(confirmation);
+    backdrop.addEventListener("click", (event) => {
+      if (event.target === backdrop) {
+        event.preventDefault();
+        finish(false);
+      }
+    });
+    backdrop.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        finish(false);
+      }
+    });
     (document.body || document.documentElement).append(backdrop);
     confirm.focus();
   });
@@ -164,7 +178,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     const element = document.createElement("article");
     element.style.padding = "14px";
     element.style.borderRadius = "10px";
-    element.style.background = "#23252a";
+    element.style.background = "#2b2e35";
     element.style.display = "grid";
     element.style.gap = "8px";
     return element;
@@ -1418,6 +1432,16 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         color: #f9fafb !important;
         background-color: #111827 !important;
       }
+      [${DIALOG_ATTR}] [role="tab"][aria-selected="true"] {
+        color: #ffffff !important;
+        background-color: #374151 !important;
+        border-color: #93c5fd !important;
+      }
+      [${DIALOG_ATTR}] [role="tab"][aria-selected="false"] {
+        color: #cbd5e1 !important;
+        background-color: #111827 !important;
+        border-color: #6b7280 !important;
+      }
     `;
 
     const header = document.createElement("div");
@@ -1474,9 +1498,6 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       for (const tab of tabs.querySelectorAll('[role="tab"]')) {
         const active = tab.dataset.panelId === id;
         tab.setAttribute("aria-selected", active ? "true" : "false");
-        tab.style.background = active
-          ? "#30333a"
-          : "transparent";
       }
       for (const panel of panels.querySelectorAll('[role="tabpanel"]')) {
         const active = panel.dataset.panelId === id;
@@ -1499,7 +1520,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       panel.setAttribute("role", "tabpanel");
       panel.style.padding = "18px";
       panel.style.borderRadius = "12px";
-      panel.style.background = "#23252a";
+      panel.style.background = "#202228";
       panel.style.display = "grid";
       panel.style.gap = "14px";
       panel.append(

--- a/patch_companion_settings.py
+++ b/patch_companion_settings.py
@@ -386,7 +386,7 @@ def _verify_archive(
         'const CONFIRM_VALUE = "confirmed";',
         'method: "GET"',
         'method: "POST"',
-        "window.confirm",
+        "confirmAction",
         "data-olivia-companion-settings-root",
         "panel.dataset.oliviaCompanionPanel",
         "长期记忆",

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -54,8 +54,22 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
     assert 'color: #cbd5e1 !important;' in BOOTSTRAP_JAVASCRIPT
     assert '[role="dialog"] select' in BOOTSTRAP_JAVASCRIPT
     assert 'background-color: #111827 !important;' in BOOTSTRAP_JAVASCRIPT
-    assert 'panel.style.background = "#23252a";' in BOOTSTRAP_JAVASCRIPT
+    assert 'panel.style.background = "#202228";' in BOOTSTRAP_JAVASCRIPT
+    assert 'element.style.background = "#2b2e35";' in BOOTSTRAP_JAVASCRIPT
     assert "var(--el-fill-color-light" not in BOOTSTRAP_JAVASCRIPT
+
+
+def test_selected_settings_tab_keeps_a_distinct_visual_state() -> None:
+    source = BOOTSTRAP_JAVASCRIPT
+    generic_controls = '[${DIALOG_ATTR}] [role="dialog"] button,'
+    selected_tab = '[${DIALOG_ATTR}] [role="tab"][aria-selected="true"] {'
+    unselected_tab = '[${DIALOG_ATTR}] [role="tab"][aria-selected="false"] {'
+
+    assert selected_tab in source
+    assert unselected_tab in source
+    assert source.index(generic_controls) < source.index(selected_tab)
+    assert "background-color: #374151 !important;" in source
+    assert "tab.style.background =" not in source
 
 
 def test_original_settings_can_apply_a_user_downloaded_patch_and_roll_back() -> None:

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -38,7 +38,9 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
     assert 'const LETTER_COMPOSER_TITLE = "写下你的感受";' in BOOTSTRAP_JAVASCRIPT
     assert 'const LETTER_SUBMIT_LABEL = "寄出信件";' in BOOTSTRAP_JAVASCRIPT
     assert "Promise.allSettled" in BOOTSTRAP_JAVASCRIPT
-    assert "window.confirm" in BOOTSTRAP_JAVASCRIPT
+    assert "window.confirm" not in BOOTSTRAP_JAVASCRIPT
+    assert "const confirmAction = (message) => new Promise" in BOOTSTRAP_JAVASCRIPT
+    assert 'confirmation.style.backgroundColor = "#18191c";' in BOOTSTRAP_JAVASCRIPT
     assert "crypto.randomUUID" in BOOTSTRAP_JAVASCRIPT
     assert 'element.style.pointerEvents = "auto";' in BOOTSTRAP_JAVASCRIPT
     assert 'element.style.webkitAppRegion = "no-drag";' in BOOTSTRAP_JAVASCRIPT
@@ -52,6 +54,8 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
     assert 'color: #cbd5e1 !important;' in BOOTSTRAP_JAVASCRIPT
     assert '[role="dialog"] select' in BOOTSTRAP_JAVASCRIPT
     assert 'background-color: #111827 !important;' in BOOTSTRAP_JAVASCRIPT
+    assert 'panel.style.background = "#23252a";' in BOOTSTRAP_JAVASCRIPT
+    assert "var(--el-fill-color-light" not in BOOTSTRAP_JAVASCRIPT
 
 
 def test_original_settings_can_apply_a_user_downloaded_patch_and_roll_back() -> None:
@@ -617,8 +621,20 @@ const context = {
   document, window, fetch,
 };
 vm.runInNewContext(source, context);
-(async () => {
-  const findButton = (label) => body.querySelectorAll("button").find((item) => item.textContent === label);
+    (async () => {
+      const findButton = (label) => body.querySelectorAll("button").find((item) => item.textContent === label);
+      const clickConfirmed = async (target, count = 1) => {
+        const pending = target.click();
+        for (let index = 0; index < count; index += 1) {
+          await flush();
+          const dialogs = body.querySelectorAll('[role="dialog"]');
+          const confirmation = dialogs[dialogs.length - 1];
+          const buttons = confirmation && confirmation.querySelectorAll("button");
+          if (!buttons || buttons.length < 2) throw new Error("confirmation dialog missing");
+          await buttons[buttons.length - 1].click();
+        }
+        await pending;
+      };
   const open = findButton("打开");
   if (!open) throw new Error(`open button missing: ${body.querySelectorAll("button").map((item) => item.textContent).join("|")}`);
       await open.click();
@@ -628,19 +644,19 @@ vm.runInNewContext(source, context);
       await findButton("已关闭").click();
       await flush();
       if (!body.querySelectorAll("div").some((item) => item.textContent.includes("原设置保持不变"))) throw new Error("video mutation error was hidden");
-      await findButton("暂停长期记忆").click();
+          await clickConfirmed(findButton("暂停长期记忆"));
   await flush();
   const resume = findButton("恢复长期记忆");
   if (!resume) throw new Error("resume button was not rendered after pause");
-  await resume.click();
+      await clickConfirmed(resume);
   await flush();
   const pause = findButton("暂停长期记忆");
   if (!pause) throw new Error("pause button was not rendered after resume");
-  await pause.click();
+      await clickConfirmed(pause);
   await flush();
   const pending = findButton("继续完成清空");
   if (!pending) throw new Error("pending clear recovery was not rendered");
-  await pending.click();
+      await clickConfirmed(pending, 2);
   await flush();
   if (!findButton("暂停长期记忆")) throw new Error("clear recovery did not refresh status");
   process.stdout.write(JSON.stringify({ mutationPaths, videoMethods, statusIndex }));

--- a/tests/installer/test_original_settings_javascript.py
+++ b/tests/installer/test_original_settings_javascript.py
@@ -44,6 +44,112 @@ def test_original_settings_actions_remain_bounded_and_in_client() -> None:
     assert 'method: "PUT"' not in source
 
 
+def test_confirmation_dialog_can_be_cancelled_by_backdrop_or_escape() -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is unavailable for confirmation behavior validation")
+    harness = r'''
+const fs = require("fs");
+const vm = require("vm");
+let source = fs.readFileSync(0, "utf8");
+source = source.replace(/\s*schedule\(\);\s*\}\)\(\);\s*$/, `
+  globalThis.confirmAction = confirmAction;
+})();\n`);
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag;
+    this.children = [];
+    this.attributes = {};
+    this.listeners = {};
+    this.style = {};
+    this.parent = null;
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  getAttribute(name) { return this.attributes[name] || null; }
+  addEventListener(name, listener) {
+    (this.listeners[name] ||= []).push(listener);
+  }
+  append(...children) {
+    for (const child of children) {
+      child.parent = this;
+      this.children.push(child);
+    }
+  }
+  remove() {
+    if (this.parent) {
+      this.parent.children = this.parent.children.filter((child) => child !== this);
+    }
+  }
+  focus() {}
+}
+
+const body = new Element("body");
+const document = {
+  currentScript: { dataset: { apiBase: "http://127.0.0.1:8899/" } },
+  body,
+  documentElement: body,
+  createElement: (tag) => new Element(tag),
+  querySelector: () => body.children[body.children.length - 1] || null,
+};
+const context = {
+  URL,
+  document,
+  MutationObserver: class { observe() {} },
+  window: { addEventListener: () => {} },
+};
+vm.runInNewContext(source, context);
+
+(async () => {
+  const backdropPending = context.confirmAction("确认删除？");
+  const backdrop = body.children[0];
+  const confirmation = backdrop.children[0];
+  const message = confirmation.children[0];
+  let clickPrevented = false;
+  for (const listener of backdrop.listeners.click || []) {
+    listener({ target: backdrop, preventDefault: () => { clickPrevented = true; } });
+  }
+  const backdropResult = await backdropPending;
+
+  const escapePending = context.confirmAction("确认回滚？");
+  const escapeBackdrop = body.children[0];
+  let escapePrevented = false;
+  for (const listener of escapeBackdrop.listeners.keydown || []) {
+    listener({ key: "Escape", preventDefault: () => { escapePrevented = true; } });
+  }
+  const escapeResult = await escapePending;
+
+  process.stdout.write(JSON.stringify({
+    backdropResult,
+    escapeResult,
+    clickPrevented,
+    escapePrevented,
+    labelledBy: confirmation.getAttribute("aria-labelledby"),
+    messageId: message.id || null,
+    remainingBackdrops: body.children.length,
+  }));
+})().catch((error) => { console.error(error.stack); process.exitCode = 1; });
+'''
+    completed = subprocess.run(
+        [node, "-e", harness],
+        input=BOOTSTRAP_JAVASCRIPT.encode("utf-8"),
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    output = (completed.stderr or completed.stdout).decode("utf-8", errors="replace")
+    assert completed.returncode == 0, output
+    assert json.loads(completed.stdout) == {
+        "backdropResult": False,
+        "escapeResult": False,
+        "clickPrevented": True,
+        "escapePrevented": True,
+        "labelledBy": "olivia-companion-confirm-message",
+        "messageId": "olivia-companion-confirm-message",
+        "remainingBackdrops": 0,
+    }
+
+
 def test_original_settings_reuses_llm_setup_after_login() -> None:
     source = BOOTSTRAP_JAVASCRIPT
     assert 'const SETUP_STATUS_PATH = "/toy/setup/status"' in source

--- a/tests/installer/test_original_settings_javascript.py
+++ b/tests/installer/test_original_settings_javascript.py
@@ -32,7 +32,8 @@ def test_original_settings_actions_remain_bounded_and_in_client() -> None:
     assert source.count('method: "GET"') == 1
     assert '"Content-Type": "application/json"' in source
     assert 'const CONFIRM_VALUE = "confirmed"' in source
-    assert "window.confirm" in source
+    assert "window.confirm" not in source
+    assert "confirmAction" in source
     assert "window.open" not in source
     assert "innerHTML" not in source
     assert "document.write" not in source

--- a/tests/installer/test_patch_companion_settings.py
+++ b/tests/installer/test_patch_companion_settings.py
@@ -127,7 +127,8 @@ def test_patch_adds_original_settings_management_and_preserves_existing_assets(
     assert 'method: "GET"' in bootstrap
     assert 'method: "POST"' in bootstrap
     assert "X-Olivia-Companion-Action" in bootstrap
-    assert "window.confirm" in bootstrap
+    assert "window.confirm" not in bootstrap
+    assert "confirmAction" in bootstrap
     assert "crypto.randomUUID" in bootstrap
     assert "<iframe" not in bootstrap.casefold()
     assert "window.open" not in bootstrap


### PR DESCRIPTION
Fixes the two unreadable settings surfaces reported from the installed Windows client. The settings tab panels now use an explicit dark surface instead of inheriting the original client light fill variable. Native WebView confirmation dialogs are replaced by an accessible in-client confirmation dialog with explicit foreground, background, border, focus, and no-drag behavior. Scope is limited to the bootstrap, patch verifier, and focused regression tests. Verification: 36 focused tests passed; git diff --check passed. No local full suite was run per user instruction.