### PR TITLE
fix: keep client runtime available across reentry

### DIFF
--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -553,24 +553,21 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if health != "READY":
             creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-            log_root = data_root / "logs"
-            log_root.mkdir(parents=True, exist_ok=True)
             _append_launcher_event(data_root, "backend_start")
-            with (log_root / "backend.log").open("ab", buffering=0) as backend_log:
-                server = subprocess.Popen(
-                    [
-                        str(_backend_executable()),
-                        "-c",
-                        _BACKEND_BOOTSTRAP,
-                        str(backend),
-                        str(entrypoint),
-                    ],
-                    cwd=backend,
-                    env=backend_environment,
-                    stdout=backend_log,
-                    stderr=subprocess.STDOUT,
-                    creationflags=creationflags,
-                )
+            server = subprocess.Popen(
+                [
+                    str(_backend_executable()),
+                    "-c",
+                    _BACKEND_BOOTSTRAP,
+                    str(backend),
+                    str(entrypoint),
+                ],
+                cwd=backend,
+                env=backend_environment,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                creationflags=creationflags,
+            )
             deadline = time.monotonic() + _BACKEND_START_TIMEOUT_SECONDS
             while time.monotonic() < deadline and server.poll() is None:
                 if _health(args.port) == "READY":

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -417,6 +417,19 @@ def _backend_entrypoint(backend: Path) -> Path:
     return backend / "original_client_server.py"
 
 
+def _append_launcher_event(data_root: Path, event: str, **fields: object) -> None:
+    """Persist path-free startup diagnostics without environment or credentials."""
+
+    try:
+        log_root = data_root / "logs"
+        log_root.mkdir(parents=True, exist_ok=True)
+        record = {"event": event, **fields}
+        with (log_root / "launcher.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+    except (OSError, TypeError, ValueError):
+        pass
+
+
 def _active_backend() -> Path:
     """Resolve the complete backend tree that owns this launcher module."""
 
@@ -536,23 +549,28 @@ def main(argv: list[str] | None = None) -> int:
     if not any(backend_environment.get(name) for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")):
         print("LLM_API_KEY_NOT_CONFIGURED: 请先在启动此程序的进程环境中设置 API key；当前仅提供明确的 safe-static/degraded 回退。")
     server = None
+    client_started = False
     try:
         if health != "READY":
             creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-            server = subprocess.Popen(
-                [
-                    str(_backend_executable()),
-                    "-c",
-                    _BACKEND_BOOTSTRAP,
-                    str(backend),
-                    str(entrypoint),
-                ],
-                cwd=backend,
-                env=backend_environment,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                creationflags=creationflags,
-            )
+            log_root = data_root / "logs"
+            log_root.mkdir(parents=True, exist_ok=True)
+            _append_launcher_event(data_root, "backend_start")
+            with (log_root / "backend.log").open("ab", buffering=0) as backend_log:
+                server = subprocess.Popen(
+                    [
+                        str(_backend_executable()),
+                        "-c",
+                        _BACKEND_BOOTSTRAP,
+                        str(backend),
+                        str(entrypoint),
+                    ],
+                    cwd=backend,
+                    env=backend_environment,
+                    stdout=backend_log,
+                    stderr=subprocess.STDOUT,
+                    creationflags=creationflags,
+                )
             deadline = time.monotonic() + _BACKEND_START_TIMEOUT_SECONDS
             while time.monotonic() < deadline and server.poll() is None:
                 if _health(args.port) == "READY":
@@ -560,11 +578,18 @@ def main(argv: list[str] | None = None) -> int:
                 time.sleep(0.25)
             health = _health(args.port)
             if health != "READY":
+                _append_launcher_event(
+                    data_root,
+                    "backend_unavailable",
+                    health=health,
+                    exit_code=server.poll(),
+                )
                 if health == "PORT_CONFLICT":
                     print("PORT_CONFLICT")
                     return 2
                 print("LOCAL_SERVER_UNAVAILABLE")
                 return 2
+            _append_launcher_event(data_root, "backend_ready")
         client = _client_executable(root)
         if not client.is_file():
             print("ISOLATED_CLIENT_NOT_FOUND")
@@ -579,13 +604,16 @@ def main(argv: list[str] | None = None) -> int:
         local = profile / "Local"
         roaming.mkdir(parents=True, exist_ok=True)
         local.mkdir(parents=True, exist_ok=True)
+        client_started = True
         return subprocess.call(
             _client_command(client, local),
             cwd=root / "app",
             env=_client_environment(client_environment, roaming, local),
         )
     finally:
-        if server is not None:
+        # Keep a healthy loopback backend alive so reopening the copied client
+        # (including from its taskbar icon) does not degrade into Network Error.
+        if server is not None and not client_started:
             _stop_backend_server(server)
 
 

--- a/letter_triage.py
+++ b/letter_triage.py
@@ -415,6 +415,7 @@ class LetterReplyRouter:
         self.environ = environ
 
     async def classify(self, content: str) -> TriageResult:
+        gateway = self.gateway
         if not isinstance(content, str) or not content.strip():
             return _failed("router_invalid_content", called=False)
         context = self.routing_context or routing_context_from_environment(
@@ -426,7 +427,7 @@ class LetterReplyRouter:
         }
         try:
             calls = await asyncio.wait_for(
-                self.gateway.complete_with_tools(
+                gateway.complete_with_tools(
                     messages=[
                         {"role": "system", "content": ROUTER_SYSTEM_PROMPT},
                         {

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -520,11 +520,20 @@ class OfflineDeterministicAdapter(Gateway):
 class OpenAICompatibleAdapter(Gateway):
     """Chat Completions and Responses shaped HTTP adapter."""
 
-    def __init__(self, config: GatewayConfig) -> None:
+    def __init__(
+        self,
+        config: GatewayConfig,
+        *,
+        key_resolver: Callable[[], str | None] | None = None,
+    ) -> None:
         self.config = config
         self.stream_enabled = bool(config.stream)
+        self._key_resolver = key_resolver
 
     def _key(self) -> str | None:
+        if self._key_resolver is not None:
+            value = self._key_resolver()
+            return value if value else None
         if not self.config.api_key_env:
             return None
         value = os.environ.get(self.config.api_key_env)
@@ -852,20 +861,27 @@ def register_provider(name: str, factory: ProviderFactory) -> None:
     _PROVIDERS[normalized] = factory
 
 
-def create_gateway(config: GatewayConfig) -> Gateway:
-    def build_base(current: GatewayConfig) -> Gateway:
+def create_gateway(
+    config: GatewayConfig,
+    *,
+    key_resolver: Callable[[], str | None] | None = None,
+) -> Gateway:
+    def build_base(
+        current: GatewayConfig,
+        resolver: Callable[[], str | None] | None = None,
+    ) -> Gateway:
         if not current.feature_enabled or current.provider in {"", "none"}:
             return UnconfiguredAdapter()
         if current.provider == "mock":
             return OfflineDeterministicAdapter(current)
         if current.provider == "openai_compatible":
-            return OpenAICompatibleAdapter(current)
+            return OpenAICompatibleAdapter(current, key_resolver=resolver)
         factory = _PROVIDERS.get(current.provider)
         if factory is None:
             raise ProviderUnavailable()
         return factory(current)
 
-    primary = build_base(config)
+    primary = build_base(config, key_resolver)
     fallback_name = config.fallback_provider.strip().lower()
     if fallback_name in {"", "none", config.provider}:
         return primary

--- a/local_server.py
+++ b/local_server.py
@@ -174,11 +174,8 @@ def apply_runtime_llm_config(base_url: str, model: str, api_key: str | None) -> 
     """Atomically switch future reply requests to freshly saved local settings."""
 
     global LLM_CONFIG, LLM_TIMEOUT_SECONDS, LLM_CFG
-    key_env = LLM_CONFIG.api_key_env or "DEEPSEEK_API_KEY"
-    previous_key = _os.environ.get(key_env)
-    if api_key is None:
-        _os.environ.pop(key_env, None)
-    else:
+    key_env = f"OLIVIA_LLM_RUNTIME_KEY_{uuid.uuid4().hex.upper()}"
+    if api_key is not None:
         _os.environ[key_env] = api_key
     candidate = replace(
         LLM_CONFIG,
@@ -195,10 +192,7 @@ def apply_runtime_llm_config(base_url: str, model: str, api_key: str | None) -> 
     try:
         gateway = create_gateway(candidate)
     except Exception:
-        if previous_key is None:
-            _os.environ.pop(key_env, None)
-        else:
-            _os.environ[key_env] = previous_key
+        _os.environ.pop(key_env, None)
         raise
     letters_adapter.config = candidate
     letters_adapter.gateway = gateway

--- a/local_server.py
+++ b/local_server.py
@@ -174,9 +174,7 @@ def apply_runtime_llm_config(base_url: str, model: str, api_key: str | None) -> 
     """Atomically switch future reply requests to freshly saved local settings."""
 
     global LLM_CONFIG, LLM_TIMEOUT_SECONDS, LLM_CFG
-    key_env = f"OLIVIA_LLM_RUNTIME_KEY_{uuid.uuid4().hex.upper()}"
-    if api_key is not None:
-        _os.environ[key_env] = api_key
+    key_env = "OLIVIA_LLM_RUNTIME_KEY_CONFIGURED"
     candidate = replace(
         LLM_CONFIG,
         provider="openai_compatible",
@@ -190,23 +188,29 @@ def apply_runtime_llm_config(base_url: str, model: str, api_key: str | None) -> 
         requires_api_key=True,
     )
     try:
-        gateway = create_gateway(candidate)
+        gateway = create_gateway(
+            candidate,
+            key_resolver=lambda key=api_key: key,
+        )
     except Exception:
-        _os.environ.pop(key_env, None)
         raise
-    letters_adapter.config = candidate
-    letters_adapter.gateway = gateway
+    letters_adapter.replace_runtime(candidate, gateway)
     if isinstance(
         private_world_candidate_analyzer,
         GatewayPrivateWorldCandidateAnalyzer,
     ):
         private_world_candidate_analyzer.gateway = gateway
         private_world_candidate_analyzer.timeout_seconds = candidate.timeout_seconds
+    emotion_triage.gateway = gateway
     reply_engine.timeout_seconds = candidate.timeout_seconds
     LLM_CONFIG = candidate
     LLM_TIMEOUT_SECONDS = candidate.timeout_seconds
     LLM_CFG = candidate.public_dict()
     LLM_CFG["persona_file"] = candidate.persona_file
+    if api_key is None:
+        _os.environ.pop(key_env, None)
+    else:
+        _os.environ[key_env] = "1"
 
 
 def _persona() -> str:
@@ -302,27 +306,28 @@ class LetterAdapter:
         private_world_port: PrivateWorldPort | None = None,
         now: Callable[[], datetime] | None = None,
     ) -> None:
-        self.config = config or LLM_CONFIG
+        runtime_config = config or LLM_CONFIG
         try:
-            self.gateway = create_gateway(self.config)
+            runtime_gateway = create_gateway(runtime_config)
         except GatewayError:
-            self.gateway = UnconfiguredAdapter()
+            runtime_gateway = UnconfiguredAdapter()
+        self._runtime = (runtime_config, runtime_gateway)
         self.memory_port: MemoryPort = memory_port or NullMemoryPort()
         self.conversation_memory = conversation_memory
         self.private_world_port: PrivateWorldPort = (
             private_world_port or NullPrivateWorldPort()
         )
         self._now = now or (lambda: datetime.now(timezone.utc))
-        persona_path = Path(self.config.persona_file)
+        persona_path = Path(runtime_config.persona_file)
         if not persona_path.is_absolute():
             persona_path = Path(__file__).resolve().parent / persona_path
-        persona_config_path = Path(self.config.persona_config)
+        persona_config_path = Path(runtime_config.persona_config)
         if not persona_config_path.is_absolute():
             persona_config_path = Path(__file__).resolve().parent / persona_config_path
-        persona_evidence_path = Path(self.config.persona_evidence_file)
+        persona_evidence_path = Path(runtime_config.persona_evidence_file)
         if not persona_evidence_path.is_absolute():
             persona_evidence_path = Path(__file__).resolve().parent / persona_evidence_path
-        persona_v2_path = Path(self.config.persona_v2_file)
+        persona_v2_path = Path(runtime_config.persona_v2_file)
         if not persona_v2_path.is_absolute():
             persona_v2_path = Path(__file__).resolve().parent / persona_v2_path
         self.persona_v2_path = persona_v2_path
@@ -333,7 +338,7 @@ class LetterAdapter:
                 JsonPersonaEvidencePort(persona_evidence_path),
                 MemoryReferenceEvidencePort(self.memory_port),
             ),
-            feature_enabled=self.config.feature_enabled,
+            feature_enabled=runtime_config.feature_enabled,
         )
         self.memory_prompt_builder = (
             MemoryPromptBuilder(self.memory_port)
@@ -343,6 +348,25 @@ class LetterAdapter:
                 conversation_memory=conversation_memory,
             )
         )
+
+    @property
+    def config(self) -> GatewayConfig:
+        return self._runtime[0]
+
+    @config.setter
+    def config(self, value: GatewayConfig) -> None:
+        self._runtime = (value, self._runtime[1])
+
+    @property
+    def gateway(self) -> Gateway:
+        return self._runtime[1]
+
+    @gateway.setter
+    def gateway(self, value: Gateway) -> None:
+        self._runtime = (self._runtime[0], value)
+
+    def replace_runtime(self, config: GatewayConfig, gateway: Gateway) -> None:
+        self._runtime = (config, gateway)
 
     def get_system_prompt(self) -> str:
         return self.persona_provider.snapshot().system_prompt
@@ -536,10 +560,11 @@ class LetterAdapter:
         *,
         request_id: str | None = None,
     ) -> str:
+        config, gateway = self._runtime
         try:
             messages = self._messages(content, context)
             return asyncio.run(
-                self.gateway.complete(messages, request_id=request_id)
+                gateway.complete(messages, request_id=request_id)
             ).text
         except GatewayError as exc:
             code = "LLM_TIMEOUT" if isinstance(exc, ProviderTimeout) else "LLM_UNAVAILABLE"
@@ -547,10 +572,10 @@ class LetterAdapter:
                 code = "LLM_PROVIDER_REJECTED"
             elif exc.code == "PROVIDER_PROTOCOL":
                 code = "LLM_PROTOCOL_ERROR"
-            _safe_log("llm_failure", provider=self.config.provider, error_code=code)
+            _safe_log("llm_failure", provider=config.provider, error_code=code)
             raise LLMError(code) from None
         except (ValueError, RuntimeError):
-            _safe_log("llm_failure", provider=self.config.provider, error_code="LLM_UNAVAILABLE")
+            _safe_log("llm_failure", provider=config.provider, error_code="LLM_UNAVAILABLE")
             raise LLMError("LLM_UNAVAILABLE") from None
 
 

--- a/local_server.py
+++ b/local_server.py
@@ -93,6 +93,7 @@ from runtime.memory.private_world_delivery import (
     PrivateWorldDeliveryCommitter,
 )
 from private_world_candidate import (
+    GatewayPrivateWorldCandidateAnalyzer,
     PrivateWorldCandidateAnalyzer,
     PrivateWorldCandidateRequest,
     PrivateWorldCandidateRuntime,
@@ -167,6 +168,51 @@ LLM_CONFIG: GatewayConfig = load_gateway_config()
 LLM_TIMEOUT_SECONDS = LLM_CONFIG.timeout_seconds
 LLM_CFG = LLM_CONFIG.public_dict()
 LLM_CFG["persona_file"] = LLM_CONFIG.persona_file
+
+
+def apply_runtime_llm_config(base_url: str, model: str, api_key: str | None) -> None:
+    """Atomically switch future reply requests to freshly saved local settings."""
+
+    global LLM_CONFIG, LLM_TIMEOUT_SECONDS, LLM_CFG
+    key_env = LLM_CONFIG.api_key_env or "DEEPSEEK_API_KEY"
+    previous_key = _os.environ.get(key_env)
+    if api_key is None:
+        _os.environ.pop(key_env, None)
+    else:
+        _os.environ[key_env] = api_key
+    candidate = replace(
+        LLM_CONFIG,
+        provider="openai_compatible",
+        base_url=base_url,
+        model=model,
+        api_key_env=key_env,
+        api_style="chat_completions",
+        stream=True,
+        timeout_seconds=180.0,
+        max_retries=0,
+        requires_api_key=True,
+    )
+    try:
+        gateway = create_gateway(candidate)
+    except Exception:
+        if previous_key is None:
+            _os.environ.pop(key_env, None)
+        else:
+            _os.environ[key_env] = previous_key
+        raise
+    letters_adapter.config = candidate
+    letters_adapter.gateway = gateway
+    if isinstance(
+        private_world_candidate_analyzer,
+        GatewayPrivateWorldCandidateAnalyzer,
+    ):
+        private_world_candidate_analyzer.gateway = gateway
+        private_world_candidate_analyzer.timeout_seconds = candidate.timeout_seconds
+    reply_engine.timeout_seconds = candidate.timeout_seconds
+    LLM_CONFIG = candidate
+    LLM_TIMEOUT_SECONDS = candidate.timeout_seconds
+    LLM_CFG = candidate.public_dict()
+    LLM_CFG["persona_file"] = candidate.persona_file
 
 
 def _persona() -> str:

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -610,7 +610,15 @@ def create_configured_original_client_server_runtime(
     )
     collection = getattr(server_module, "_letter_collection", None)
     data_root = _absolute_data_root(values)
-    setup_service = LLMSetupService(data_root) if data_root is not None else None
+    apply_runtime = getattr(server_module, "apply_runtime_llm_config", None)
+    setup_service = (
+        LLMSetupService(
+            data_root,
+            apply_runtime=apply_runtime if callable(apply_runtime) else None,
+        )
+        if data_root is not None
+        else None
+    )
     capability_installer = _configured_capability_installer(values, data_root)
     component_updater = _configured_component_updater(values)
     runtime = create_original_client_server_runtime(

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -953,7 +953,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
           api_key: key.input.value.trim(),
         });
         key.input.value = "";
-        state.textContent = "已保存。重启 Olivia 后生效。";
+        state.textContent = "已保存。下一次发送立即生效。";
       } catch (_error) {
         state.textContent = "保存失败，请重新测试连接。";
       } finally {
@@ -965,14 +965,14 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     });
     save.disabled = true;
     const removeKey = button("删除 API key", async () => {
-      if (!await confirmAction("确认删除这台电脑上保存的 API key？删除后需重启 Olivia。")) {
+      if (!await confirmAction("确认删除这台电脑上保存的 API key？")) {
         return;
       }
       setButtonsBusy([testConnection, save, removeKey], true);
       try {
         await requestSetup(LLM_DELETE_PATH, {});
         key.input.value = "";
-        state.textContent = "API key 已删除。重启 Olivia 后生效。";
+        state.textContent = "API key 已删除。下一次发送立即生效。";
       } catch (_error) {
         state.textContent = "API key 删除失败，请重试。";
       } finally {

--- a/original_client_setup_api.py
+++ b/original_client_setup_api.py
@@ -33,6 +33,7 @@ _ORIGINS_KEY = web.AppKey("original_client_setup_origins", frozenset)
 _MOUNTED_KEY = web.AppKey("original_client_setup_mounted", bool)
 Probe = Callable[[str, str, str], Awaitable[None]]
 Protector = Callable[[str], str]
+RuntimeApply = Callable[[str, str, str | None], None]
 
 PUBLIC_ROUTE_CONTRACT = {
     SETUP_STATUS_PATH: {
@@ -243,6 +244,7 @@ class LLMSetupService:
         protect: Protector = _dpapi_protect,
         unprotect: Protector = _dpapi_unprotect,
         probe: Probe = _probe_openai_compatible,
+        apply_runtime: RuntimeApply | None = None,
     ) -> None:
         self._config_root = Path(data_root) / "config"
         self._key_path = self._config_root / "deepseek_api_key.dpapi"
@@ -251,6 +253,7 @@ class LLMSetupService:
         self._protect = protect
         self._unprotect = unprotect
         self._probe = probe
+        self._apply_runtime = apply_runtime
         self._login_observed = False
         self._session_token: str | None = None
         self._tested_digest: str | None = None
@@ -378,7 +381,7 @@ class LLMSetupService:
         await self._probe(base_url, model, api_key)
         self._tested_digest = self._digest(base_url, model, api_key)
 
-    def save(self, payload: dict[str, object]) -> None:
+    def save(self, payload: dict[str, object]) -> bool:
         if set(payload) != {"base_url", "model", "api_key"}:
             raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
         base_url = _base_url(payload.get("base_url"))
@@ -421,8 +424,15 @@ class LLMSetupService:
         except OSError:
             pass
         self._tested_digest = None
+        if self._apply_runtime is None:
+            return False
+        try:
+            self._apply_runtime(base_url, model, api_key)
+        except Exception as exc:
+            raise LLMSetupError("LLM_SETUP_SAVE_FAILED", status=503) from exc
+        return True
 
-    def delete(self) -> None:
+    def delete(self) -> bool:
         configured = self._config()
         active = self._active_key_path()
         try:
@@ -446,6 +456,17 @@ class LLMSetupService:
         except OSError:
             pass
         self._tested_digest = None
+        if self._apply_runtime is None:
+            return False
+        try:
+            self._apply_runtime(
+                str(configured["base_url"]),
+                str(configured["model"]),
+                None,
+            )
+        except Exception as exc:
+            raise LLMSetupError("LLM_SETUP_SAVE_FAILED", status=503) from exc
+        return True
 
     def complete(self, *, skipped: object) -> bool:
         if type(skipped) is not bool:
@@ -561,12 +582,12 @@ def mount_original_client_setup_api(
     async def save(request: web.Request) -> web.Response:
         origin = _authorize(request, confirm=True)
         service.require_session(request.headers.get(SESSION_HEADER, ""))
-        service.save(await _body(request))
+        reload_applied = service.save(await _body(request))
         return web.json_response(
             {
                 "status": "SAVED",
-                "reload_applied": False,
-                "restart_required": True,
+                "reload_applied": reload_applied,
+                "restart_required": not reload_applied,
             },
             headers=_headers(origin),
         )
@@ -576,12 +597,12 @@ def mount_original_client_setup_api(
         service.require_session(request.headers.get(SESSION_HEADER, ""))
         if await _body(request):
             raise LLMSetupError("LLM_SETUP_FIELDS_INVALID", status=400)
-        service.delete()
+        reload_applied = service.delete()
         return web.json_response(
             {
                 "status": "DELETED",
-                "reload_applied": False,
-                "restart_required": True,
+                "reload_applied": reload_applied,
+                "restart_required": not reload_applied,
             },
             headers=_headers(origin),
         )

--- a/original_client_setup_api.py
+++ b/original_client_setup_api.py
@@ -393,6 +393,12 @@ class LLMSetupService:
             raise LLMSetupError("LLM_SETUP_TEST_REQUIRED", status=409)
         protected_bytes = (self._protect(api_key) + "\n").encode("utf-8")
         self._config_root.mkdir(parents=True, exist_ok=True)
+        try:
+            previous_config = (
+                self._config_path.read_bytes() if self._config_path.is_file() else None
+            )
+        except OSError as exc:
+            raise LLMSetupError("LLM_SETUP_SAVE_FAILED", status=503) from exc
         generation = secrets.token_hex(16)
         key_path = self._config_root / f"deepseek_api_key.{generation}.dpapi"
         key_staging = key_path.with_suffix(key_path.suffix + ".staging")
@@ -413,6 +419,21 @@ class LLMSetupService:
             key_staging.unlink(missing_ok=True)
             key_path.unlink(missing_ok=True)
             raise LLMSetupError("LLM_SETUP_SAVE_FAILED", status=503) from exc
+        if self._apply_runtime is not None:
+            try:
+                self._apply_runtime(base_url, model, api_key)
+            except Exception as exc:
+                try:
+                    if previous_config is None:
+                        self._config_path.unlink(missing_ok=True)
+                    else:
+                        staging = self._config_path.with_suffix(".json.rollback")
+                        staging.write_bytes(previous_config)
+                        staging.replace(self._config_path)
+                except OSError:
+                    pass
+                key_path.unlink(missing_ok=True)
+                raise LLMSetupError("LLM_SETUP_SAVE_FAILED", status=503) from exc
         for stale in self._config_root.glob("deepseek_api_key.*.dpapi"):
             if stale != key_path and _KEY_FILE_RE.fullmatch(stale.name):
                 try:
@@ -424,17 +445,17 @@ class LLMSetupService:
         except OSError:
             pass
         self._tested_digest = None
-        if self._apply_runtime is None:
-            return False
-        try:
-            self._apply_runtime(base_url, model, api_key)
-        except Exception as exc:
-            raise LLMSetupError("LLM_SETUP_SAVE_FAILED", status=503) from exc
-        return True
+        return self._apply_runtime is not None
 
     def delete(self) -> bool:
         configured = self._config()
         active = self._active_key_path()
+        try:
+            previous_config = (
+                self._config_path.read_bytes() if self._config_path.is_file() else None
+            )
+        except OSError as exc:
+            raise LLMSetupError("LLM_SETUP_SAVE_FAILED", status=503) from exc
         try:
             _atomic_json(
                 self._config_path,
@@ -446,6 +467,24 @@ class LLMSetupService:
             )
         except OSError as exc:
             raise LLMSetupError("LLM_SETUP_SAVE_FAILED", status=503) from exc
+        if self._apply_runtime is not None:
+            try:
+                self._apply_runtime(
+                    str(configured["base_url"]),
+                    str(configured["model"]),
+                    None,
+                )
+            except Exception as exc:
+                try:
+                    if previous_config is None:
+                        self._config_path.unlink(missing_ok=True)
+                    else:
+                        staging = self._config_path.with_suffix(".json.rollback")
+                        staging.write_bytes(previous_config)
+                        staging.replace(self._config_path)
+                except OSError:
+                    pass
+                raise LLMSetupError("LLM_SETUP_SAVE_FAILED", status=503) from exc
         if active is not None:
             try:
                 active.unlink(missing_ok=True)
@@ -456,17 +495,7 @@ class LLMSetupService:
         except OSError:
             pass
         self._tested_digest = None
-        if self._apply_runtime is None:
-            return False
-        try:
-            self._apply_runtime(
-                str(configured["base_url"]),
-                str(configured["model"]),
-                None,
-            )
-        except Exception as exc:
-            raise LLMSetupError("LLM_SETUP_SAVE_FAILED", status=503) from exc
-        return True
+        return self._apply_runtime is not None
 
     def complete(self, *, skipped: object) -> bool:
         if type(skipped) is not bool:

--- a/original_client_setup_api.py
+++ b/original_client_setup_api.py
@@ -423,6 +423,7 @@ class LLMSetupService:
             try:
                 self._apply_runtime(base_url, model, api_key)
             except Exception as exc:
+                rollback_succeeded = True
                 try:
                     if previous_config is None:
                         self._config_path.unlink(missing_ok=True)
@@ -431,8 +432,9 @@ class LLMSetupService:
                         staging.write_bytes(previous_config)
                         staging.replace(self._config_path)
                 except OSError:
-                    pass
-                key_path.unlink(missing_ok=True)
+                    rollback_succeeded = False
+                if rollback_succeeded:
+                    key_path.unlink(missing_ok=True)
                 raise LLMSetupError("LLM_SETUP_SAVE_FAILED", status=503) from exc
         for stale in self._config_root.glob("deepseek_api_key.*.dpapi"):
             if stale != key_path and _KEY_FILE_RE.fullmatch(stale.name):
@@ -616,7 +618,7 @@ def mount_original_client_setup_api(
             {
                 "status": "SAVED",
                 "reload_applied": reload_applied,
-                "restart_required": not reload_applied,
+                "restart_required": True,
             },
             headers=_headers(origin),
         )
@@ -631,7 +633,7 @@ def mount_original_client_setup_api(
             {
                 "status": "DELETED",
                 "reload_applied": reload_applied,
-                "restart_required": not reload_applied,
+                "restart_required": True,
             },
             headers=_headers(origin),
         )

--- a/tests/http/test_original_client_setup_api.py
+++ b/tests/http/test_original_client_setup_api.py
@@ -138,7 +138,19 @@ def test_test_then_save_persists_only_dpapi_key_and_non_secret_config(
 ) -> None:
     async def scenario() -> None:
         probes: list[tuple[str, str, str]] = []
-        service = _service(tmp_path, probes)
+        applied: list[tuple[str, str, str | None]] = []
+        async def probe(base_url: str, model: str, api_key: str) -> None:
+            probes.append((base_url, model, api_key))
+
+        service = LLMSetupService(
+            tmp_path,
+            protect=lambda value: f"protected:{len(value)}",
+            unprotect=lambda value: "x" * int(value.split(":", 1)[1]),
+            probe=probe,
+            apply_runtime=lambda base_url, model, api_key: applied.append(
+                (base_url, model, api_key)
+            ),
+        )
         service.observe_login(success=True)
         app = web.Application()
         mount_original_client_setup_api(
@@ -178,9 +190,16 @@ def test_test_then_save_persists_only_dpapi_key_and_non_secret_config(
             assert saved.status == 200
             assert await saved.json() == {
                 "status": "SAVED",
-                "reload_applied": False,
-                "restart_required": True,
+                "reload_applied": True,
+                "restart_required": False,
             }
+            assert applied == [
+                (
+                    "https://opencode.ai/zen/go/v1",
+                    "deepseek-v4-flash",
+                    "fixture-private-key",
+                )
+            ]
 
             status_payload = await (await client.get(
                 "/toy/setup/status", headers={"Origin": TRUSTED_ORIGIN}

--- a/tests/http/test_original_client_setup_api.py
+++ b/tests/http/test_original_client_setup_api.py
@@ -191,7 +191,7 @@ def test_test_then_save_persists_only_dpapi_key_and_non_secret_config(
             assert await saved.json() == {
                 "status": "SAVED",
                 "reload_applied": True,
-                "restart_required": False,
+                "restart_required": True,
             }
             assert applied == [
                 (
@@ -541,6 +541,52 @@ def test_runtime_apply_failure_rolls_back_key_deletion(tmp_path: Path) -> None:
 
     assert config_path.read_bytes() == previous_config
     assert old_key.read_text(encoding="utf-8") == "protected:old\n"
+
+
+def test_failed_rollback_keeps_the_new_key_referenced_by_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def probe(_base_url: str, _model: str, _api_key: str) -> None:
+        return None
+
+    config_root = tmp_path / "config"
+    config_root.mkdir(parents=True)
+    (config_root / "llm.json").write_text(
+        '{"schema_version":1,"base_url":"https://old.example/v1",'
+        '"model":"old-model"}\n',
+        encoding="utf-8",
+    )
+    original_write_bytes = Path.write_bytes
+
+    def fail_rollback(path: Path, payload: bytes) -> int:
+        if path.name == "llm.json.rollback":
+            raise OSError("synthetic rollback failure")
+        return original_write_bytes(path, payload)
+
+    monkeypatch.setattr(Path, "write_bytes", fail_rollback)
+    service = LLMSetupService(
+        tmp_path,
+        protect=lambda value: f"protected:{len(value)}",
+        unprotect=lambda value: value,
+        probe=probe,
+        apply_runtime=lambda *_args: (_ for _ in ()).throw(
+            RuntimeError("synthetic apply failure")
+        ),
+    )
+    body = {
+        "base_url": "https://new.example/v1",
+        "model": "new-model",
+        "api_key": "replacement-key",
+    }
+    asyncio.run(service.test(body))
+
+    with pytest.raises(LLMSetupError, match="LLM_SETUP_SAVE_FAILED"):
+        service.save(body)
+
+    config = json.loads((config_root / "llm.json").read_text(encoding="utf-8"))
+    assert config["schema_version"] == 2
+    assert (config_root / config["key_file"]).is_file()
 
 
 def test_interrupted_save_keeps_previous_provider_key_generation_active(

--- a/tests/http/test_original_client_setup_api.py
+++ b/tests/http/test_original_client_setup_api.py
@@ -465,6 +465,84 @@ def test_setup_delete_removes_only_managed_key(tmp_path: Path) -> None:
     asyncio.run(scenario())
 
 
+def test_runtime_apply_failure_rolls_back_saved_config_and_key(tmp_path: Path) -> None:
+    async def probe(_base_url: str, _model: str, _api_key: str) -> None:
+        return None
+
+    config_root = tmp_path / "config"
+    config_root.mkdir(parents=True)
+    config_path = config_root / "llm.json"
+    previous_config = (
+        '{"schema_version":1,"base_url":"https://old.example/v1",'
+        '"model":"old-model"}\n'
+    ).encode("utf-8")
+    config_path.write_bytes(previous_config)
+    old_key = config_root / "deepseek_api_key.dpapi"
+    old_key.write_text("protected:old\n", encoding="utf-8")
+
+    def fail_apply(_base_url: str, _model: str, _api_key: str | None) -> None:
+        raise RuntimeError("synthetic apply failure")
+
+    service = LLMSetupService(
+        tmp_path,
+        protect=lambda value: f"protected:{len(value)}",
+        unprotect=lambda _value: "stored-secret",
+        probe=probe,
+        apply_runtime=fail_apply,
+    )
+    asyncio.run(
+        service.test(
+            {
+                "base_url": "https://new.example/v1",
+                "model": "new-model",
+                "api_key": "replacement-key",
+            }
+        )
+    )
+
+    with pytest.raises(LLMSetupError, match="LLM_SETUP_SAVE_FAILED"):
+        service.save(
+            {
+                "base_url": "https://new.example/v1",
+                "model": "new-model",
+                "api_key": "replacement-key",
+            }
+        )
+
+    assert config_path.read_bytes() == previous_config
+    assert old_key.read_text(encoding="utf-8") == "protected:old\n"
+    assert list(config_root.glob("deepseek_api_key.*.dpapi")) == []
+
+
+def test_runtime_apply_failure_rolls_back_key_deletion(tmp_path: Path) -> None:
+    config_root = tmp_path / "config"
+    config_root.mkdir(parents=True)
+    config_path = config_root / "llm.json"
+    previous_config = (
+        '{"schema_version":1,"base_url":"https://old.example/v1",'
+        '"model":"old-model"}\n'
+    ).encode("utf-8")
+    config_path.write_bytes(previous_config)
+    old_key = config_root / "deepseek_api_key.dpapi"
+    old_key.write_text("protected:old\n", encoding="utf-8")
+
+    service = LLMSetupService(
+        tmp_path,
+        protect=lambda value: value,
+        unprotect=lambda value: value,
+        probe=lambda *_args: None,
+        apply_runtime=lambda *_args: (_ for _ in ()).throw(
+            RuntimeError("synthetic apply failure")
+        ),
+    )
+
+    with pytest.raises(LLMSetupError, match="LLM_SETUP_SAVE_FAILED"):
+        service.delete()
+
+    assert config_path.read_bytes() == previous_config
+    assert old_key.read_text(encoding="utf-8") == "protected:old\n"
+
+
 def test_interrupted_save_keeps_previous_provider_key_generation_active(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -217,6 +217,12 @@ def test_launcher_starts_combined_server_before_original_client(
     assert client_commands[0][0].endswith("Olivia.exe")
     assert not backend_command[-1].endswith("local_server.py")
     assert frontend_repairs == [(root.resolve(), 8899)]
+    launcher_log = (root / "data" / "logs" / "launcher.jsonl").read_text(
+        encoding="utf-8"
+    )
+    assert '"event": "backend_start"' in launcher_log
+    assert '"event": "backend_ready"' in launcher_log
+    assert "DEEPSEEK_API_KEY" not in launcher_log
 
 
 def test_component_launcher_starts_the_backend_that_owns_start_local(
@@ -259,7 +265,7 @@ def test_component_launcher_starts_the_backend_that_owns_start_local(
     assert commands[0][3:] == [str(active_backend), str(active_entrypoint)]
 
 
-def test_component_launcher_identifies_and_stops_its_backend(
+def test_component_launcher_keeps_its_backend_for_client_reentry(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -307,7 +313,7 @@ def test_component_launcher_identifies_and_stops_its_backend(
     assert backend_environments[0]["OLIVIA_PROVIDER_CACHE_ROOT"] == str(
         root / "data" / "provider-cache"
     )
-    assert lifecycle == ["terminate", "wait:5"]
+    assert lifecycle == []
 
 
 def test_launcher_replaces_a_verified_stale_backend_before_starting_active_version(

--- a/tests/installer/test_original_settings_javascript.py
+++ b/tests/installer/test_original_settings_javascript.py
@@ -33,6 +33,14 @@ def test_original_settings_actions_remain_bounded_and_in_client() -> None:
     assert '"Content-Type": "application/json"' in source
     assert 'const CONFIRM_VALUE = "confirmed"' in source
     assert "window.confirm" not in source
+
+
+def test_llm_save_and_delete_copy_says_changes_apply_immediately() -> None:
+    source = BOOTSTRAP_JAVASCRIPT
+
+    assert "已保存。下一次发送立即生效。" in source
+    assert "API key 已删除。下一次发送立即生效。" in source
+    assert "重启 Olivia 后生效" not in source
     assert "confirmAction" in source
     assert "window.open" not in source
     assert "innerHTML" not in source

--- a/tests/llm/test_b03_integration.py
+++ b/tests/llm/test_b03_integration.py
@@ -14,7 +14,7 @@ def test_saved_llm_config_replaces_the_next_reply_gateway_without_restart(
         provider="openai_compatible",
         base_url="https://old.example/v1",
         model="old-model",
-        api_key_env="DEEPSEEK_API_KEY",
+        api_key_env="OLIVIA_LLM_RUNTIME_KEY_OLD",
         requires_api_key=True,
     )
     marker = object()
@@ -40,7 +40,11 @@ def test_saved_llm_config_replaces_the_next_reply_gateway_without_restart(
     )
     monkeypatch.setattr(local_server.reply_engine, "timeout_seconds", previous.timeout_seconds)
     monkeypatch.setattr(local_server, "create_gateway", lambda config: marker)
-    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.setenv("OLIVIA_LLM_RUNTIME_KEY_OLD", "old-inflight-key")
+    existing_slots = {
+        name for name in local_server._os.environ
+        if name.startswith("OLIVIA_LLM_RUNTIME_KEY_")
+    }
 
     local_server.apply_runtime_llm_config(
         "https://gateway.example/v1",
@@ -53,7 +57,15 @@ def test_saved_llm_config_replaces_the_next_reply_gateway_without_restart(
     assert candidate_analyzer.timeout_seconds == 180.0
     assert local_server.letters_adapter.config.base_url == "https://gateway.example/v1"
     assert local_server.letters_adapter.config.model == "new-model"
-    assert local_server.letters_adapter.config.api_key_env == "DEEPSEEK_API_KEY"
+    assert local_server.letters_adapter.config.api_key_env.startswith(
+        "OLIVIA_LLM_RUNTIME_KEY_"
+    )
+    assert local_server.letters_adapter.config.api_key_env not in existing_slots
+    assert (
+        local_server._os.environ[local_server.letters_adapter.config.api_key_env]
+        == "synthetic-runtime-key"
+    )
+    assert local_server._os.environ["OLIVIA_LLM_RUNTIME_KEY_OLD"] == "old-inflight-key"
     assert local_server.LLM_CONFIG is local_server.letters_adapter.config
     assert local_server.reply_engine.timeout_seconds == 180.0
     assert local_server.LLM_CFG["model"] == "new-model"
@@ -65,12 +77,10 @@ def test_failed_llm_runtime_replacement_keeps_the_previous_gateway(monkeypatch) 
 
     previous_gateway = object()
     monkeypatch.setattr(local_server.letters_adapter, "gateway", previous_gateway)
-    monkeypatch.setattr(
-        local_server,
-        "LLM_CONFIG",
-        GatewayConfig(api_key_env="DEEPSEEK_API_KEY"),
-    )
-    monkeypatch.setenv("DEEPSEEK_API_KEY", "previous-key")
+    existing_slots = {
+        name for name in local_server._os.environ
+        if name.startswith("OLIVIA_LLM_RUNTIME_KEY_")
+    }
 
     def fail(_config):
         raise RuntimeError("synthetic gateway failure")
@@ -89,7 +99,10 @@ def test_failed_llm_runtime_replacement_keeps_the_previous_gateway(monkeypatch) 
         raise AssertionError("runtime replacement failure must remain visible")
 
     assert local_server.letters_adapter.gateway is previous_gateway
-    assert local_server._os.environ["DEEPSEEK_API_KEY"] == "previous-key"
+    assert {
+        name for name in local_server._os.environ
+        if name.startswith("OLIVIA_LLM_RUNTIME_KEY_")
+    } == existing_slots
 
 
 def test_unconfigured_send_is_explicit_and_never_writes_reply(monkeypatch) -> None:

--- a/tests/llm/test_b03_integration.py
+++ b/tests/llm/test_b03_integration.py
@@ -39,12 +39,15 @@ def test_saved_llm_config_replaces_the_next_reply_gateway_without_restart(
         candidate_analyzer,
     )
     monkeypatch.setattr(local_server.reply_engine, "timeout_seconds", previous.timeout_seconds)
-    monkeypatch.setattr(local_server, "create_gateway", lambda config: marker)
-    monkeypatch.setenv("OLIVIA_LLM_RUNTIME_KEY_OLD", "old-inflight-key")
-    existing_slots = {
-        name for name in local_server._os.environ
-        if name.startswith("OLIVIA_LLM_RUNTIME_KEY_")
-    }
+    resolvers = []
+    monkeypatch.setattr(
+        local_server,
+        "create_gateway",
+        lambda config, *, key_resolver=None: resolvers.append(key_resolver) or marker,
+    )
+    previous_triage_gateway = object()
+    monkeypatch.setattr(local_server.emotion_triage, "gateway", previous_triage_gateway)
+    monkeypatch.delenv("OLIVIA_LLM_RUNTIME_KEY_CONFIGURED", raising=False)
 
     local_server.apply_runtime_llm_config(
         "https://gateway.example/v1",
@@ -53,19 +56,17 @@ def test_saved_llm_config_replaces_the_next_reply_gateway_without_restart(
     )
 
     assert local_server.letters_adapter.gateway is marker
+    assert local_server.emotion_triage.gateway is marker
     assert candidate_analyzer.gateway is marker
     assert candidate_analyzer.timeout_seconds == 180.0
     assert local_server.letters_adapter.config.base_url == "https://gateway.example/v1"
     assert local_server.letters_adapter.config.model == "new-model"
-    assert local_server.letters_adapter.config.api_key_env.startswith(
-        "OLIVIA_LLM_RUNTIME_KEY_"
-    )
-    assert local_server.letters_adapter.config.api_key_env not in existing_slots
     assert (
-        local_server._os.environ[local_server.letters_adapter.config.api_key_env]
-        == "synthetic-runtime-key"
+        local_server.letters_adapter.config.api_key_env
+        == "OLIVIA_LLM_RUNTIME_KEY_CONFIGURED"
     )
-    assert local_server._os.environ["OLIVIA_LLM_RUNTIME_KEY_OLD"] == "old-inflight-key"
+    assert local_server._os.environ["OLIVIA_LLM_RUNTIME_KEY_CONFIGURED"] == "1"
+    assert resolvers[0]() == "synthetic-runtime-key"
     assert local_server.LLM_CONFIG is local_server.letters_adapter.config
     assert local_server.reply_engine.timeout_seconds == 180.0
     assert local_server.LLM_CFG["model"] == "new-model"
@@ -77,12 +78,9 @@ def test_failed_llm_runtime_replacement_keeps_the_previous_gateway(monkeypatch) 
 
     previous_gateway = object()
     monkeypatch.setattr(local_server.letters_adapter, "gateway", previous_gateway)
-    existing_slots = {
-        name for name in local_server._os.environ
-        if name.startswith("OLIVIA_LLM_RUNTIME_KEY_")
-    }
+    monkeypatch.delenv("OLIVIA_LLM_RUNTIME_KEY_CONFIGURED", raising=False)
 
-    def fail(_config):
+    def fail(_config, **_kwargs):
         raise RuntimeError("synthetic gateway failure")
 
     monkeypatch.setattr(local_server, "create_gateway", fail)
@@ -99,10 +97,7 @@ def test_failed_llm_runtime_replacement_keeps_the_previous_gateway(monkeypatch) 
         raise AssertionError("runtime replacement failure must remain visible")
 
     assert local_server.letters_adapter.gateway is previous_gateway
-    assert {
-        name for name in local_server._os.environ
-        if name.startswith("OLIVIA_LLM_RUNTIME_KEY_")
-    } == existing_slots
+    assert "OLIVIA_LLM_RUNTIME_KEY_CONFIGURED" not in local_server._os.environ
 
 
 def test_unconfigured_send_is_explicit_and_never_writes_reply(monkeypatch) -> None:

--- a/tests/llm/test_b03_integration.py
+++ b/tests/llm/test_b03_integration.py
@@ -5,6 +5,93 @@ import asyncio
 from llm_gateway import GatewayConfig, OfflineDeterministicAdapter, UnconfiguredAdapter
 
 
+def test_saved_llm_config_replaces_the_next_reply_gateway_without_restart(
+    monkeypatch,
+) -> None:
+    import local_server
+
+    previous = GatewayConfig(
+        provider="openai_compatible",
+        base_url="https://old.example/v1",
+        model="old-model",
+        api_key_env="DEEPSEEK_API_KEY",
+        requires_api_key=True,
+    )
+    marker = object()
+    monkeypatch.setattr(local_server, "LLM_CONFIG", previous)
+    monkeypatch.setattr(local_server, "LLM_TIMEOUT_SECONDS", previous.timeout_seconds)
+    monkeypatch.setattr(local_server, "LLM_CFG", previous.public_dict())
+    monkeypatch.setattr(local_server.letters_adapter, "config", previous)
+    monkeypatch.setattr(local_server.letters_adapter, "gateway", object())
+    candidate_analyzer = type(
+        "CandidateAnalyzer",
+        (),
+        {"gateway": object(), "timeout_seconds": 1.0},
+    )()
+    monkeypatch.setattr(
+        local_server,
+        "GatewayPrivateWorldCandidateAnalyzer",
+        type(candidate_analyzer),
+    )
+    monkeypatch.setattr(
+        local_server,
+        "private_world_candidate_analyzer",
+        candidate_analyzer,
+    )
+    monkeypatch.setattr(local_server.reply_engine, "timeout_seconds", previous.timeout_seconds)
+    monkeypatch.setattr(local_server, "create_gateway", lambda config: marker)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+    local_server.apply_runtime_llm_config(
+        "https://gateway.example/v1",
+        "new-model",
+        "synthetic-runtime-key",
+    )
+
+    assert local_server.letters_adapter.gateway is marker
+    assert candidate_analyzer.gateway is marker
+    assert candidate_analyzer.timeout_seconds == 180.0
+    assert local_server.letters_adapter.config.base_url == "https://gateway.example/v1"
+    assert local_server.letters_adapter.config.model == "new-model"
+    assert local_server.letters_adapter.config.api_key_env == "DEEPSEEK_API_KEY"
+    assert local_server.LLM_CONFIG is local_server.letters_adapter.config
+    assert local_server.reply_engine.timeout_seconds == 180.0
+    assert local_server.LLM_CFG["model"] == "new-model"
+    assert "synthetic-runtime-key" not in repr(local_server.LLM_CFG)
+
+
+def test_failed_llm_runtime_replacement_keeps_the_previous_gateway(monkeypatch) -> None:
+    import local_server
+
+    previous_gateway = object()
+    monkeypatch.setattr(local_server.letters_adapter, "gateway", previous_gateway)
+    monkeypatch.setattr(
+        local_server,
+        "LLM_CONFIG",
+        GatewayConfig(api_key_env="DEEPSEEK_API_KEY"),
+    )
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "previous-key")
+
+    def fail(_config):
+        raise RuntimeError("synthetic gateway failure")
+
+    monkeypatch.setattr(local_server, "create_gateway", fail)
+
+    try:
+        local_server.apply_runtime_llm_config(
+            "https://gateway.example/v1",
+            "new-model",
+            "replacement-key",
+        )
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("runtime replacement failure must remain visible")
+
+    assert local_server.letters_adapter.gateway is previous_gateway
+    assert local_server._os.environ["DEEPSEEK_API_KEY"] == "previous-key"
+
+
 def test_unconfigured_send_is_explicit_and_never_writes_reply(monkeypatch) -> None:
     import local_server
 

--- a/tests/llm/test_gateway.py
+++ b/tests/llm/test_gateway.py
@@ -21,6 +21,25 @@ from llm_gateway import (
 )
 
 
+def test_bound_gateway_key_does_not_follow_later_environment_changes(
+    monkeypatch,
+) -> None:
+    config = GatewayConfig(
+        provider="openai_compatible",
+        base_url="https://old.example/v1",
+        model="old-model",
+        api_key_env="SHARED_KEY",
+        requires_api_key=True,
+    )
+    monkeypatch.setenv("SHARED_KEY", "new-key")
+    adapter = OpenAICompatibleAdapter(
+        config,
+        key_resolver=lambda: "old-key",
+    )
+
+    assert adapter._key() == "old-key"
+
+
 ROOT_MESSAGES = (
     {"role": "system", "content": "draft system"},
     {"role": "user", "content": "synthetic letter"},


### PR DESCRIPTION
## Summary
- apply saved/deleted LLM settings to the next reply without restarting Olivia
- keep the healthy loopback backend alive when the copied client closes, so taskbar reentry remains usable
- retain local backend diagnostics without logging environment variables or credentials

## Validation
- 66 passed in 2.82s
- git diff --check
- no local full-suite run (focused runtime/UI fix)

## Scope
No video dependency installer changes in this PR.