### PR TITLE
feat(installer): build verified component patches

### DIFF
--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -116,6 +116,14 @@ webplayer.dat.orig
 - `contracts/component_update_state.schema.json`
 - `contracts/component_update_state.example.json`
 
+维护者应从干净、已冻结的 Git 提交生成补丁及两个独立摘要文件：
+
+```powershell
+python -m installer build-update --source <源码目录> --output <发布目录>\olivia-local-backend-<版本>.oliviapatch --version <版本> --source-commit <40位提交SHA>
+```
+
+命令拒绝 tracked 文件有改动或 HEAD 与 `--source-commit` 不一致的源码，并生成 `.manifest.sha256`（供客户端安装页粘贴）和 `.sha256`（用于核对整个补丁文件）。相同源码提交和版本会生成字节一致的包。
+
 安装命令：
 
 ```powershell

--- a/installer/__main__.py
+++ b/installer/__main__.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
+from .component_package import ComponentPackageBuildError, build_component_package
 from .component_update import (
     ComponentUpdateError,
     apply_component_update,
@@ -30,6 +31,11 @@ def main(argv: list[str] | None = None) -> int:
     update.add_argument("--installation", type=Path, required=True)
     update.add_argument("--package", type=Path, required=True)
     update.add_argument("--manifest-sha256", required=True)
+    build_update = sub.add_parser("build-update")
+    build_update.add_argument("--source", type=Path, required=True)
+    build_update.add_argument("--output", type=Path, required=True)
+    build_update.add_argument("--version", required=True)
+    build_update.add_argument("--source-commit", required=True)
     rollback = sub.add_parser("rollback-update")
     rollback.add_argument("--installation", type=Path, required=True)
     args = parser.parse_args(argv)
@@ -50,11 +56,18 @@ def main(argv: list[str] | None = None) -> int:
                 args.package,
                 expected_manifest_sha256=args.manifest_sha256,
             )
+        elif args.command == "build-update":
+            result = build_component_package(
+                args.source,
+                args.output,
+                version=args.version,
+                expected_source_commit=args.source_commit,
+            )
         else:
             result = rollback_component_update(args.installation)
         print(json.dumps(result, ensure_ascii=False, sort_keys=True))
         return 0
-    except (PatchInstallError, ComponentUpdateError) as exc:
+    except (PatchInstallError, ComponentPackageBuildError, ComponentUpdateError) as exc:
         print(json.dumps({"status": "ERROR", "code": str(exc)}, ensure_ascii=False))
         return 2
 

--- a/installer/component_package.py
+++ b/installer/component_package.py
@@ -11,7 +11,7 @@ import stat
 import subprocess
 import tempfile
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from installer.full_patch import PatchInstallError, copy_project_payload
 
@@ -51,12 +51,55 @@ def _verify_source(source: Path, expected_source_commit: str) -> str:
     expected = expected_source_commit.lower()
     if not _COMMIT_RE.fullmatch(expected):
         raise ComponentPackageBuildError("UPDATE_SOURCE_COMMIT_INVALID")
+    top_level = Path(_git(source, "rev-parse", "--show-toplevel")).resolve()
+    if top_level != source:
+        raise ComponentPackageBuildError("UPDATE_SOURCE_NOT_TOPLEVEL")
     actual = _git(source, "rev-parse", "HEAD").lower()
     if actual != expected:
         raise ComponentPackageBuildError("UPDATE_SOURCE_COMMIT_MISMATCH")
     if _git(source, "status", "--porcelain=v1", "--untracked-files=no"):
         raise ComponentPackageBuildError("UPDATE_SOURCE_DIRTY")
     return actual
+
+
+def _export_commit(source: Path, commit: str, destination: Path, archive_path: Path) -> None:
+    try:
+        with archive_path.open("wb") as stream:
+            subprocess.run(
+                ["git", "-C", str(source), "archive", "--format=zip", commit],
+                check=True,
+                stdout=stream,
+                stderr=subprocess.PIPE,
+                timeout=30,
+            )
+        with zipfile.ZipFile(archive_path) as archive:
+            for info in archive.infolist():
+                name = info.filename
+                relative = PurePosixPath(name)
+                member_kind = stat.S_IFMT(info.external_attr >> 16)
+                if (
+                    not name
+                    or "\\" in name
+                    or relative.is_absolute()
+                    or any(part in {"", ".", ".."} for part in relative.parts)
+                    or (not info.is_dir() and member_kind not in {0, stat.S_IFREG})
+                ):
+                    raise ComponentPackageBuildError("UPDATE_SOURCE_ARCHIVE_UNSAFE")
+                target = destination.joinpath(*relative.parts)
+                if info.is_dir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(archive.read(info))
+    except ComponentPackageBuildError:
+        raise
+    except (
+        OSError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        zipfile.BadZipFile,
+    ) as exc:
+        raise ComponentPackageBuildError("UPDATE_SOURCE_ARCHIVE_FAILED") from exc
 
 
 def _payload_files(root: Path) -> list[Path]:
@@ -103,9 +146,17 @@ def build_component_package(
 
     staging = Path(tempfile.mkdtemp(prefix=".olivia-update-build-", dir=package.parent))
     try:
+        exported_source = staging / "source"
+        exported_source.mkdir()
+        _export_commit(
+            source_root,
+            source_commit,
+            exported_source,
+            staging / "source.zip",
+        )
         payload = staging / "payload"
         try:
-            copy_project_payload(source_root, payload)
+            copy_project_payload(exported_source, payload)
         except PatchInstallError as exc:
             raise ComponentPackageBuildError(str(exc)) from exc
         _verify_source(source_root, source_commit)

--- a/installer/component_package.py
+++ b/installer/component_package.py
@@ -1,0 +1,168 @@
+"""Build one verified local-backend component update package."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+
+from installer.full_patch import PatchInstallError, copy_project_payload
+
+
+PACKAGE_SCHEMA = "olivia.component-package.v1"
+_COMMIT_RE = re.compile(r"[0-9a-f]{40}")
+_VERSION_RE = re.compile(r"[0-9A-Za-z][0-9A-Za-z.+-]{0,63}")
+
+
+class ComponentPackageBuildError(RuntimeError):
+    """Stable release-builder failure code."""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _git(source: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(source), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise ComponentPackageBuildError("UPDATE_SOURCE_GIT_INVALID") from exc
+    return result.stdout.strip()
+
+
+def _verify_source(source: Path, expected_source_commit: str) -> str:
+    expected = expected_source_commit.lower()
+    if not _COMMIT_RE.fullmatch(expected):
+        raise ComponentPackageBuildError("UPDATE_SOURCE_COMMIT_INVALID")
+    actual = _git(source, "rev-parse", "HEAD").lower()
+    if actual != expected:
+        raise ComponentPackageBuildError("UPDATE_SOURCE_COMMIT_MISMATCH")
+    if _git(source, "status", "--porcelain=v1", "--untracked-files=no"):
+        raise ComponentPackageBuildError("UPDATE_SOURCE_DIRTY")
+    return actual
+
+
+def _payload_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if path.is_symlink() or not path.is_file():
+            if path.is_symlink():
+                raise ComponentPackageBuildError("UPDATE_PAYLOAD_UNSAFE")
+            continue
+        files.append(path)
+    return sorted(files, key=lambda item: item.relative_to(root).as_posix())
+
+
+def _write_member(archive: zipfile.ZipFile, name: str, content: bytes) -> None:
+    info = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = (stat.S_IFREG | 0o644) << 16
+    archive.writestr(info, content, compresslevel=9)
+
+
+def build_component_package(
+    source: str | os.PathLike[str],
+    output: str | os.PathLike[str],
+    *,
+    version: str,
+    expected_source_commit: str,
+) -> dict[str, object]:
+    """Build a deterministic package plus independent manifest/package digests."""
+
+    source_root = Path(source).expanduser().resolve()
+    package = Path(output).expanduser().resolve()
+    if not source_root.is_dir():
+        raise ComponentPackageBuildError("UPDATE_SOURCE_INVALID")
+    if package.suffix.lower() != ".oliviapatch":
+        raise ComponentPackageBuildError("UPDATE_OUTPUT_INVALID")
+    if not _VERSION_RE.fullmatch(version):
+        raise ComponentPackageBuildError("UPDATE_VERSION_INVALID")
+    manifest_sidecar = Path(f"{package}.manifest.sha256")
+    package_sidecar = Path(f"{package}.sha256")
+    if any(path.exists() for path in (package, manifest_sidecar, package_sidecar)):
+        raise ComponentPackageBuildError("UPDATE_OUTPUT_EXISTS")
+    source_commit = _verify_source(source_root, expected_source_commit)
+    package.parent.mkdir(parents=True, exist_ok=True)
+
+    staging = Path(tempfile.mkdtemp(prefix=".olivia-update-build-", dir=package.parent))
+    try:
+        payload = staging / "payload"
+        try:
+            copy_project_payload(source_root, payload)
+        except PatchInstallError as exc:
+            raise ComponentPackageBuildError(str(exc)) from exc
+        _verify_source(source_root, source_commit)
+        files = _payload_files(payload)
+        manifest = {
+            "schema_version": PACKAGE_SCHEMA,
+            "component": "local_backend",
+            "version": version,
+            "files": [
+                {
+                    "path": path.relative_to(payload).as_posix(),
+                    "size_bytes": path.stat().st_size,
+                    "sha256": _sha256(path),
+                }
+                for path in files
+            ],
+        }
+        manifest_bytes = json.dumps(
+            manifest,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        manifest_sha256 = hashlib.sha256(manifest_bytes).hexdigest()
+        staged_package = staging / package.name
+        with zipfile.ZipFile(staged_package, "w") as archive:
+            _write_member(archive, "manifest.json", manifest_bytes)
+            for path in files:
+                relative = path.relative_to(payload).as_posix()
+                _write_member(archive, f"payload/{relative}", path.read_bytes())
+        package_sha256 = _sha256(staged_package)
+        staged_manifest_sidecar = staging / manifest_sidecar.name
+        staged_package_sidecar = staging / package_sidecar.name
+        staged_manifest_sidecar.write_text(manifest_sha256 + "\n", encoding="ascii")
+        staged_package_sidecar.write_text(package_sha256 + "\n", encoding="ascii")
+        os.replace(staged_manifest_sidecar, manifest_sidecar)
+        os.replace(staged_package_sidecar, package_sidecar)
+        os.replace(staged_package, package)
+        return {
+            "status": "BUILT",
+            "component": "local_backend",
+            "version": version,
+            "source_commit": source_commit,
+            "file_count": len(files),
+            "package": str(package),
+            "manifest_sha256": manifest_sha256,
+            "package_sha256": package_sha256,
+        }
+    except ComponentPackageBuildError:
+        raise
+    except OSError as exc:
+        raise ComponentPackageBuildError("UPDATE_BUILD_FAILED") from exc
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+__all__ = [
+    "ComponentPackageBuildError",
+    "build_component_package",
+]

--- a/installer/component_package.py
+++ b/installer/component_package.py
@@ -13,6 +13,7 @@ import tempfile
 import zipfile
 from pathlib import Path, PurePosixPath
 
+from installer.component_update import ComponentUpdateError, _validate_relative_path
 from installer.full_patch import PatchInstallError, copy_project_payload
 
 
@@ -73,19 +74,40 @@ def _export_commit(source: Path, commit: str, destination: Path, archive_path: P
                 timeout=30,
             )
         with zipfile.ZipFile(archive_path) as archive:
+            files: set[str] = set()
+            directories: set[str] = set()
             for info in archive.infolist():
                 name = info.filename
-                relative = PurePosixPath(name)
+                value = name[:-1] if info.is_dir() and name.endswith("/") else name
+                try:
+                    normalized = _validate_relative_path(value)
+                except ComponentUpdateError as exc:
+                    raise ComponentPackageBuildError(
+                        "UPDATE_SOURCE_ARCHIVE_UNSAFE"
+                    ) from exc
+                relative = PurePosixPath(normalized)
                 member_kind = stat.S_IFMT(info.external_attr >> 16)
                 if (
                     not name
                     or "\\" in name
-                    or relative.is_absolute()
-                    or any(part in {"", ".", ".."} for part in relative.parts)
                     or (not info.is_dir() and member_kind not in {0, stat.S_IFREG})
                 ):
                     raise ComponentPackageBuildError("UPDATE_SOURCE_ARCHIVE_UNSAFE")
+                key = normalized.casefold()
+                parent_keys = {
+                    PurePosixPath(*relative.parts[:index]).as_posix().casefold()
+                    for index in range(1, len(relative.parts))
+                }
+                if key in files or key in directories or parent_keys & files:
+                    raise ComponentPackageBuildError("UPDATE_SOURCE_ARCHIVE_UNSAFE")
+                directories.update(parent_keys)
+                if info.is_dir():
+                    directories.add(key)
+                else:
+                    files.add(key)
                 target = destination.joinpath(*relative.parts)
+                if not target.resolve().is_relative_to(destination.resolve()):
+                    raise ComponentPackageBuildError("UPDATE_SOURCE_ARCHIVE_UNSAFE")
                 if info.is_dir():
                     target.mkdir(parents=True, exist_ok=True)
                     continue
@@ -100,6 +122,37 @@ def _export_commit(source: Path, commit: str, destination: Path, archive_path: P
         zipfile.BadZipFile,
     ) as exc:
         raise ComponentPackageBuildError("UPDATE_SOURCE_ARCHIVE_FAILED") from exc
+
+
+def _publish_outputs(staged: list[tuple[Path, Path]]) -> None:
+    reserved: list[Path] = []
+    try:
+        for _source, destination in staged:
+            descriptor = os.open(
+                destination,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+            os.close(descriptor)
+            reserved.append(destination)
+    except FileExistsError as exc:
+        for path in reserved:
+            path.unlink(missing_ok=True)
+        raise ComponentPackageBuildError("UPDATE_OUTPUT_EXISTS") from exc
+    except OSError as exc:
+        for path in reserved:
+            path.unlink(missing_ok=True)
+        raise ComponentPackageBuildError("UPDATE_BUILD_FAILED") from exc
+    try:
+        for source, destination in staged:
+            os.replace(source, destination)
+    except OSError as exc:
+        for path in reserved:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise ComponentPackageBuildError("UPDATE_BUILD_FAILED") from exc
 
 
 def _payload_files(root: Path) -> list[Path]:
@@ -129,23 +182,25 @@ def build_component_package(
 ) -> dict[str, object]:
     """Build a deterministic package plus independent manifest/package digests."""
 
-    source_root = Path(source).expanduser().resolve()
-    package = Path(output).expanduser().resolve()
-    if not source_root.is_dir():
-        raise ComponentPackageBuildError("UPDATE_SOURCE_INVALID")
-    if package.suffix.lower() != ".oliviapatch":
-        raise ComponentPackageBuildError("UPDATE_OUTPUT_INVALID")
-    if not _VERSION_RE.fullmatch(version):
-        raise ComponentPackageBuildError("UPDATE_VERSION_INVALID")
-    manifest_sidecar = Path(f"{package}.manifest.sha256")
-    package_sidecar = Path(f"{package}.sha256")
-    if any(path.exists() for path in (package, manifest_sidecar, package_sidecar)):
-        raise ComponentPackageBuildError("UPDATE_OUTPUT_EXISTS")
-    source_commit = _verify_source(source_root, expected_source_commit)
-    package.parent.mkdir(parents=True, exist_ok=True)
-
-    staging = Path(tempfile.mkdtemp(prefix=".olivia-update-build-", dir=package.parent))
+    staging: Path | None = None
     try:
+        source_root = Path(source).expanduser().resolve()
+        package = Path(output).expanduser().resolve()
+        if not source_root.is_dir():
+            raise ComponentPackageBuildError("UPDATE_SOURCE_INVALID")
+        if package.suffix.lower() != ".oliviapatch":
+            raise ComponentPackageBuildError("UPDATE_OUTPUT_INVALID")
+        if not _VERSION_RE.fullmatch(version):
+            raise ComponentPackageBuildError("UPDATE_VERSION_INVALID")
+        manifest_sidecar = Path(f"{package}.manifest.sha256")
+        package_sidecar = Path(f"{package}.sha256")
+        if any(path.exists() for path in (package, manifest_sidecar, package_sidecar)):
+            raise ComponentPackageBuildError("UPDATE_OUTPUT_EXISTS")
+        source_commit = _verify_source(source_root, expected_source_commit)
+        package.parent.mkdir(parents=True, exist_ok=True)
+        staging = Path(
+            tempfile.mkdtemp(prefix=".olivia-update-build-", dir=package.parent)
+        )
         exported_source = staging / "source"
         exported_source.mkdir()
         _export_commit(
@@ -192,9 +247,13 @@ def build_component_package(
         staged_package_sidecar = staging / package_sidecar.name
         staged_manifest_sidecar.write_text(manifest_sha256 + "\n", encoding="ascii")
         staged_package_sidecar.write_text(package_sha256 + "\n", encoding="ascii")
-        os.replace(staged_manifest_sidecar, manifest_sidecar)
-        os.replace(staged_package_sidecar, package_sidecar)
-        os.replace(staged_package, package)
+        _publish_outputs(
+            [
+                (staged_manifest_sidecar, manifest_sidecar),
+                (staged_package_sidecar, package_sidecar),
+                (staged_package, package),
+            ]
+        )
         return {
             "status": "BUILT",
             "component": "local_backend",
@@ -207,10 +266,11 @@ def build_component_package(
         }
     except ComponentPackageBuildError:
         raise
-    except OSError as exc:
+    except (OSError, RuntimeError) as exc:
         raise ComponentPackageBuildError("UPDATE_BUILD_FAILED") from exc
     finally:
-        shutil.rmtree(staging, ignore_errors=True)
+        if staging is not None:
+            shutil.rmtree(staging, ignore_errors=True)
 
 
 __all__ = [

--- a/tests/installer/test_component_package_build.py
+++ b/tests/installer/test_component_package_build.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from installer import __main__ as installer_cli
+from installer.component_package import (
+    ComponentPackageBuildError,
+    build_component_package,
+)
+from installer.component_update import apply_component_update
+from installer.full_patch import (
+    PAYLOAD_REQUIRED_RELATIVE_FILES,
+    PAYLOAD_REQUIRED_ROOT_FILES,
+)
+
+
+def _run_git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _clean_payload_repo(tmp_path: Path) -> tuple[Path, str]:
+    source = tmp_path / "source"
+    source.mkdir()
+    for relative in sorted(PAYLOAD_REQUIRED_ROOT_FILES):
+        (source / relative).write_text(f"root:{relative}\n", encoding="utf-8")
+    for relative in sorted(PAYLOAD_REQUIRED_RELATIVE_FILES):
+        target = source.joinpath(*relative.split("/"))
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"relative:{relative}\n", encoding="utf-8")
+    for relative in (
+        "installer/configure.py",
+        "installer/start_local.py",
+        "installer/uninstall.py",
+    ):
+        target = source.joinpath(*relative.split("/"))
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"entrypoint:{relative}\n", encoding="utf-8")
+    _run_git(source, "init")
+    _run_git(source, "config", "user.email", "test@example.invalid")
+    _run_git(source, "config", "user.name", "Olivia Test")
+    _run_git(source, "add", ".")
+    _run_git(source, "commit", "-m", "fixture")
+    return source, _run_git(source, "rev-parse", "HEAD")
+
+
+def _managed_installation(tmp_path: Path) -> Path:
+    installation = tmp_path / "install"
+    (installation / "local_backend").mkdir(parents=True)
+    (installation / "local_backend" / "legacy.py").write_text(
+        "legacy\n", encoding="utf-8"
+    )
+    (installation / ".olivia-full-patch.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.full-patch.install.v2",
+                "owned_root": str(installation.resolve()),
+            }
+        ),
+        encoding="utf-8",
+    )
+    return installation
+
+
+def test_builds_release_ready_component_package_that_the_updater_accepts(
+    tmp_path: Path,
+) -> None:
+    source, commit = _clean_payload_repo(tmp_path)
+    package = tmp_path / "olivia-local-backend-0.1.1.oliviapatch"
+
+    result = build_component_package(
+        source,
+        package,
+        version="0.1.1",
+        expected_source_commit=commit,
+    )
+
+    assert result["status"] == "BUILT"
+    assert result["source_commit"] == commit
+    assert result["manifest_sha256"] == Path(
+        f"{package}.manifest.sha256"
+    ).read_text(encoding="ascii").strip()
+    assert result["package_sha256"] == Path(f"{package}.sha256").read_text(
+        encoding="ascii"
+    ).strip()
+    with zipfile.ZipFile(package) as archive:
+        assert archive.namelist()[0] == "manifest.json"
+        manifest = json.loads(archive.read("manifest.json"))
+        assert manifest["version"] == "0.1.1"
+        assert {item["path"] for item in manifest["files"]} >= {
+            "installer/start_local.py",
+            "installer/configure.py",
+            "installer/uninstall.py",
+        }
+
+    installation = _managed_installation(tmp_path)
+    applied = apply_component_update(
+        installation,
+        package,
+        expected_manifest_sha256=result["manifest_sha256"],
+    )
+    assert applied == {
+        "status": "APPLIED",
+        "component": "local_backend",
+        "version": "0.1.1",
+    }
+
+    second = tmp_path / "second.oliviapatch"
+    second_result = build_component_package(
+        source,
+        second,
+        version="0.1.1",
+        expected_source_commit=commit,
+    )
+    assert second_result["package_sha256"] == result["package_sha256"]
+    assert second.read_bytes() == package.read_bytes()
+
+
+def test_rejects_dirty_or_wrong_source_before_writing_outputs(tmp_path: Path) -> None:
+    source, commit = _clean_payload_repo(tmp_path)
+    package = tmp_path / "update.oliviapatch"
+
+    with pytest.raises(ComponentPackageBuildError, match="UPDATE_SOURCE_COMMIT_MISMATCH"):
+        build_component_package(
+            source,
+            package,
+            version="0.1.1",
+            expected_source_commit="0" * 40,
+        )
+    assert not package.exists()
+
+    (source / "local_server.py").write_text("dirty\n", encoding="utf-8")
+    with pytest.raises(ComponentPackageBuildError, match="UPDATE_SOURCE_DIRTY"):
+        build_component_package(
+            source,
+            package,
+            version="0.1.1",
+            expected_source_commit=commit,
+        )
+    assert not package.exists()
+
+
+def test_cli_builds_component_package(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    source, commit = _clean_payload_repo(tmp_path)
+    package = tmp_path / "cli.oliviapatch"
+
+    exit_code = installer_cli.main(
+        [
+            "build-update",
+            "--source",
+            str(source),
+            "--output",
+            str(package),
+            "--version",
+            "0.1.1",
+            "--source-commit",
+            commit,
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "BUILT"
+    assert package.is_file()

--- a/tests/installer/test_component_package_build.py
+++ b/tests/installer/test_component_package_build.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import zipfile
 from pathlib import Path
@@ -171,3 +172,44 @@ def test_cli_builds_component_package(tmp_path: Path, capsys: pytest.CaptureFixt
     assert exit_code == 0
     assert json.loads(capsys.readouterr().out)["status"] == "BUILT"
     assert package.is_file()
+
+
+def test_rejects_an_untracked_nested_tree_as_the_claimed_source(tmp_path: Path) -> None:
+    source, commit = _clean_payload_repo(tmp_path)
+    nested = source / "untracked-export"
+    nested.mkdir()
+    for child in source.iterdir():
+        if child.name in {".git", nested.name}:
+            continue
+        if child.is_dir():
+            shutil.copytree(child, nested / child.name)
+        else:
+            shutil.copy2(child, nested / child.name)
+
+    with pytest.raises(ComponentPackageBuildError, match="UPDATE_SOURCE_NOT_TOPLEVEL"):
+        build_component_package(
+            nested,
+            tmp_path / "nested.oliviapatch",
+            version="0.1.1",
+            expected_source_commit=commit,
+        )
+
+
+def test_packages_git_objects_not_an_assume_unchanged_worktree_file(
+    tmp_path: Path,
+) -> None:
+    source, commit = _clean_payload_repo(tmp_path)
+    committed = (source / "local_server.py").read_bytes()
+    _run_git(source, "update-index", "--assume-unchanged", "local_server.py")
+    (source / "local_server.py").write_text("hidden worktree mutation\n", encoding="utf-8")
+    package = tmp_path / "object-backed.oliviapatch"
+
+    build_component_package(
+        source,
+        package,
+        version="0.1.1",
+        expected_source_commit=commit,
+    )
+
+    with zipfile.ZipFile(package) as archive:
+        assert archive.read("payload/local_server.py") == committed

--- a/tests/installer/test_component_package_build.py
+++ b/tests/installer/test_component_package_build.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import json
 import shutil
+import stat
 import subprocess
 import zipfile
 from pathlib import Path
 
 import pytest
 
+from installer import component_package
 from installer import __main__ as installer_cli
 from installer.component_package import (
     ComponentPackageBuildError,
@@ -213,3 +215,123 @@ def test_packages_git_objects_not_an_assume_unchanged_worktree_file(
 
     with zipfile.ZipFile(package) as archive:
         assert archive.read("payload/local_server.py") == committed
+
+
+@pytest.mark.parametrize("fail_at", [2, 3])
+def test_publish_failure_removes_every_reserved_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fail_at: int,
+) -> None:
+    source, commit = _clean_payload_repo(tmp_path)
+    package = tmp_path / "transaction.oliviapatch"
+    real_replace = component_package.os.replace
+    calls = 0
+
+    def fail_one_replace(source_path: Path, destination_path: Path) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == fail_at:
+            raise PermissionError("synthetic publish failure")
+        real_replace(source_path, destination_path)
+
+    monkeypatch.setattr(component_package.os, "replace", fail_one_replace)
+    with pytest.raises(ComponentPackageBuildError, match="UPDATE_BUILD_FAILED"):
+        build_component_package(
+            source,
+            package,
+            version="0.1.1",
+            expected_source_commit=commit,
+        )
+
+    assert not package.exists()
+    assert not Path(f"{package}.manifest.sha256").exists()
+    assert not Path(f"{package}.sha256").exists()
+    assert not list(tmp_path.glob(".olivia-update-build-*"))
+
+
+@pytest.mark.parametrize("unsafe_name", ["CON.txt", "asset:stream", "name. "])
+def test_commit_archive_rejects_windows_unsafe_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    unsafe_name: str,
+) -> None:
+    malicious = tmp_path / "malicious.zip"
+    with zipfile.ZipFile(malicious, "w") as archive:
+        archive.writestr(unsafe_name, b"unsafe")
+
+    def fake_archive(_command, **kwargs):
+        kwargs["stdout"].write(malicious.read_bytes())
+        return subprocess.CompletedProcess(_command, 0)
+
+    monkeypatch.setattr(component_package.subprocess, "run", fake_archive)
+    with pytest.raises(ComponentPackageBuildError, match="UPDATE_SOURCE_ARCHIVE_UNSAFE"):
+        component_package._export_commit(
+            tmp_path,
+            "a" * 40,
+            tmp_path / "export",
+            tmp_path / "export.zip",
+        )
+
+
+@pytest.mark.parametrize("archive_kind", ["casefold-alias", "symlink"])
+def test_commit_archive_rejects_aliases_and_symlinks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    archive_kind: str,
+) -> None:
+    malicious = tmp_path / "malicious.zip"
+    with zipfile.ZipFile(malicious, "w") as archive:
+        if archive_kind == "casefold-alias":
+            archive.writestr("Model.py", b"one")
+            archive.writestr("model.py", b"two")
+        else:
+            info = zipfile.ZipInfo("link.py")
+            info.external_attr = (stat.S_IFLNK | 0o777) << 16
+            archive.writestr(info, b"target.py")
+
+    def fake_archive(_command, **kwargs):
+        kwargs["stdout"].write(malicious.read_bytes())
+        return subprocess.CompletedProcess(_command, 0)
+
+    monkeypatch.setattr(component_package.subprocess, "run", fake_archive)
+    with pytest.raises(ComponentPackageBuildError, match="UPDATE_SOURCE_ARCHIVE_UNSAFE"):
+        component_package._export_commit(
+            tmp_path,
+            "a" * 40,
+            tmp_path / "export",
+            tmp_path / "export.zip",
+        )
+
+
+def test_cli_returns_stable_json_when_staging_cannot_be_created(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source, commit = _clean_payload_repo(tmp_path)
+    secret_path = str(tmp_path / "private-user-path")
+    monkeypatch.setattr(
+        component_package.tempfile,
+        "mkdtemp",
+        lambda **_kwargs: (_ for _ in ()).throw(PermissionError(secret_path)),
+    )
+
+    exit_code = installer_cli.main(
+        [
+            "build-update",
+            "--source",
+            str(source),
+            "--output",
+            str(tmp_path / "failure.oliviapatch"),
+            "--version",
+            "0.1.1",
+            "--source-commit",
+            commit,
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 2
+    assert json.loads(output) == {"status": "ERROR", "code": "UPDATE_BUILD_FAILED"}
+    assert secret_path not in output


### PR DESCRIPTION
## Summary

- add a production `build-update` command for deterministic `.oliviapatch` packages
- require an exact clean Git source commit before packaging the complete managed backend payload
- emit independent manifest and whole-package SHA-256 sidecars for client update/release use
- document the maintainer command

## Verification

- `python -m pytest -q tests/installer/test_component_package_build.py tests/installer/test_component_update.py tests/installer/test_windows_full_patch.py`
- 73 passed, 1 skipped
- `git diff --check`

No full local suite was run.