### PR TITLE
fix: keep memory Chinese and finish official import

### DIFF
--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -475,6 +475,10 @@ def _configure_memory_environment(
         "OLIVIA_MEMORY_LLM_DEFAULT_API_KEY_ENV",
         environment.get("OLIVIA_LLM_API_KEY_ENV", "DEEPSEEK_API_KEY"),
     )
+    environment.setdefault(
+        "OLIVIA_MEMORY_WRITE_TIMEOUT_SECONDS",
+        environment.get("OLIVIA_LLM_TIMEOUT_SECONDS", "180"),
+    )
     environment.update(
         {
             "HF_HUB_DISABLE_TELEMETRY": "1",

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import os
 from pathlib import Path
 import re
@@ -450,6 +451,16 @@ def _memory_enabled(value: object) -> str:
     return "0" if normalized in {"0", "false", "no", "off"} else "1"
 
 
+def _memory_write_timeout(environment: dict[str, str]) -> str:
+    try:
+        value = float(environment.get("OLIVIA_LLM_TIMEOUT_SECONDS", "180"))
+    except (TypeError, ValueError):
+        value = 180.0
+    if not math.isfinite(value):
+        value = 180.0
+    return format(min(300.0, max(0.1, value)), "g")
+
+
 def _configure_memory_environment(
     environment: dict[str, str],
     data_root: Path,
@@ -477,7 +488,7 @@ def _configure_memory_environment(
     )
     environment.setdefault(
         "OLIVIA_MEMORY_WRITE_TIMEOUT_SECONDS",
-        environment.get("OLIVIA_LLM_TIMEOUT_SECONDS", "180"),
+        _memory_write_timeout(environment),
     )
     environment.update(
         {

--- a/local_server.py
+++ b/local_server.py
@@ -828,8 +828,14 @@ def _official_history_private_world_available() -> bool:
 
 async def _migrate_official_history(
     payload: Mapping[str, object],
+    *,
+    skip_source_record_ids: frozenset[str] = frozenset(),
 ) -> HistoricalMigrationResult:
-    exchanges = exchanges_from_legacy_payload(payload)
+    exchanges = tuple(
+        exchange
+        for exchange in exchanges_from_legacy_payload(payload)
+        if exchange.source_record_id not in skip_source_record_ids
+    )
     result = await asyncio.to_thread(
         migrate_historical_exchanges,
         exchanges,
@@ -1756,6 +1762,37 @@ def _legacy_import_adapter() -> MemoryPort:
     return adapter
 
 
+def _existing_legacy_source_record_ids() -> frozenset[str] | None:
+    if not getattr(memory_adapter, "enabled", False):
+        return frozenset()
+    try:
+        list_legacy = getattr(memory_adapter, "list_legacy", None)
+        if callable(list_legacy):
+            records = list_legacy()
+        else:
+            exported = memory_adapter.export_records(domains=("legacy",))
+            records = exported.get("legacy")
+    except Exception:
+        return None
+    if not isinstance(records, list):
+        return None
+    source_ids: set[str] = set()
+    for record in records:
+        if not isinstance(record, Mapping):
+            return None
+        source_id = record.get("source_record_id")
+        if not isinstance(source_id, str) or not source_id:
+            return None
+        metadata = record.get("metadata")
+        if (
+            isinstance(metadata, Mapping)
+            and metadata.get(OFFICIAL_HISTORY_PUBLISH_STATUS_KEY)
+            == OFFICIAL_HISTORY_PUBLISH_STATUS_COMPLETED
+        ):
+            source_ids.add(source_id)
+    return frozenset(source_ids)
+
+
 def _legacy_records(body: dict) -> list[LegacyLetter] | None:
     if body.get("mode") != "read_only":
         return None
@@ -2233,7 +2270,21 @@ async def route(
             })
         migration = None
         if official_import:
-            migration = await _migrate_official_history(body)
+            existing_source_ids = _existing_legacy_source_record_ids()
+            if existing_source_ids is None:
+                return err(503, "MEMORY_UNAVAILABLE", {
+                    "status": "UNAVAILABLE",
+                    "error_code": "MEMORY_UNAVAILABLE",
+                    "retryable": True,
+                })
+            migration = (
+                await _migrate_official_history(
+                    body,
+                    skip_source_record_ids=existing_source_ids,
+                )
+                if existing_source_ids
+                else await _migrate_official_history(body)
+            )
             if migration.status != "completed":
                 error_code = (
                     "PRIVATE_WORLD_HISTORY_UNAVAILABLE"

--- a/local_server.py
+++ b/local_server.py
@@ -2244,6 +2244,7 @@ async def route(
                     "status": "UNAVAILABLE",
                     "error_code": error_code,
                     "retryable": True,
+                    "migration": migration.to_dict(),
                 })
             records = [
                 replace(

--- a/mem0_memory.py
+++ b/mem0_memory.py
@@ -678,6 +678,12 @@ class Mem0ConversationMemoryAdapter:
         *,
         failure_code: str,
     ) -> object | None:
+        pending_state, _pending_value = self._provider_call.settle(
+            timeout_seconds=self.config.search_timeout_seconds,
+        )
+        if pending_state == "timeout":
+            self._last_error_code = "MEM0_SEARCH_TIMEOUT"
+            return None
         state, value = self._provider_call.call(
             lambda: self._locked_provider_call(operation),
             timeout_seconds=self.config.search_timeout_seconds,
@@ -694,13 +700,13 @@ class Mem0ConversationMemoryAdapter:
         with self._lock:
             return operation()
 
-    def _source_id_exists_in_exact_response(
+    def _source_id_records_in_exact_response(
         self,
         value: object,
         *,
         user_id: str,
         source_id: str,
-    ) -> bool | None:
+    ) -> tuple[ConversationMemoryRecord, ...] | None:
         rows = self._exact_source_id_rows(value)
         if rows is None:
             return None
@@ -723,7 +729,20 @@ class Mem0ConversationMemoryAdapter:
         if any(record is None or record.source_id != source_id for record in records):
             return None
         self._last_error_code = None
-        return bool(records)
+        return tuple(record for record in records if record is not None)
+
+    def _delete_provider_memories(
+        self,
+        memory_ids: Sequence[str],
+    ) -> tuple[str, ...]:
+        pending: list[str] = []
+        for memory_id in memory_ids:
+            try:
+                if not _has_delete_acknowledgement(self.backend.delete(memory_id)):
+                    pending.append(memory_id)
+            except Exception:
+                pending.append(memory_id)
+        return tuple(pending)
 
     def _exact_source_id_rows(
         self,
@@ -776,7 +795,7 @@ class Mem0ConversationMemoryAdapter:
             try:
                 exact_response = self.backend.get_all(
                     filters={**self._provider_filters(alias), "source_id": source_id},
-                    top_k=1,
+                    top_k=64,
                 )
             except Exception:
                 return MemoryWriteResult(
@@ -784,18 +803,32 @@ class Mem0ConversationMemoryAdapter:
                     source_id,
                     error_code="MEM0_SOURCE_DEDUP_UNAVAILABLE",
                 )
-            source_exists = self._source_id_exists_in_exact_response(
+            source_records = self._source_id_records_in_exact_response(
                 exact_response,
                 user_id=alias,
                 source_id=source_id,
             )
-            if source_exists is None:
+            if source_records is None:
                 return MemoryWriteResult(
                     MemoryWriteStatus.UNAVAILABLE,
                     source_id,
                     error_code="MEM0_SOURCE_DEDUP_UNAVAILABLE",
                 )
-            if source_exists:
+            if source_records and _CJK_RE.search(
+                f"{user_message}\n{assistant_message}"
+            ) and any(_CJK_RE.search(record.text) is None for record in source_records):
+                pending_ids = self._delete_provider_memories(
+                    tuple(record.memory_id for record in source_records)
+                )
+                if pending_ids:
+                    return MemoryWriteResult(
+                        MemoryWriteStatus.UNAVAILABLE,
+                        source_id,
+                        pending_ids,
+                        error_code="MEM0_LANGUAGE_MISMATCH_ROLLBACK_FAILED",
+                    )
+                continue
+            if source_records:
                 return MemoryWriteResult(MemoryWriteStatus.DUPLICATE, source_id)
         metadata = {
             "source_id": source_id,
@@ -829,19 +862,16 @@ class Mem0ConversationMemoryAdapter:
         if _CJK_RE.search(f"{user_message}\n{assistant_message}") and any(
             _CJK_RE.search(memory) is None for _memory_id, memory in acknowledgements
         ):
-            cleanup_failed = False
-            for memory_id, _memory in acknowledgements:
-                try:
-                    if not _has_delete_acknowledgement(self.backend.delete(memory_id)):
-                        cleanup_failed = True
-                except Exception:
-                    cleanup_failed = True
+            pending_ids = self._delete_provider_memories(
+                tuple(memory_id for memory_id, _memory in acknowledgements)
+            )
             return MemoryWriteResult(
                 MemoryWriteStatus.UNAVAILABLE,
                 source_id,
+                pending_ids,
                 error_code=(
                     "MEM0_LANGUAGE_MISMATCH_ROLLBACK_FAILED"
-                    if cleanup_failed
+                    if pending_ids
                     else "MEM0_LANGUAGE_MISMATCH"
                 ),
             )
@@ -924,7 +954,6 @@ class Mem0ConversationMemoryAdapter:
                 source_id,
                 error_code="MEM0_EXCHANGE_INVALID",
             )
-        deadline = time.monotonic() + self.config.write_timeout_seconds
         if not self._write_gate.acquire(timeout=self.config.write_timeout_seconds):
             return MemoryWriteResult(
                 MemoryWriteStatus.UNAVAILABLE,
@@ -932,62 +961,19 @@ class Mem0ConversationMemoryAdapter:
                 error_code="MEM0_WRITE_UNCERTAIN",
             )
         try:
-            while self._write_call.inflight:
-                if time.monotonic() >= deadline:
-                    return MemoryWriteResult(
-                        MemoryWriteStatus.UNAVAILABLE,
-                        source_id,
-                        error_code="MEM0_WRITE_UNCERTAIN",
-                    )
-                time.sleep(0.01)
-            memory_ids: list[str] = []
-            for alias in self._configured_user_aliases(user_id):
-                try:
-                    value = self._locked_provider_call(
-                        lambda alias=alias: self.backend.get_all(
-                            filters={
-                                **self._provider_filters(alias),
-                                "source_id": source_id,
-                            },
-                            top_k=64,
-                        )
-                    )
-                except Exception:
-                    return MemoryWriteResult(
-                        MemoryWriteStatus.UNAVAILABLE,
-                        source_id,
-                        error_code="MEM0_WRITE_UNCERTAIN",
-                    )
-                rows = self._exact_source_id_rows(value)
-                if rows is None:
-                    return MemoryWriteResult(
-                        MemoryWriteStatus.UNAVAILABLE,
-                        source_id,
-                        error_code="MEM0_WRITE_UNCERTAIN",
-                    )
-                for row in rows:
-                    record = _row_to_record(
-                        row,
-                        user_id=alias,
-                        agent_id=self.config.agent_id,
-                    )
-                    if record is None or record.source_id != source_id:
-                        return MemoryWriteResult(
-                            MemoryWriteStatus.UNAVAILABLE,
-                            source_id,
-                            error_code="MEM0_WRITE_UNCERTAIN",
-                        )
-                    memory_ids.append(record.memory_id)
-            if not memory_ids:
-                return MemoryWriteResult(
-                    MemoryWriteStatus.UNAVAILABLE,
-                    source_id,
-                    error_code="MEM0_WRITE_FAILED",
-                )
+            state, value = self._write_call.settle()
+            if (
+                state == "completed"
+                and isinstance(value, MemoryWriteResult)
+                and value.source_id == source_id
+            ):
+                self._last_error_code = value.error_code
+                return value
+            self._last_error_code = "MEM0_WRITE_UNCERTAIN"
             return MemoryWriteResult(
-                MemoryWriteStatus.WRITTEN,
+                MemoryWriteStatus.UNAVAILABLE,
                 source_id,
-                tuple(dict.fromkeys(memory_ids)),
+                error_code="MEM0_WRITE_UNCERTAIN",
             )
         finally:
             self._write_gate.release()

--- a/mem0_memory.py
+++ b/mem0_memory.py
@@ -59,6 +59,11 @@ _EMBEDDING_SNAPSHOT_FILES = frozenset(
 )
 _DOMAIN = "conversation_memory"
 _ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
+_MEMORY_LANGUAGE_INSTRUCTIONS = (
+    "使用与输入消息相同的语言和文字提取长期记忆；"
+    "不得把中文内容翻译成英文；保留原文中的人名、专有名词和称呼；"
+    "用简洁、自然、适合普通用户阅读的句子记录事实。"
+)
 
 
 class Mem0AdapterError(RuntimeError):
@@ -208,6 +213,7 @@ class Mem0Config:
     ) -> dict[str, object]:
         environment = environ if environ is not None else os.environ
         return {
+            "custom_instructions": _MEMORY_LANGUAGE_INSTRUCTIONS,
             "vector_store": {
                 "provider": "qdrant",
                 "config": {

--- a/mem0_memory.py
+++ b/mem0_memory.py
@@ -59,6 +59,7 @@ _EMBEDDING_SNAPSHOT_FILES = frozenset(
 )
 _DOMAIN = "conversation_memory"
 _ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
+_CJK_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]")
 _MEMORY_LANGUAGE_INSTRUCTIONS = (
     "使用与输入消息相同的语言和文字提取长期记忆；"
     "不得把中文内容翻译成英文；保留原文中的人名、专有名词和称呼；"
@@ -825,6 +826,25 @@ class Mem0ConversationMemoryAdapter:
                 source_id,
                 error_code="MEM0_WRITE_FAILED",
             )
+        if _CJK_RE.search(f"{user_message}\n{assistant_message}") and any(
+            _CJK_RE.search(memory) is None for _memory_id, memory in acknowledgements
+        ):
+            cleanup_failed = False
+            for memory_id, _memory in acknowledgements:
+                try:
+                    if not _has_delete_acknowledgement(self.backend.delete(memory_id)):
+                        cleanup_failed = True
+                except Exception:
+                    cleanup_failed = True
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                source_id,
+                error_code=(
+                    "MEM0_LANGUAGE_MISMATCH_ROLLBACK_FAILED"
+                    if cleanup_failed
+                    else "MEM0_LANGUAGE_MISMATCH"
+                ),
+            )
         memory_ids = tuple(memory_id for memory_id, _memory in acknowledgements)
         return MemoryWriteResult(
             MemoryWriteStatus.WRITTEN if memory_ids else MemoryWriteStatus.SKIPPED,
@@ -887,6 +907,90 @@ class Mem0ConversationMemoryAdapter:
             )
         self._last_error_code = value.error_code
         return value
+
+    def settle_exchange_write(
+        self,
+        *,
+        source_id: str,
+        user_id: str,
+    ) -> MemoryWriteResult:
+        """Resolve a timed-out exchange write by its stable source id."""
+
+        try:
+            user_id = self._normalized_user_id(user_id)
+        except Mem0AdapterError:
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                source_id,
+                error_code="MEM0_EXCHANGE_INVALID",
+            )
+        deadline = time.monotonic() + self.config.write_timeout_seconds
+        if not self._write_gate.acquire(timeout=self.config.write_timeout_seconds):
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                source_id,
+                error_code="MEM0_WRITE_UNCERTAIN",
+            )
+        try:
+            while self._write_call.inflight:
+                if time.monotonic() >= deadline:
+                    return MemoryWriteResult(
+                        MemoryWriteStatus.UNAVAILABLE,
+                        source_id,
+                        error_code="MEM0_WRITE_UNCERTAIN",
+                    )
+                time.sleep(0.01)
+            memory_ids: list[str] = []
+            for alias in self._configured_user_aliases(user_id):
+                try:
+                    value = self._locked_provider_call(
+                        lambda alias=alias: self.backend.get_all(
+                            filters={
+                                **self._provider_filters(alias),
+                                "source_id": source_id,
+                            },
+                            top_k=64,
+                        )
+                    )
+                except Exception:
+                    return MemoryWriteResult(
+                        MemoryWriteStatus.UNAVAILABLE,
+                        source_id,
+                        error_code="MEM0_WRITE_UNCERTAIN",
+                    )
+                rows = self._exact_source_id_rows(value)
+                if rows is None:
+                    return MemoryWriteResult(
+                        MemoryWriteStatus.UNAVAILABLE,
+                        source_id,
+                        error_code="MEM0_WRITE_UNCERTAIN",
+                    )
+                for row in rows:
+                    record = _row_to_record(
+                        row,
+                        user_id=alias,
+                        agent_id=self.config.agent_id,
+                    )
+                    if record is None or record.source_id != source_id:
+                        return MemoryWriteResult(
+                            MemoryWriteStatus.UNAVAILABLE,
+                            source_id,
+                            error_code="MEM0_WRITE_UNCERTAIN",
+                        )
+                    memory_ids.append(record.memory_id)
+            if not memory_ids:
+                return MemoryWriteResult(
+                    MemoryWriteStatus.UNAVAILABLE,
+                    source_id,
+                    error_code="MEM0_WRITE_FAILED",
+                )
+            return MemoryWriteResult(
+                MemoryWriteStatus.WRITTEN,
+                source_id,
+                tuple(dict.fromkeys(memory_ids)),
+            )
+        finally:
+            self._write_gate.release()
 
     def add_manual_memory(
         self,

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -716,11 +716,11 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
 
     const heading = text("h3", "长期记忆（Mem0 + BGE）", "text-text-title text-title-m");
     const paused = capability && capability.reason_code === "MEMORY_ADMIN_PAUSED";
-    const summary = text(
-      "p",
-      `状态：${paused ? "已暂停（不检索、不写入）" : stateLabels[state]}${Number.isInteger(capability.count) ? `，共 ${capability.count} 条` : ""}`,
-      "text-text-secondary text-body-m font-regular"
-    );
+    const summary = text("p", "", "text-text-secondary text-body-m font-regular");
+    const updateSummary = (count) => {
+      summary.textContent = `状态：${paused ? "已暂停（不检索、不写入）" : stateLabels[state]}${Number.isInteger(count) ? `，共 ${count} 条` : ""}`;
+    };
+    updateSummary(capability.count);
     const controls = document.createElement("div");
     controls.style.display = "flex";
     controls.style.gap = "10px";
@@ -750,6 +750,14 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
           limit: 50,
         });
         renderMemories(list, payload.memories, load, resultState);
+        if (!input.value.trim()) {
+          const latestStatus = await requestJson(STATUS_PATH);
+          const latestCapabilities = latestStatus.capabilities && typeof latestStatus.capabilities === "object"
+            ? latestStatus.capabilities
+            : {};
+          const latestMemory = latestCapabilities.memory;
+          updateSummary(latestMemory && latestMemory.count);
+        }
         resultState.textContent = input.value.trim()
           ? `搜索结果：${Array.isArray(payload.memories) ? payload.memories.length : 0} 条`
           : "已读取本机长期记忆。";

--- a/runtime/imports/historical_memory.py
+++ b/runtime/imports/historical_memory.py
@@ -330,6 +330,7 @@ def migrate_historical_exchanges(
         raise ValueError("historical source ids must be unique")
 
     written = duplicates = skipped = processed = 0
+    created_memory_ids: list[str] = []
     for exchange in ordered:
         try:
             result = memory.remember_exchange(
@@ -348,26 +349,41 @@ def migrate_historical_exchanges(
         if not isinstance(result, MemoryWriteResult):
             return _partial(ordered, processed, written, duplicates, skipped, "MEM0_WRITE_RESULT_INVALID")
         if result.status is MemoryWriteStatus.UNAVAILABLE:
+            failure_code = result.error_code or "MEM0_WRITE_FAILED"
+            if require_persisted:
+                failure_code = _rollback_created_memories(
+                    memory,
+                    created_memory_ids,
+                    user_id=normalized_user_id,
+                    failure_code=failure_code,
+                )
             return _partial(
                 ordered,
                 processed,
                 written,
                 duplicates,
                 skipped,
-                result.error_code or "MEM0_WRITE_FAILED",
+                failure_code,
             )
         if require_persisted and result.status is MemoryWriteStatus.SKIPPED:
+            failure_code = _rollback_created_memories(
+                memory,
+                created_memory_ids,
+                user_id=normalized_user_id,
+                failure_code="MEM0_WRITE_SKIPPED",
+            )
             return _partial(
                 ordered,
                 processed,
                 written,
                 duplicates,
                 skipped,
-                "MEM0_WRITE_SKIPPED",
+                failure_code,
             )
         processed += 1
         if result.status is MemoryWriteStatus.WRITTEN:
             written += 1
+            created_memory_ids.extend(result.memory_ids)
         elif result.status is MemoryWriteStatus.DUPLICATE:
             duplicates += 1
         else:
@@ -406,6 +422,22 @@ def migrate_historical_exchanges(
         skipped,
         private_world_status=private_world_status,
     )
+
+
+def _rollback_created_memories(
+    memory: ConversationMemoryPort,
+    memory_ids: Iterable[str],
+    *,
+    user_id: str,
+    failure_code: str,
+) -> str:
+    try:
+        for memory_id in reversed(tuple(memory_ids)):
+            if memory.delete_memory(memory_id, user_id=user_id) is not True:
+                return "MEM0_ROLLBACK_FAILED"
+    except Exception:
+        return "MEM0_ROLLBACK_FAILED"
+    return failure_code
 
 
 def _partial(

--- a/runtime/imports/historical_memory.py
+++ b/runtime/imports/historical_memory.py
@@ -390,6 +390,11 @@ def migrate_historical_exchanges(
         if result.status is MemoryWriteStatus.UNAVAILABLE:
             failure_code = result.error_code or "MEM0_WRITE_FAILED"
             if require_persisted:
+                created_memory_ids.extend(
+                    memory_id
+                    for memory_id in result.memory_ids
+                    if memory_id not in created_memory_ids
+                )
                 failure_code = _rollback_created_memories(
                     memory,
                     created_memory_ids,

--- a/runtime/imports/historical_memory.py
+++ b/runtime/imports/historical_memory.py
@@ -409,21 +409,6 @@ def migrate_historical_exchanges(
                 skipped,
                 failure_code,
             )
-        if require_persisted and result.status is MemoryWriteStatus.SKIPPED:
-            failure_code = _rollback_created_memories(
-                memory,
-                created_memory_ids,
-                user_id=normalized_user_id,
-                failure_code="MEM0_WRITE_SKIPPED",
-            )
-            return _partial(
-                ordered,
-                processed,
-                written,
-                duplicates,
-                skipped,
-                failure_code,
-            )
         processed += 1
         if result.status is MemoryWriteStatus.WRITTEN:
             written += 1

--- a/runtime/imports/historical_memory.py
+++ b/runtime/imports/historical_memory.py
@@ -347,7 +347,46 @@ def migrate_historical_exchanges(
                 error_code="MEM0_WRITE_FAILED",
             )
         if not isinstance(result, MemoryWriteResult):
-            return _partial(ordered, processed, written, duplicates, skipped, "MEM0_WRITE_RESULT_INVALID")
+            failure_code = "MEM0_WRITE_RESULT_INVALID"
+            if require_persisted:
+                failure_code = _rollback_created_memories(
+                    memory,
+                    created_memory_ids,
+                    user_id=normalized_user_id,
+                    failure_code=failure_code,
+                )
+            return _partial(
+                ordered,
+                processed,
+                written,
+                duplicates,
+                skipped,
+                failure_code,
+            )
+        if (
+            require_persisted
+            and result.status is MemoryWriteStatus.UNAVAILABLE
+            and result.error_code == "MEM0_WRITE_TIMEOUT"
+        ):
+            settle_exchange_write = getattr(memory, "settle_exchange_write", None)
+            if callable(settle_exchange_write):
+                try:
+                    settled = settle_exchange_write(
+                        source_id=exchange.memory_source_id,
+                        user_id=normalized_user_id,
+                    )
+                except Exception:
+                    settled = None
+                result = (
+                    settled
+                    if isinstance(settled, MemoryWriteResult)
+                    and settled.source_id == exchange.memory_source_id
+                    else MemoryWriteResult(
+                        MemoryWriteStatus.UNAVAILABLE,
+                        exchange.memory_source_id,
+                        error_code="MEM0_WRITE_UNCERTAIN",
+                    )
+                )
         if result.status is MemoryWriteStatus.UNAVAILABLE:
             failure_code = result.error_code or "MEM0_WRITE_FAILED"
             if require_persisted:
@@ -431,13 +470,14 @@ def _rollback_created_memories(
     user_id: str,
     failure_code: str,
 ) -> str:
-    try:
-        for memory_id in reversed(tuple(memory_ids)):
+    cleanup_failed = False
+    for memory_id in reversed(tuple(memory_ids)):
+        try:
             if memory.delete_memory(memory_id, user_id=user_id) is not True:
-                return "MEM0_ROLLBACK_FAILED"
-    except Exception:
-        return "MEM0_ROLLBACK_FAILED"
-    return failure_code
+                cleanup_failed = True
+        except Exception:
+            cleanup_failed = True
+    return "MEM0_ROLLBACK_FAILED" if cleanup_failed else failure_code
 
 
 def _partial(

--- a/runtime/memory/bounded_daemon_call.py
+++ b/runtime/memory/bounded_daemon_call.py
@@ -31,6 +31,7 @@ class BoundedDaemonCall:
         self._thread_name = thread_name
         self._lock = threading.Lock()
         self._inflight = False
+        self._pending: tuple[threading.Event, dict[str, object]] | None = None
 
     @property
     def inflight(self) -> bool:
@@ -48,7 +49,11 @@ class BoundedDaemonCall:
         if pending is None:
             return "inflight", None
         done, outcome = pending
-        return self._result(outcome) if done.wait(timeout_seconds) else ("timeout", None)
+        if not done.wait(timeout_seconds):
+            return "timeout", None
+        result = self._result(outcome)
+        self._consume(pending)
+        return result
 
     async def call_async(
         self,
@@ -67,17 +72,41 @@ class BoundedDaemonCall:
             if remaining <= 0:
                 return "timeout", None
             await asyncio.sleep(min(0.01, remaining))
-        return self._result(outcome)
+        result = self._result(outcome)
+        self._consume(pending)
+        return result
+
+    def settle(
+        self,
+        *,
+        timeout_seconds: float | None = None,
+    ) -> tuple[str, object | None]:
+        """Wait for and consume the exact result of a previously timed-out call."""
+
+        if timeout_seconds is not None:
+            timeout_seconds = validate_timeout_seconds(timeout_seconds)
+        with self._lock:
+            pending = self._pending
+        if pending is None:
+            return "missing", None
+        done, outcome = pending
+        if not done.wait(timeout_seconds):
+            return "timeout", None
+        result = self._result(outcome)
+        self._consume(pending)
+        return result
 
     def _start(
         self,
         operation: Callable[[], object],
     ) -> tuple[threading.Event, dict[str, object]] | None:
         with self._lock:
-            if self._inflight:
+            if self._inflight or self._pending is not None:
                 return None
             self._inflight = True
-        done, outcome = threading.Event(), {}
+            done, outcome = threading.Event(), {}
+            pending = done, outcome
+            self._pending = pending
 
         def run() -> None:
             try:
@@ -90,7 +119,15 @@ class BoundedDaemonCall:
                 done.set()
 
         threading.Thread(target=run, name=self._thread_name, daemon=True).start()
-        return done, outcome
+        return pending
+
+    def _consume(
+        self,
+        pending: tuple[threading.Event, dict[str, object]],
+    ) -> None:
+        with self._lock:
+            if self._pending is pending:
+                self._pending = None
 
     @staticmethod
     def _result(outcome: dict[str, object]) -> tuple[str, object | None]:

--- a/tests/imports/test_historical_memory.py
+++ b/tests/imports/test_historical_memory.py
@@ -113,21 +113,23 @@ def test_migration_stops_at_first_failed_write_and_does_not_finalize() -> None:
     assert result.error_code == "MEM0_WRITE_FAILED"
 
 
-def test_official_history_strict_migration_rejects_skipped_memory_write() -> None:
-    memory = RecordingMemory([MemoryWriteStatus.SKIPPED])
+def test_official_history_strict_migration_accepts_uninformative_skips() -> None:
+    memory = RecordingMemory(
+        [MemoryWriteStatus.SKIPPED, MemoryWriteStatus.WRITTEN]
+    )
 
     result = migrate_historical_exchanges(
-        (_exchange("first", 10),),
+        (_exchange("first", 10), _exchange("second", 20)),
         memory=memory,
         user_id="local-user",
         require_persisted=True,
     )
 
-    assert result.status == "partial"
-    assert result.processed == 0
-    assert result.written == 0
-    assert result.skipped == 0
-    assert result.error_code == "MEM0_WRITE_SKIPPED"
+    assert result.status == "completed"
+    assert result.processed == 2
+    assert result.written == 1
+    assert result.skipped == 1
+    assert result.error_code is None
 
 
 def test_official_history_strict_migration_rolls_back_new_writes_on_failure() -> None:

--- a/tests/imports/test_historical_memory.py
+++ b/tests/imports/test_historical_memory.py
@@ -24,6 +24,7 @@ class RecordingMemory:
     def __init__(self, statuses: list[MemoryWriteStatus]) -> None:
         self.statuses = list(statuses)
         self.events: list[tuple[str, str]] = []
+        self.deleted: list[str] = []
 
     def remember_exchange(self, **kwargs: object) -> MemoryWriteResult:
         source_id = str(kwargs["source_id"])
@@ -42,6 +43,11 @@ class RecordingMemory:
 
     def status(self):
         return type("Status", (), {"status": "available"})()
+
+    def delete_memory(self, memory_id: str, *, user_id: str) -> bool:
+        assert user_id == "local-user"
+        self.deleted.append(memory_id)
+        return True
 
 
 def _exchange(name: str, timestamp: int) -> HistoricalExchange:
@@ -122,6 +128,23 @@ def test_official_history_strict_migration_rejects_skipped_memory_write() -> Non
     assert result.written == 0
     assert result.skipped == 0
     assert result.error_code == "MEM0_WRITE_SKIPPED"
+
+
+def test_official_history_strict_migration_rolls_back_new_writes_on_failure() -> None:
+    memory = RecordingMemory(
+        [MemoryWriteStatus.WRITTEN, MemoryWriteStatus.UNAVAILABLE]
+    )
+
+    result = migrate_historical_exchanges(
+        (_exchange("first", 10), _exchange("second", 20)),
+        memory=memory,
+        user_id="local-user",
+        require_persisted=True,
+    )
+
+    assert result.status == "partial"
+    assert result.error_code == "MEM0_WRITE_FAILED"
+    assert memory.deleted == ["memory.1"]
 
 
 def test_migration_uses_stable_source_ids_so_a_retry_can_resume_by_deduplication() -> None:

--- a/tests/imports/test_historical_memory.py
+++ b/tests/imports/test_historical_memory.py
@@ -181,6 +181,42 @@ def test_official_history_strict_migration_reconciles_a_timed_out_write() -> Non
     assert memory.deleted == []
 
 
+def test_official_history_does_not_rollback_a_timed_out_duplicate() -> None:
+    class TimedOutDuplicateMemory(RecordingMemory):
+        def remember_exchange(self, **kwargs: object) -> MemoryWriteResult:
+            self.events.append(("write", str(kwargs["user_message"])))
+            if len(self.events) == 1:
+                return MemoryWriteResult(
+                    MemoryWriteStatus.UNAVAILABLE,
+                    str(kwargs["source_id"]),
+                    error_code="MEM0_WRITE_TIMEOUT",
+                )
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                str(kwargs["source_id"]),
+                error_code="MEM0_WRITE_FAILED",
+            )
+
+        def settle_exchange_write(self, **kwargs: object) -> MemoryWriteResult:
+            return MemoryWriteResult(
+                MemoryWriteStatus.DUPLICATE,
+                str(kwargs["source_id"]),
+            )
+
+    memory = TimedOutDuplicateMemory([])
+
+    result = migrate_historical_exchanges(
+        (_exchange("first", 10), _exchange("second", 20)),
+        memory=memory,
+        user_id="local-user",
+        require_persisted=True,
+    )
+
+    assert result.status == "partial"
+    assert result.duplicates == 1
+    assert memory.deleted == []
+
+
 def test_official_history_strict_migration_rolls_back_after_invalid_result() -> None:
     class InvalidSecondResultMemory(RecordingMemory):
         def remember_exchange(self, **kwargs: object):
@@ -226,6 +262,30 @@ def test_official_history_rollback_attempts_every_new_memory_id() -> None:
 
     assert result.error_code == "MEM0_ROLLBACK_FAILED"
     assert memory.deleted == ["memory.2", "memory.1"]
+
+
+def test_official_history_rolls_back_pending_ids_from_failed_current_write() -> None:
+    class PendingMismatchMemory(RecordingMemory):
+        def remember_exchange(self, **kwargs: object) -> MemoryWriteResult:
+            self.events.append(("write", str(kwargs["user_message"])))
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE,
+                str(kwargs["source_id"]),
+                ("memory.pending",),
+                "MEM0_LANGUAGE_MISMATCH_ROLLBACK_FAILED",
+            )
+
+    memory = PendingMismatchMemory([])
+
+    result = migrate_historical_exchanges(
+        (_exchange("first", 10),),
+        memory=memory,
+        user_id="local-user",
+        require_persisted=True,
+    )
+
+    assert result.status == "partial"
+    assert memory.deleted == ["memory.pending"]
 
 
 def test_migration_uses_stable_source_ids_so_a_retry_can_resume_by_deduplication() -> None:

--- a/tests/imports/test_historical_memory.py
+++ b/tests/imports/test_historical_memory.py
@@ -147,6 +147,87 @@ def test_official_history_strict_migration_rolls_back_new_writes_on_failure() ->
     assert memory.deleted == ["memory.1"]
 
 
+def test_official_history_strict_migration_reconciles_a_timed_out_write() -> None:
+    class TimedOutThenSettledMemory(RecordingMemory):
+        def remember_exchange(self, **kwargs: object) -> MemoryWriteResult:
+            if len(self.events) == 1:
+                self.events.append(("write", str(kwargs["user_message"])))
+                return MemoryWriteResult(
+                    MemoryWriteStatus.UNAVAILABLE,
+                    str(kwargs["source_id"]),
+                    error_code="MEM0_WRITE_TIMEOUT",
+                )
+            return super().remember_exchange(**kwargs)
+
+        def settle_exchange_write(self, **kwargs: object) -> MemoryWriteResult:
+            return MemoryWriteResult(
+                MemoryWriteStatus.WRITTEN,
+                str(kwargs["source_id"]),
+                ("memory.late",),
+            )
+
+    memory = TimedOutThenSettledMemory([MemoryWriteStatus.WRITTEN])
+
+    result = migrate_historical_exchanges(
+        (_exchange("first", 10), _exchange("second", 20)),
+        memory=memory,
+        user_id="local-user",
+        require_persisted=True,
+    )
+
+    assert result.status == "completed"
+    assert result.processed == 2
+    assert result.written == 2
+    assert memory.deleted == []
+
+
+def test_official_history_strict_migration_rolls_back_after_invalid_result() -> None:
+    class InvalidSecondResultMemory(RecordingMemory):
+        def remember_exchange(self, **kwargs: object):
+            if len(self.events) == 1:
+                self.events.append(("write", str(kwargs["user_message"])))
+                return object()
+            return super().remember_exchange(**kwargs)
+
+    memory = InvalidSecondResultMemory([MemoryWriteStatus.WRITTEN])
+
+    result = migrate_historical_exchanges(
+        (_exchange("first", 10), _exchange("second", 20)),
+        memory=memory,
+        user_id="local-user",
+        require_persisted=True,
+    )
+
+    assert result.status == "partial"
+    assert result.error_code == "MEM0_WRITE_RESULT_INVALID"
+    assert memory.deleted == ["memory.1"]
+
+
+def test_official_history_rollback_attempts_every_new_memory_id() -> None:
+    class PartlyFailingDeleteMemory(RecordingMemory):
+        def delete_memory(self, memory_id: str, *, user_id: str) -> bool:
+            super().delete_memory(memory_id, user_id=user_id)
+            return memory_id != "memory.2"
+
+    memory = PartlyFailingDeleteMemory(
+        [
+            MemoryWriteStatus.WRITTEN,
+            MemoryWriteStatus.WRITTEN,
+            MemoryWriteStatus.UNAVAILABLE,
+        ]
+    )
+
+    result = migrate_historical_exchanges(
+        (_exchange("first", 10), _exchange("second", 20), _exchange("third", 30)),
+        memory=memory,
+        user_id="local-user",
+        require_persisted=True,
+    )
+
+    assert result.error_code == "MEM0_ROLLBACK_FAILED"
+    assert memory.deleted == ["memory.2", "memory.1"]
+
+
 def test_migration_uses_stable_source_ids_so_a_retry_can_resume_by_deduplication() -> None:
     exchange = _exchange("same", 10)
     first = RecordingMemory([MemoryWriteStatus.WRITTEN])

--- a/tests/imports/test_official_letters.py
+++ b/tests/imports/test_official_letters.py
@@ -639,6 +639,103 @@ def test_official_import_persists_memory_before_publishing_read_only_mailbox(
     assert detail["data"]["scope"] == "legacy"
 
 
+def test_official_duplicate_does_not_retry_a_previously_skipped_memory(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import local_server
+
+    class SkipThenWriteMemory:
+        enabled = True
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def status(self) -> ConversationMemoryStatus:
+            return ConversationMemoryStatus(
+                "available",
+                True,
+                "mem0",
+                "qdrant-local",
+                memory_count=0,
+            )
+
+        def remember_exchange(self, **kwargs: object) -> MemoryWriteResult:
+            self.calls += 1
+            source_id = str(kwargs["source_id"])
+            if self.calls == 1:
+                return MemoryWriteResult(MemoryWriteStatus.SKIPPED, source_id)
+            return MemoryWriteResult(
+                MemoryWriteStatus.WRITTEN,
+                source_id,
+                ("memory.unexpected",),
+            )
+
+    class ExistingPrivateWorld:
+        def snapshot(self) -> PrivateWorldSnapshot:
+            return PrivateWorldSnapshot(version=2, trust=1)
+
+    memory = SkipThenWriteMemory()
+    official_payload = {
+        "mode": "read_only",
+        "account_id": "200717",
+        "letters": [
+            {
+                "source_record_id": "official:200717:skipped-letter",
+                "source": "official-olivia",
+                "occurred_at": 1710000000,
+                "content": "用户来信：你好\n林离回信：你好。",
+                "metadata": {
+                    "user_content": "你好",
+                    "reply_text": "你好。",
+                    "replied_at": 1710000100,
+                    "import_kind": "official_text_reply",
+                    "official_account_id": "200717",
+                },
+            }
+        ],
+    }
+    monkeypatch.setenv("OLIVIA_MEMORY_ROOT", str(tmp_path / "memory"))
+    monkeypatch.setattr(local_server, "memory_adapter", NullMemoryPort())
+    monkeypatch.setattr(local_server.letters_adapter, "memory_port", NullMemoryPort())
+    monkeypatch.setattr(local_server, "conversation_memory_adapter", memory)
+    monkeypatch.setattr(local_server, "private_world_port", ExistingPrivateWorld())
+    monkeypatch.setattr(local_server, "private_world_command_service", object())
+    monkeypatch.setattr(
+        local_server,
+        "collect_default_official_text_replies",
+        lambda: official_payload,
+        raising=False,
+    )
+
+    first = asyncio.run(
+        local_server.route(
+            "POST",
+            "/toy/letter/legacy/official-import",
+            {},
+            {},
+            companion_confirmed=True,
+        )
+    )
+    duplicate = asyncio.run(
+        local_server.route(
+            "POST",
+            "/toy/letter/legacy/official-import",
+            {},
+            {},
+            companion_confirmed=True,
+        )
+    )
+
+    assert first["code"] == 0, first
+    assert first["data"]["memory_migration"]["skipped"] == 1
+    assert duplicate["code"] == 0, duplicate
+    assert duplicate["data"]["inserted"] == 0
+    assert duplicate["data"]["duplicates"] == 1
+    assert duplicate["data"]["memory_migration"]["processed"] == 0
+    assert memory.calls == 1
+
+
 def test_official_import_failure_returns_only_a_sanitized_error(monkeypatch) -> None:
     import local_server
 

--- a/tests/imports/test_official_letters.py
+++ b/tests/imports/test_official_letters.py
@@ -363,6 +363,16 @@ def test_official_import_does_not_publish_mailbox_when_mem0_write_fails(
         "status": "UNAVAILABLE",
         "error_code": "OFFICIAL_HISTORY_MEMORY_WRITE_FAILED",
         "retryable": True,
+        "migration": {
+            "status": "partial",
+            "total": 1,
+            "processed": 0,
+            "written": 0,
+            "duplicates": 0,
+            "skipped": 0,
+            "private_world_status": None,
+            "error_code": "MEM0_WRITE_FAILED",
+        },
     }
 
 

--- a/tests/installer/test_mem0_first_install_lifecycle.py
+++ b/tests/installer/test_mem0_first_install_lifecycle.py
@@ -54,6 +54,25 @@ def test_first_install_preserves_an_explicit_memory_opt_out(tmp_path: Path) -> N
     assert environment["OLIVIA_MEMORY_ENABLED"] == "0"
 
 
+def test_launcher_gives_memory_extraction_the_primary_llm_timeout(
+    tmp_path: Path,
+) -> None:
+    inherited = _configure_memory_environment(
+        {"OLIVIA_LLM_TIMEOUT_SECONDS": "180"},
+        tmp_path / "data",
+    )
+    explicit = _configure_memory_environment(
+        {
+            "OLIVIA_LLM_TIMEOUT_SECONDS": "180",
+            "OLIVIA_MEMORY_WRITE_TIMEOUT_SECONDS": "240",
+        },
+        tmp_path / "data",
+    )
+
+    assert inherited["OLIVIA_MEMORY_WRITE_TIMEOUT_SECONDS"] == "180"
+    assert explicit["OLIVIA_MEMORY_WRITE_TIMEOUT_SECONDS"] == "240"
+
+
 @pytest.mark.parametrize("provider", ["sqlite", "none"])
 def test_launcher_preserves_explicit_memory_provider_and_independent_endpoint(
     tmp_path: Path,

--- a/tests/installer/test_mem0_first_install_lifecycle.py
+++ b/tests/installer/test_mem0_first_install_lifecycle.py
@@ -68,9 +68,24 @@ def test_launcher_gives_memory_extraction_the_primary_llm_timeout(
         },
         tmp_path / "data",
     )
+    clamped_high = _configure_memory_environment(
+        {"OLIVIA_LLM_TIMEOUT_SECONDS": "600"},
+        tmp_path / "data",
+    )
+    clamped_low = _configure_memory_environment(
+        {"OLIVIA_LLM_TIMEOUT_SECONDS": "0.05"},
+        tmp_path / "data",
+    )
+    invalid = _configure_memory_environment(
+        {"OLIVIA_LLM_TIMEOUT_SECONDS": "not-a-duration"},
+        tmp_path / "data",
+    )
 
     assert inherited["OLIVIA_MEMORY_WRITE_TIMEOUT_SECONDS"] == "180"
     assert explicit["OLIVIA_MEMORY_WRITE_TIMEOUT_SECONDS"] == "240"
+    assert clamped_high["OLIVIA_MEMORY_WRITE_TIMEOUT_SECONDS"] == "300"
+    assert clamped_low["OLIVIA_MEMORY_WRITE_TIMEOUT_SECONDS"] == "0.1"
+    assert invalid["OLIVIA_MEMORY_WRITE_TIMEOUT_SECONDS"] == "180"
 
 
 @pytest.mark.parametrize("provider", ["sqlite", "none"])

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -431,6 +431,13 @@ def test_original_settings_clear_memory_uses_two_explicit_confirmations() -> Non
     assert "confirmed: true" in source
 
 
+def test_memory_list_refreshes_the_visible_count_after_mutations() -> None:
+    source = BOOTSTRAP_JAVASCRIPT
+    assert "const updateSummary = (count) =>" in source
+    assert "const latestStatus = await requestJson(STATUS_PATH);" in source
+    assert "updateSummary(latestMemory && latestMemory.count);" in source
+
+
 def test_original_settings_management_ui_javascript_is_parseable() -> None:
     node = shutil.which("node")
     if node is None:

--- a/tests/memory/test_bounded_daemon_call.py
+++ b/tests/memory/test_bounded_daemon_call.py
@@ -40,6 +40,31 @@ def test_permanently_blocked_call_times_out_without_starting_another_worker() ->
                 thread.join(timeout=0.5)
 
 
+def test_timed_out_call_keeps_its_exact_result_until_settled() -> None:
+    release = threading.Event()
+    call = BoundedDaemonCall(thread_name="mem0-provider-settle")
+
+    def finish_later() -> str:
+        release.wait()
+        return "original-result"
+
+    assert call.call(finish_later, timeout_seconds=0.02) == ("timeout", None)
+    release.set()
+    deadline = time.monotonic() + 0.5
+    while call.inflight and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert call.call(lambda: "wrong-result", timeout_seconds=0.02) == (
+        "inflight",
+        None,
+    )
+    assert call.settle() == ("completed", "original-result")
+    assert call.call(lambda: "next-result", timeout_seconds=0.02) == (
+        "completed",
+        "next-result",
+    )
+
+
 @pytest.mark.parametrize("timeout_seconds", [float("nan"), float("inf"), -float("inf")])
 def test_calls_reject_non_finite_timeouts_before_starting_workers(
     timeout_seconds: float,

--- a/tests/memory/test_mem0_memory.py
+++ b/tests/memory/test_mem0_memory.py
@@ -387,6 +387,33 @@ def test_provider_failures_degrade_without_echoing_private_text(tmp_path: Path) 
     assert status["reason_code"] == "MEM0_LIST_FAILED"
 
 
+def test_chinese_exchange_rejects_and_deletes_english_extracted_fact(
+    tmp_path: Path,
+) -> None:
+    class EnglishFactMem0(FakeMem0):
+        def add(self, messages, **kwargs):
+            value = super().add(messages, **kwargs)
+            self.rows[-1]["memory"] = "User prefers quiet evenings."
+            value["results"][0]["memory"] = "User prefers quiet evenings."
+            return value
+
+    backend = EnglishFactMem0()
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+
+    result = adapter.remember_exchange(
+        user_message="我喜欢安静的晚上。",
+        assistant_message="我会记住的。",
+        occurred_at=NOW,
+        source_id="letter:fixture:chinese-language",
+        user_id="local-user",
+    )
+
+    assert result.status is MemoryWriteStatus.UNAVAILABLE
+    assert result.error_code == "MEM0_LANGUAGE_MISMATCH"
+    assert backend.rows == []
+    assert ("delete", "memory.fixture.1") in backend.calls
+
+
 def test_outbox_retry_after_a_timed_out_source_check_never_adds_duplicate(
     tmp_path: Path,
 ) -> None:
@@ -1090,6 +1117,43 @@ def test_exchange_write_timeout_keeps_one_daemon_and_fails_closed_on_retry(
         for thread in threading.enumerate():
             if thread.name == "olivia-mem0-write" and thread not in existing_threads:
                 thread.join(timeout=0.5)
+
+
+def test_timed_out_exchange_can_be_reconciled_to_its_persisted_source(
+    tmp_path: Path,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+
+    class BlockingAddMem0(FakeMem0):
+        def add(self, messages, **kwargs):
+            entered.set()
+            release.wait()
+            return super().add(messages, **kwargs)
+
+    backend = BlockingAddMem0()
+    adapter = Mem0ConversationMemoryAdapter(
+        backend,
+        replace(_config(tmp_path), write_timeout_seconds=0.1),
+    )
+    timed_out = adapter.remember_exchange(
+        user_message="synthetic user",
+        assistant_message="synthetic reply",
+        occurred_at=NOW,
+        source_id="reply:write-timeout:settle",
+        user_id="local-user",
+    )
+    assert entered.is_set()
+    assert timed_out.error_code == "MEM0_WRITE_TIMEOUT"
+
+    release.set()
+    settled = adapter.settle_exchange_write(
+        source_id="reply:write-timeout:settle",
+        user_id="local-user",
+    )
+
+    assert settled.status is MemoryWriteStatus.WRITTEN
+    assert settled.memory_ids == ("memory.fixture.1",)
 
 
 def test_exchange_fails_closed_when_exact_source_id_page_is_incomplete(

--- a/tests/memory/test_mem0_memory.py
+++ b/tests/memory/test_mem0_memory.py
@@ -414,6 +414,44 @@ def test_chinese_exchange_rejects_and_deletes_english_extracted_fact(
     assert ("delete", "memory.fixture.1") in backend.calls
 
 
+def test_chinese_exchange_retries_cleanup_instead_of_accepting_english_duplicate(
+    tmp_path: Path,
+) -> None:
+    class EnglishThenChineseMem0(FakeMem0):
+        def add(self, messages, **kwargs):
+            value = super().add(messages, **kwargs)
+            if self.counter == 1:
+                self.rows[-1]["memory"] = "User prefers quiet evenings."
+                value["results"][0]["memory"] = "User prefers quiet evenings."
+            return value
+
+    backend = EnglishThenChineseMem0()
+    backend.fail.add("delete")
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+    first = adapter.remember_exchange(
+        user_message="我喜欢安静的晚上。",
+        assistant_message="我会记住的。",
+        occurred_at=NOW,
+        source_id="letter:fixture:chinese-retry",
+        user_id="local-user",
+    )
+    assert first.error_code == "MEM0_LANGUAGE_MISMATCH_ROLLBACK_FAILED"
+    assert len(backend.rows) == 1
+
+    backend.fail.clear()
+    retry = adapter.remember_exchange(
+        user_message="我喜欢安静的晚上。",
+        assistant_message="我会记住的。",
+        occurred_at=NOW,
+        source_id="letter:fixture:chinese-retry",
+        user_id="local-user",
+    )
+
+    assert retry.status is MemoryWriteStatus.WRITTEN
+    assert retry.memory_ids == ("memory.fixture.2",)
+    assert [row["memory"] for row in backend.rows] == ["用户在东京工作。"]
+
+
 def test_outbox_retry_after_a_timed_out_source_check_never_adds_duplicate(
     tmp_path: Path,
 ) -> None:
@@ -1154,6 +1192,59 @@ def test_timed_out_exchange_can_be_reconciled_to_its_persisted_source(
 
     assert settled.status is MemoryWriteStatus.WRITTEN
     assert settled.memory_ids == ("memory.fixture.1",)
+
+
+def test_timed_out_duplicate_settles_as_duplicate_without_created_ids(
+    tmp_path: Path,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+
+    class SlowDedupMem0(FakeMem0):
+        def get_all(self, **kwargs):
+            entered.set()
+            release.wait()
+            return super().get_all(**kwargs)
+
+    backend = SlowDedupMem0()
+    backend.rows.append(
+        {
+            "id": "memory.existing",
+            "memory": "用户喜欢安静的晚上。",
+            "user_id": "local-user",
+            "agent_id": "linli",
+            "metadata": {
+                "source_id": "reply:write-timeout:duplicate",
+                "occurred_at": NOW.isoformat(),
+                "domain": "conversation_memory",
+                "canonical": True,
+            },
+            "created_at": NOW.isoformat(),
+        }
+    )
+    adapter = Mem0ConversationMemoryAdapter(
+        backend,
+        replace(_config(tmp_path), write_timeout_seconds=0.1),
+    )
+    timed_out = adapter.remember_exchange(
+        user_message="这是重复消息。",
+        assistant_message="这是重复回复。",
+        occurred_at=NOW,
+        source_id="reply:write-timeout:duplicate",
+        user_id="local-user",
+    )
+    assert entered.is_set()
+    assert timed_out.error_code == "MEM0_WRITE_TIMEOUT"
+
+    release.set()
+    settled = adapter.settle_exchange_write(
+        source_id="reply:write-timeout:duplicate",
+        user_id="local-user",
+    )
+
+    assert settled.status is MemoryWriteStatus.DUPLICATE
+    assert settled.memory_ids == ()
+    assert [row["id"] for row in backend.rows] == ["memory.existing"]
 
 
 def test_exchange_fails_closed_when_exact_source_id_page_is_incomplete(

--- a/tests/memory/test_mem0_memory.py
+++ b/tests/memory/test_mem0_memory.py
@@ -194,6 +194,8 @@ def test_version_and_config_match_current_mem0_oss_contract(tmp_path: Path) -> N
     }
     assert mapping["llm"]["config"]["openai_base_url"] == "http://127.0.0.1:9/v1"
     assert mapping["llm"]["config"]["api_key"] == "fixture-secret"
+    assert "使用与输入消息相同的语言和文字" in mapping["custom_instructions"]
+    assert "不得把中文内容翻译成英文" in mapping["custom_instructions"]
     assert "private_world" not in repr(mapping)
 
 


### PR DESCRIPTION
## What changed\n- Make Mem0 preserve the input language so Chinese conversations produce Chinese user-facing memories.\n- Give Mem0 extraction the same default timeout as the primary LLM while preserving explicit overrides.\n- Return sanitized migration diagnostics for failed official-history imports.\n- Roll back new strict-import memory writes when a later write fails.\n\n## Verification\n- Focused memory/import/installer tests: 90 passed.\n- git diff --check: PASS.\n- No full local suite was run.\n\n## Live evidence before repair\n- Existing installed runtime was READY, but official import wrote three Mem0 rows and failed on the next write without publishing history.\n- Existing Chinese conversations were displayed as English facts because no Mem0 language instruction was configured.\n\n## Boundary\n- Existing user memories are not silently translated or deleted by this PR. The repaired import can safely retry after the updated component is installed.