### PR TITLE
fix: show relationship state after history import

### DIFF
--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-SETTINGS_UI_VERSION = "p03.original-settings-manage.v8"
+SETTINGS_UI_VERSION = "p03.original-settings-manage.v9"
 
 BOOTSTRAP_JAVASCRIPT = r'''(() => {
   "use strict";
@@ -14,6 +14,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const DIALOG_ATTR = "data-olivia-companion-settings-dialog";
   const STATUS_PATH = "/toy/companion/status";
   const MEMORY_PATH = "/toy/companion/memory";
+  const PRIVATE_WORLD_PATH = "/toy/companion/private-world";
   const VIDEO_REPLY_SETTINGS_PATH = "/toy/settings/video-reply";
   const VIDEO_CAPABILITY_PATH = "/toy/capabilities/video";
   const VIDEO_CAPABILITY_ACTION_PATH = "/toy/capabilities/video/action";
@@ -849,15 +850,49 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       && /^[A-Z][A-Z0-9_]{0,95}$/.test(privateCapability.reason_code)
       ? privateCapability.reason_code
       : null;
-    panel.replaceChildren(
-      heading,
-      summary,
-      text(
-        "p",
-        reasonCode ? `原因代码：${reasonCode}` : "原因代码：无",
-        "text-text-secondary text-body-m font-regular"
-      )
-    );
+    if (privateState !== "available") {
+      panel.replaceChildren(
+        heading,
+        summary,
+        text(
+          "p",
+          reasonCode ? `原因代码：${reasonCode}` : "原因代码：无",
+          "text-text-secondary text-body-m font-regular"
+        )
+      );
+      return;
+    }
+    try {
+      const payload = await requestJson(PRIVATE_WORLD_PATH);
+      const stages = { unknown: "尚未形成", acquaintance: "初识", familiar: "熟悉", close: "亲近" };
+      const levelLabels = { unknown: "未知", low: "低", medium: "中", high: "高" };
+      const fields = [
+        ["familiarity", "熟悉度"], ["trust", "信任"], ["comfort", "舒适"],
+        ["closeness", "亲密"], ["tension", "紧张"],
+      ];
+      const levels = payload && payload.levels;
+      if (
+        !payload || payload.status !== "READY" || !stages[payload.relationship_stage]
+        || !levels || fields.some(([key]) => !levelLabels[levels[key]])
+      ) throw new Error("PRIVATE_WORLD_SUMMARY_INVALID");
+      panel.replaceChildren(
+        heading,
+        summary,
+        text("p", `关系阶段：${stages[payload.relationship_stage]}`, "text-text-body text-body-m font-regular"),
+        text(
+          "p",
+          fields.map(([key, label]) => `${label}：${levelLabels[levels[key]]}`).join(" · "),
+          "text-text-secondary text-body-m font-regular"
+        ),
+        text("p", "该状态由林离与用户的历史来信和回信形成，不是可手动修改的分数。", "text-text-secondary text-caption-m font-regular")
+      );
+    } catch (_error) {
+      panel.replaceChildren(
+        heading,
+        summary,
+        text("p", "关系状态暂时无法读取。", "text-text-secondary text-body-m font-regular")
+      );
+    }
   };
 
   const setupInput = (label, type = "text") => {
@@ -1689,7 +1724,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     importState.setAttribute("aria-live", "polite");
     importCopy.append(
       text("div", "导入官方文字信件", "text-text-body text-label-l"),
-      text("div", "导入后将按原时间进入信箱并写入长期记忆。只导入原信和文字回信，不导入视频；重复信件会自动跳过。", "text-text-secondary text-body-m font-regular"),
+      text("div", "原信和林离的文字回信会按原时间进入信箱；双方内容会形成长期语义记忆，历史往来会初始化关系状态。不导入视频，重复信件自动跳过。", "text-text-secondary text-body-m font-regular"),
       importState
     );
     const importButton = button("导入", async () => {
@@ -1719,7 +1754,10 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         const memoryText = migration && migration.status === "completed"
           ? `记忆已按时间顺序处理 ${migration.processed || 0} 封。`
           : "长期记忆写入未完成，历史信件未发布。";
-        importState.textContent = `已导入 ${inserted} 封，跳过 ${duplicates} 封重复信件。${memoryText}`;
+        const relationText = migration && ["initialized", "already_initialized"].includes(migration.private_world_status)
+          ? "林离的历史关系状态已同步。"
+          : "关系状态未更新。";
+        importState.textContent = `已导入 ${inserted} 封，跳过 ${duplicates} 封重复信件。${memoryText}${relationText}`;
       } catch (error) {
         importState.textContent = error && [
           "OFFICIAL_HISTORY_MEMORY_UNAVAILABLE",

--- a/patch_companion_settings.py
+++ b/patch_companion_settings.py
@@ -411,7 +411,6 @@ def _verify_archive(
         'method: "DELETE"',
         "eval(",
         "new Function",
-        "PRIVATE_WORLD_PATH",
         "CANDIDATES_PATH",
         "待确认的关系建议",
         "批准",

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -14,7 +14,7 @@ from original_client_settings_ui import (
 
 # The shipped CEF surface needs explicit no-drag/pointer and display-state guards.
 def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
-    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v8"
+    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v9"
     for declaration in (
             'const STATUS_PATH = "/toy/companion/status";',
             'const MEMORY_PATH = "/toy/companion/memory";',
@@ -94,7 +94,9 @@ def test_original_settings_can_import_official_text_reply_history() -> None:
         'const OFFICIAL_LETTER_IMPORT_PATH = "/toy/letter/legacy/official-import";'
     ) == 1
     assert "导入官方文字信件" in BOOTSTRAP_JAVASCRIPT
-    assert "只导入原信和文字回信，不导入视频" in BOOTSTRAP_JAVASCRIPT
+    assert "原信和林离的文字回信会按原时间进入信箱" in BOOTSTRAP_JAVASCRIPT
+    assert "双方内容会形成长期语义记忆" in BOOTSTRAP_JAVASCRIPT
+    assert "历史往来会初始化关系状态" in BOOTSTRAP_JAVASCRIPT
     assert "requestMutation(OFFICIAL_LETTER_IMPORT_PATH, {})" in BOOTSTRAP_JAVASCRIPT
     assert "path === OFFICIAL_LETTER_IMPORT_PATH ? 600000 : 8000" in BOOTSTRAP_JAVASCRIPT
     assert "payload.inserted" in BOOTSTRAP_JAVASCRIPT
@@ -287,13 +289,12 @@ const flush = async () => { for (let index = 0; index < 8; index += 1) await Pro
     }
 
 
-def test_original_settings_private_world_entry_is_limited_to_safe_status() -> None:
+def test_original_settings_private_world_entry_shows_safe_relationship_summary() -> None:
     source = BOOTSTRAP_JAVASCRIPT
 
     assert "私人世界状态" in source
     assert "原因代码" in source
     for forbidden in (
-        "PRIVATE_WORLD_PATH",
         "CANDIDATES_PATH",
         "legacyPrivateWorldLabels",
         "legacyCandidateRoute",
@@ -307,6 +308,17 @@ def test_original_settings_private_world_entry_is_limited_to_safe_status() -> No
         "renderPrivateWorldPanel(\n          panels.privateWorld,\n          capabilities.private_world,",
     ):
         assert forbidden not in source
+    for required in (
+        "PRIVATE_WORLD_PATH",
+        "relationship_stage",
+        "关系阶段",
+        "熟悉度",
+        "信任",
+        "舒适",
+        "亲密",
+        "紧张",
+    ):
+        assert required in source
 
 
 def test_original_settings_private_world_status_fails_closed() -> None:
@@ -338,8 +350,22 @@ const document = {
 };
 const context = {
   URL, AbortController, document,
+  fetch: async (url) => ({
+    ok: true,
+    json: async () => ({
+      status: "READY",
+      relationship_stage: "familiar",
+      levels: {
+        familiarity: "high", trust: "medium", comfort: "medium",
+        closeness: "low", tension: "low",
+      },
+    }),
+  }),
   MutationObserver: class { constructor() {} observe() {} },
-  window: { requestAnimationFrame: () => {}, addEventListener: () => {} },
+  window: {
+    requestAnimationFrame: () => {}, addEventListener: () => {},
+    setTimeout: () => 1, clearTimeout: () => {},
+  },
 };
 vm.runInNewContext(source, context);
 (async () => {
@@ -379,6 +405,8 @@ vm.runInNewContext(source, context);
     assert rendered[3][2] == "原因代码：无"
     assert rendered[4][2] == "原因代码：无"
     assert rendered[7][2] == "原因代码：无"
+    assert rendered[0][2] == "关系阶段：熟悉"
+    assert rendered[0][3] == "熟悉度：高 · 信任：中 · 舒适：中 · 亲密：低 · 紧张：低"
 
 
 def test_original_settings_management_ui_renders_untrusted_data_as_text_only() -> None:

--- a/tests/installer/test_patch_companion_settings.py
+++ b/tests/installer/test_patch_companion_settings.py
@@ -109,9 +109,7 @@ def test_patch_adds_original_settings_management_and_preserves_existing_assets(
     ):
         assert visible_text in bootstrap
     for hidden_artifact in (
-        "/toy/companion/private-world",
         "/toy/companion/private-world/candidates",
-        "PRIVATE_WORLD_PATH",
         "CANDIDATES_PATH",
         "待确认的关系建议",
         "批准",
@@ -122,6 +120,8 @@ def test_patch_adds_original_settings_management_and_preserves_existing_assets(
         "encodeURIComponent",
     ):
         assert hidden_artifact not in bootstrap
+    assert "/toy/companion/private-world" in bootstrap
+    assert "PRIVATE_WORLD_PATH" in bootstrap
     assert "MutationObserver" in bootstrap
     assert "replaceChildren" in bootstrap
     assert 'method: "GET"' in bootstrap

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1177,7 +1177,7 @@ def test_install_isolated_copy_activates_original_client_surfaces(
         main = archive.read("assets/main-917d29fc.js").decode("utf-8")
     assert "assets/olivia-companion-settings.js" in names
     assert "data-olivia-companion-settings" in index
-    assert "data-ui-version=\"p03.original-settings-manage.v8\"" in index
+    assert "data-ui-version=\"p03.original-settings-manage.v9\"" in index
     assert (installed / "local_backend" / "original_client_setup_api.py").is_file()
     assert (installed / "local_backend" / "original_client_capability_api.py").is_file()
     assert (installed / "local_backend" / "original_client_update_api.py").is_file()


### PR DESCRIPTION
## Outcome
- shows the imported relationship stage and qualitative familiarity/trust/comfort/closeness/tension in the client
- makes clear that both the user's letters and Lin Li's replies feed long-term semantic memory
- reports whether historical relationship state was initialized after import
- keeps exact correspondence in the read-only mailbox and keeps hidden numeric scores private

## Validation
- 61 focused import, historical-memory, companion API/backend, and UI tests pass
- git diff --check passes

## Scope
Two files: client rendering plus its executable Node regression coverage.