### PR TITLE
fix(video): keep partial installs recoverable

### DIFF
--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -1181,6 +1181,29 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     panel.replaceChildren(heading, summary, metadata, controls, offlineNote, result);
   };
 
+  const videoCapabilityViewState = (bundles) => {
+    const states = bundles.map((item) => typeof item.state === "string" ? item.state : "missing");
+    const state = states.every((value) => value === "ready")
+      ? "ready"
+      : states.some((value) => ["queued", "downloading", "verifying"].includes(value))
+      ? "downloading"
+      : states.some((value) => value === "failed")
+      ? "failed"
+      : states.some((value) => value === "paused")
+      ? "paused"
+      : states.some((value) => value === "license_review_required")
+      ? "license_review_required"
+      : states.some((value) => value === "prerequisites_required")
+      ? "prerequisites_required"
+      : "missing";
+    const downloadable = states.some((value) =>
+      !["ready", "queued", "downloading", "verifying", "license_review_required", "prerequisites_required"].includes(value)
+    );
+    const runtimeRequired = states.some((value) => value === "prerequisites_required")
+      && states.every((value) => ["ready", "prerequisites_required"].includes(value));
+    return { state, downloadable, runtimeRequired };
+  };
+
   const renderVideoCapabilityPanel = async (panel) => {
     let payload = null;
     try {
@@ -1201,20 +1224,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       downloaded_bytes: 0,
       total_bytes: 0,
     });
-    const states = bundles.map((item) => typeof item.state === "string" ? item.state : "missing");
-    const state = states.every((value) => value === "ready")
-      ? "ready"
-      : states.some((value) => ["queued", "downloading", "verifying"].includes(value))
-      ? "downloading"
-      : states.some((value) => value === "failed")
-      ? "failed"
-      : states.some((value) => value === "paused")
-      ? "paused"
-      : states.some((value) => value === "license_review_required")
-      ? "license_review_required"
-      : states.some((value) => value === "prerequisites_required")
-      ? "prerequisites_required"
-      : "missing";
+    const { state, downloadable, runtimeRequired } = videoCapabilityViewState(bundles);
     const downloadedBytes = bundles.reduce((total, item) => total + (Number(item.downloaded_bytes) || 0), 0);
     const totalBytes = bundles.reduce((total, item) => total + (Number(item.total_bytes) || 0), 0);
     let videoSourceMode = "auto";
@@ -1222,7 +1232,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     const heading = text("h3", "视频回信一键安装", "text-text-title text-title-m");
     const summary = text(
       "p",
-      "视频回信固定包含说话与音乐。点击一次自动准备语音、音乐、口型、媒体工具和固定场景所需组件；下载默认国内源优先，失败自动回退官方源。",
+      "视频回信固定包含说话与音乐。点击一次自动准备语音、音乐、口型、媒体工具和固定场景所需组件；可用组件优先使用国内源，没有国内镜像时使用官方源。",
       "text-text-secondary text-body-m font-regular"
     );
     const item = card();
@@ -1239,9 +1249,9 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       : "未安装";
     const result = text("div", "", "text-text-secondary text-caption-m font-regular");
     const sourceControls = actions();
-    const domesticSource = button("国内源优先", () => {
+    const domesticSource = button("自动选择（可用国内源优先）", () => {
       videoSourceMode = "auto";
-      result.textContent = "下载时优先使用国内源，失败后回退官方源。";
+      result.textContent = "可用组件优先使用国内源；没有国内镜像的组件会直接使用官方源。";
     });
     const officialSource = button("仅官方源", () => {
       videoSourceMode = "official";
@@ -1265,7 +1275,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         }
       });
       item.append(pause);
-    } else if (state !== "ready" && !["license_review_required", "prerequisites_required"].includes(state)) {
+    } else if (downloadable) {
       const actionLabel = state === "paused" ? "继续下载" : state === "failed" ? "失败重试" : "一键下载并安装";
       const install = button(actionLabel, async () => {
         if (!await confirmAction("确认下载并安装视频回信？将自动准备说话与音乐所需的全部组件；下载即表示你已阅读并同意各上游许可证与使用条款。")) return;
@@ -1290,7 +1300,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       });
       item.append(install);
     }
-    if (state === "prerequisites_required") {
+    if (runtimeRequired) {
       const runtimeNote = text(
         "p",
         "公开源当前只安装模型与受管组件，尚未提供可迁移运行时归档；可选择本机已准备且清单匹配的运行时目录。",

--- a/original_client_video_capability_api.py
+++ b/original_client_video_capability_api.py
@@ -57,13 +57,18 @@ def _runtime_root_path(value: object) -> Path:
 def _select_windows_runtime_root() -> Path | None:
     if os.name != "nt":
         raise VideoCapabilityAPIError("VIDEO_RUNTIME_PICKER_UNAVAILABLE", status=503)
+    system_root = os.environ.get("SystemRoot") or os.environ.get("WINDIR")
+    if not system_root:
+        raise VideoCapabilityAPIError("VIDEO_RUNTIME_PICKER_UNAVAILABLE", status=503)
     powershell = (
-        Path(os.environ.get("SystemRoot", "C:\\Windows"))
+        Path(system_root)
         / "System32"
         / "WindowsPowerShell"
         / "v1.0"
         / "powershell.exe"
     )
+    if not powershell.is_file():
+        raise VideoCapabilityAPIError("VIDEO_RUNTIME_PICKER_UNAVAILABLE", status=503)
     script = (
         "Add-Type -AssemblyName System.Windows.Forms;"
         "$dialog = New-Object System.Windows.Forms.FolderBrowserDialog;"

--- a/tests/installer/test_original_settings_javascript.py
+++ b/tests/installer/test_original_settings_javascript.py
@@ -213,7 +213,7 @@ def test_initial_and_later_settings_share_the_complete_optional_capability_panel
     assert "下载并安装" in source
     assert "失败重试" in source
     assert "导入官方素材" not in active_video_panel
-    assert "下载默认国内源优先" in source
+    assert "可用组件优先使用国内源" in source
     assert "LiveTalking 保持独立可选" not in active_video_panel
     assert "重新检测" in source
     assert 'const VIDEO_CAPABILITY_PATH = "/toy/capabilities/video";' in source
@@ -240,6 +240,55 @@ def test_video_capability_offers_verified_runtime_root_selection() -> None:
     assert "尚未提供可迁移运行时归档" in source
     assert "选择离线运行时目录" not in source
     assert 'accept_licenses: dependency.id === "music_video"' in source
+
+
+def test_partial_video_install_still_offers_missing_bundle_download() -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is unavailable for video capability state validation")
+    harness = r'''
+const fs = require("fs");
+const vm = require("vm");
+let source = fs.readFileSync(0, "utf8");
+source = source.replace(/\s*schedule\(\);\s*\}\)\(\);\s*$/, `
+  globalThis.videoCapabilityViewState = videoCapabilityViewState;
+})();\n`);
+const context = {
+  URL,
+  document: {
+    currentScript: { dataset: { apiBase: "http://127.0.0.1:8899/" } },
+    documentElement: {},
+  },
+  MutationObserver: class { observe() {} },
+  window: { addEventListener: () => {} },
+};
+vm.runInNewContext(source, context);
+process.stdout.write(JSON.stringify(context.videoCapabilityViewState([
+  { id: "ordinary_video", state: "prerequisites_required" },
+  { id: "music_video", state: "missing" },
+])));
+'''
+    completed = subprocess.run(
+        [node, "-e", harness],
+        input=BOOTSTRAP_JAVASCRIPT.encode("utf-8"),
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    output = (completed.stderr or completed.stdout).decode("utf-8", errors="replace")
+    assert completed.returncode == 0, output
+    assert json.loads(completed.stdout) == {
+        "state": "prerequisites_required",
+        "downloadable": True,
+        "runtimeRequired": False,
+    }
+
+
+def test_video_download_copy_only_promises_available_domestic_mirrors() -> None:
+    source = BOOTSTRAP_JAVASCRIPT
+
+    assert "可用组件优先使用国内源；没有国内镜像的组件会直接使用官方源。" in source
+    assert "下载默认国内源优先，失败自动回退官方源。" not in source
 
 
 def test_initial_setup_dialog_survives_mailbox_route_cleanup() -> None:

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -32,6 +32,7 @@ from video_capability_install import (
     VideoFileInstall,
     VideoManifest,
 )
+import original_client_video_capability_api as video_capability_api
 from original_client_video_capability_api import mount_original_client_video_capability_api
 
 
@@ -592,6 +593,24 @@ def test_music_bundle_install_applies_seed_patch_or_fails_closed(
         assert (installed / ".olivia-overlap-frames-patched.json").is_file()
     else:
         assert not (installer.install_root / "music_video" / ".ready.json").exists()
+
+
+def test_windows_runtime_picker_fails_closed_without_a_system_directory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(video_capability_api.os, "name", "nt")
+    monkeypatch.delenv("SystemRoot", raising=False)
+    monkeypatch.delenv("WINDIR", raising=False)
+    monkeypatch.setattr(
+        video_capability_api.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("picker process must not start"),
+    )
+
+    with pytest.raises(video_capability_api.VideoCapabilityAPIError) as captured:
+        video_capability_api._select_windows_runtime_root()
+
+    assert captured.value.code == "VIDEO_RUNTIME_PICKER_UNAVAILABLE"
 
 
 def test_video_capability_api_selects_and_imports_runtime_root(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- keep the missing-bundle download action visible when another video bundle only lacks its portable runtime
- show runtime import only after both managed bundles are installed
- narrow mainland mirror copy to the sources actually mirrored
- resolve Windows PowerShell through the real system directory and fail closed when unavailable

## Focused validation

- RED: mixed `prerequisites_required + missing` state had no view-state helper and could not expose a recovery action
- GREEN: `36 passed` in the two affected installer/UI test modules
- `git diff --check` passed

## Scope and rollback

- Four files only: settings bootstrap, native runtime picker, and their focused tests.
- No manifest, model, memory, media pipeline, or installer package format changes.
- Revert commit `951e504` to restore the previous behavior.
