### PR TITLE
fix(installer): include component package in setup

### DIFF
--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -102,6 +102,7 @@ RELEASE_INSTALLER_FILES = {
     "installer/__init__.py",
     "installer/__main__.py",
     "installer/bootstrap_install.py",
+    "installer/component_package.py",
     "installer/component_update.py",
     "installer/configure.py",
     "installer/Create-Shortcut.ps1",

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -148,6 +148,7 @@ def test_setup_payload_uses_positive_runtime_allowlist() -> None:
     assert _is_release_file("original_client_update_api.py")
     assert _is_release_file("control_center/static/index.html")
     assert _is_release_file("installer/full_patch.py")
+    assert _is_release_file("installer/component_package.py")
     assert _is_release_file("installer/seed-vc-overlap-frames.patch")
     assert _is_release_file("installer/assets/olivia.ico")
     assert _is_release_file("tools/livetalking_worker.py")
@@ -170,6 +171,7 @@ def test_real_head_setup_payload_excludes_build_audit_test_and_scm_files() -> No
         "installer/Install.ps1",
         "installer/assets/olivia.ico",
         "installer/full_patch.py",
+        "installer/component_package.py",
         "installer/seed-vc-overlap-frames.patch",
         "local_server.py",
         "control_center/static/index.html",


### PR DESCRIPTION
## Problem
The generated Windows setup omits installer/component_package.py, but installer/__main__.py imports it during installation. A real clean install fails with ModuleNotFoundError and surfaces SETUP_INSTALL_FAILED.

## Fix
- include the runtime module in the setup payload allowlist
- lock the inclusion in focused setup-payload tests

## TDD evidence
- RED: 2 failed, 15 passed
- GREEN: 17 passed
- git diff --check: PASS

## External, privacy, and rights boundary
- no new external dependency, credential, private user data, or third-party asset
- this only packages an already tracked project module under the repository license

## Rollback
Revert commit 8fb5b8f0ae3ce7245bbc278ce10d3a2bd5819f68 and rebuild the setup. Existing installed releases are unchanged.

## Verification boundary
Focused installer payload tests and CI only at this point; the rebuilt setup will receive fresh manual Windows E2E acceptance after merge.