### PR TITLE
fix(installer): preserve video models during source extraction

### DIFF
--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -551,6 +551,21 @@ def test_safe_archive_rejects_windows_unsafe_paths(tmp_path: Path, names, reason
         _extract_zip_safely(archive, tmp_path / "runtime", strip_components=0)
 
 
+def test_safe_archive_preserves_preinstalled_model_files(tmp_path: Path) -> None:
+    destination = tmp_path / "runtime"
+    model = destination / "models" / "weights.bin"
+    model.parent.mkdir(parents=True)
+    model.write_bytes(b"model")
+    archive = tmp_path / "source.zip"
+    with zipfile.ZipFile(archive, "w") as payload:
+        payload.writestr("source-main/inference.py", "print('ready')\n")
+
+    _extract_zip_safely(archive, destination, strip_components=1)
+
+    assert model.read_bytes() == b"model"
+    assert (destination / "inference.py").read_text(encoding="utf-8") == "print('ready')\n"
+
+
 @pytest.mark.parametrize("source_matches", [True, False])
 def test_music_bundle_install_applies_seed_patch_or_fails_closed(
     tmp_path: Path, source_matches: bool

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -1170,8 +1170,6 @@ def _extract_zip_safely(
     *,
     strip_components: int,
 ) -> list[dict[str, object]]:
-    if destination.exists():
-        shutil.rmtree(destination)
     destination.mkdir(parents=True, exist_ok=True)
     written: set[str] = set()
     expected: list[dict[str, object]] = []
@@ -1217,7 +1215,9 @@ def _extract_zip_safely(
                         digest.update(chunk)
                         written_bytes += len(chunk)
                 expected.append({"path": relative, "size_bytes": written_bytes, "sha256": digest.hexdigest()})
-        _verify_staged_tree(destination, expected)
+        for item in expected:
+            if _tree_entry(destination, str(item["path"])) != item:
+                raise VideoCapabilityError("VIDEO_ARCHIVE_INVALID")
         return expected
     except (OSError, zipfile.BadZipFile, ComponentUpdateError) as exc:
         raise VideoCapabilityError("VIDEO_ARCHIVE_INVALID") from exc


### PR DESCRIPTION
## Summary
- preserve already downloaded model/checkpoint files when extracting pinned runtime source archives
- verify archive-owned files without rejecting the preverified model files sharing the destination
- add a regression test for the real archive/model directory overlap

## Evidence
- RED: new focused regression failed because extraction deleted runtime/models/weights.bin
- GREEN: 27 focused installer tests passed
- git diff --check passed
- real client diagnosis: the complete 12.84 GB music cache reached VIDEO_BUNDLE_INSTALL_FAILED because ComfyUI extraction removed minimax/runtime/models; the ordinary bundle has the same LatentSync/runtime/checkpoints overlap

## Scope and safety
- no new dependencies, credentials, private data, or third-party assets
- existing archive path, duplicate, size, and link checks remain unchanged
- complete staged-tree verification still runs after model and archive assembly
- rollback: revert this commit; cached downloads are retained

## Verification boundary
- focused synthetic tests and live installed-client cache/log diagnosis completed
- final Windows client retry and end-to-end media stages remain pending until this PR is merged and patched into the running client