### PR TITLE
fix(installer): restore ModelScope memory downloads

### DIFF
--- a/docs/THIRD_PARTY_DOWNLOADS.md
+++ b/docs/THIRD_PARTY_DOWNLOADS.md
@@ -69,7 +69,7 @@ $thirdPartyRoot = Join-Path $env:LOCALAPPDATA 'BSideOliviaLocal\third-party'
 
 | 能力 | 国内优先路线 | 官方兼容路线 | 当前自动安装状态 |
 | --- | --- | --- | --- |
-| BGE 中文 Embedding | `hf-mirror.com/BAAI/bge-small-zh-v1.5` | `huggingface.co/BAAI/bge-small-zh-v1.5` | 已有固定 revision 与逐文件 SHA-256 |
+| BGE 中文 Embedding | [ModelScope / BAAI](https://modelscope.cn/models/BAAI/bge-small-zh-v1.5)，固定 revision `9534737c4ead352e88e6eb6faf4dab9ec1be9eed` | [Hugging Face / BAAI](https://huggingface.co/BAAI/bge-small-zh-v1.5) | 国内源失败后自动回退官方源；逐文件校验大小与 SHA-256 |
 | CosyVoice 3 模型 | [ModelScope / FunAudioLLM](https://modelscope.cn/models/FunAudioLLM/Fun-CosyVoice3-0.5B-2512) | [Hugging Face / FunAudioLLM](https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512) | `ordinary_video` 固定 BOM，一键下载并逐文件校验 |
 | LatentSync | [ByteDance Gitee 镜像](https://gitee.com/ByteDance/LatentSync)；权重走 `hf-mirror.com/ByteDance/...` | [GitHub / bytedance](https://github.com/bytedance/LatentSync)；Hugging Face | `ordinary_video` 固定 BOM，一键下载并逐文件校验 |
 | MiniMax Music 3 权重 | `hf-mirror.com/Comfy-Org/MiniMax-Music-3` | [Hugging Face / Comfy-Org](https://huggingface.co/Comfy-Org/MiniMax-Music-3) | `music_video` 固定三文件 BOM，一键下载并逐文件校验 |

--- a/installer/mem0-capability-manifest.json
+++ b/installer/mem0-capability-manifest.json
@@ -38,7 +38,7 @@
       "official": "https://huggingface.co"
     },
     "source_revisions": {
-      "mirror": "8399f11f8da998fe932df2684586c92024219d05",
+      "mirror": "9534737c4ead352e88e6eb6faf4dab9ec1be9eed",
       "official": "7999e1d3359715c523056ef9478215996d62a620"
     },
     "files": {

--- a/mem0_capability_install.py
+++ b/mem0_capability_install.py
@@ -365,6 +365,7 @@ class ResumableModelDownloader:
         self._completed: set[str] = set()
         self.last_source: str | None = None
         self._source_history: list[str] = []
+        self._failed_sources: set[str] = set()
 
     def _record_source(self, source: str) -> None:
         if source not in self._source_history:
@@ -392,7 +393,11 @@ class ResumableModelDownloader:
                 partial.unlink()
                 partial_source.unlink(missing_ok=True)
             last_error: Exception | None = None
+            attempted = False
             for source in self.sources:
+                if source in self._failed_sources:
+                    continue
+                attempted = True
                 try:
                     try:
                         recorded_source = partial_source.read_text(encoding="utf-8")
@@ -413,8 +418,9 @@ class ResumableModelDownloader:
                 except _DownloadPaused:
                     raise
                 except (OSError, RuntimeError) as exc:
+                    self._failed_sources.add(source)
                     last_error = exc
-            if last_error is not None:
+            if not attempted or last_error is not None:
                 raise RuntimeError("MEM0_MODEL_DOWNLOAD_FAILED") from last_error
             partial.replace(cached)
             partial_source.unlink(missing_ok=True)

--- a/tests/installer/test_mem0_capability_install.py
+++ b/tests/installer/test_mem0_capability_install.py
@@ -57,7 +57,7 @@ def test_mem0_bom_closes_runtime_model_hashes_sources_and_license() -> None:
         "https://huggingface.co",
     )
     assert bom.model.source_revisions == (
-        "8399f11f8da998fe932df2684586c92024219d05",
+        "9534737c4ead352e88e6eb6faf4dab9ec1be9eed",
         "7999e1d3359715c523056ef9478215996d62a620",
     )
     assert len(bom.model.files) == 10
@@ -193,6 +193,62 @@ def test_model_download_retries_official_when_mirror_payload_hash_is_wrong(
     downloader.opener = lambda *_args, **_kwargs: pytest.fail("network must not be used")
     downloader.download(revision="a" * 40, relative_path="weights.bin", destination=tmp_path / "cached" / "weights.bin")
     assert downloader.last_source == "https://official.example"
+
+
+def test_model_download_stops_retrying_failed_mirror_for_remaining_files(
+    tmp_path: Path,
+) -> None:
+    payloads = {
+        "first.bin": b"first trusted model bytes",
+        "second.bin": b"second trusted model bytes",
+    }
+    artifacts = {
+        name: ModelArtifact(len(content), hashlib.sha256(content).hexdigest())
+        for name, content in payloads.items()
+    }
+    observed: list[str] = []
+
+    def opener(request, *, timeout: float):
+        assert timeout == 30
+        observed.append(request.full_url)
+        if request.full_url.startswith("https://mirror.example"):
+            raise OSError("synthetic mirror outage")
+        return _Response(
+            payloads[request.full_url.rsplit("/", 1)[-1]],
+            status=200,
+        )
+
+    downloader = ResumableModelDownloader(
+        repo_id="owner/model",
+        revision="a" * 40,
+        files=artifacts,
+        sources=("https://mirror.example", "https://official.example"),
+        download_root=tmp_path / "downloads",
+        source_mode="auto",
+        pause_requested=threading.Event(),
+        progress=lambda *_args: None,
+        opener=opener,
+    )
+
+    for name in payloads:
+        downloader.download(
+            revision="a" * 40,
+            relative_path=name,
+            destination=tmp_path / "stage" / name,
+        )
+
+    revision_path = "/owner/model/resolve/" + "a" * 40 + "/"
+    assert observed == [
+        "https://mirror.example" + revision_path + "first.bin",
+        "https://official.example" + revision_path + "first.bin",
+        "https://official.example" + revision_path + "second.bin",
+    ]
+    assert (tmp_path / "stage" / "first.bin").read_bytes() == payloads[
+        "first.bin"
+    ]
+    assert (tmp_path / "stage" / "second.bin").read_bytes() == payloads[
+        "second.bin"
+    ]
 
 
 def test_modelscope_fixed_revision_resumes_200_content_range_response(


### PR DESCRIPTION
## Summary
- update the pinned ModelScope BGE revision to the current byte-identical commit
- stop retrying a failed mirror for every remaining model file during one install attempt
- keep the official Hugging Face source as the verified fallback and refresh the download documentation

## Evidence
- ModelScope metadata: old revision returns no files; new revision matches all 10 pinned sizes and SHA-256 values
- RED/GREEN for the revision and a two-file mirror-outage circuit-breaker
- 24 focused Mem0 installer tests passed
- git diff --check passed

## Scope and safety
- no model hashes, licenses, credentials, private data, schema, or cache layout changed
- mirror is retried on a fresh installer attempt; only the current failed installation cycle is short-circuited
- official fallback remains pinned and hash-verified
- rollback: revert this commit

## Verification boundary
- ModelScope official metadata and global download endpoint were verified
- the current Tokyo network cannot prove mainland-China throughput for modelscope.cn; final client acceptance verifies retry/fallback behavior without claiming geographic speed