### PR TITLE
fix(installer): repair stale shortcut launch arguments

### DIFF
--- a/installer/Create-Shortcut.ps1
+++ b/installer/Create-Shortcut.ps1
@@ -96,11 +96,17 @@ foreach ($path in $shortcutPaths) {
             New-Item -ItemType Directory -Force -Path $shortcutParent | Out-Null
         }
         $shortcut = $shell.CreateShortcut($path)
-        if (-not $RefreshExisting) {
-            $shortcut.TargetPath = $start
-            $shortcut.WorkingDirectory = $root
-            $shortcut.Description = 'Olivia local client and backend'
+        if ($RefreshExisting -and -not [string]::Equals(
+            [IO.Path]::GetFullPath([string]$shortcut.TargetPath),
+            [IO.Path]::GetFullPath($start),
+            [StringComparison]::OrdinalIgnoreCase
+        )) {
+            continue
         }
+        $shortcut.TargetPath = $start
+        $shortcut.Arguments = ''
+        $shortcut.WorkingDirectory = $root
+        $shortcut.Description = 'Olivia local client and backend'
         $shortcut.IconLocation = "$icon,0"
         $shortcut.Save()
     }

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -289,6 +289,126 @@ def test_shortcut_refresh_repairs_arguments_and_uses_the_active_patch_icon(
     assert metadata["icon"] == f"{active_icon},0"
 
 
+def test_shortcut_refresh_does_not_rewrite_another_installation(
+    tmp_path: Path,
+) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows shortcuts are only available on Windows")
+
+    repo_root = Path(__file__).parents[2]
+    script = repo_root / "installer" / "Create-Shortcut.ps1"
+    install_root = tmp_path / "current installation"
+    client = install_root / "app" / "0.0.9.615" / "Olivia.exe"
+    icon = install_root / "local_backend" / "installer" / "assets" / "olivia.ico"
+    start = install_root / "START.cmd"
+    client.parent.mkdir(parents=True)
+    icon.parent.mkdir(parents=True)
+    client.write_bytes(b"synthetic client")
+    icon.write_bytes(b"current icon")
+    start.write_text("@exit /b 0\n", encoding="utf-8")
+    (install_root / ".olivia-full-patch.json").write_text(
+        json.dumps({"client_version": "0.0.9.615"}),
+        encoding="utf-8",
+    )
+
+    other_root = tmp_path / "other installation"
+    other_start = other_root / "START.cmd"
+    other_icon = other_root / "olivia.ico"
+    other_root.mkdir(parents=True)
+    other_start.write_text("@exit /b 0\n", encoding="utf-8")
+    other_icon.write_bytes(b"other icon")
+    shortcut = tmp_path / "desktop" / "Olivia-local.lnk"
+    shortcut.parent.mkdir(parents=True)
+    arguments = '--keep "other install"'
+    description = "Other Olivia installation"
+    powershell = str(
+        Path(os.environ["WINDIR"])
+        / "System32"
+        / "WindowsPowerShell"
+        / "v1.0"
+        / "powershell.exe"
+    )
+    configured = subprocess.run(
+        [
+            powershell,
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            (
+                "$p=[Console]::In.ReadToEnd()|ConvertFrom-Json;"
+                "$s=(New-Object -ComObject WScript.Shell).CreateShortcut($p.shortcut);"
+                "$s.TargetPath=$p.target;$s.Arguments=$p.arguments;"
+                "$s.WorkingDirectory=$p.working;$s.Description=$p.description;"
+                "$s.IconLocation=$p.icon;$s.Save()"
+            ),
+        ],
+        input=json.dumps(
+            {
+                "shortcut": str(shortcut),
+                "target": str(other_start),
+                "arguments": arguments,
+                "working": str(other_root),
+                "description": description,
+                "icon": f"{other_icon},0",
+            }
+        ),
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    assert configured.returncode == 0, configured.stderr or configured.stdout
+
+    refreshed = subprocess.run(
+        [
+            powershell,
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script),
+            "-InstallRoot",
+            str(install_root),
+            "-ShortcutPath",
+            str(shortcut),
+            "-RefreshExisting",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    assert refreshed.returncode == 0, refreshed.stderr or refreshed.stdout
+
+    inspect = subprocess.run(
+        [
+            powershell,
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            (
+                "$s=(New-Object -ComObject WScript.Shell).CreateShortcut("
+                "[Console]::In.ReadToEnd().Trim());"
+                "[pscustomobject]@{target=$s.TargetPath;arguments=$s.Arguments;"
+                "working=$s.WorkingDirectory;description=$s.Description;"
+                "icon=$s.IconLocation}|ConvertTo-Json -Compress"
+            ),
+        ],
+        input=str(shortcut),
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    metadata = json.loads(inspect.stdout)
+    assert Path(metadata["target"]) == other_start
+    assert metadata["arguments"] == arguments
+    assert Path(metadata["working"]) == other_root
+    assert metadata["description"] == description
+    assert metadata["icon"] == f"{other_icon},0"
+
+
 def test_shortcut_refresh_discovers_desktop_and_programs_independently() -> None:
     repo_root = Path(__file__).parents[2]
     script = (repo_root / "installer" / "Create-Shortcut.ps1").read_text(

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -97,6 +97,28 @@ def test_installer_shortcut_starts_selected_install_entrypoint(
         / "v1.0"
         / "powershell.exe"
     )
+    shortcut.parent.mkdir(parents=True)
+    stale = subprocess.run(
+        [
+            powershell,
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            (
+                "$s=(New-Object -ComObject WScript.Shell).CreateShortcut("
+                "[Console]::In.ReadToEnd().Trim());"
+                "$s.TargetPath=$env:COMSPEC;"
+                "$s.Arguments='//B //Nologo \"F:\\old\\START.vbs\"';"
+                "$s.Save()"
+            ),
+        ],
+        input=str(shortcut),
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    assert stale.returncode == 0, stale.stderr or stale.stdout
     result = subprocess.run(
         [
             powershell,
@@ -127,7 +149,7 @@ def test_installer_shortcut_starts_selected_install_entrypoint(
             (
                 "$s=(New-Object -ComObject WScript.Shell).CreateShortcut("
                 "[Console]::In.ReadToEnd().Trim());"
-                "[pscustomobject]@{target=$s.TargetPath;working=$s.WorkingDirectory;"
+                "[pscustomobject]@{target=$s.TargetPath;arguments=$s.Arguments;working=$s.WorkingDirectory;"
                 "icon=$s.IconLocation}|ConvertTo-Json -Compress"
             ),
         ],
@@ -139,11 +161,12 @@ def test_installer_shortcut_starts_selected_install_entrypoint(
     )
     metadata = json.loads(inspect.stdout)
     assert Path(metadata["target"]) == start
+    assert metadata["arguments"] == ""
     assert Path(metadata["working"]) == install_root
     assert metadata["icon"] == f"{icon},0"
 
 
-def test_shortcut_refresh_uses_the_active_patch_icon_without_changing_target(
+def test_shortcut_refresh_repairs_arguments_and_uses_the_active_patch_icon(
     tmp_path: Path,
 ) -> None:
     if os.name != "nt":
@@ -262,7 +285,7 @@ def test_shortcut_refresh_uses_the_active_patch_icon_without_changing_target(
     )
     metadata = json.loads(inspect.stdout)
     assert Path(metadata["target"]) == start
-    assert metadata["arguments"] == arguments
+    assert metadata["arguments"] == ""
     assert metadata["icon"] == f"{active_icon},0"
 
 


### PR DESCRIPTION
## Summary
- clear stale command-line arguments whenever setup creates or replaces the Olivia shortcut
- let patch activation repair arguments, working directory, description, and icon for shortcuts that already target this installation
- skip shortcuts that point at a different Olivia installation

## Real defect
A pre-existing desktop shortcut was reused during installation. Setup updated its target to `F:\Olivia-E2E-Final-2\install\START.cmd` but preserved obsolete arguments for another root (`F:\oliva\install\START.vbs`), so ordinary users could not reliably start the selected installation.

## Evidence
- RED: create and refresh tests both preserved stale arguments
- GREEN: 3 focused Windows shortcut tests passed
- git diff --check passed

## Scope and safety
- no dependencies, credentials, private data, or assets changed
- refresh only rewrites a shortcut whose target already equals this install root entrypoint
- rollback: revert this commit

## Verification boundary
- real shortcut metadata inspection and focused Windows COM tests completed
- final desktop double-click/restart is pending after merge and patch activation