### PR TITLE
fix(launcher): stop owned backend after client exit

### DIFF
--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -604,7 +604,6 @@ def main(argv: list[str] | None = None) -> int:
     if not any(backend_environment.get(name) for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")):
         print("LLM_API_KEY_NOT_CONFIGURED: 请先在启动此程序的进程环境中设置 API key；当前仅提供明确的 safe-static/degraded 回退。")
     server = None
-    client_started = False
     try:
         if health != "READY":
             creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
@@ -656,16 +655,15 @@ def main(argv: list[str] | None = None) -> int:
         local = profile / "Local"
         roaming.mkdir(parents=True, exist_ok=True)
         local.mkdir(parents=True, exist_ok=True)
-        client_started = True
         return subprocess.call(
             _client_command(client, local),
             cwd=root / "app",
             env=_client_environment(client_environment, roaming, local),
         )
     finally:
-        # Keep a healthy loopback backend alive so reopening the copied client
-        # (including from its taskbar icon) does not degrade into Network Error.
-        if server is not None and not client_started:
+        # Stop only the backend process spawned and owned by this launcher.
+        # A healthy backend reused from an earlier launcher has no local handle.
+        if server is not None:
             _stop_backend_server(server)
 
 

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -263,8 +263,8 @@ def _stop_backend_server(server: object) -> None:
     except subprocess.TimeoutExpired:
         kill = getattr(server, "kill", None)
         if callable(kill):
-            kill()
             try:
+                kill()
                 wait(timeout=5)
             except (OSError, subprocess.TimeoutExpired):
                 pass

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -307,7 +307,7 @@ def test_component_launcher_starts_the_backend_that_owns_start_local(
     assert commands[0][3:] == [str(active_backend), str(active_entrypoint)]
 
 
-def test_component_launcher_keeps_its_backend_for_client_reentry(
+def test_component_launcher_stops_its_owned_backend_after_client_exit(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -355,7 +355,40 @@ def test_component_launcher_keeps_its_backend_for_client_reentry(
     assert backend_environments[0]["OLIVIA_PROVIDER_CACHE_ROOT"] == str(
         root / "data" / "provider-cache"
     )
-    assert lifecycle == []
+    assert lifecycle == ["terminate", "wait:5"]
+
+
+def test_component_launcher_does_not_stop_a_reused_ready_backend(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    root = _installation(tmp_path)
+    backend = root / "local_backend"
+    expected_backend_id = start_local._backend_id(backend, root.resolve())
+    stopped: list[object] = []
+
+    monkeypatch.setattr(start_local, "_active_backend", lambda: backend)
+    monkeypatch.setattr(start_local, "_health", lambda _port: "READY")
+    monkeypatch.setattr(
+        start_local,
+        "_server_backend_id",
+        lambda _port: expected_backend_id,
+    )
+    monkeypatch.setattr(
+        start_local.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: pytest.fail("must not start a second backend"),
+    )
+    monkeypatch.setattr(start_local.subprocess, "call", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(start_local, "_repair_client_frontend", lambda *_args: "PATCHED")
+    monkeypatch.setattr(
+        start_local,
+        "_stop_backend_server",
+        lambda process: stopped.append(process),
+    )
+
+    assert start_local.main(["--install-root", str(root), "--port", "8899"]) == 0
+    assert stopped == []
 
 
 def test_launcher_replaces_a_verified_stale_backend_before_starting_active_version(

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -391,6 +391,39 @@ def test_component_launcher_does_not_stop_a_reused_ready_backend(
     assert stopped == []
 
 
+@pytest.mark.parametrize("failure", ["none", "kill_oserror", "second_wait_timeout"])
+def test_owned_backend_stop_escalation_remains_best_effort(failure: str) -> None:
+    lifecycle: list[str] = []
+    waits = 0
+
+    class Process:
+        @staticmethod
+        def terminate() -> None:
+            lifecycle.append("terminate")
+
+        @staticmethod
+        def kill() -> None:
+            lifecycle.append("kill")
+            if failure == "kill_oserror":
+                raise OSError("synthetic process-exit race")
+
+        @staticmethod
+        def wait(*, timeout: float) -> int:
+            nonlocal waits
+            waits += 1
+            lifecycle.append(f"wait:{timeout}")
+            if waits == 1 or failure == "second_wait_timeout":
+                raise start_local.subprocess.TimeoutExpired("backend", timeout)
+            return 0
+
+    start_local._stop_backend_server(Process())
+
+    expected = ["terminate", "wait:5", "kill"]
+    if failure != "kill_oserror":
+        expected.append("wait:5")
+    assert lifecycle == expected
+
+
 def test_launcher_replaces_a_verified_stale_backend_before_starting_active_version(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- stop the backend process spawned and owned by this launcher after the Olivia client actually exits
- keep an already-running verified backend untouched when this launcher only reuses it
- preserve tray behavior because cleanup does not run while the client process remains open

## Real defect
After choosing “直接退出应用”, Olivia and its launcher exited but the owned `original_client_server.py` pythonw process remained listening on 127.0.0.1:8899 with a dead parent. This recreated the restart/Network Error risk.

## Evidence
- RED: existing test locked the orphaning behavior and failed when changed to expect terminate/wait
- GREEN: owned cleanup, reused-ready backend, and stale-backend replacement tests all passed
- live process inspection confirmed the orphan and dead parent
- git diff --check passed

## Scope and safety
- cleanup only receives the local Popen handle created by this launcher
- a verified backend reused from another launch has `server=None` and is not stopped
- no credentials, private data, dependencies, or external assets changed
- rollback: revert this commit

## Verification boundary
- focused lifecycle tests and real post-exit process diagnosis completed
- final close/restart from the desktop shortcut remains pending after merge and patch activation