### PR TITLE
fix(installer): prefer saved LLM key

### DIFF
--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -141,6 +141,8 @@ def _load_llm_environment(
         "OLIVIA_LLM_MAX_RETRIES": "0",
     }.items():
         values.setdefault(name, value)
+    if values.get("OLIVIA_LLM_API_KEY"):
+        values["OLIVIA_LLM_API_KEY_ENV"] = "OLIVIA_LLM_API_KEY"
     generic_key_present = any(
         values.get(name) for name in ("DEEPSEEK_API_KEY", "OPENAI_API_KEY")
     )

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -88,6 +88,7 @@ def _load_llm_environment(
     provider = "openai_compatible"
     key_path = data_root / "config" / "deepseek_api_key.dpapi"
     config_path = data_root / "config" / "llm.json"
+    saved_key_binding = False
     try:
         payload = json.loads(config_path.read_text(encoding="utf-8"))
         candidate_url = str(payload["base_url"]).strip().rstrip("/")
@@ -121,6 +122,7 @@ def _load_llm_environment(
                 key_path = config_path.parent / name
                 if hashlib.sha256(key_path.read_bytes()).hexdigest() != expected_hash:
                     raise ValueError("invalid key binding")
+                saved_key_binding = True
         else:
             raise ValueError("invalid LLM config")
     except FileNotFoundError:
@@ -139,9 +141,16 @@ def _load_llm_environment(
         "OLIVIA_LLM_MAX_RETRIES": "0",
     }.items():
         values.setdefault(name, value)
-    if include_secret and key_path != Path() and not any(
-        values.get(name)
-        for name in ("OLIVIA_LLM_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY")
+    generic_key_present = any(
+        values.get(name) for name in ("DEEPSEEK_API_KEY", "OPENAI_API_KEY")
+    )
+    # A schema-v2 binding is the user's explicit saved choice; inherited generic
+    # keys must not outrank it.  The Olivia-specific override remains explicit.
+    if (
+        include_secret
+        and key_path != Path()
+        and not values.get("OLIVIA_LLM_API_KEY")
+        and (saved_key_binding or not generic_key_present)
     ):
         configured_key = _load_dpapi_key(key_path)
         if configured_key:

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import errno
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -134,6 +135,54 @@ def test_launcher_loads_user_managed_llm_config_without_exposing_key(tmp_path: P
     assert environment["OLIVIA_LLM_API_KEY_ENV"] == "DEEPSEEK_API_KEY"
 
 
+@pytest.mark.parametrize(
+    "inherited",
+    [
+        {"DEEPSEEK_API_KEY": "inherited-deepseek-key"},
+        {"OPENAI_API_KEY": "inherited-openai-key"},
+        {
+            "DEEPSEEK_API_KEY": "inherited-deepseek-key",
+            "OPENAI_API_KEY": "inherited-openai-key",
+        },
+    ],
+)
+def test_launcher_prefers_valid_saved_key_to_inherited_generic_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    inherited: dict[str, str],
+) -> None:
+    data_root = tmp_path / "data"
+    config_root = data_root / "config"
+    config_root.mkdir(parents=True)
+    key_name = f"deepseek_api_key.{'a' * 32}.dpapi"
+    key_path = config_root / key_name
+    key_path.write_bytes(b"synthetic-protected-key")
+    (config_root / "llm.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "base_url": "https://api.deepseek.com",
+                "model": "deepseek-v4-flash",
+                "key_file": key_name,
+                "key_sha256": hashlib.sha256(key_path.read_bytes()).hexdigest(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        start_local,
+        "_load_dpapi_key",
+        lambda path: "saved-key-for-test" if path == key_path else "",
+    )
+
+    environment = start_local._load_llm_environment(
+        inherited, data_root, include_secret=True
+    )
+
+    assert environment["OLIVIA_LLM_API_KEY_ENV"] == "DEEPSEEK_API_KEY"
+    assert environment["DEEPSEEK_API_KEY"] == "saved-key-for-test"
+
+
 def test_launcher_loads_persisted_video_runtime_environment(tmp_path: Path) -> None:
     data_root = (tmp_path / "data").resolve()
     runtime_root = data_root / "capabilities" / "video" / "ordinary_video" / "latentsync" / "runtime"
@@ -188,14 +237,19 @@ def test_launcher_ignores_invalid_user_managed_llm_config(tmp_path: Path) -> Non
         "synthetic-ciphertext\n", encoding="utf-8"
     )
 
+    inherited = {
+        "DEEPSEEK_API_KEY": "inherited-deepseek-key",
+        "OPENAI_API_KEY": "inherited-openai-key",
+    }
     environment = start_local._load_llm_environment(
-        {}, data_root, include_secret=True
+        inherited, data_root, include_secret=True
     )
 
     assert environment["OLIVIA_LLM_BASE_URL"] == "https://api.deepseek.com"
     assert environment["OLIVIA_LLM_MODEL"] == "deepseek-v4-flash"
     assert environment["OLIVIA_LLM_PROVIDER"] == "none"
-    assert "DEEPSEEK_API_KEY" not in environment
+    assert environment["DEEPSEEK_API_KEY"] == inherited["DEEPSEEK_API_KEY"]
+    assert environment["OPENAI_API_KEY"] == inherited["OPENAI_API_KEY"]
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows DPAPI is required")

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -183,6 +183,49 @@ def test_launcher_prefers_valid_saved_key_to_inherited_generic_keys(
     assert environment["DEEPSEEK_API_KEY"] == "saved-key-for-test"
 
 
+def test_launcher_prefers_explicit_olivia_key_to_valid_saved_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_root = tmp_path / "data"
+    config_root = data_root / "config"
+    config_root.mkdir(parents=True)
+    key_name = f"deepseek_api_key.{'b' * 32}.dpapi"
+    key_path = config_root / key_name
+    key_path.write_bytes(b"synthetic-protected-key")
+    (config_root / "llm.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "base_url": "https://api.deepseek.com",
+                "model": "deepseek-v4-flash",
+                "key_file": key_name,
+                "key_sha256": hashlib.sha256(key_path.read_bytes()).hexdigest(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        start_local,
+        "_load_dpapi_key",
+        lambda _path: pytest.fail("explicit Olivia key must skip DPAPI"),
+    )
+    inherited = {
+        "OLIVIA_LLM_API_KEY": "explicit-olivia-key",
+        "DEEPSEEK_API_KEY": "inherited-deepseek-key",
+        "OPENAI_API_KEY": "inherited-openai-key",
+    }
+
+    environment = start_local._load_llm_environment(
+        inherited, data_root, include_secret=True
+    )
+
+    assert environment["OLIVIA_LLM_API_KEY_ENV"] == "OLIVIA_LLM_API_KEY"
+    assert environment["OLIVIA_LLM_API_KEY"] == inherited["OLIVIA_LLM_API_KEY"]
+    assert environment["DEEPSEEK_API_KEY"] == inherited["DEEPSEEK_API_KEY"]
+    assert environment["OPENAI_API_KEY"] == inherited["OPENAI_API_KEY"]
+
+
 def test_launcher_loads_persisted_video_runtime_environment(tmp_path: Path) -> None:
     data_root = (tmp_path / "data").resolve()
     runtime_root = data_root / "capabilities" / "video" / "ordinary_video" / "latentsync" / "runtime"


### PR DESCRIPTION
## Summary

- prefer a valid schema-v2 DPAPI-bound saved LLM key over inherited generic `DEEPSEEK_API_KEY` / `OPENAI_API_KEY` values
- retain the explicit Olivia-specific key override and preserve inherited generic keys when the saved binding is invalid
- cover inherited DeepSeek-only, OpenAI-only, combined, and explicit Olivia-specific environments with synthetic fixtures

## TDD evidence

- Round 1 RED: the new three-case generic-key regression failed before implementation
- Round 1 BLOCK: Spec review found that explicit `OLIVIA_LLM_API_KEY` skipped DPAPI but still selected `DEEPSEEK_API_KEY`
- Round 2 RED: a focused explicit-Olivia-key regression reproduced the selector error
- Round 2 GREEN: `python -m pytest tests/installer/test_original_client_server_launcher.py -q -k "llm_config or saved_key or dpapi_key_format"` -> `7 passed, 37 deselected`
- `git diff --check origin/main...HEAD` -> clean

## Frozen review pair

- base: `1b7c8b2cd9cfb879e3b2aae69856884b3766683b`
- head: `7c26029a5609823261d508293f6f768bb68882a1`
- Round 2 Spec: PASS
- Round 2 Standards: PASS
- exact-head CI: public smoke PASS; Windows setup PASS

## Verification boundary

- two files only
- no installation, private data, or real credentials accessed during review
- real saved-provider and manual client behavior remain release-acceptance checks
