### PR TITLE
fix(video): stop rehashing ready bundles during status polling

### DIFF
--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -16,6 +16,7 @@ from jsonschema import Draft202012Validator
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+import video_capability_install
 from video_capability_install import (
     apply_runtime_text_patch,
     _extract_zip_safely,
@@ -281,6 +282,53 @@ def test_downloaded_models_remain_installed_when_runtime_prerequisites_are_missi
     assert load_video_runtime_environment(installer.data_root) == {}
 
 
+def test_install_fully_verifies_staged_payload_before_writing_ready_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = b"verified model"
+    offline_root = tmp_path / "offline"
+    source = offline_root / "models" / "model.bin"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(payload)
+    bundle = VideoBundle(
+        "ordinary_video",
+        "ordinary",
+        "FIXED",
+        False,
+        (),
+        (
+            VideoFile(
+                "model",
+                "models/model.bin",
+                len(payload),
+                hashlib.sha256(payload).hexdigest(),
+                "fixture",
+                {},
+            ),
+        ),
+    )
+    marker_presence_during_verification: list[bool] = []
+    original_verify_staged_tree = video_capability_install._verify_staged_tree
+
+    def observe_verification(root: Path, expected: list[dict[str, object]]) -> None:
+        marker_presence_during_verification.append((root / ".ready.json").exists())
+        original_verify_staged_tree(root, expected)
+
+    monkeypatch.setattr(
+        video_capability_install, "_verify_staged_tree", observe_verification
+    )
+    installer = VideoCapabilityInstaller(
+        data_root=(tmp_path / "data").resolve(),
+        manifest=VideoManifest("1.0", (bundle,)),
+    )
+
+    assert installer.import_offline(
+        bundle_id=bundle.identifier, offline_root=offline_root
+    ) == "APPLIED"
+    assert _wait(installer, 0, "ready", "failed") == "ready"
+    assert marker_presence_during_verification == [False]
+
+
 def test_import_runtime_root_verifies_manifest_and_persists_external_profile(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -342,7 +390,16 @@ def test_import_runtime_root_verifies_manifest_and_persists_external_profile(
     )
     final = installer.install_root / "ordinary_video"
     final.mkdir(parents=True)
-    (final / ".ready.json").write_text("{}", encoding="utf-8")
+    (final / ".ready.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.video-bundle.v1",
+                "bundle": "ordinary_video",
+                "version": "1.0",
+            }
+        ),
+        encoding="utf-8",
+    )
 
     assert installer.import_runtime_root(
         runtime_root=runtime_root,
@@ -451,7 +508,16 @@ def test_ready_state_uses_complete_video_dependency_probe(tmp_path: Path) -> Non
     for bundle_id in ("ordinary_video", "music_video"):
         root = installer.install_root / bundle_id
         root.mkdir(parents=True)
-        (root / ".ready.json").write_text("{}", encoding="utf-8")
+        (root / ".ready.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "olivia.video-bundle.v1",
+                    "bundle": bundle_id,
+                    "version": "1.0",
+                }
+            ),
+            encoding="utf-8",
+        )
     ffmpeg = (installer.install_root / "ordinary_video" / "ffmpeg.exe").resolve()
     ffmpeg.write_bytes(b"fixture")
     (installer.install_root / "runtime-environment.json").write_text(
@@ -473,6 +539,110 @@ def test_ready_state_uses_complete_video_dependency_probe(tmp_path: Path) -> Non
     assert status["bundles"][1]["reason_code"] == "VIDEO_RUNTIME_DEPENDENCIES_MISSING"
     assert observed[-1]["OLIVIA_LOCAL_DATA_ROOT"] == str(data_root)
     assert observed[-1]["OLIVIA_FFMPEG_EXE"] == str(ffmpeg)
+
+
+def test_ready_status_does_not_rehash_installed_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_root = (tmp_path / "data").resolve()
+    bundle = VideoBundle(
+        "ordinary_video",
+        "ordinary",
+        "FIXED",
+        False,
+        (),
+        (
+            VideoFile(
+                "model",
+                "models/model.bin",
+                7,
+                hashlib.sha256(b"fixture").hexdigest(),
+                "MIT",
+                {},
+            ),
+        ),
+    )
+    root = data_root / "capabilities" / "video" / bundle.identifier
+    (root / "models").mkdir(parents=True)
+    (root / "models" / "model.bin").write_bytes(b"fixture")
+    (root / ".ready.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.video-bundle.v1",
+                "bundle": bundle.identifier,
+                "version": "1.0",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def reject_hash(*_args, **_kwargs):
+        raise AssertionError("steady-state status must not hash installed files")
+
+    monkeypatch.setattr(video_capability_install, "_sha256_file", reject_hash)
+
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=VideoManifest("1.0", (bundle,)),
+    )
+
+    assert installer.status()["bundles"][0]["state"] == "ready"
+
+
+@pytest.mark.parametrize(
+    "damage",
+    ("corrupt_marker", "wrong_bundle", "wrong_version", "missing_file", "wrong_size"),
+)
+def test_ready_status_fails_closed_on_stale_marker_or_payload_shape(
+    tmp_path: Path, damage: str
+) -> None:
+    data_root = (tmp_path / damage / "data").resolve()
+    bundle = VideoBundle(
+        "ordinary_video",
+        "ordinary",
+        "FIXED",
+        False,
+        (),
+        (
+            VideoFile(
+                "model",
+                "models/model.bin",
+                7,
+                hashlib.sha256(b"fixture").hexdigest(),
+                "MIT",
+                {},
+            ),
+        ),
+    )
+    root = data_root / "capabilities" / "video" / bundle.identifier
+    model = root / "models" / "model.bin"
+    model.parent.mkdir(parents=True)
+    model.write_bytes(b"fixture")
+    marker = root / ".ready.json"
+    marker_payload = {
+        "schema_version": "olivia.video-bundle.v1",
+        "bundle": bundle.identifier,
+        "version": "1.0",
+    }
+    if damage == "corrupt_marker":
+        marker.write_text("{", encoding="utf-8")
+    else:
+        if damage == "wrong_bundle":
+            marker_payload["bundle"] = "music_video"
+        elif damage == "wrong_version":
+            marker_payload["version"] = "0.9"
+        elif damage == "missing_file":
+            model.unlink()
+        elif damage == "wrong_size":
+            model.write_bytes(b"fixture!")
+        marker.write_text(json.dumps(marker_payload), encoding="utf-8")
+
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=VideoManifest("1.0", (bundle,)),
+    )
+
+    assert installer.status()["bundles"][0]["state"] == "missing"
 
 
 def test_auto_install_reuses_verified_local_artifact_before_network(

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -590,6 +590,102 @@ def test_ready_status_does_not_rehash_installed_bundle(
 
 
 @pytest.mark.parametrize(
+    "target_kind", ("bundle_root", "nested_parent", "marker", "file")
+)
+def test_ready_status_rejects_reparse_points_in_bundle_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target_kind: str
+) -> None:
+    data_root = (tmp_path / target_kind / "data").resolve()
+    bundle = VideoBundle(
+        "ordinary_video",
+        "ordinary",
+        "FIXED",
+        False,
+        (),
+        (
+            VideoFile(
+                "model",
+                "models/nested/model.bin",
+                7,
+                hashlib.sha256(b"fixture").hexdigest(),
+                "MIT",
+                {},
+            ),
+        ),
+    )
+    root = data_root / "capabilities" / "video" / bundle.identifier
+    model = root / "models" / "nested" / "model.bin"
+    model.parent.mkdir(parents=True)
+    model.write_bytes(b"fixture")
+    marker = root / ".ready.json"
+    marker.write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.video-bundle.v1",
+                "bundle": bundle.identifier,
+                "version": "1.0",
+            }
+        ),
+        encoding="utf-8",
+    )
+    targets = {
+        "bundle_root": root,
+        "nested_parent": model.parent,
+        "marker": marker,
+        "file": model,
+    }
+    target = targets[target_kind]
+    monkeypatch.setattr(
+        video_capability_install,
+        "_is_reparse_point",
+        lambda path: path == target,
+    )
+
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=VideoManifest("1.0", (bundle,)),
+    )
+
+    assert installer.status()["bundles"][0]["state"] == "missing"
+
+
+def test_ready_status_fails_closed_when_reparse_lstat_races(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_root = (tmp_path / "data").resolve()
+    bundle = VideoBundle("ordinary_video", "ordinary", "FIXED", False, (), ())
+    root = data_root / "capabilities" / "video" / bundle.identifier
+    root.mkdir(parents=True)
+    marker = root / ".ready.json"
+    marker.write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.video-bundle.v1",
+                "bundle": bundle.identifier,
+                "version": "1.0",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def race(path: Path) -> bool:
+        if path == marker:
+            raise video_capability_install.ComponentUpdateError(
+                "UPDATE_STAGED_TREE_MISMATCH"
+            )
+        return False
+
+    monkeypatch.setattr(video_capability_install, "_is_reparse_point", race)
+
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=VideoManifest("1.0", (bundle,)),
+    )
+
+    assert installer.status()["bundles"][0]["state"] == "missing"
+
+
+@pytest.mark.parametrize(
     "damage",
     ("corrupt_marker", "wrong_bundle", "wrong_version", "missing_file", "wrong_size"),
 )

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -715,11 +715,11 @@ class VideoCapabilityInstaller:
                 content_ready = (
                     _ready_marker_matches(root, bundle, self.manifest.version)
                     and all(
-                        _size_matches(root / item.relative_path, item)
+                        _size_matches(root, root / item.relative_path, item)
                         for item in bundle.files
                     )
                 )
-            except (OSError, VideoCapabilityError):
+            except (OSError, ComponentUpdateError, VideoCapabilityError):
                 content_ready = False
             if content_ready:
                 state, reason = self._installed_state(root, bundle)
@@ -1171,11 +1171,11 @@ def _verify_and_true(path: Path, item: VideoFile) -> bool:
 
 def _ready_marker_matches(root: Path, bundle: VideoBundle, version: str) -> bool:
     marker = root / ".ready.json"
-    if not marker.is_file() or _is_reparse_point(marker):
+    if not _regular_file_without_reparse_ancestors(root, marker):
         return False
     try:
         payload = json.loads(marker.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError):
+    except (OSError, ComponentUpdateError, UnicodeError, json.JSONDecodeError):
         return False
     return payload == {
         "schema_version": "olivia.video-bundle.v1",
@@ -1184,14 +1184,28 @@ def _ready_marker_matches(root: Path, bundle: VideoBundle, version: str) -> bool
     }
 
 
-def _size_matches(path: Path, item: VideoFile) -> bool:
+def _regular_file_without_reparse_ancestors(root: Path, path: Path) -> bool:
+    try:
+        relative = path.relative_to(root)
+        if not root.is_dir() or _is_reparse_point(root):
+            return False
+        current = root
+        for part in relative.parts[:-1]:
+            current /= part
+            if not current.is_dir() or _is_reparse_point(current):
+                return False
+        return path.is_file() and not _is_reparse_point(path)
+    except (OSError, ComponentUpdateError, ValueError):
+        return False
+
+
+def _size_matches(root: Path, path: Path, item: VideoFile) -> bool:
     try:
         return (
-            path.is_file()
-            and not _is_reparse_point(path)
+            _regular_file_without_reparse_ancestors(root, path)
             and path.stat().st_size == item.size_bytes
         )
-    except OSError:
+    except (OSError, ComponentUpdateError):
         return False
 
 

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -713,8 +713,11 @@ class VideoCapabilityInstaller:
             root = self._final_root(bundle)
             try:
                 content_ready = (
-                    (root / ".ready.json").is_file()
-                    and all(_verify_and_true(root / item.relative_path, item) for item in bundle.files)
+                    _ready_marker_matches(root, bundle, self.manifest.version)
+                    and all(
+                        _size_matches(root / item.relative_path, item)
+                        for item in bundle.files
+                    )
                 )
             except (OSError, VideoCapabilityError):
                 content_ready = False
@@ -980,13 +983,21 @@ class VideoCapabilityInstaller:
             expected.extend(self._assemble_archives(root, bundle))
             self._set(bundle, VideoCapabilityState.VERIFYING, downloaded, source=source_used)
             final = self._final_root(bundle)
-            (root / ".ready.json").write_text(json.dumps({"schema_version": "olivia.video-bundle.v1", "bundle": bundle.identifier, "version": self.manifest.version}), encoding="utf-8")
-            expected.append(_tree_entry(root, ".ready.json"))
             if len({item["path"].casefold() for item in expected}) != len(expected):
                 raise VideoCapabilityError("VIDEO_STAGED_TREE_INVALID")
             if _is_reparse_point(root):
                 raise VideoCapabilityError("VIDEO_STAGING_INVALID")
             _verify_staged_tree(root, expected)
+            (root / ".ready.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": "olivia.video-bundle.v1",
+                        "bundle": bundle.identifier,
+                        "version": self.manifest.version,
+                    }
+                ),
+                encoding="utf-8",
+            )
             self._promote_directory(root, final, refresh_environment=True)
             with self._lock:
                 state, reason = self._installed_state(final, bundle)
@@ -1156,6 +1167,32 @@ def _verify_and_true(path: Path, item: VideoFile) -> bool:
     except (OSError, VideoCapabilityError):
         return False
     return True
+
+
+def _ready_marker_matches(root: Path, bundle: VideoBundle, version: str) -> bool:
+    marker = root / ".ready.json"
+    if not marker.is_file() or _is_reparse_point(marker):
+        return False
+    try:
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return False
+    return payload == {
+        "schema_version": "olivia.video-bundle.v1",
+        "bundle": bundle.identifier,
+        "version": version,
+    }
+
+
+def _size_matches(path: Path, item: VideoFile) -> bool:
+    try:
+        return (
+            path.is_file()
+            and not _is_reparse_point(path)
+            and path.stat().st_size == item.size_bytes
+        )
+    except OSError:
+        return False
 
 
 def _tree_entry(root: Path, relative: str) -> dict[str, object]:


### PR DESCRIPTION
## Summary

- validate ready-marker identity and use fail-closed path metadata plus exact-size checks for steady-state polling
- stop steady-state polling from rehashing installed multi-GB bundles
- retain full staged-tree SHA-256 verification during installation and write `.ready.json` only after it passes

## TDD and review evidence

- RED 1: ready status called `_sha256_file`; install verification observed an early ready marker
- GREEN 1: 36 focused tests passed; diff check clean
- Round 1 Spec: PASS
- Round 1 Standards: BLOCK — root/intermediate-directory junctions and `lstat` races were not fail-closed
- RED 2: root/nested reparse paths were reported ready and a marker `lstat` race escaped
- GREEN 2: five focused negative cases passed; full focused file reported `41 passed in 1.06s`; diff check clean
- Round 2 Spec: PASS
- Round 2 Standards: PASS
- exact-head CI: two public-smoke jobs PASS; Windows setup PASS

## Frozen review pair

- base: `5f20281f9b4d1e6342dff670d61ab9e109c1855c`
- head: `4a981a2dfcf08c19e76cea8547a1b89c612cd2bb`

## Verification boundary

- two files only
- no running installation, private data, or credentials accessed during implementation/review
- reparse cases are focused fixtures/mocks; real 28.1 GB responsiveness remains subject to manual Windows-client acceptance
