### PR TITLE
fix(installer): allow time for runtime folder selection

### DIFF
--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -1330,7 +1330,8 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         try {
           const selected = await requestCapability(
             VIDEO_CAPABILITY_ACTION_PATH,
-            { action: "select_runtime" }
+            { action: "select_runtime" },
+            310000
           );
           if (selected.status === "SELECTED" && typeof selected.runtime_root === "string") {
             runtimeRoot = selected.runtime_root;

--- a/tests/installer/test_original_settings_javascript.py
+++ b/tests/installer/test_original_settings_javascript.py
@@ -232,6 +232,7 @@ def test_video_capability_offers_verified_runtime_root_selection() -> None:
     source = BOOTSTRAP_JAVASCRIPT
 
     assert '{ action: "select_runtime" }' in source
+    assert '{ action: "select_runtime" },\n            310000' in source
     assert 'action: "import_runtime"' in source
     assert "manifest_sha256: runtimeDigest.input.value.trim().toLowerCase()" in source
     assert 'source: videoSourceMode' in source


### PR DESCRIPTION
Fixes the Windows runtime-folder picker timing out in the settings UI before a normal user can finish selecting a directory. The backend already permits 300 seconds; this gives the select_runtime request 310 seconds and adds a focused regression assertion. Verification: RED reproduced before the change; focused UI test 1 passed; focused runtime-root API test 1 passed; git diff --check passed. Scope: 2 files, 3 insertions, 1 deletion.