### PR TITLE
fix(installer): make runtime manifest validation linear

### DIFF
--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -460,6 +460,49 @@ def test_runtime_manifest_generator_hashes_the_exact_sorted_tree(tmp_path: Path)
     assert not any(str(runtime_root) in value for value in payload["environment"].values())
 
 
+def test_runtime_manifest_duplicate_check_is_linear(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class CountingPath(str):
+        calls = 0
+
+        def casefold(self) -> str:
+            type(self).calls += 1
+            return super().casefold()
+
+    runtime_root = (tmp_path / "runtime").resolve()
+    python = runtime_root / "python/python.exe"
+    python.parent.mkdir(parents=True)
+    python.write_bytes(b"python")
+    manifest_path = runtime_root / "runtime-manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    digest = "a" * 64
+    paths = [CountingPath("python/python.exe")]
+    paths.extend(CountingPath(f"packages/item-{index}.bin") for index in range(99))
+    payload = {
+        "schema_version": "olivia.video-runtime-root.v1",
+        "version": "2026.08.29",
+        "environment": {"OLIVIA_LATENTSYNC_PYTHON": paths[0]},
+        "files": [
+            {"path": path, "size_bytes": 1, "sha256": "0" * 64}
+            for path in paths
+        ],
+    }
+    monkeypatch.setattr(video_capability_install, "_safe_relative", lambda value: value)
+    monkeypatch.setattr(video_capability_install, "_sha256_file", lambda _path: (1, digest))
+    monkeypatch.setattr(video_capability_install.json, "loads", lambda _raw: payload)
+
+    environment = video_capability_install._load_runtime_root_manifest(
+        runtime_root,
+        digest,
+        verify_files=False,
+    )
+
+    assert environment["OLIVIA_LATENTSYNC_PYTHON"] == str(python)
+    assert CountingPath.calls <= len(paths) * 4
+
+
 def test_portable_python_probe_rejects_a_runtime_outside_its_base_prefix(
     tmp_path: Path,
 ) -> None:

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -419,6 +419,7 @@ def _load_runtime_root_manifest(
         environment[key] = str(candidate)
         environment_paths[key] = relative
     files: dict[str, tuple[int, str]] = {}
+    seen_files: set[str] = set()
     for raw in payload["files"]:
         if (
             not isinstance(raw, dict)
@@ -433,8 +434,10 @@ def _load_runtime_root_manifest(
             candidate = _inside(root, root / relative)
         except (OSError, VideoCapabilityError):
             raise VideoCapabilityError("VIDEO_RUNTIME_ROOT_INVALID") from None
-        if relative.casefold() in {item.casefold() for item in files}:
+        folded = relative.casefold()
+        if folded in seen_files:
             raise VideoCapabilityError("VIDEO_RUNTIME_ROOT_INVALID")
+        seen_files.add(folded)
         files[relative] = (raw["size_bytes"], digest)
         if verify_files:
             try:


### PR DESCRIPTION
Fixes runtime-root import becoming effectively stuck on large portable environments. Duplicate path detection rebuilt a case-folded set for every manifest entry, making validation O(n^2); it now maintains one incremental set while preserving case-insensitive duplicate rejection. Focused RED: 100 entries caused 5,052 casefold calls. GREEN: linear bound plus existing manifest generation/import coverage, 3 passed; git diff --check passed. Scope: 2 files, +47/-1, no API or trust-boundary change.