### PR TITLE
fix(video): keep runtime probes read-only

### DIFF
--- a/music_reply.py
+++ b/music_reply.py
@@ -93,7 +93,7 @@ def _python_runtime_ready(
         "assert torch.cuda.is_available(); "
         "torch.ones(1, device='cuda')"
     )
-    return _run_runtime_probe([str(executable), "-c", script], cwd=cwd)
+    return _run_runtime_probe([str(executable), "-B", "-c", script], cwd=cwd)
 
 
 def _executable_runtime_ready(executable: Path | None) -> bool:

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -243,6 +243,7 @@ def test_python_runtime_probe_checks_version_imports_cuda_and_has_hard_timeout(
         imports=("torch", "provider.module"),
         accepted_torch_versions=("2.9.1+cu128",),
     )
+    assert observed["command"][1] == "-B"
     script = observed["command"][-1]
     assert "sys.version_info[:2]" in script
     assert "import_module" in script


### PR DESCRIPTION
## Summary
- run Python dependency probes with -B so validation does not create undeclared bytecode in portable runtime roots
- lock the read-only probe flag with a focused regression test

## TDD
- RED: focused test observed -c as the first Python flag and failed
- GREEN: 1 passed, 11 deselected
- live local proof: CosyVoice CUDA probe passes with -B, then exact manifest tree remains 192,671 declared / 192,671 actual / 0 extra / 0 missing

## Boundary
No key or letter content accessed. Full suite intentionally not run for this two-line behavioral fix.