### PR TITLE
fix: keep video readiness visible on Windows

### DIFF
--- a/local_server.py
+++ b/local_server.py
@@ -2104,7 +2104,8 @@ async def route(
                 return ok(setting.to_dict())
             environment = MappingProxyType(dict(_os.environ))
             try:
-                readiness = video_reply_dependency_status(
+                readiness = await asyncio.to_thread(
+                    video_reply_dependency_status,
                     environment,
                     performance_video_path=_current_music_performance(environment),
                 )
@@ -2140,7 +2141,8 @@ async def route(
         if body.get("enabled") is True:
             environment = MappingProxyType(dict(_os.environ))
             try:
-                readiness = video_reply_dependency_status(
+                readiness = await asyncio.to_thread(
+                    video_reply_dependency_status,
                     environment,
                     performance_video_path=_current_music_performance(environment),
                 )

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -270,7 +270,10 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       }
     }
     const controller = new AbortController();
-    const timeout = window.setTimeout(() => controller.abort(), 5000);
+    const timeoutMs = path === VIDEO_CAPABILITY_PATH || path === VIDEO_REPLY_SETTINGS_PATH
+      ? 300000
+      : 5000;
+    const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
     try {
       const response = await fetch(endpoint, {
         method: "GET",
@@ -1216,6 +1219,14 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   };
 
   const renderVideoCapabilityPanel = async (panel) => {
+    panel.replaceChildren(
+      text("div", "正在检测本机视频运行环境……", "text-text-body text-label-l"),
+      text(
+        "div",
+        "第一次检测可能需要几分钟，设置页面仍可继续使用。",
+        "text-text-secondary text-body-m font-regular"
+      )
+    );
     let payload = null;
     try {
       payload = await requestJson(VIDEO_CAPABILITY_PATH);
@@ -1767,13 +1778,13 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     row.className = "flex items-center justify-between px-0 py-3 rounded-3";
     const copy = document.createElement("div");
     copy.className = "flex flex-col gap-0 flex-1 min-w-0";
-    const state = text("div", "正在读取设置…", "text-text-secondary text-caption-m font-regular");
+    const state = text("div", "正在检测视频运行环境，第一次可能需要几分钟…", "text-text-secondary text-caption-m font-regular");
     state.setAttribute("aria-live", "polite");
     copy.append(text("div", "允许视频回信", "text-text-body text-label-l"), text("div", "已接收的信件不会因设置变化被取消。", "text-text-secondary text-body-m font-regular"), state);
     let enabled = null;
     let ready = false;
     let missingDependencies = [];
-    let message = "正在读取设置…";
+    let message = "正在检测视频运行环境，第一次可能需要几分钟…";
     let toggle = null;
     let downloads = null;
     const render = () => {

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -302,7 +302,11 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const requestMutation = async (path, body) => {
     const endpoint = new URL(path, apiBase);
     const controller = new AbortController();
-    const timeoutMs = path === OFFICIAL_LETTER_IMPORT_PATH ? 600000 : 8000;
+    const timeoutMs = path === OFFICIAL_LETTER_IMPORT_PATH
+      ? 600000
+      : path === VIDEO_REPLY_SETTINGS_PATH
+      ? 300000
+      : 8000;
     const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
     try {
       const response = await fetch(endpoint, {

--- a/runtime/media/music_reply.py
+++ b/runtime/media/music_reply.py
@@ -67,6 +67,7 @@ def _run_runtime_probe(command: list[str], *, cwd: Path) -> bool:
             capture_output=True,
             check=False,
             timeout=_RUNTIME_PROBE_TIMEOUT_SECONDS,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         )
     except (OSError, subprocess.TimeoutExpired):
         return False

--- a/tests/http/test_video_reply_settings.py
+++ b/tests/http/test_video_reply_settings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import asyncio
 import json
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 import pytest
@@ -163,6 +164,110 @@ def test_handler_errors_match_video_reply_schema(monkeypatch, tmp_path):
     assert [response["data"]["error_code"] for _, response in responses] == ["METHOD_NOT_ALLOWED", "INVALID_JSON", "INVALID_BODY", "MISSING_FIELD", "MISSING_FIELD", "VIDEO_REPLY_SETTING_REQUEST_ID_INVALID"]
     for status, response in responses:
         assert not list(validator.iter_errors(response)), response
+
+
+@pytest.mark.parametrize("method", ["GET", "POST"])
+def test_video_reply_settings_requests_keep_http_responsive_during_probe(
+    monkeypatch, tmp_path, method
+):
+    import local_server
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    settings = VideoReplySettingsStore.initialize(tmp_path)
+    monkeypatch.setattr(local_server, "video_reply_settings_store", settings)
+    monkeypatch.setattr(local_server, "_current_music_performance", lambda _environment: None)
+    started = threading.Event()
+    release = threading.Event()
+    preflight_complete = threading.Event()
+
+    def slow_probe(_environment, *, performance_video_path):
+        assert performance_video_path is None
+        started.set()
+        assert release.wait(2)
+        return {"ready": True, "dependencies": []}
+
+    monkeypatch.setattr(local_server, "video_reply_dependency_status", slow_probe)
+
+    def release_probe() -> None:
+        assert started.wait(1)
+        preflight_complete.wait(0.5)
+        release.set()
+
+    releaser = threading.Thread(target=release_probe, daemon=True)
+    releaser.start()
+
+    async def calls():
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app)) as client:
+            if method == "POST":
+                probe_request = asyncio.create_task(
+                    client.post(
+                        "/toy/settings/video-reply",
+                        json={
+                            "enabled": True,
+                            "request_id": "video_reply_setting:slow-probe",
+                        },
+                    )
+                )
+            else:
+                probe_request = asyncio.create_task(
+                    client.get("/toy/settings/video-reply")
+                )
+            assert await asyncio.to_thread(started.wait, 1)
+            preflight = await client.options(
+                "/toy/settings/video-reply",
+                headers={
+                    "Origin": "http://localhost:3000",
+                    "Access-Control-Request-Method": "POST",
+                },
+            )
+            responsive_while_probe_blocked = not release.is_set()
+            preflight_complete.set()
+            response = await probe_request
+            payload = await response.json()
+            refreshed = None
+            if method == "POST":
+                refreshed_response = await client.get("/toy/settings/video-reply")
+                refreshed = await refreshed_response.json()
+            return (
+                responsive_while_probe_blocked,
+                preflight.status,
+                response.status,
+                payload,
+                refreshed,
+            )
+
+    try:
+        responsive_while_probe_blocked, preflight_status, status, payload, refreshed = (
+            asyncio.run(calls())
+        )
+    finally:
+        release.set()
+        releaser.join(timeout=1)
+
+    assert responsive_while_probe_blocked
+    assert preflight_status == 204
+    assert status == 200
+    if method == "POST":
+        assert payload["data"] == {
+            "request_id": "video_reply_setting:slow-probe",
+            "status": "APPLIED",
+            "enabled": True,
+        }
+        assert refreshed["data"]["enabled"] is True
+        assert refreshed["data"]["effective_enabled"] is True
+    else:
+        assert payload["data"] == {
+            "state": "available",
+            "enabled": False,
+            "effective_enabled": False,
+            "ready": True,
+            "dependencies": [],
+        }
+
+
 def test_factory_init_failure_returns_stable_unavailable(monkeypatch):
     import local_server
     def fail(_root):

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -207,7 +207,8 @@ def test_original_settings_can_import_official_text_reply_history() -> None:
     assert "双方内容会形成长期语义记忆" in BOOTSTRAP_JAVASCRIPT
     assert "历史往来会初始化关系状态" in BOOTSTRAP_JAVASCRIPT
     assert "requestMutation(OFFICIAL_LETTER_IMPORT_PATH, {})" in BOOTSTRAP_JAVASCRIPT
-    assert "path === OFFICIAL_LETTER_IMPORT_PATH ? 600000 : 8000" in BOOTSTRAP_JAVASCRIPT
+    assert "path === OFFICIAL_LETTER_IMPORT_PATH\n      ? 600000" in BOOTSTRAP_JAVASCRIPT
+    assert ": 8000;" in BOOTSTRAP_JAVASCRIPT
     assert "payload.inserted" in BOOTSTRAP_JAVASCRIPT
     assert "payload.memory_migration" in BOOTSTRAP_JAVASCRIPT
     assert "记忆已按时间顺序处理" in BOOTSTRAP_JAVASCRIPT

--- a/tests/installer/test_original_settings_javascript.py
+++ b/tests/installer/test_original_settings_javascript.py
@@ -228,6 +228,38 @@ def test_initial_and_later_settings_share_the_complete_optional_capability_panel
     assert source.index('states.some((value) => ["queued", "downloading", "verifying"].includes(value))') < source.index('states.some((value) => value === "failed")')
 
 
+def test_video_capability_first_probe_has_truthful_progress_and_timeout() -> None:
+    source = BOOTSTRAP_JAVASCRIPT
+    video_panel = source.split(
+        "const renderVideoCapabilityPanel = async (panel) => {", 1
+    )[1].split("const renderCapabilityPanel = async (panel) => {", 1)[0]
+
+    assert "path === VIDEO_CAPABILITY_PATH || path === VIDEO_REPLY_SETTINGS_PATH" in source
+    assert "正在检测本机视频运行环境" in video_panel
+    assert "第一次检测可能需要几分钟，设置页面仍可继续使用" in video_panel
+    assert video_panel.index("正在检测本机视频运行环境") < video_panel.index(
+        "await requestJson(VIDEO_CAPABILITY_PATH)"
+    )
+
+
+def test_video_reply_setting_hydrate_waits_for_the_real_dependency_probe() -> None:
+    source = BOOTSTRAP_JAVASCRIPT
+    setting = source.split("const mountVideoReplySetting = (section) => {", 1)[1].split(
+        "const mountOfficialLetterImport", 1
+    )[0]
+
+    assert (
+        "path === VIDEO_CAPABILITY_PATH || path === VIDEO_REPLY_SETTINGS_PATH"
+        in source
+    )
+    assert "? 300000" in source
+    assert ": 5000;" in source
+    assert "正在检测视频运行环境，第一次可能需要几分钟" in setting
+    assert setting.index("正在检测视频运行环境") < setting.index(
+        "await requestJson(VIDEO_REPLY_SETTINGS_PATH)"
+    )
+
+
 def test_video_capability_offers_verified_runtime_root_selection() -> None:
     source = BOOTSTRAP_JAVASCRIPT
     runtime_import = source.split(

--- a/tests/installer/test_original_settings_javascript.py
+++ b/tests/installer/test_original_settings_javascript.py
@@ -260,6 +260,21 @@ def test_video_reply_setting_hydrate_waits_for_the_real_dependency_probe() -> No
     )
 
 
+def test_video_reply_setting_mutation_waits_for_probe_and_uses_committed_value() -> None:
+    source = BOOTSTRAP_JAVASCRIPT
+    mutation = source.split("const requestMutation = async (path, body) => {", 1)[
+        1
+    ].split("const requestSetup = async", 1)[0]
+    setting = source.split("const mountVideoReplySetting = (section) => {", 1)[1].split(
+        "const mountOfficialLetterImport", 1
+    )[0]
+
+    assert "path === VIDEO_REPLY_SETTINGS_PATH" in mutation
+    assert "? 300000" in mutation
+    assert ": 8000;" in mutation
+    assert "enabled = payload.enabled;" in setting
+
+
 def test_video_capability_offers_verified_runtime_root_selection() -> None:
     source = BOOTSTRAP_JAVASCRIPT
     runtime_import = source.split(

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -577,6 +577,30 @@ def test_portable_python_probe_rejects_a_runtime_outside_its_base_prefix(
     assert not _portable_python_runtime(Path(sys.executable).resolve(), tmp_path.resolve())
 
 
+def test_portable_python_probe_hides_its_windows_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = (tmp_path / "runtime").resolve()
+    python = runtime_root / "python.exe"
+    runtime_root.mkdir()
+    python.write_bytes(b"fixture")
+    observed: dict[str, object] = {}
+
+    def run(*_args, **kwargs):
+        observed.update(kwargs)
+        return video_capability_install.subprocess.CompletedProcess([], 0)
+
+    monkeypatch.setattr(video_capability_install.subprocess, "run", run)
+
+    assert _portable_python_runtime(python, runtime_root)
+    assert observed["creationflags"] == getattr(
+        video_capability_install.subprocess,
+        "CREATE_NO_WINDOW",
+        0,
+    )
+
+
 def test_runtime_profile_restores_interrupted_bundle_backup(tmp_path: Path) -> None:
     install_root = tmp_path / "data" / "capabilities" / "video"
     backup = install_root / ".ordinary_video.backup"

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -644,6 +644,7 @@ def test_ready_state_uses_complete_video_dependency_probe(tmp_path: Path) -> Non
         "prerequisites_required",
     ]
     assert status["bundles"][1]["reason_code"] == "VIDEO_RUNTIME_DEPENDENCIES_MISSING"
+    assert len(observed) == 1
     assert observed[-1]["OLIVIA_LOCAL_DATA_ROOT"] == str(data_root)
     assert observed[-1]["OLIVIA_FFMPEG_EXE"] == str(ffmpeg)
 

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -296,6 +296,7 @@ def test_python_runtime_probe_checks_version_imports_cuda_and_has_hard_timeout(
     assert "torch.cuda.is_available()" in script
     assert "2.9.1+cu128" in script
     assert observed["timeout"] == music_reply._RUNTIME_PROBE_TIMEOUT_SECONDS
+    assert observed["creationflags"] == getattr(subprocess, "CREATE_NO_WINDOW", 0)
 
     def timeout(*_args, **_kwargs):
         raise subprocess.TimeoutExpired("python", 1)

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -347,6 +347,7 @@ def _portable_python_runtime(python: Path, runtime_root: Path) -> bool:
             capture_output=True,
             check=False,
             timeout=_RUNTIME_PORTABILITY_TIMEOUT_SECONDS,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         )
     except (OSError, subprocess.SubprocessError):
         return False

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -701,22 +701,31 @@ class VideoCapabilityInstaller:
         return VideoCapabilityState.READY, None
 
     def _runtime_dependency_state(
-        self, bundle: VideoBundle
+        self,
+        bundle: VideoBundle,
+        *,
+        probe_cache: dict[str, Mapping[str, object]] | None = None,
     ) -> tuple[VideoCapabilityState, str | None]:
         if self._readiness_probe is None:
             return self._assembled_state(bundle)
-        try:
-            environment = dict(os.environ)
-            environment.update(load_video_runtime_environment(self.data_root))
-            environment["OLIVIA_LOCAL_DATA_ROOT"] = str(self.data_root)
-            result = self._readiness_probe(environment)
-            if bundle.identifier == "ordinary_video":
-                missing = result.get("ordinary_missing_dependencies")
-                ready = isinstance(missing, (list, tuple)) and not missing
-            else:
-                ready = result.get("music_ready") is True
-        except Exception:
-            ready = False
+        result = probe_cache.get("result") if probe_cache is not None else None
+        if result is None:
+            try:
+                environment = dict(os.environ)
+                environment.update(load_video_runtime_environment(self.data_root))
+                environment["OLIVIA_LOCAL_DATA_ROOT"] = str(self.data_root)
+                result = self._readiness_probe(environment)
+            except Exception:
+                result = {}
+            if not isinstance(result, Mapping):
+                result = {}
+            if probe_cache is not None:
+                probe_cache["result"] = result
+        if bundle.identifier == "ordinary_video":
+            missing = result.get("ordinary_missing_dependencies")
+            ready = isinstance(missing, (list, tuple)) and not missing
+        else:
+            ready = result.get("music_ready") is True
         if ready:
             return VideoCapabilityState.READY, None
         return (
@@ -725,7 +734,11 @@ class VideoCapabilityInstaller:
         )
 
     def _installed_state(
-        self, root: Path, bundle: VideoBundle
+        self,
+        root: Path,
+        bundle: VideoBundle,
+        *,
+        probe_cache: dict[str, Mapping[str, object]] | None = None,
     ) -> tuple[VideoCapabilityState, str | None]:
         if not self._runtime_wiring_ready(root, bundle):
             return (
@@ -748,9 +761,10 @@ class VideoCapabilityInstaller:
                 return VideoCapabilityState.READY, None
         except (OSError, UnicodeError, json.JSONDecodeError):
             pass
-        return self._runtime_dependency_state(bundle)
+        return self._runtime_dependency_state(bundle, probe_cache=probe_cache)
 
     def _load_status(self) -> None:
+        probe_cache: dict[str, Mapping[str, object]] = {}
         for bundle in self.manifest.bundles:
             current = self._status.get(bundle.identifier)
             thread = self._threads.get(bundle.identifier)
@@ -772,7 +786,11 @@ class VideoCapabilityInstaller:
             except (OSError, ComponentUpdateError, VideoCapabilityError):
                 content_ready = False
             if content_ready:
-                state, reason = self._installed_state(root, bundle)
+                state, reason = self._installed_state(
+                    root,
+                    bundle,
+                    probe_cache=probe_cache,
+                )
                 self._status[bundle.identifier] = VideoBundleStatus(bundle.identifier, state, sum(item.size_bytes for item in bundle.files), sum(item.size_bytes for item in bundle.files), reason_code=reason)
             elif current is None or current.state not in {VideoCapabilityState.FAILED, VideoCapabilityState.PAUSED}:
                 self._status[bundle.identifier] = VideoBundleStatus(bundle.identifier, VideoCapabilityState.MISSING, 0, sum(item.size_bytes for item in bundle.files))


### PR DESCRIPTION
## Summary
- keep the real video settings and capability readiness requests alive for the full bounded GPU probe window
- show a clear first-run detection message while the settings page remains usable
- hide Windows runtime probe consoles
- reuse one readiness result across both video bundles in a single status refresh

## Focused verification
- 72 installer/settings/media probe tests passed
- git diff --check passed

This PR is intentionally separate from Persona assembly fixes. No private letters, API keys, or local paths are included.