### PR TITLE
feat: bound PrivateWorld intimacy growth

### DIFF
--- a/private_world_reducer.py
+++ b/private_world_reducer.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 import re
 
 from private_world_commands import (
     ConfirmRelationshipStage,
     DeleteContinuationFact,
+    GrantIntimacy,
     GrantNickname,
     InitializeHistoricalRelationship,
     PrivateWorldCommand,
@@ -22,8 +23,14 @@ from private_world_commands import (
     UpsertContinuationFact,
 )
 from private_world_port import (
+    IntimacyGrant,
     LocalContinuationFact,
     PrivateWorldSnapshot,
+)
+from runtime.reply.reply_context import (
+    IntimacyTier,
+    ReplyContextError,
+    intimacy_ceiling_for_stage,
 )
 
 
@@ -37,6 +44,7 @@ class ReducerEventKind(str, Enum):
     CONFLICT = "conflict"
     REPAIR = "repair"
     STAGE_CONFIRMED = "stage_confirmed"
+    INTIMACY_GRANTED = "intimacy_granted"
     HIGH_FREQUENCY_MESSAGE = "high_frequency_message"
     GIFT = "gift"
     REPEATED_PHRASE = "repeated_phrase"
@@ -47,6 +55,13 @@ class ReducerEventKind(str, Enum):
 _TOKEN_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
 _STAGE_RE = re.compile(r"^[A-Za-z0-9._:-]{1,64}$")
 _DEDUPLICATION_WINDOW = timedelta(hours=24)
+_GROWTH_WINDOW = timedelta(days=7)
+_WEEKLY_GROWTH_CAP = 6
+_INTIMACY_TIER_ORDER = (
+    IntimacyTier.NONE,
+    IntimacyTier.LIGHT_CONTACT,
+    IntimacyTier.CLOSE_CONTACT,
+)
 _NO_EFFECT_KINDS = {
     ReducerEventKind.CANONICAL_REPLY_DELIVERED,
     ReducerEventKind.HIGH_FREQUENCY_MESSAGE,
@@ -65,6 +80,7 @@ class ReducerEvent:
     last_equivalent_at: datetime | None = None
     target_stage: str | None = None
     basis_event_ids: tuple[str, ...] = ()
+    intimacy_grant: IntimacyGrant | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.kind, ReducerEventKind):
@@ -96,6 +112,10 @@ class ReducerEvent:
                 tuple(self.basis_event_ids),
             )
         if self.kind is ReducerEventKind.STAGE_CONFIRMED:
+            if self.intimacy_grant is not None:
+                raise ReducerInputError(
+                    "stage confirmation cannot carry an intimacy grant"
+                )
             if not isinstance(self.target_stage, str) or not _STAGE_RE.fullmatch(
                 self.target_stage
             ):
@@ -114,9 +134,26 @@ class ReducerEvent:
                 raise ReducerInputError(
                     "stage confirmation requires explicit evidence"
                 )
-        elif self.target_stage is not None or self.basis_event_ids:
+        elif self.kind is ReducerEventKind.INTIMACY_GRANTED:
+            if not isinstance(self.intimacy_grant, IntimacyGrant):
+                raise ReducerInputError(
+                    "intimacy grant event requires a typed grant"
+                )
+            if self.intimacy_grant.tier is IntimacyTier.NONE:
+                raise ReducerInputError(
+                    "intimacy grant tier must grant contact"
+                )
+            if self.target_stage is not None or self.basis_event_ids:
+                raise ReducerInputError(
+                    "intimacy grant cannot carry stage evidence"
+                )
+        elif (
+            self.target_stage is not None
+            or self.basis_event_ids
+            or self.intimacy_grant is not None
+        ):
             raise ReducerInputError(
-                "stage evidence is only valid for stage confirmation"
+                "event payload is invalid for this event kind"
             )
 
 
@@ -150,6 +187,33 @@ def _duplicate(event: ReducerEvent) -> bool:
     return (
         event.occurred_at - event.last_equivalent_at
         < _DEDUPLICATION_WINDOW
+    )
+
+
+def _growth_window(
+    snapshot: PrivateWorldSnapshot,
+    now: datetime,
+) -> tuple[str, int]:
+    now_utc = now.astimezone(timezone.utc)
+    if snapshot.growth_window_start:
+        started_at = datetime.fromisoformat(
+            snapshot.growth_window_start.replace("Z", "+00:00")
+        )
+        if now_utc - started_at < _GROWTH_WINDOW:
+            return snapshot.growth_window_start, snapshot.growth_used
+    return now_utc.isoformat(), 0
+
+
+def _intimacy_exceeds_stage(
+    stage: str,
+    tier: IntimacyTier,
+) -> bool:
+    try:
+        ceiling = intimacy_ceiling_for_stage(stage)
+    except ReplyContextError:
+        ceiling = IntimacyTier.NONE
+    return _INTIMACY_TIER_ORDER.index(tier) > _INTIMACY_TIER_ORDER.index(
+        ceiling
     )
 
 
@@ -203,11 +267,26 @@ def reduce_private_world(
         return _no_change(snapshot, "SEMANTIC_DUPLICATE")
 
     updates: dict[str, object] = {}
+    reason_code = event.kind.value.upper()
     if event.kind is ReducerEventKind.BOUNDARY_RESPECTED:
         updates = {
             "trust": _bounded(snapshot.trust, 1),
             "comfort": _bounded(snapshot.comfort, 1),
         }
+        growth_start, growth_used = _growth_window(
+            snapshot,
+            event.occurred_at,
+        )
+        if growth_used + 1 <= _WEEKLY_GROWTH_CAP:
+            updates.update(
+                {
+                    "familiarity": _bounded(snapshot.familiarity, 1),
+                    "growth_window_start": growth_start,
+                    "growth_used": growth_used + 1,
+                }
+            )
+        else:
+            reason_code = "GROWTH_CAP_REACHED"
     elif event.kind is ReducerEventKind.CONFLICT:
         updates = {
             "trust": _bounded(snapshot.trust, -2),
@@ -224,11 +303,57 @@ def reduce_private_world(
         updates = {
             "relationship_stage": event.target_stage or "unknown",
         }
+        if event.target_stage != snapshot.relationship_stage:
+            updates.update(
+                {
+                    "closeness": _bounded(snapshot.closeness, 5),
+                    "familiarity": _bounded(snapshot.familiarity, 3),
+                }
+            )
+    elif event.kind is ReducerEventKind.INTIMACY_GRANTED:
+        grant = event.intimacy_grant
+        if grant is None:
+            raise ReducerInputError("intimacy grant event is invalid")
+        if _intimacy_exceeds_stage(snapshot.relationship_stage, grant.tier):
+            return _no_change(snapshot, "INTIMACY_EXCEEDS_STAGE")
+        if any(
+            existing.grant_id == grant.grant_id
+            for existing in snapshot.intimacy_grants
+        ):
+            return _no_change(snapshot, "INTIMACY_ALREADY_GRANTED")
+        if len(snapshot.intimacy_grants) >= 16:
+            return _no_change(snapshot, "INTIMACY_LIMIT_REACHED")
+        updates = {
+            "intimacy_grants": (*snapshot.intimacy_grants, grant),
+        }
+        growth_start, growth_used = _growth_window(
+            snapshot,
+            event.occurred_at,
+        )
+        if growth_used + 2 <= _WEEKLY_GROWTH_CAP:
+            updates.update(
+                {
+                    "closeness": _bounded(snapshot.closeness, 2),
+                    "growth_window_start": growth_start,
+                    "growth_used": growth_used + 2,
+                }
+            )
+        else:
+            return _apply_updates(
+                snapshot,
+                updates,
+                reason_code="GROWTH_CAP_REACHED",
+            )
 
     return _apply_updates(
         snapshot,
         updates,
-        reason_code=event.kind.value.upper(),
+        reason_code=reason_code,
+        unchanged_reason=(
+            "GROWTH_CAP_REACHED"
+            if reason_code == "GROWTH_CAP_REACHED"
+            else "BOUNDED_NO_CHANGE"
+        ),
     )
 
 
@@ -248,6 +373,17 @@ def _relationship_command_event(
             semantic_key=command.idempotency_key,
             target_stage=command.target_stage.value,
             basis_event_ids=command.basis_event_ids,
+        )
+    elif isinstance(command, GrantIntimacy):
+        return ReducerEvent(
+            kind=ReducerEventKind.INTIMACY_GRANTED,
+            occurred_at=command.occurred_at,
+            semantic_key=command.idempotency_key,
+            intimacy_grant=IntimacyGrant(
+                grant_id=command.grant_id,
+                tier=command.tier,
+                statement=command.statement,
+            ),
         )
     else:
         return None

--- a/private_world_service.py
+++ b/private_world_service.py
@@ -11,6 +11,7 @@ from typing import Protocol, runtime_checkable
 
 from private_world_commands import (
     ConfirmRelationshipStage,
+    GrantIntimacy,
     PrivateWorldActor,
     PrivateWorldCommand,
     PrivateWorldCommandKind,
@@ -164,6 +165,16 @@ class PrivateWorldCommandService:
 
     @staticmethod
     def _authorize(command: PrivateWorldCommand) -> None:
+        if isinstance(command, GrantIntimacy):
+            if (
+                command.actor is not PrivateWorldActor.LOCAL_USER
+                or command.source
+                is not PrivateWorldCommandSource.CONTROL_CENTER
+            ):
+                raise PrivateWorldCommandServiceError(
+                    "PRIVATE_WORLD_COMMAND_SOURCE_FORBIDDEN"
+                )
+            return
         if command.actor is PrivateWorldActor.SYSTEM_CANDIDATE:
             raise PrivateWorldCommandServiceError(
                 "PRIVATE_WORLD_COMMAND_APPROVAL_REQUIRED"

--- a/runtime/memory/private_world_delivery.py
+++ b/runtime/memory/private_world_delivery.py
@@ -10,6 +10,7 @@ import re
 import sqlite3
 
 from private_world_ledger import LedgerEvent, LedgerWriteError, SQLitePrivateWorldLedger
+from private_world_port import IntimacyGrant
 from private_world_reducer import ReducerEvent, ReducerEventKind, reduce_private_world
 
 
@@ -31,6 +32,7 @@ class DeliveryEvent:
     last_equivalent_at: datetime | None = None
     target_stage: str | None = None
     basis_event_ids: tuple[str, ...] = ()
+    intimacy_grant: IntimacyGrant | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.delivery_id, str) or not _ID_RE.fullmatch(
@@ -38,12 +40,13 @@ class DeliveryEvent:
         ):
             raise ValueError("delivery_id is invalid")
         ReducerEvent(
-            self.kind,
-            self.occurred_at,
-            self.semantic_key,
-            self.last_equivalent_at,
-            self.target_stage,
-            self.basis_event_ids,
+            kind=self.kind,
+            occurred_at=self.occurred_at,
+            semantic_key=self.semantic_key,
+            last_equivalent_at=self.last_equivalent_at,
+            target_stage=self.target_stage,
+            basis_event_ids=self.basis_event_ids,
+            intimacy_grant=self.intimacy_grant,
         )
 
 
@@ -55,12 +58,13 @@ class PrivateWorldDeliveryCommitter:
         if not isinstance(delivery, DeliveryEvent):
             raise TypeError("typed delivery is required")
         event = ReducerEvent(
-            delivery.kind,
-            delivery.occurred_at,
-            delivery.semantic_key,
-            delivery.last_equivalent_at,
-            delivery.target_stage,
-            delivery.basis_event_ids,
+            kind=delivery.kind,
+            occurred_at=delivery.occurred_at,
+            semantic_key=delivery.semantic_key,
+            last_equivalent_at=delivery.last_equivalent_at,
+            target_stage=delivery.target_stage,
+            basis_event_ids=delivery.basis_event_ids,
+            intimacy_grant=delivery.intimacy_grant,
         )
         try:
             snapshot = self.ledger.snapshot()

--- a/runtime/private_world/commands.py
+++ b/runtime/private_world/commands.py
@@ -8,11 +8,12 @@ from enum import StrEnum
 import re
 from typing import ClassVar, TypeAlias
 
-from runtime.reply.reply_context import RelationshipStage
+from runtime.reply.reply_context import IntimacyTier, RelationshipStage
 
 from .port import (
     ContinuationAwareness,
     HomeAccess,
+    IntimacyGrant,
     LocalContinuationFact,
     PrivateWorldError,
 )
@@ -40,6 +41,7 @@ class PrivateWorldCommandKind(StrEnum):
     RECORD_CONFLICT = "record_conflict"
     RECORD_REPAIR = "record_repair"
     CONFIRM_RELATIONSHIP_STAGE = "confirm_relationship_stage"
+    GRANT_INTIMACY = "grant_intimacy"
     GRANT_NICKNAME = "grant_nickname"
     REVOKE_NICKNAME = "revoke_nickname"
     SET_HOME_ACCESS = "set_home_access"
@@ -214,6 +216,42 @@ class ConfirmRelationshipStage(PrivateWorldCommand):
         return {
             "target_stage": self.target_stage.value,
             "basis_event_ids": list(self.basis_event_ids),
+        }
+
+
+@dataclass(frozen=True, kw_only=True)
+class GrantIntimacy(PrivateWorldCommand):
+    grant_id: str
+    tier: IntimacyTier
+    statement: str
+
+    kind: ClassVar[PrivateWorldCommandKind] = (
+        PrivateWorldCommandKind.GRANT_INTIMACY
+    )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        try:
+            grant = IntimacyGrant(
+                grant_id=self.grant_id,
+                tier=self.tier,
+                statement=self.statement,
+            )
+        except PrivateWorldError as exc:
+            raise PrivateWorldCommandError(str(exc)) from exc
+        if grant.tier is IntimacyTier.NONE:
+            raise PrivateWorldCommandError(
+                "intimacy grant tier must grant contact"
+            )
+        object.__setattr__(self, "grant_id", grant.grant_id)
+        object.__setattr__(self, "tier", grant.tier)
+        object.__setattr__(self, "statement", grant.statement)
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "grant_id": self.grant_id,
+            "tier": self.tier.value,
+            "statement": self.statement,
         }
 
 
@@ -394,6 +432,7 @@ PrivateWorldMutation: TypeAlias = (
     | RecordConflict
     | RecordRepair
     | ConfirmRelationshipStage
+    | GrantIntimacy
     | GrantNickname
     | RevokeNickname
     | SetHomeAccess
@@ -407,6 +446,7 @@ PrivateWorldMutation: TypeAlias = (
 __all__ = [
     "ConfirmRelationshipStage",
     "DeleteContinuationFact",
+    "GrantIntimacy",
     "GrantNickname",
     "InitializeHistoricalRelationship",
     "PrivateWorldActor",

--- a/tests/private_world/test_private_world_command_reducer.py
+++ b/tests/private_world/test_private_world_command_reducer.py
@@ -7,9 +7,11 @@ import pytest
 from private_world_commands import (
     ConfirmRelationshipStage,
     DeleteContinuationFact,
+    GrantIntimacy,
     GrantNickname,
     PrivateWorldActor,
     PrivateWorldCommandSource,
+    PrivateWorldCommandError,
     RecordBoundaryRespected,
     RecordConflict,
     RecordRepair,
@@ -29,6 +31,7 @@ from private_world_reducer import (
     reduce_private_world_command,
 )
 from runtime.reply.reply_context import RelationshipStage
+from runtime.reply.reply_context import IntimacyTier
 
 
 NOW = datetime(2026, 8, 22, 20, 0, tzinfo=timezone.utc)
@@ -44,6 +47,57 @@ def _common(sequence: int = 1) -> dict[str, object]:
         "reason": "synthetic confirmed change",
         "evidence_refs": (f"letter:synthetic-{sequence}",),
     }
+
+
+def test_intimacy_grant_command_is_typed_and_serializable() -> None:
+    command = GrantIntimacy(
+        **_common(),
+        grant_id="intimacy.synthetic-1",
+        tier=IntimacyTier.LIGHT_CONTACT,
+        statement="A synthetic consent statement.",
+    )
+
+    assert command.to_dict()["kind"] == "grant_intimacy"
+    assert command.to_dict()["payload"] == {
+        "grant_id": "intimacy.synthetic-1",
+        "tier": "light_contact",
+        "statement": "A synthetic consent statement.",
+    }
+
+    with pytest.raises(PrivateWorldCommandError):
+        GrantIntimacy(
+            **_common(2),
+            grant_id="intimacy.synthetic-none",
+            tier=IntimacyTier.NONE,
+            statement="A synthetic non-grant.",
+        )
+
+
+def test_intimacy_grant_command_is_idempotent_without_a_revoke_path() -> None:
+    import private_world_commands
+
+    command = GrantIntimacy(
+        **_common(),
+        grant_id="intimacy.synthetic-1",
+        tier=IntimacyTier.LIGHT_CONTACT,
+        statement="A synthetic consent statement.",
+    )
+    before = PrivateWorldSnapshot(
+        version=4,
+        relationship_stage="close",
+    )
+
+    added = reduce_private_world_command(before, command)
+    assert added.delta.reason_code == "INTIMACY_GRANTED"
+    assert added.snapshot.intimacy_grants[0].grant_id == command.grant_id
+    assert added.snapshot.closeness == 2
+    assert added.snapshot.growth_used == 2
+
+    duplicate = reduce_private_world_command(added.snapshot, command)
+    assert duplicate.snapshot == added.snapshot
+    assert duplicate.delta.applied is False
+    assert duplicate.delta.reason_code == "INTIMACY_ALREADY_GRANTED"
+    assert not hasattr(private_world_commands, "RevokeIntimacy")
 
 
 def test_relationship_commands_reuse_slow_bounded_reducer_policy() -> None:
@@ -70,7 +124,12 @@ def test_relationship_commands_reuse_slow_bounded_reducer_policy() -> None:
     assert boundary.delta.reason_code == "BOUNDARY_RESPECTED"
     assert tuple(
         change.field for change in boundary.delta.changes
-    ) == ("trust",)
+    ) == (
+        "trust",
+        "familiarity",
+        "growth_window_start",
+        "growth_used",
+    )
 
     conflict = reduce_private_world_command(
         boundary.snapshot,

--- a/tests/private_world/test_private_world_delivery.py
+++ b/tests/private_world/test_private_world_delivery.py
@@ -12,13 +12,68 @@ from runtime.memory.private_world_delivery import (
     PrivateWorldDeliveryCommitter,
 )
 from private_world_ledger import LedgerEvent, SQLitePrivateWorldLedger
-from private_world_port import PrivateWorldSnapshot
+from private_world_port import IntimacyGrant, PrivateWorldSnapshot
 from private_world_reducer import ReducerEventKind
 from reply_orchestrator import ReplyState
 from runtime.reply.reply_pipeline import PipelineResult
+from runtime.reply.reply_context import IntimacyTier
 
 
 NOW = datetime(2026, 8, 22, tzinfo=timezone.utc)
+
+
+def test_delivery_event_validates_intimacy_payload_without_stage_fields(
+    tmp_path: Path,
+) -> None:
+    grant = IntimacyGrant(
+        grant_id="intimacy.synthetic-delivery",
+        tier=IntimacyTier.LIGHT_CONTACT,
+        statement="A synthetic consent statement.",
+    )
+    delivery = DeliveryEvent(
+        delivery_id="letter-intimacy:1",
+        kind=ReducerEventKind.INTIMACY_GRANTED,
+        occurred_at=NOW,
+        semantic_key="intimacy.synthetic-delivery",
+        intimacy_grant=grant,
+    )
+
+    with pytest.raises(ValueError):
+        DeliveryEvent(
+            delivery_id="letter-intimacy-missing:1",
+            kind=ReducerEventKind.INTIMACY_GRANTED,
+            occurred_at=NOW,
+            semantic_key="intimacy.synthetic-missing",
+        )
+    with pytest.raises(ValueError):
+        DeliveryEvent(
+            delivery_id="letter-intimacy-stage:1",
+            kind=ReducerEventKind.INTIMACY_GRANTED,
+            occurred_at=NOW,
+            semantic_key="intimacy.synthetic-stage",
+            target_stage="close",
+            basis_event_ids=("basis.synthetic",),
+            intimacy_grant=grant,
+        )
+
+    ledger = SQLitePrivateWorldLedger(tmp_path / "private.sqlite3")
+    ledger.apply_once(
+        LedgerEvent(
+            event_id="seed.intimacy-stage",
+            delivery_id="seed.intimacy-stage",
+            event_type="stage_confirmed",
+            payload={"synthetic": True},
+            occurred_at=NOW.isoformat(),
+        ),
+        PrivateWorldSnapshot(relationship_stage="close"),
+    )
+    committer = PrivateWorldDeliveryCommitter(ledger)
+    assert committer.commit(delivery) is DeliveryStatus.COMMITTED
+    assert committer.commit(delivery) is DeliveryStatus.DUPLICATE
+    reopened = SQLitePrivateWorldLedger(tmp_path / "private.sqlite3")
+    assert reopened.snapshot().intimacy_grants == (grant,)
+    assert reopened.snapshot().closeness == 2
+    assert reopened.snapshot().growth_used == 2
 
 
 def test_delivery_commits_once_with_stable_delivery_id(tmp_path: Path) -> None:

--- a/tests/private_world/test_private_world_reducer.py
+++ b/tests/private_world/test_private_world_reducer.py
@@ -2,13 +2,14 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from private_world_port import PrivateWorldSnapshot
+from private_world_port import IntimacyGrant, PrivateWorldSnapshot
 from private_world_reducer import (
     ReducerEvent,
     ReducerEventKind,
     ReducerInputError,
     reduce_private_world,
 )
+from runtime.reply.reply_context import IntimacyTier
 
 
 NOW = datetime(2026, 8, 22, tzinfo=timezone.utc)
@@ -24,6 +25,44 @@ def _event(kind: ReducerEventKind, **changes: object) -> ReducerEvent:
     return ReducerEvent(**values)  # type: ignore[arg-type]
 
 
+def _grant(number: int, tier: IntimacyTier) -> IntimacyGrant:
+    return IntimacyGrant(
+        grant_id=f"intimacy.synthetic-{number}",
+        tier=tier,
+        statement=f"Synthetic intimacy grant {number}.",
+    )
+
+
+@pytest.mark.parametrize(
+    ("stage", "tier", "applied", "reason_code"),
+    [
+        ("familiar", IntimacyTier.LIGHT_CONTACT, False, "INTIMACY_EXCEEDS_STAGE"),
+        ("close", IntimacyTier.LIGHT_CONTACT, True, "INTIMACY_GRANTED"),
+        ("close", IntimacyTier.CLOSE_CONTACT, False, "INTIMACY_EXCEEDS_STAGE"),
+        ("committed", IntimacyTier.CLOSE_CONTACT, True, "INTIMACY_GRANTED"),
+        ("custom_future_stage", IntimacyTier.LIGHT_CONTACT, False, "INTIMACY_EXCEEDS_STAGE"),
+    ],
+)
+def test_intimacy_grant_respects_the_stage_ceiling(
+    stage: str,
+    tier: IntimacyTier,
+    applied: bool,
+    reason_code: str,
+) -> None:
+    before = PrivateWorldSnapshot(version=3, relationship_stage=stage)
+    grant = _grant(1, tier)
+
+    result = reduce_private_world(
+        before,
+        _event(ReducerEventKind.INTIMACY_GRANTED, intimacy_grant=grant),
+    )
+
+    assert result.delta.applied is applied
+    assert result.delta.reason_code == reason_code
+    assert result.snapshot.intimacy_grants == ((grant,) if applied else ())
+    assert result.snapshot.closeness == (2 if applied else 0)
+
+
 def test_boundary_respect_changes_state_slowly_and_explains_delta() -> None:
     before = PrivateWorldSnapshot(version=3, trust=10, comfort=20)
 
@@ -35,14 +74,228 @@ def test_boundary_respect_changes_state_slowly_and_explains_delta() -> None:
     assert result.snapshot.version == 4
     assert result.snapshot.trust == 11
     assert result.snapshot.comfort == 21
+    assert result.snapshot.familiarity == 1
     assert result.delta.applied is True
     assert result.delta.reason_code == "BOUNDARY_RESPECTED"
-    assert {change.field for change in result.delta.changes} == {"trust", "comfort"}
+    assert {change.field for change in result.delta.changes} == {
+        "trust",
+        "comfort",
+        "familiarity",
+        "growth_window_start",
+        "growth_used",
+    }
+
+
+def test_weekly_growth_cap_blocks_only_growth_and_resets_at_seven_days() -> None:
+    snapshot = PrivateWorldSnapshot(version=1)
+    for index in range(6):
+        snapshot = reduce_private_world(
+            snapshot,
+            _event(
+                ReducerEventKind.BOUNDARY_RESPECTED,
+                occurred_at=NOW + timedelta(hours=index),
+                semantic_key=f"boundary.synthetic-{index}",
+            ),
+        ).snapshot
+
+    assert snapshot.familiarity == 6
+    assert snapshot.growth_used == 6
+    assert snapshot.growth_window_start == NOW.isoformat()
+
+    capped = reduce_private_world(
+        snapshot,
+        _event(
+            ReducerEventKind.BOUNDARY_RESPECTED,
+            occurred_at=NOW + timedelta(days=6),
+            semantic_key="boundary.synthetic-capped",
+        ),
+    )
+    assert capped.delta.applied is True
+    assert capped.delta.reason_code == "GROWTH_CAP_REACHED"
+    assert capped.snapshot.familiarity == 6
+    assert capped.snapshot.trust == 7
+    assert capped.snapshot.comfort == 7
+    assert capped.snapshot.growth_used == 6
+
+    reset = reduce_private_world(
+        capped.snapshot,
+        _event(
+            ReducerEventKind.BOUNDARY_RESPECTED,
+            occurred_at=NOW + timedelta(days=7),
+            semantic_key="boundary.synthetic-reset",
+        ),
+    )
+    assert reset.delta.reason_code == "BOUNDARY_RESPECTED"
+    assert reset.snapshot.familiarity == 7
+    assert reset.snapshot.growth_used == 1
+    assert reset.snapshot.growth_window_start == (
+        NOW + timedelta(days=7)
+    ).isoformat()
+
+
+def test_growth_cap_keeps_an_admitted_grant_without_free_growth() -> None:
+    grant = _grant(2, IntimacyTier.LIGHT_CONTACT)
+    before = PrivateWorldSnapshot(
+        version=4,
+        relationship_stage="close",
+        closeness=12,
+        growth_window_start=NOW.isoformat(),
+        growth_used=6,
+    )
+
+    result = reduce_private_world(
+        before,
+        _event(ReducerEventKind.INTIMACY_GRANTED, intimacy_grant=grant),
+    )
+
+    assert result.delta.applied is True
+    assert result.delta.reason_code == "GROWTH_CAP_REACHED"
+    assert result.snapshot.intimacy_grants == (grant,)
+    assert result.snapshot.closeness == 12
+    assert result.snapshot.growth_used == 6
+
+
+def test_growth_can_exactly_fill_the_remaining_weekly_quota() -> None:
+    grant = _grant(3, IntimacyTier.LIGHT_CONTACT)
+    before = PrivateWorldSnapshot(
+        relationship_stage="close",
+        closeness=8,
+        growth_window_start=NOW.isoformat(),
+        growth_used=4,
+    )
+
+    result = reduce_private_world(
+        before,
+        _event(ReducerEventKind.INTIMACY_GRANTED, intimacy_grant=grant),
+    )
+
+    assert result.delta.reason_code == "INTIMACY_GRANTED"
+    assert result.snapshot.closeness == 10
+    assert result.snapshot.growth_used == 6
+
+
+def test_event_before_the_window_start_keeps_the_existing_window() -> None:
+    before = PrivateWorldSnapshot(
+        growth_window_start=NOW.isoformat(),
+        growth_used=1,
+    )
+
+    result = reduce_private_world(
+        before,
+        _event(
+            ReducerEventKind.BOUNDARY_RESPECTED,
+            occurred_at=NOW - timedelta(days=1),
+        ),
+    )
+
+    assert result.snapshot.growth_window_start == NOW.isoformat()
+    assert result.snapshot.growth_used == 2
+    assert result.snapshot.familiarity == 1
+
+
+def test_exhausted_growth_with_bounded_non_growth_is_a_cap_noop() -> None:
+    before = PrivateWorldSnapshot(
+        familiarity=100,
+        trust=100,
+        comfort=100,
+        growth_window_start=NOW.isoformat(),
+        growth_used=6,
+    )
+
+    result = reduce_private_world(
+        before,
+        _event(ReducerEventKind.BOUNDARY_RESPECTED),
+    )
+
+    assert result.snapshot == before
+    assert result.delta.applied is False
+    assert result.delta.reason_code == "GROWTH_CAP_REACHED"
+
+
+def test_grant_admission_order_precedes_capacity_and_growth_checks() -> None:
+    existing = tuple(
+        _grant(index, IntimacyTier.LIGHT_CONTACT)
+        for index in range(1, 17)
+    )
+    full = PrivateWorldSnapshot(
+        version=9,
+        relationship_stage="close",
+        intimacy_grants=existing,
+        growth_window_start=NOW.isoformat(),
+        growth_used=6,
+    )
+
+    duplicate = reduce_private_world(
+        full,
+        _event(
+            ReducerEventKind.INTIMACY_GRANTED,
+            intimacy_grant=existing[0],
+        ),
+    )
+    assert duplicate.snapshot == full
+    assert duplicate.delta.reason_code == "INTIMACY_ALREADY_GRANTED"
+
+    at_capacity = reduce_private_world(
+        full,
+        _event(
+            ReducerEventKind.INTIMACY_GRANTED,
+            intimacy_grant=_grant(17, IntimacyTier.LIGHT_CONTACT),
+        ),
+    )
+    assert at_capacity.snapshot == full
+    assert at_capacity.delta.reason_code == "INTIMACY_LIMIT_REACHED"
+
+    exceeds_stage = reduce_private_world(
+        PrivateWorldSnapshot(
+            version=9,
+            relationship_stage="familiar",
+            intimacy_grants=existing,
+        ),
+        _event(
+            ReducerEventKind.INTIMACY_GRANTED,
+            intimacy_grant=existing[0],
+        ),
+    )
+    assert exceeds_stage.delta.reason_code == "INTIMACY_EXCEEDS_STAGE"
+
+
+def test_stage_growth_requires_an_actual_explicit_stage_change() -> None:
+    before = PrivateWorldSnapshot(
+        version=2,
+        relationship_stage="familiar",
+        familiarity=10,
+        closeness=20,
+    )
+
+    repeated = reduce_private_world(
+        before,
+        _event(
+            ReducerEventKind.STAGE_CONFIRMED,
+            target_stage="familiar",
+            basis_event_ids=("basis.repeat",),
+        ),
+    )
+    assert repeated.snapshot == before
+    assert repeated.delta.reason_code == "BOUNDED_NO_CHANGE"
+
+    downgraded = reduce_private_world(
+        before,
+        _event(
+            ReducerEventKind.STAGE_CONFIRMED,
+            target_stage="acquaintance",
+            basis_event_ids=("basis.downgrade",),
+        ),
+    )
+    assert downgraded.snapshot.relationship_stage == "acquaintance"
+    assert downgraded.snapshot.familiarity == 13
+    assert downgraded.snapshot.closeness == 25
+    assert downgraded.snapshot.growth_used == 0
 
 
 @pytest.mark.parametrize(
     "kind",
     [
+        ReducerEventKind.CANONICAL_REPLY_DELIVERED,
         ReducerEventKind.HIGH_FREQUENCY_MESSAGE,
         ReducerEventKind.GIFT,
         ReducerEventKind.REPEATED_PHRASE,
@@ -59,6 +312,7 @@ def test_spam_gifts_confession_and_inactivity_do_not_upgrade_state(
 
     assert result.snapshot == before
     assert result.delta.applied is False
+    assert result.delta.reason_code == "NO_RELATIONSHIP_EFFECT"
     assert result.delta.changes == ()
 
 
@@ -110,6 +364,30 @@ def test_stage_never_changes_from_score_threshold_alone() -> None:
         )
 
 
+def test_event_sequences_never_downgrade_a_stage_implicitly() -> None:
+    snapshot = PrivateWorldSnapshot(
+        relationship_stage="committed",
+        trust=1,
+        comfort=1,
+        tension=99,
+    )
+    for index, kind in enumerate(
+        (
+            ReducerEventKind.CONFLICT,
+            ReducerEventKind.REPAIR,
+            ReducerEventKind.BOUNDARY_RESPECTED,
+            ReducerEventKind.INACTIVITY,
+            ReducerEventKind.CONFESSION,
+        )
+    ):
+        snapshot = reduce_private_world(
+            snapshot,
+            _event(kind, semantic_key=f"sequence.synthetic-{index}"),
+        ).snapshot
+
+    assert snapshot.relationship_stage == "committed"
+
+
 def test_same_semantic_event_is_deduplicated_inside_fixed_window() -> None:
     before = PrivateWorldSnapshot(version=1, trust=10)
     duplicate = _event(
@@ -126,3 +404,92 @@ def test_same_semantic_event_is_deduplicated_inside_fixed_window() -> None:
         last_equivalent_at=NOW - timedelta(hours=25),
     )
     assert reduce_private_world(before, outside_window).delta.applied is True
+
+
+def test_intimacy_grant_obeys_the_same_semantic_deduplication_window() -> None:
+    before = PrivateWorldSnapshot(
+        version=3,
+        relationship_stage="close",
+    )
+    grant = _grant(30, IntimacyTier.LIGHT_CONTACT)
+
+    blocked = reduce_private_world(
+        before,
+        _event(
+            ReducerEventKind.INTIMACY_GRANTED,
+            intimacy_grant=grant,
+            last_equivalent_at=NOW - timedelta(hours=2),
+        ),
+    )
+    assert blocked.snapshot == before
+    assert blocked.delta.reason_code == "SEMANTIC_DUPLICATE"
+
+    applied = reduce_private_world(
+        before,
+        _event(
+            ReducerEventKind.INTIMACY_GRANTED,
+            intimacy_grant=grant,
+            last_equivalent_at=NOW - timedelta(hours=24),
+        ),
+    )
+    assert applied.delta.reason_code == "INTIMACY_GRANTED"
+    assert applied.snapshot.intimacy_grants == (grant,)
+
+
+def test_growth_scores_remain_bounded_and_window_start_is_utc() -> None:
+    offset_time = NOW.astimezone(timezone(timedelta(hours=9)))
+    boundary = reduce_private_world(
+        PrivateWorldSnapshot(
+            familiarity=100,
+            trust=100,
+            comfort=100,
+        ),
+        _event(
+            ReducerEventKind.BOUNDARY_RESPECTED,
+            occurred_at=offset_time,
+        ),
+    )
+    assert boundary.snapshot.familiarity == 100
+    assert boundary.snapshot.trust == 100
+    assert boundary.snapshot.comfort == 100
+    assert boundary.snapshot.growth_window_start == NOW.isoformat()
+
+    confirmed = reduce_private_world(
+        PrivateWorldSnapshot(
+            relationship_stage="familiar",
+            familiarity=99,
+            closeness=99,
+        ),
+        _event(
+            ReducerEventKind.STAGE_CONFIRMED,
+            target_stage="close",
+            basis_event_ids=("basis.bounded",),
+        ),
+    )
+    assert confirmed.snapshot.familiarity == 100
+    assert confirmed.snapshot.closeness == 100
+
+
+def test_intimacy_event_payload_is_strictly_exclusive_and_nonzero() -> None:
+    grant = _grant(31, IntimacyTier.LIGHT_CONTACT)
+    with pytest.raises(ReducerInputError):
+        _event(
+            ReducerEventKind.BOUNDARY_RESPECTED,
+            intimacy_grant=grant,
+        )
+    with pytest.raises(ReducerInputError):
+        _event(
+            ReducerEventKind.STAGE_CONFIRMED,
+            target_stage="close",
+            basis_event_ids=("basis.invalid",),
+            intimacy_grant=grant,
+        )
+    with pytest.raises(ReducerInputError):
+        _event(
+            ReducerEventKind.INTIMACY_GRANTED,
+            intimacy_grant=IntimacyGrant(
+                grant_id="intimacy.synthetic-none",
+                tier=IntimacyTier.NONE,
+                statement="A synthetic non-grant.",
+            ),
+        )

--- a/tests/private_world/test_private_world_service.py
+++ b/tests/private_world/test_private_world_service.py
@@ -8,6 +8,7 @@ import pytest
 
 from private_world_commands import (
     ConfirmRelationshipStage,
+    GrantIntimacy,
     GrantNickname,
     PrivateWorldActor,
     PrivateWorldCommandSource,
@@ -28,7 +29,7 @@ from private_world_service import (
     PrivateWorldCommandService,
     PrivateWorldCommandServiceError,
 )
-from runtime.reply.reply_context import RelationshipStage
+from runtime.reply.reply_context import IntimacyTier, RelationshipStage
 
 
 NOW = datetime(2026, 8, 22, 20, 0, tzinfo=timezone.utc)
@@ -200,6 +201,79 @@ def test_noop_is_audited_without_incrementing_snapshot() -> None:
     assert noop.snapshot_version == 2
     assert len(ledger.items) == 2
     assert ledger.items[1].payload["applied"] is False
+
+
+def test_intimacy_grant_uses_authorized_atomic_audit_without_values() -> None:
+    ledger = FakeLedger()
+    ledger.current = PrivateWorldSnapshot(relationship_stage="close")
+    service = PrivateWorldCommandService(ledger)
+    command = GrantIntimacy(
+        **_common(1),
+        grant_id="intimacy.synthetic-service",
+        tier=IntimacyTier.LIGHT_CONTACT,
+        statement="A synthetic private consent statement.",
+    )
+
+    applied = service.execute(command)
+    duplicate = service.execute(command)
+    repeated_grant = service.execute(
+        GrantIntimacy(
+            **_common(2),
+            grant_id=command.grant_id,
+            tier=command.tier,
+            statement=command.statement,
+        )
+    )
+
+    assert applied.status is CommandExecutionStatus.APPLIED
+    assert duplicate.status is CommandExecutionStatus.DUPLICATE
+    assert repeated_grant.status is CommandExecutionStatus.NOOP
+    assert repeated_grant.reason_code == "INTIMACY_ALREADY_GRANTED"
+    assert ledger.current.closeness == 2
+    assert ledger.current.growth_used == 2
+    assert len(ledger.items) == 2
+    audit = ledger.items[0].payload
+    assert audit["payload_fields"] == ["grant_id", "statement", "tier"]
+    serialized = repr(audit)
+    assert command.grant_id not in serialized
+    assert command.statement not in serialized
+    assert command.tier.value not in serialized
+
+
+@pytest.mark.parametrize(
+    ("actor", "source"),
+    [
+        (
+            PrivateWorldActor.SYSTEM_CANDIDATE,
+            PrivateWorldCommandSource.APPROVED_CANDIDATE,
+        ),
+        (
+            PrivateWorldActor.LOCAL_USER,
+            PrivateWorldCommandSource.APPROVED_CANDIDATE,
+        ),
+        (
+            PrivateWorldActor.MIGRATION,
+            PrivateWorldCommandSource.MIGRATION,
+        ),
+        (
+            PrivateWorldActor.MIGRATION,
+            PrivateWorldCommandSource.IMPORT,
+        ),
+    ],
+)
+def test_intimacy_grant_rejects_candidate_authority(
+    actor: PrivateWorldActor,
+    source: PrivateWorldCommandSource,
+) -> None:
+    command = GrantIntimacy(
+        **_common(actor=actor, source=source),
+        grant_id="intimacy.synthetic-forbidden",
+        tier=IntimacyTier.LIGHT_CONTACT,
+        statement="A synthetic private consent statement.",
+    )
+
+    with pytest.raises(PrivateWorldCommandServiceError):
+        PrivateWorldCommandService(FakeLedger()).execute(command)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Workorder scope

Implements WORKORDER-intimacy-model.md section 2: bounded intimacy growth in the PrivateWorld reducer.

- Adds typed GrantIntimacy and INTIMACY_GRANTED.
- Enforces a seven-day growth window and weekly cap.
- Preserves append-only grants, stage ceilings, 24-hour deduplication, explicit stage confirmation, and reducer purity.
- Restricts GrantIntimacy authorization to LOCAL_USER plus CONTROL_CENTER through PrivateWorldCommandService.

## Non-goals self-check

- [x] No source text or implementation copied from reference repository A.
- [x] No new relationship stage or intimacy tier.
- [x] No change to permanent-availability policy.
- [x] No media, ASR, visual, packaging, installer, desktop-client, network, telemetry, or dependency change.
- [x] No private statement, hidden score, or growth-window value exposed to character context or health endpoints.

## Local verification before merge

- Focused: 73 passed.
- Full suite: 1377 passed, 1 skipped, 1 deselected.
- baseline_hardening_scan.py --mode all: PASS.
- git diff --check: PASS.

## Review and merge evidence

- Frozen base: ecf82c00b6fa034d11954e408de8a573c9b1eff9.
- Frozen head: 5c0176d63cf3dfd3e6392935d924c0859b9a4bed.
- Standards: PASS.
- Spec: PASS after applying the then-current user-approved exact-assertion exception.
- Merge: 9fcbb91e06095de0a4f2e4668d04e5251cf031c2.

Post-merge authorization-boundary findings are handled in a separate P0 remediation PR; this historical description does not claim those later findings were covered by the original review.
