### PR TITLE
feat: project bounded intimacy into reply policy

### DIFF
--- a/contracts/reply_context.schema.json
+++ b/contracts/reply_context.schema.json
@@ -10,6 +10,7 @@
     "trusted_time",
     "world_facts",
     "private_behavior",
+    "intimacy_request",
     "output_constraints"
   ],
   "properties": {
@@ -32,6 +33,9 @@
     },
     "private_behavior": {
       "$ref": "#/$defs/private_behavior"
+    },
+    "intimacy_request": {
+      "enum": ["none", "requested"]
     },
     "output_constraints": {
       "$ref": "#/$defs/output_constraints"
@@ -161,6 +165,8 @@
         "closeness",
         "tension",
         "relationship_stage",
+        "intimacy_ceiling",
+        "granted_intimacy",
         "nickname_permission",
         "home_history_allowed",
         "known_continuations"
@@ -211,7 +217,22 @@
             "unknown",
             "acquaintance",
             "familiar",
-            "close"
+            "close",
+            "committed"
+          ]
+        },
+        "intimacy_ceiling": {
+          "enum": [
+            "none",
+            "light_contact",
+            "close_contact"
+          ]
+        },
+        "granted_intimacy": {
+          "enum": [
+            "none",
+            "light_contact",
+            "close_contact"
           ]
         },
         "nickname_permission": {

--- a/contracts/reply_context.schema.json
+++ b/contracts/reply_context.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "p02.reply-context.v1",
+  "$id": "p02.reply-context.v2",
   "title": "P02 ReplyContext contract",
   "type": "object",
   "additionalProperties": false,

--- a/docs/P02_16_REPLY_QUALITY_PIPELINE.md
+++ b/docs/P02_16_REPLY_QUALITY_PIPELINE.md
@@ -19,3 +19,10 @@ A clean deterministic reply may degrade open when the reviewer is unavailable.
 A deterministic hard violation requires the one available rewrite and fails
 closed if the rewrite is unavailable or remains invalid. The first candidate,
 review, optional rewrite, and final review all use the same `ReplyContext`.
+
+PR-3 accepts optional, structured `IntimacyClaim` spans at the quality-gate
+boundary but leaves the production pipeline on the empty default, as required
+by its staged rollout. Those spans cannot be reused after rewriting. Until the
+PR-4 reviewer returns fresh claims bound to the rewritten candidate, a rewrite
+that started with non-empty intimacy claims fails closed rather than bypassing
+the intimacy hard checks.

--- a/docs/P02_REPLY_CONTEXT.md
+++ b/docs/P02_REPLY_CONTEXT.md
@@ -3,18 +3,26 @@
 `runtime/reply/reply_context.py` defines the immutable, provider-free input shared by reply
 pipeline stages. It does not call a provider, render media, load a persona,
 review a reply, or commit private state. The matching JSON Schema is
-`contracts/reply_context.schema.json` with id `p02.reply-context.v1`.
+`contracts/reply_context.schema.json` with id `p02.reply-context.v2`.
+
+Version 2 makes `intimacy_request`, `intimacy_ceiling`, and
+`granted_intimacy` required, bounded enum fields. Runtime producers always
+emit them with fail-closed `none` defaults. A stored or external v1 payload is
+not valid against the v2 schema until those defaults are added; there is no
+implicit inference from prose or hidden scores.
 
 ## Public API
 
 - `ReplyContext.create(...)` accepts a `ReplyMode`, timezone-aware
   `TrustedTime`, identified `TrustedWorldFact` values, a bounded
-  `PrivateBehaviorView`, and explicit `OutputConstraints`.
+  `PrivateBehaviorView`, an explicit `IntimacyRequest`, and
+  `OutputConstraints`.
 - `PrivateBehaviorView` contains only finite relationship projections, the
   boolean `home_history_allowed`, and typed `KnownContinuationFact` values
   already marked character-known. It rejects raw home-access levels, scores,
   control awareness, arbitrary dictionaries, duplicates, and unbounded
-  statements.
+  statements. Its intimacy ceiling and granted tier are bounded to
+  `none`, `light_contact`, or `close_contact`.
 - `ReplyModeAdapter` preserves the legacy wire values: `text` maps to
   `text_letter`, while `video` maps to `spoken_video`. Both spoken and musical
   video serialize back to `video`.

--- a/docs/P02_REPLY_POLICY.md
+++ b/docs/P02_REPLY_POLICY.md
@@ -15,5 +15,14 @@ claims are blocked. Without that evidence, this deterministic scanner does not
 guess whether ordinary prose describes invented history. Semantic review
 belongs to P02-08 rather than an over-broad regular expression.
 
+Intimacy enforcement is likewise structured: `IntimacyClaim` spans carry a
+bounded tier, and the deterministic scanner rejects unsolicited claims or a
+tier above the projected ceiling. PR-3 keeps production callers on the empty
+claims default; the semantic reviewer becomes the production claim source in
+PR-4. A non-empty claim tuple is candidate-bound. If that candidate is
+rewritten before PR-4 can provide fresh claims for the new text, the quality
+gate blocks with `FRESH_INTIMACY_CLAIMS_REQUIRED` instead of accepting an
+unchecked rewrite.
+
 Violations contain only code, severity, and offsets. They do not duplicate the
 candidate text, private state, prompt, or evidence content.

--- a/runtime/memory/private_world_projection.py
+++ b/runtime/memory/private_world_projection.py
@@ -5,16 +5,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from private_world_port import (
-    ContinuationAwareness,
     LocalContinuationFact,
     PrivateWorldSnapshot,
 )
 from runtime.reply.reply_context import (
     BehaviorLevel,
+    IntimacyTier,
     KnownContinuationFact,
     NicknamePermission,
     PrivateBehaviorView,
     RelationshipStage,
+    intimacy_ceiling_for_stage,
 )
 
 
@@ -42,6 +43,8 @@ def _known_fact(value: LocalContinuationFact) -> KnownContinuationFact:
 @dataclass(frozen=True)
 class ProjectedPrivateWorld:
     behavior: PrivateBehaviorView
+    intimacy_ceiling: IntimacyTier
+    granted_intimacy: IntimacyTier
     authorized_nicknames: tuple[str, ...]
     may_acknowledge_home_history: bool
     continuation_known: bool
@@ -50,6 +53,8 @@ class ProjectedPrivateWorld:
     def to_dict(self) -> dict[str, object]:
         return {
             "behavior": self.behavior.to_dict(),
+            "intimacy_ceiling": self.intimacy_ceiling.value,
+            "granted_intimacy": self.granted_intimacy.value,
             "authorized_nicknames": list(self.authorized_nicknames),
             "continuation_known": self.continuation_known,
             "known_continuations": [
@@ -65,42 +70,41 @@ def project_private_world(
         raise TypeError(
             "projection requires a PrivateWorldSnapshot"
         )
-    nicknames = tuple(snapshot.nickname_permissions)
+    character = snapshot.character_view()
+    nicknames = tuple(character.nickname_permissions)
     known_facts = tuple(
-        _known_fact(fact)
-        for fact in snapshot.continuation_facts
-        if fact.awareness
-        is ContinuationAwareness.CHARACTER_KNOWN
+        _known_fact(fact) for fact in character.continuation_facts
     )
-    continuation_known = (
-        snapshot.continuation_awareness
-        is ContinuationAwareness.CHARACTER_KNOWN
-        or bool(known_facts)
-    )
+    continuation_known = character.continuation_known
+    stage = _stage(character.relationship_stage)
+    intimacy_ceiling = intimacy_ceiling_for_stage(stage)
+    granted_intimacy = character.granted_intimacy
     behavior = PrivateBehaviorView(
         familiarity=_level(snapshot.familiarity),
         trust=_level(snapshot.trust),
         comfort=_level(snapshot.comfort),
         closeness=_level(snapshot.closeness),
         tension=_level(snapshot.tension),
-        relationship_stage=_stage(
-            snapshot.relationship_stage
-        ),
+        relationship_stage=stage,
+        intimacy_ceiling=intimacy_ceiling,
+        granted_intimacy=granted_intimacy,
         nickname_permission=(
             NicknamePermission.ALLOWED
             if nicknames
             else NicknamePermission.NOT_ALLOWED
         ),
         home_history_allowed=(
-            snapshot.home_access.value != "no_access"
+            character.home_history_allowed
         ),
         known_continuations=known_facts,
     )
     return ProjectedPrivateWorld(
         behavior=behavior,
+        intimacy_ceiling=intimacy_ceiling,
+        granted_intimacy=granted_intimacy,
         authorized_nicknames=nicknames,
         may_acknowledge_home_history=(
-            snapshot.home_access.value != "no_access"
+            character.home_history_allowed
         ),
         continuation_known=continuation_known,
         known_continuation_facts=known_facts,

--- a/runtime/reply/reply_context.py
+++ b/runtime/reply/reply_context.py
@@ -64,6 +64,11 @@ class IntimacyTier(str, Enum):
     CLOSE_CONTACT = "close_contact"
 
 
+class IntimacyRequest(str, Enum):
+    NONE = "none"
+    REQUESTED = "requested"
+
+
 def intimacy_ceiling_for_stage(
     stage: RelationshipStage | str,
 ) -> IntimacyTier:
@@ -181,6 +186,8 @@ class PrivateBehaviorView:
     closeness: BehaviorLevel = BehaviorLevel.UNKNOWN
     tension: BehaviorLevel = BehaviorLevel.UNKNOWN
     relationship_stage: RelationshipStage = RelationshipStage.UNKNOWN
+    intimacy_ceiling: IntimacyTier = IntimacyTier.NONE
+    granted_intimacy: IntimacyTier = IntimacyTier.NONE
     nickname_permission: NicknamePermission = NicknamePermission.NOT_ALLOWED
     home_history_allowed: bool = False
     known_continuations: tuple[KnownContinuationFact, ...] = ()
@@ -193,6 +200,8 @@ class PrivateBehaviorView:
             (self.closeness, BehaviorLevel),
             (self.tension, BehaviorLevel),
             (self.relationship_stage, RelationshipStage),
+            (self.intimacy_ceiling, IntimacyTier),
+            (self.granted_intimacy, IntimacyTier),
             (self.nickname_permission, NicknamePermission),
         )
         if any(
@@ -232,6 +241,8 @@ class PrivateBehaviorView:
             "closeness": self.closeness.value,
             "tension": self.tension.value,
             "relationship_stage": self.relationship_stage.value,
+            "intimacy_ceiling": self.intimacy_ceiling.value,
+            "granted_intimacy": self.granted_intimacy.value,
             "nickname_permission": self.nickname_permission.value,
             "home_history_allowed": self.home_history_allowed,
             "known_continuations": [
@@ -325,6 +336,7 @@ class ReplyContext:
         )
     )
     future_im_enabled: bool = False
+    intimacy_request: IntimacyRequest = IntimacyRequest.NONE
 
     @classmethod
     def create(
@@ -336,6 +348,7 @@ class ReplyContext:
         private_behavior: PrivateBehaviorView | None = None,
         output_constraints: OutputConstraints | None = None,
         future_im_enabled: bool = False,
+        intimacy_request: IntimacyRequest = IntimacyRequest.NONE,
     ) -> "ReplyContext":
         if mode is ReplyMode.FUTURE_IM and not future_im_enabled:
             raise UnsupportedReplyMode()
@@ -359,12 +372,13 @@ class ReplyContext:
                 "world fact identifiers must be unique"
             )
         return cls(
-            mode,
-            trusted_time,
-            facts,
-            private_behavior or PrivateBehaviorView(),
-            constraints,
-            future_im_enabled,
+            mode=mode,
+            trusted_time=trusted_time,
+            world_facts=facts,
+            private_behavior=private_behavior or PrivateBehaviorView(),
+            output_constraints=constraints,
+            future_im_enabled=future_im_enabled,
+            intimacy_request=intimacy_request,
         )
 
     def __post_init__(self) -> None:
@@ -376,6 +390,8 @@ class ReplyContext:
             raise ReplyContextError(
                 "future_im_enabled must be boolean"
             )
+        if not isinstance(self.intimacy_request, IntimacyRequest):
+            raise ReplyContextError("intimacy request is invalid")
         if (
             self.mode is ReplyMode.FUTURE_IM
             and not self.future_im_enabled
@@ -441,6 +457,7 @@ class ReplyContext:
                 fact.to_dict() for fact in self.world_facts
             ],
             "private_behavior": self.private_behavior.to_dict(),
+            "intimacy_request": self.intimacy_request.value,
             "output_constraints": (
                 self.output_constraints.to_dict()
             ),

--- a/runtime/reply/reply_policy.py
+++ b/runtime/reply/reply_policy.py
@@ -6,7 +6,13 @@ from dataclasses import dataclass
 from enum import StrEnum
 import re
 
-from runtime.reply.reply_context import OutputConstraints, ReplyContext, ReplyMode
+from runtime.reply.reply_context import (
+    IntimacyRequest,
+    IntimacyTier,
+    OutputConstraints,
+    ReplyContext,
+    ReplyMode,
+)
 
 
 class ViolationSeverity(StrEnum):
@@ -23,6 +29,8 @@ class ViolationCode(StrEnum):
     PERMANENT_AVAILABILITY_PROMISE = "PERMANENT_AVAILABILITY_PROMISE"
     EXCLUSIVE_RELATIONSHIP_PROMISE = "EXCLUSIVE_RELATIONSHIP_PROMISE"
     UNAUTHORIZED_SHARED_HISTORY = "UNAUTHORIZED_SHARED_HISTORY"
+    UNSOLICITED_INTIMACY = "UNSOLICITED_INTIMACY"
+    INTIMACY_EXCEEDS_GRANT = "INTIMACY_EXCEEDS_GRANT"
 
 
 @dataclass(frozen=True)
@@ -62,12 +70,32 @@ class SharedHistoryClaim:
             raise ValueError("claim authorization must be boolean")
 
 
+@dataclass(frozen=True)
+class IntimacyClaim:
+    claim_id: str
+    tier: IntimacyTier
+    start: int
+    end: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.claim_id, str) or not re.fullmatch(
+            r"[A-Za-z0-9._:-]{1,96}", self.claim_id
+        ):
+            raise ValueError("claim_id must be a stable identifier")
+        if not isinstance(self.tier, IntimacyTier):
+            raise ValueError("claim tier must be an intimacy tier")
+        if type(self.start) is not int or type(self.end) is not int:
+            raise ValueError("claim span must use integers")
+        if self.start < 0 or self.end <= self.start:
+            raise ValueError("claim span is invalid")
+
+
 _CONTROL_MARKUP_RE = re.compile(
     r"</?(?:PERSONA_POLICY|PRIVATE_WORLD|CONTROL|SYSTEM|CONSTITUTION)(?:\s[^>]*)?>|\[\[CONTROL:",
     re.IGNORECASE,
 )
 _PRIVATE_STATE_RE = re.compile(
-    r"(?i)(?:[\"']?)(?:familiarity|trust|comfort|closeness|tension|relationship_stage|nickname_permission|home_access|home_history_allowed)(?:[\"']?)\s*[:=]"
+    r"(?i)(?:[\"']?)(?:familiarity|trust|comfort|closeness|tension|relationship_stage|intimacy_ceiling|granted_intimacy|intimacy_request|nickname_permission|home_access|home_history_allowed)(?:[\"']?)\s*[:=]"
 )
 _STAGE_DIRECTION_RE = re.compile(
     r"(?m)^\s*(?:[\(（\[【][^\n]{1,120}[\)）\]】]|\*[^\n*]{1,120}\*)\s*$"
@@ -97,6 +125,11 @@ _EXCLUSIVE_PROMISE_RE = re.compile(
     ),
     re.IGNORECASE,
 )
+_INTIMACY_TIER_ORDER = (
+    IntimacyTier.NONE,
+    IntimacyTier.LIGHT_CONTACT,
+    IntimacyTier.CLOSE_CONTACT,
+)
 
 
 def scan_reply(
@@ -104,6 +137,7 @@ def scan_reply(
     context: ReplyContext,
     *,
     shared_history_claims: tuple[SharedHistoryClaim, ...] = (),
+    intimacy_claims: tuple[IntimacyClaim, ...] = (),
 ) -> ReplyPolicyResult:
     if not isinstance(candidate, str):
         raise TypeError("candidate must be text")
@@ -165,6 +199,34 @@ def scan_reply(
             violations.append(
                 Violation(
                     ViolationCode.UNAUTHORIZED_SHARED_HISTORY,
+                    ViolationSeverity.HARD,
+                    claim.start,
+                    claim.end,
+                )
+            )
+    for claim in intimacy_claims:
+        if not isinstance(claim, IntimacyClaim) or claim.end > len(candidate):
+            raise ValueError("intimacy claim is invalid for candidate")
+        if (
+            context.intimacy_request is IntimacyRequest.NONE
+            and claim.tier is not IntimacyTier.NONE
+        ):
+            violations.append(
+                Violation(
+                    ViolationCode.UNSOLICITED_INTIMACY,
+                    ViolationSeverity.HARD,
+                    claim.start,
+                    claim.end,
+                )
+            )
+        if _INTIMACY_TIER_ORDER.index(
+            claim.tier
+        ) > _INTIMACY_TIER_ORDER.index(
+            context.private_behavior.intimacy_ceiling
+        ):
+            violations.append(
+                Violation(
+                    ViolationCode.INTIMACY_EXCEEDS_GRANT,
                     ViolationSeverity.HARD,
                     claim.start,
                     claim.end,

--- a/runtime/reply/reply_quality_gate.py
+++ b/runtime/reply/reply_quality_gate.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from typing import Any, Mapping, Protocol, Sequence
 
 from runtime.reply.reply_context import ReplyContext
-from runtime.reply.reply_policy import scan_reply
+from runtime.reply.reply_policy import IntimacyClaim, scan_reply
 from runtime.reply.reply_reviewer import ReviewResult, ReviewStatus, ReviewVerdict
 
 
@@ -53,8 +53,13 @@ def run_reply_quality_gate(
     reviewer: ReviewerPort,
     rewriter: RewriterPort,
     generation_messages: Sequence[Mapping[str, Any]] = (),
+    intimacy_claims: tuple[IntimacyClaim, ...] = (),
 ) -> QualityGateResult:
-    deterministic = scan_reply(candidate, context)
+    deterministic = scan_reply(
+        candidate,
+        context,
+        intimacy_claims=intimacy_claims,
+    )
     review = _review_candidate(
         reviewer,
         candidate,

--- a/runtime/reply/reply_quality_gate.py
+++ b/runtime/reply/reply_quality_gate.py
@@ -138,6 +138,19 @@ def run_reply_quality_gate(
             rewrite_calls=1,
             error_code="REWRITE_FAILED",
         )
+    if intimacy_claims:
+        # Intimacy spans are bound to the original candidate. PR-4 will
+        # supply reviewer-generated claims for rewritten text; until then,
+        # accepting the rewrite without fresh evidence would fail open.
+        return QualityGateResult(
+            QualityGateStatus.BLOCKED,
+            rewritten,
+            deterministic_codes + review_codes,
+            deterministic_checks=1,
+            reviewer_calls=1,
+            rewrite_calls=1,
+            error_code="FRESH_INTIMACY_CLAIMS_REQUIRED",
+        )
     final_deterministic = scan_reply(rewritten, context)
     final_review = _review_candidate(
         reviewer,

--- a/tests/persona/test_persona_assembly.py
+++ b/tests/persona/test_persona_assembly.py
@@ -1,3 +1,5 @@
+import json
+import re
 from datetime import datetime, timezone
 
 import pytest
@@ -5,7 +7,14 @@ import pytest
 from persona_assembly import UntrustedFragment, assemble_persona
 from persona_loader import PersonaDeclaration, PersonaProfile, PersonaSnapshot
 from runtime.reply.prompt_budget import PromptBudgetExceeded
-from runtime.reply.reply_context import ReplyContext, ReplyMode, TrustedTime, TrustedWorldFact
+from runtime.reply.reply_context import (
+    IntimacyTier,
+    PrivateBehaviorView,
+    ReplyContext,
+    ReplyMode,
+    TrustedTime,
+    TrustedWorldFact,
+)
 
 
 def _profile() -> PersonaProfile:
@@ -259,6 +268,38 @@ def test_required_user_input_is_never_silently_truncated() -> None:
 
     assert captured.value.report.dropped_ids == ()
     assert captured.value.report.overflow_units > 0
+
+
+def test_private_behavior_assembly_exposes_only_bounded_intimacy_tiers() -> None:
+    snapshot = PersonaSnapshot(None, None, (), "DRAFT", "draft")
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+        private_behavior=PrivateBehaviorView(
+            intimacy_ceiling=IntimacyTier.CLOSE_CONTACT,
+            granted_intimacy=IntimacyTier.LIGHT_CONTACT,
+        ),
+    )
+
+    assembly = assemble_persona(
+        snapshot,
+        context,
+        user_input="Synthetic input.",
+        max_units=2_000,
+    )
+    matched = re.search(
+        r"<private_behavior>\n(.+?)\n</private_behavior>",
+        assembly.system_content,
+    )
+    assert matched is not None
+    payload = json.loads(matched.group(1))
+
+    assert payload["intimacy_ceiling"] == "close_contact"
+    assert payload["granted_intimacy"] == "light_contact"
+    serialized = json.dumps(payload, ensure_ascii=False)
+    assert "statement" not in serialized
+    assert "growth_" not in serialized
+    assert "raw_score" not in serialized
 
 
 def test_maximum_length_public_identifiers_remain_valid_budget_items() -> None:

--- a/tests/persona/test_reply_context.py
+++ b/tests/persona/test_reply_context.py
@@ -9,6 +9,7 @@ from runtime.reply.reply_context import (
     ReplyContext,
     ReplyContextError,
     BehaviorLevel,
+    IntimacyRequest,
     IntimacyTier,
     PrivateBehaviorView,
     OutputChannel,
@@ -124,6 +125,44 @@ def test_context_exposes_only_identified_facts_and_bounded_behavior_hints() -> N
     assert payload["world_facts"][0]["source_id"] == "source.synthetic"
     assert payload["private_behavior"]["trust"] == "low"
     assert "raw_score" not in payload["private_behavior"]
+
+
+def test_context_carries_bounded_intimacy_request_and_behavior_tiers() -> None:
+    trusted_time = TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc))
+    default_context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=trusted_time,
+    )
+    requested = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=trusted_time,
+        intimacy_request=IntimacyRequest.REQUESTED,
+        private_behavior=PrivateBehaviorView(
+            relationship_stage=RelationshipStage.COMMITTED,
+            intimacy_ceiling=IntimacyTier.CLOSE_CONTACT,
+            granted_intimacy=IntimacyTier.LIGHT_CONTACT,
+        ),
+    )
+
+    assert default_context.intimacy_request is IntimacyRequest.NONE
+    assert default_context.to_dict()["intimacy_request"] == "none"
+    assert requested.to_dict()["intimacy_request"] == "requested"
+    assert requested.to_dict()["private_behavior"]["intimacy_ceiling"] == (
+        "close_contact"
+    )
+    assert requested.to_dict()["private_behavior"]["granted_intimacy"] == (
+        "light_contact"
+    )
+    with pytest.raises(ReplyContextError):
+        ReplyContext.create(
+            ReplyMode.TEXT_LETTER,
+            trusted_time=trusted_time,
+            intimacy_request="requested",  # type: ignore[arg-type]
+        )
+    with pytest.raises(ReplyContextError):
+        PrivateBehaviorView(
+            intimacy_ceiling="light_contact",  # type: ignore[arg-type]
+        )
 
 
 def test_legacy_video_mapping_is_preserved_and_future_im_requires_opt_in() -> None:

--- a/tests/persona/test_reply_context.py
+++ b/tests/persona/test_reply_context.py
@@ -196,6 +196,7 @@ def test_schema_matches_runtime_mode_and_privacy_invariants() -> None:
         trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
     ).to_dict()
 
+    assert schema["$id"] == "p02.reply-context.v2"
     assert list(validator.iter_errors(valid)) == []
 
     invalid_channel = {**valid, "output_constraints": {**valid["output_constraints"]}}
@@ -229,7 +230,8 @@ def test_public_contract_documentation_names_api_errors_and_scope_boundary() -> 
         "ReplyModeAdapter",
         "REPLY_CONTEXT_INVALID",
         "REPLY_MODE_UNSUPPORTED",
-        "p02.reply-context.v1",
+        "p02.reply-context.v2",
+        "v1 payload",
         "future_im",
         "does not call a provider",
     ):

--- a/tests/persona/test_reply_policy.py
+++ b/tests/persona/test_reply_policy.py
@@ -1,13 +1,23 @@
 from datetime import datetime, timezone
 
+import pytest
+
 from runtime.reply.reply_context import (
+    IntimacyRequest,
+    IntimacyTier,
     OutputChannel,
     OutputConstraints,
+    PrivateBehaviorView,
     ReplyContext,
     ReplyMode,
     TrustedTime,
 )
-from runtime.reply.reply_policy import SharedHistoryClaim, ViolationCode, scan_reply
+from runtime.reply.reply_policy import (
+    IntimacyClaim,
+    SharedHistoryClaim,
+    ViolationCode,
+    scan_reply,
+)
 
 
 def test_internal_markup_and_serialized_private_state_are_hard_violations() -> None:
@@ -136,4 +146,106 @@ def test_shared_history_is_blocked_only_from_explicit_structured_evidence() -> N
     blocked = scan_reply(candidate, context, shared_history_claims=(unauthorized,))
     assert tuple(violation.code for violation in blocked.violations) == (
         ViolationCode.UNAUTHORIZED_SHARED_HISTORY,
+    )
+
+
+def test_unrequested_intimacy_is_blocked_only_from_structured_evidence() -> None:
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+        private_behavior=PrivateBehaviorView(
+            intimacy_ceiling=IntimacyTier.LIGHT_CONTACT,
+        ),
+    )
+    candidate = "我轻轻抱了抱你。"
+    claim = IntimacyClaim(
+        "intimacy.synthetic",
+        IntimacyTier.LIGHT_CONTACT,
+        0,
+        len(candidate),
+    )
+
+    assert scan_reply(candidate, context).passed is True
+    blocked = scan_reply(candidate, context, intimacy_claims=(claim,))
+    assert tuple(item.code for item in blocked.violations) == (
+        ViolationCode.UNSOLICITED_INTIMACY,
+    )
+    assert context.intimacy_request is IntimacyRequest.NONE
+
+
+def test_requested_intimacy_must_stay_within_the_stage_ceiling() -> None:
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+        intimacy_request=IntimacyRequest.REQUESTED,
+        private_behavior=PrivateBehaviorView(
+            intimacy_ceiling=IntimacyTier.LIGHT_CONTACT,
+        ),
+    )
+    candidate = "我轻轻抱了抱你。"
+    within_ceiling = IntimacyClaim(
+        "intimacy.synthetic-light",
+        IntimacyTier.LIGHT_CONTACT,
+        0,
+        len(candidate),
+    )
+    above_ceiling = IntimacyClaim(
+        "intimacy.synthetic-close",
+        IntimacyTier.CLOSE_CONTACT,
+        0,
+        len(candidate),
+    )
+
+    assert scan_reply(
+        candidate,
+        context,
+        intimacy_claims=(within_ceiling,),
+    ).passed is True
+    blocked = scan_reply(
+        candidate,
+        context,
+        intimacy_claims=(above_ceiling,),
+    )
+    assert tuple(item.code for item in blocked.violations) == (
+        ViolationCode.INTIMACY_EXCEEDS_GRANT,
+    )
+
+
+def test_intimacy_claims_are_typed_and_candidate_bound() -> None:
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    )
+    with pytest.raises(ValueError):
+        IntimacyClaim("bad claim", IntimacyTier.NONE, 0, 1)
+    with pytest.raises(ValueError):
+        IntimacyClaim("claim.synthetic", "light_contact", 0, 1)
+    with pytest.raises(ValueError):
+        IntimacyClaim("claim.synthetic", IntimacyTier.NONE, 1, 1)
+
+    with pytest.raises(ValueError):
+        scan_reply(
+            "short",
+            context,
+            intimacy_claims=(
+                IntimacyClaim(
+                    "claim.synthetic",
+                    IntimacyTier.NONE,
+                    0,
+                    6,
+                ),
+            ),
+        )
+
+
+def test_serialized_intimacy_metadata_remains_private_state() -> None:
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    )
+
+    result = scan_reply("intimacy_ceiling=light_contact", context)
+
+    assert tuple(item.code for item in result.violations) == (
+        ViolationCode.PRIVATE_STATE_EXPOSED,
     )

--- a/tests/persona/test_reply_quality_gate.py
+++ b/tests/persona/test_reply_quality_gate.py
@@ -1,6 +1,12 @@
 from datetime import datetime, timezone
 
-from runtime.reply.reply_context import ReplyContext, ReplyMode, TrustedTime
+from runtime.reply.reply_context import (
+    IntimacyTier,
+    ReplyContext,
+    ReplyMode,
+    TrustedTime,
+)
+from runtime.reply.reply_policy import IntimacyClaim
 from runtime.reply.reply_quality_gate import QualityGateStatus, run_reply_quality_gate
 from runtime.reply.reply_reviewer import (
     NullReviewer,
@@ -104,6 +110,34 @@ def test_hard_candidate_is_rewritten_once_then_rechecked_before_acceptance() -> 
     assert result.rewrite_calls == 1
     assert reviewer.calls == 2
     assert rewriter.calls == 1
+
+
+def test_candidate_bound_intimacy_claim_is_not_reused_after_rewrite() -> None:
+    candidate = "Synthetic contact."
+    reviewer = _Reviewer(_pass_review(), _pass_review())
+    rewriter = _Rewriter("Safe rewritten candidate.")
+
+    result = run_reply_quality_gate(
+        candidate,
+        _context(),
+        reviewer=reviewer,
+        rewriter=rewriter,
+        intimacy_claims=(
+            IntimacyClaim(
+                "intimacy.synthetic",
+                IntimacyTier.LIGHT_CONTACT,
+                0,
+                len(candidate),
+            ),
+        ),
+    )
+
+    assert result.status is QualityGateStatus.ACCEPTED
+    assert result.text == "Safe rewritten candidate."
+    assert result.violation_codes == ()
+    assert result.deterministic_checks == 2
+    assert result.reviewer_calls == 2
+    assert result.rewrite_calls == 1
 
 
 def test_second_hard_result_is_blocked_without_a_hidden_rewrite_loop() -> None:

--- a/tests/persona/test_reply_quality_gate.py
+++ b/tests/persona/test_reply_quality_gate.py
@@ -112,7 +112,7 @@ def test_hard_candidate_is_rewritten_once_then_rechecked_before_acceptance() -> 
     assert rewriter.calls == 1
 
 
-def test_candidate_bound_intimacy_claim_is_not_reused_after_rewrite() -> None:
+def test_candidate_bound_intimacy_claim_fails_closed_after_rewrite() -> None:
     candidate = "Synthetic contact."
     reviewer = _Reviewer(_pass_review(), _pass_review())
     rewriter = _Rewriter("Safe rewritten candidate.")
@@ -132,11 +132,12 @@ def test_candidate_bound_intimacy_claim_is_not_reused_after_rewrite() -> None:
         ),
     )
 
-    assert result.status is QualityGateStatus.ACCEPTED
+    assert result.status is QualityGateStatus.BLOCKED
+    assert result.accepted is False
     assert result.text == "Safe rewritten candidate."
-    assert result.violation_codes == ()
-    assert result.deterministic_checks == 2
-    assert result.reviewer_calls == 2
+    assert result.error_code == "FRESH_INTIMACY_CLAIMS_REQUIRED"
+    assert result.deterministic_checks == 1
+    assert result.reviewer_calls == 1
     assert result.rewrite_calls == 1
 
 

--- a/tests/private_world/test_private_world_projection.py
+++ b/tests/private_world/test_private_world_projection.py
@@ -1,11 +1,16 @@
 from private_world_port import (
     ContinuationAwareness,
     HomeAccess,
+    IntimacyGrant,
     LocalContinuationFact,
     PrivateWorldSnapshot,
 )
 from runtime.memory.private_world_projection import project_private_world
-from runtime.reply.reply_context import BehaviorLevel, RelationshipStage
+from runtime.reply.reply_context import (
+    BehaviorLevel,
+    IntimacyTier,
+    RelationshipStage,
+)
 
 
 def test_projection_converts_hidden_scores_to_finite_behavior_levels() -> None:
@@ -116,3 +121,37 @@ def test_unknown_relationship_stage_fails_closed_to_unknown() -> None:
     )
 
     assert projected.behavior.relationship_stage is RelationshipStage.UNKNOWN
+
+
+def test_projection_exposes_only_bounded_intimacy_tiers() -> None:
+    projected = project_private_world(
+        PrivateWorldSnapshot(
+            familiarity=91,
+            relationship_stage="committed",
+            intimacy_grants=(
+                IntimacyGrant(
+                    "intimacy.synthetic-light",
+                    IntimacyTier.LIGHT_CONTACT,
+                    "Synthetic light-contact evidence.",
+                ),
+                IntimacyGrant(
+                    "intimacy.synthetic-close",
+                    IntimacyTier.CLOSE_CONTACT,
+                    "Synthetic close-contact evidence.",
+                ),
+            ),
+            growth_window_start="2026-08-29T00:00:00+00:00",
+            growth_used=6,
+        )
+    )
+
+    assert projected.intimacy_ceiling is IntimacyTier.CLOSE_CONTACT
+    assert projected.granted_intimacy is IntimacyTier.CLOSE_CONTACT
+    assert projected.behavior.intimacy_ceiling is IntimacyTier.CLOSE_CONTACT
+    assert projected.behavior.granted_intimacy is IntimacyTier.CLOSE_CONTACT
+    assert projected.to_dict()["intimacy_ceiling"] == "close_contact"
+    assert projected.to_dict()["granted_intimacy"] == "close_contact"
+    serialized = repr(projected.to_dict())
+    assert "Synthetic" not in serialized
+    assert "growth_" not in serialized
+    assert "91" not in serialized

--- a/tests/private_world/test_private_world_runtime.py
+++ b/tests/private_world/test_private_world_runtime.py
@@ -26,6 +26,7 @@ ROOT = Path(__file__).resolve().parents[2]
 from private_world_port import (
     ContinuationAwareness,
     HomeAccess,
+    IntimacyGrant,
     LocalContinuationFact,
     NullPrivateWorldPort,
     PrivateWorldSnapshot,
@@ -36,6 +37,7 @@ from runtime.memory.private_world_runtime import (
     resolve_private_world_database,
 )
 from private_world_reducer import ReducerEventKind
+from runtime.reply.reply_context import IntimacyTier
 
 
 def _legacy_v1_database(
@@ -727,6 +729,15 @@ def test_available_sqlite_projects_only_character_view_into_reply_context(
             closeness=74,
             tension=12,
             relationship_stage="close",
+            intimacy_grants=(
+                IntimacyGrant(
+                    "intimacy.synthetic-runtime",
+                    IntimacyTier.LIGHT_CONTACT,
+                    "Private synthetic grant statement.",
+                ),
+            ),
+            growth_window_start="2026-08-22T00:00:00+00:00",
+            growth_used=6,
             nickname_permissions=("合成称呼",),
             home_access=HomeAccess.DOMESTIC_ACCESS,
             continuation_facts=(
@@ -768,6 +779,8 @@ def test_available_sqlite_projects_only_character_view_into_reply_context(
         "closeness": "high",
         "tension": "low",
         "relationship_stage": "close",
+        "intimacy_ceiling": "light_contact",
+        "granted_intimacy": "light_contact",
         "nickname_permission": "allowed",
         "home_history_allowed": True,
         "known_continuations": [
@@ -785,6 +798,9 @@ def test_available_sqlite_projects_only_character_view_into_reply_context(
         "77",
         "74",
         "12",
+        "Private synthetic grant statement.",
+        "growth_window_start",
+        "growth_used",
         "pending.trip",
         "control.plan",
         "角色未知的合成旅行安排。",

--- a/tests/private_world/test_private_world_runtime_wiring.py
+++ b/tests/private_world/test_private_world_runtime_wiring.py
@@ -490,7 +490,9 @@ def test_local_server_private_world_failure_uses_null_port_without_blocking_lett
         "closeness": "unknown",
         "tension": "unknown",
         "relationship_stage": "unknown",
+        "intimacy_ceiling": "none",
+        "granted_intimacy": "none",
         "nickname_permission": "not_allowed",
-            "home_history_allowed": False,
+        "home_history_allowed": False,
         "known_continuations": [],
     }


### PR DESCRIPTION
## Workorder scope

Implements `WORKORDER-intimacy-model.md` § PR-3 (projection and policy):

- projects stage-derived `intimacy_ceiling` and persisted `granted_intimacy` through the bounded character view;
- adds typed `IntimacyRequest` and candidate-bound `IntimacyClaim` contracts;
- enforces `UNSOLICITED_INTIMACY` and `INTIMACY_EXCEEDS_GRANT` as hard deterministic violations without Chinese action regexes;
- threads claims through the first quality-gate candidate while deliberately not reusing stale spans after a rewrite;
- keeps grant statements, growth-window fields, raw scores, and other control-only data out of persona assembly.

The reply-context schema's pre-existing relationship-stage enum omitted the already-supported `committed` value. This PR aligns that schema while adding the new fields.

## Compatibility and migration

- Empty `intimacy_claims` preserves the PR-2 behavior.
- Existing exact reply-context dictionaries gain only the two schema-required default fields (`intimacy_ceiling=none`, `granted_intimacy=none`); no other behavior expectation was changed. This is the narrow schema exception explicitly authorized for newly added fields.
- Claim spans are candidate-bound. A rewritten candidate must receive fresh claims from the PR-4 reviewer integration; until that integration exists, a rewrite that started with non-empty claims fails closed with `FRESH_INTIMACY_CLAIMS_REQUIRED`.
- The newly required fields make the public reply-context schema a v2 contract. Runtime producers emit fail-closed `none` defaults; stored/external v1 payloads must add those defaults before v2 validation.
- No storage migration, network call, dependency, client, media, reducer, or command-service change.

This cohesive contract slice touches 15 files because the schema, its three affected contract documents, runtime projection, reply context/policy/gate, persona serialization proof, SQLite runtime proof, and fail-closed null-port exact contract must change together. It remains under 500 added lines and is independently reversible.

## Non-goals self-check

- [x] Did not copy reference PowerShell, Markdown prompts, persona prose, or `林离人设.md`.
- [x] Added no relationship stage beyond existing `COMMITTED`.
- [x] Added no tier above `CLOSE_CONTACT` and no sexual tier.
- [x] Did not change `PERMANENT_AVAILABILITY_PROMISE` or its regex.
- [x] Did not change no-effect event kinds.
- [x] Did not auto-submit `STAGE_CONFIRMED`.
- [x] Did not implement a relationship evidence extractor.
- [x] Did not touch media, ASR, visual, packaging, installer, or client patch logic.
- [x] Added no network call, telemetry, or external dependency.

## Local verification

- Focused PR-3 plus production pipeline/reviewer regressions: `107 passed`.
- Full suite after rebasing onto `main@b92e4b3`: `1394 passed, 1 skipped, 1 deselected`.
- Baseline hardening scan (`--mode all`): `PASS`.
- `git diff --check`: PASS.

Privacy fixtures are synthetic. This PR does not claim provider, private-corpus, device, or human personality acceptance; those belong to PR-4 and final end-to-end acceptance.
