### PR TITLE
fix: show video reply toggle progress

### DIFF
--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -1789,13 +1789,18 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     let ready = false;
     let missingDependencies = [];
     let message = "正在检测视频运行环境，第一次可能需要几分钟…";
+    let pendingEnabled = null;
     let toggle = null;
     let downloads = null;
     const render = () => {
       if (!toggle || !downloads) return;
       const settingAvailable = typeof enabled === "boolean";
-      toggle.disabled = !settingAvailable || (!ready && !enabled);
-      toggle.textContent = settingAvailable ? (enabled ? "已开启" : "已关闭") : "暂不可用";
+      toggle.disabled = pendingEnabled !== null || !settingAvailable || (!ready && !enabled);
+      toggle.textContent = pendingEnabled !== null
+        ? (pendingEnabled ? "正在开启…" : "正在关闭…")
+        : settingAvailable
+        ? (enabled ? "已开启" : "已关闭")
+        : "暂不可用";
       toggle.setAttribute("aria-pressed", settingAvailable ? String(enabled) : "false");
       downloads.textContent = ready ? "管理下载" : "下载缺失组件";
       state.textContent = message;
@@ -1830,6 +1835,9 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     const apply = async () => {
       if (!toggle || typeof enabled !== "boolean") return;
       const previous = enabled;
+      pendingEnabled = !previous;
+      message = pendingEnabled ? "正在确认本地组件并开启视频回信…" : "正在关闭视频回信…";
+      render();
       setButtonsBusy([toggle], true);
       try {
         const payload = await requestMutation(VIDEO_REPLY_SETTINGS_PATH, { enabled: !previous, request_id: videoReplyRequestId() });
@@ -1846,6 +1854,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
           message = error && error.code === "VIDEO_REPLY_SETTING_REQUEST_CONFLICT" ? "设置请求冲突，原设置保持不变。" : "设置暂不可用，原设置保持不变。";
         }
       } finally {
+        pendingEnabled = null;
         setButtonsBusy([toggle], false);
         render();
       }

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -685,6 +685,8 @@ let currentStatus = "READY";
 const mutationPaths = [];
 const videoMethods = [];
 let videoWrites = 0;
+let resolveFirstVideoWrite;
+const firstVideoWrite = new Promise((resolve) => { resolveFirstVideoWrite = resolve; });
 const statuses = ["READY", "PAUSED", "READY"];
 const statusPayload = (status) => ({
   status,
@@ -740,7 +742,7 @@ const statusPayload = (status) => ({
         if (options.method === "GET") return { ok: true, json: async () => ({ code: 0, data: { state: "available", enabled: true } }) };
         videoWrites += 1;
         return videoWrites === 1
-          ? { ok: true, json: async () => ({ code: 0, data: { status: "APPLIED", enabled: false } }) }
+          ? firstVideoWrite
           : { ok: false, json: async () => ({ data: { error_code: "VIDEO_REPLY_SETTING_UNAVAILABLE" } }) };
       }
       if (endpoint.pathname === "/toy/capabilities/video") {
@@ -804,7 +806,11 @@ vm.runInNewContext(source, context);
   if (!open) throw new Error(`open button missing: ${body.querySelectorAll("button").map((item) => item.textContent).join("|")}`);
       await open.click();
       await flush();
-      await findButton("已开启").click();
+      const firstVideoToggle = findButton("已开启").click();
+      await flush();
+      if (!findButton("正在关闭…")) throw new Error("video mutation progress was hidden");
+      resolveFirstVideoWrite({ ok: true, json: async () => ({ code: 0, data: { status: "APPLIED", enabled: false } }) });
+      await firstVideoToggle;
       await flush();
       await findButton("已关闭").click();
       await flush();


### PR DESCRIPTION
## Summary
- show an immediate Chinese progress label while video reply is enabling or disabling
- keep the status copy live during the long dependency readiness check
- cover the pending mutation state through the rendered settings interface

## Verification
- RED: focused UI test failed with video mutation progress was hidden
- GREEN: 16 tests passed in tests/installer/test_original_client_settings_ui.py
- git diff --check passed

## Scope
Two files only. No video pipeline, dependency, Live, installer layout, memory, or persona behavior changes.