### PR TITLE
fix(letters): allow only one undelivered letter

### DIFF
--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -31,6 +31,7 @@
 | 503 | `PRIVATE_WORLD_HISTORY_UNAVAILABLE` | UNAVAILABLE | 是 | PrivateWorld 在采集前不可用，或历史基线初始化失败；本批历史信件不会发布到信箱 |
 | 400 | `INVALID_IDEMPOTENCY_KEY` | FAILED | 否 | 幂等键为空、类型错误或超过长度边界 |
 | 409 | `IDEMPOTENCY_CONFLICT` | FAILED | 否 | 同一幂等键重复提交了不同正文 |
+| 409 | `LETTER_IN_PROGRESS` | FAILED | 是 | 上一封信仍在处理或尚未送达；客户端等待当前回信可见后再寄新信 |
 | 400 | `VIDEO_REPLY_SETTING_REQUEST_ID_INVALID` / `VIDEO_REPLY_SETTING_PAYLOAD_INVALID` | FAILED | 否 | 视频回信设置 request_id 必须为 `video_reply_setting:<opaque>`；enabled 必须为布尔值 |
 | 400 | `MEMORY_CLEAR_CONFIRMATION_REQUIRED` | FAILED | 否 | 原版客户端清空当前用户 Mem0 长期记忆时缺少 body 二次确认；不执行删除 |
 | 409 | `VIDEO_REPLY_SETTING_REQUEST_CONFLICT` | FAILED | 否 | 同一视频设置 request_id 重放了不同 enabled |

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -55,6 +55,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 - 找不到信件或 MIDI job：404，不返回空的成功对象。
 - 空信箱、无匹配歌曲、空 playlist：200，但 `source=local-memory|empty`、列表和计数明确为空。
 - LLM timeout/error：发信确认保持 200/PENDING，detail 随后标记 `FAILED` 并带错误码；不得写入 `reply_text` 占位符。
+- 同一时间只接收一封未交付信：上一封仍为 PENDING/PROCESSING，或虽已生成但尚未到 `reply_not_before` 时，不同的新信返回 409 `LETTER_IN_PROGRESS`；相同请求的网络重试仍复用原信，回信可见后允许继续寄信。
 - 相同正文和素材在短窗口内失败后重试成功时，旧 FAILED 记录保留在本地审计状态，但从 current list 隐藏；直接查询旧 ID 返回 410 `LETTER_SUPERSEDED` 和替代信件 ID，不回显旧正文。
 - `/letter/resend` 当前未实现；重复请求返回相同 501，不改变信件内容或状态。
 - `scope=legacy` 的 list/detail 只读，detail 不改变 `is_read`；send 对 legacy scope 返回 403 `READ_ONLY_SCOPE`。

--- a/http_contract.py
+++ b/http_contract.py
@@ -35,6 +35,7 @@ ERROR_CODES: dict[str, dict[str, Any]] = {
     "MIDI_JOB_NOT_FOUND": {"http_status": 404, "retryable": False},
     "METHOD_NOT_ALLOWED": {"http_status": 405, "retryable": False},
     "IDEMPOTENCY_CONFLICT": {"http_status": 409, "retryable": False},
+    "LETTER_IN_PROGRESS": {"http_status": 409, "retryable": True},
     "VIDEO_REPLY_SETTING_REQUEST_ID_INVALID": {"http_status": 400, "retryable": False},
     "VIDEO_REPLY_SETTING_PAYLOAD_INVALID": {"http_status": 400, "retryable": False},
     "VIDEO_REPLY_SETTING_REQUEST_CONFLICT": {"http_status": 409, "retryable": False},

--- a/local_server.py
+++ b/local_server.py
@@ -2036,9 +2036,28 @@ def _recent_active_duplicate(
         age = current_time - float(created_at)
         if age < 0 or age > LETTER_RETRY_DEDUP_SECONDS:
             continue
-        if letter.get("letter_status") not in {"PENDING", "PROCESSING", "COMPLETED"}:
+        status = letter.get("letter_status")
+        if status not in {"PENDING", "PROCESSING", "COMPLETED"}:
+            continue
+        if (
+            status == "COMPLETED"
+            and letter.get("reply_not_before", 0.0) <= current_time
+        ):
             continue
         if letter.get("content") == content and letter.get("material", {}) == material:
+            return letter
+    return None
+
+
+def _active_undelivered_letter(*, now: float | None = None) -> dict | None:
+    current_time = time.time() if now is None else now
+    for letter in store.letters:
+        if letter.get("letter_status") in {"PENDING", "PROCESSING"}:
+            return letter
+        if (
+            letter.get("letter_status") == "COMPLETED"
+            and letter.get("reply_not_before", 0.0) > current_time
+        ):
             return letter
     return None
 
@@ -2568,6 +2587,14 @@ async def route(
             previous = _recent_active_duplicate(content, material)
             if previous is not None:
                 return _send_result_for_letter(previous)
+        active_letter = _active_undelivered_letter()
+        if active_letter is not None:
+            return err(409, "LETTER_IN_PROGRESS", {
+                "status": "FAILED",
+                "error_code": "LETTER_IN_PROGRESS",
+                "retryable": True,
+                "active_letter_id": active_letter["letter_id"],
+            })
         lid = str(uuid.uuid4())
         letter = {
             "letter_id": lid,

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -525,6 +525,127 @@ def test_http_send_acknowledges_before_slow_reply_finishes(
     assert detail["data"]["reply_text"] == "synthetic delayed reply"
 
 
+def test_http_rejects_a_new_letter_until_the_current_reply_is_delivered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    import local_server
+
+    reply_started = threading.Event()
+    allow_reply = threading.Event()
+
+    def slow_reply(*_args, **_kwargs) -> str:
+        reply_started.set()
+        allow_reply.wait(timeout=2.0)
+        return "synthetic delayed reply"
+
+    monkeypatch.setattr(local_server.letters_adapter, "reply", slow_reply)
+    monkeypatch.setenv("OLIVIA_REPLY_DELAY_ENABLED", "1")
+    monkeypatch.setenv("OLIVIA_REPLY_DELAY_MINUTES_MIN", "5")
+    monkeypatch.setenv("OLIVIA_REPLY_DELAY_MINUTES_MAX", "5")
+
+    async def exercise() -> tuple[dict, int, dict, int, dict, int, dict]:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            first_response = await client.post(
+                "/toy/letter/send",
+                json={
+                    "content": "synthetic first letter",
+                    "idempotency_key": "single-active:first",
+                },
+            )
+            first = await first_response.json()
+            assert reply_started.wait(timeout=0.2)
+
+            duplicate_response = await client.post(
+                "/toy/letter/send",
+                json={
+                    "content": "synthetic first letter",
+                    "idempotency_key": "single-active:first",
+                },
+            )
+            duplicate = await duplicate_response.json()
+
+            blocked_while_processing_response = await client.post(
+                "/toy/letter/send",
+                json={
+                    "content": "synthetic second letter",
+                    "idempotency_key": "single-active:second",
+                },
+            )
+            blocked_while_processing = await blocked_while_processing_response.json()
+
+            allow_reply.set()
+            await asyncio.gather(*tuple(local_server.reply_tasks))
+
+            blocked_before_delivery_response = await client.post(
+                "/toy/letter/send",
+                json={
+                    "content": "synthetic third letter",
+                    "idempotency_key": "single-active:third",
+                },
+            )
+            blocked_before_delivery = await blocked_before_delivery_response.json()
+            local_server.store.letters[0]["reply_not_before"] = 0.0
+            delivered_response = await client.post(
+                "/toy/letter/send",
+                json={"content": "synthetic first letter"},
+            )
+            delivered = await delivered_response.json()
+            await asyncio.gather(*tuple(local_server.reply_tasks))
+            return (
+                first,
+                blocked_while_processing_response.status,
+                blocked_while_processing,
+                blocked_before_delivery_response.status,
+                blocked_before_delivery,
+                delivered_response.status,
+                delivered,
+            ), duplicate
+
+    (
+        (
+            first,
+            processing_status,
+            blocked_while_processing,
+            delivery_status,
+            blocked_before_delivery,
+            delivered_status,
+            delivered,
+        ),
+        duplicate,
+    ) = asyncio.run(exercise())
+
+    assert first["data"]["status"] == "PENDING"
+    assert duplicate["data"]["letter_id"] == first["data"]["letter_id"]
+    assert processing_status == 409
+    assert blocked_while_processing == {
+        "code": 409,
+        "message": "LETTER_IN_PROGRESS",
+        "data": {
+            "status": "FAILED",
+            "error_code": "LETTER_IN_PROGRESS",
+            "retryable": True,
+            "active_letter_id": first["data"]["letter_id"],
+        },
+    }
+    assert delivery_status == 409
+    assert blocked_before_delivery == blocked_while_processing
+    assert delivered_status == 200
+    assert delivered["data"]["letter_id"] != first["data"]["letter_id"]
+    assert len(local_server.store.letters) == 2
+
+    import http_contract
+
+    assert http_contract.error_metadata("LETTER_IN_PROGRESS") == {
+        "http_status": 409,
+        "retryable": True,
+    }
+
+
 def test_persisted_pending_reply_resumes_when_http_runtime_starts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -674,6 +795,7 @@ def test_retry_dedup_does_not_block_distinct_expired_or_failed_letters() -> None
         "material": {"stamp_id": "stamp-a"},
         "letter_status": "COMPLETED",
         "created_at": 100,
+        "reply_not_before": 200,
     }
     local_server.store.letters.append(original)
 
@@ -698,6 +820,15 @@ def test_retry_dedup_does_not_block_distinct_expired_or_failed_letters() -> None
             "synthetic input",
             {"stamp_id": "stamp-a"},
             now=161,
+        )
+        is None
+    )
+    original["reply_not_before"] = 0
+    assert (
+        local_server._recent_active_duplicate(
+            "synthetic input",
+            {"stamp_id": "stamp-a"},
+            now=159,
         )
         is None
     )


### PR DESCRIPTION
## Summary
- reject a different new letter while the current letter is processing or waiting for delivery
- preserve explicit idempotent replay and active no-key network retry behavior
- allow a new letter after delivery, including identical content
- register the public LETTER_IN_PROGRESS contract and documentation

## Focused validation
- RED: public HTTP test initially observed 200 for a second in-flight letter instead of 409
- GREEN: 5 focused HTTP/contract tests passed
- git diff --check passed

## Review evidence
- Standards: PASS, P0/P1/P2 = 0/0/0
- Spec: PASS, P0/P1/P2 = 0/0/0

No persona routing or media implementation is changed.