### PR TITLE
fix(video): report pre-media failures truthfully

### DIFF
--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -18,7 +18,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 - 真正未实现能力：HTTP `501`，`data.status=NOT_IMPLEMENTED`。
 - 已知但不可用的可选能力：HTTP `501`，`data.status=UNAVAILABLE`，并带 `capability`；不会返回 200 假成功。
 - HTTP 发信先返回 `200`/`PENDING`；LLM 超时或不可用随后写入信件 `FAILED` 终态，detail 返回稳定 `error_code` 与 `retryable`。重启只恢复尚未派发的 `PENDING`；不确定是否已到达 provider 的 `PROCESSING` 会 fail closed 为 `LLM_INTERRUPTED`，不自动重复生成。
-- 普通说话视频的 detail 额外公开 `media_status`、`media_error_code` 与布尔值 `media_retryable`。`TTS_CONTENT_GATE_UNAVAILABLE` 为可重试的 `UNAVAILABLE`；三条有效候选均被内容门拒绝时，`TTS_CONTENT_GATE_REJECTED` 为不可重试的 `FAILED`。
+- 视频回信的 detail 额外公开 `media_status`、`media_error_code` 与布尔值 `media_retryable`。路由选中视频后、正文仍在生成时为 `PENDING`；若正文生成、质量检查或重启恢复在媒体启动前失败，则为 `NOT_REQUESTED` 且没有媒体错误；只有正文成功后才进入实际媒体任务。`TTS_CONTENT_GATE_UNAVAILABLE` 为可重试的 `UNAVAILABLE`；三条有效候选均被内容门拒绝时，`TTS_CONTENT_GATE_REJECTED` 为不可重试的 `FAILED`。
 
 机器可读定义：
 

--- a/local_server.py
+++ b/local_server.py
@@ -689,6 +689,17 @@ def _state_root() -> Path | None:
     return _local_data_root()
 
 
+def _mark_media_not_requested(letter: dict) -> None:
+    if _exact_reply_mode(letter.get("reply_mode")) not in {
+        ReplyMode.SPOKEN_VIDEO.value,
+        ReplyMode.MUSICAL_VIDEO.value,
+    }:
+        return
+    letter["media_status"] = "NOT_REQUESTED"
+    letter.pop("media_error_code", None)
+    letter["media_retryable"] = False
+
+
 def _load_store_state() -> None:
     root = _state_root()
     if root is None:
@@ -712,6 +723,7 @@ def _load_store_state() -> None:
                     if item.get("letter_status") == "PROCESSING":
                         item["letter_status"] = "FAILED"
                         item["error_code"] = "LLM_INTERRUPTED"
+                        _mark_media_not_requested(item)
                         needs_persist = True
                     if item.get("media_status") == "PROCESSING":
                         item["media_status"] = "QUEUED"
@@ -2896,6 +2908,7 @@ async def _run_reply_job(
         }:
             letter["letter_status"] = "FAILED"
             letter["error_code"] = "LLM_UNAVAILABLE"
+            _mark_media_not_requested(letter)
             _persist_store_state()
         _safe_log("letter_failed", error_code="LLM_UNAVAILABLE")
         return False
@@ -3196,9 +3209,9 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
         ReplyMode.SPOKEN_VIDEO.value,
         ReplyMode.MUSICAL_VIDEO.value,
     }:
-        letter["media_status"] = "UNAVAILABLE"
-        letter["media_error_code"] = "MEDIA_PROVIDER_UNAVAILABLE"
-        letter["media_retryable"] = True
+        letter["media_status"] = "PENDING"
+        letter.pop("media_error_code", None)
+        letter["media_retryable"] = False
     _schedule_text_reply_delay(letter, exact_mode)
     _persist_store_state()
 
@@ -3234,18 +3247,21 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
     except asyncio.CancelledError:
         letter["letter_status"] = "FAILED"
         letter["error_code"] = "LLM_INTERRUPTED"
+        _mark_media_not_requested(letter)
         _persist_store_state()
         _safe_log("letter_cancelled")
         raise
     except asyncio.TimeoutError:
         letter["letter_status"] = "FAILED"
         letter["error_code"] = "LLM_TIMEOUT"
+        _mark_media_not_requested(letter)
         _persist_store_state()
         _safe_log("letter_failed", error_code="LLM_TIMEOUT")
         return False
     except (ValueError, RuntimeError):
         letter["letter_status"] = "FAILED"
         letter["error_code"] = "LLM_UNAVAILABLE"
+        _mark_media_not_requested(letter)
         _persist_store_state()
         _safe_log("letter_failed", error_code="LLM_UNAVAILABLE")
         return False
@@ -3257,6 +3273,7 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
         public_code, _retryable = _public_llm_error(result.error_code)
         letter["letter_status"] = "FAILED"
         letter["error_code"] = public_code
+        _mark_media_not_requested(letter)
         _persist_store_state()
         _safe_log("letter_failed", error_code=public_code)
         return False
@@ -3270,6 +3287,7 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
     ):
         letter["letter_status"] = "FAILED"
         letter["error_code"] = "LLM_REPLY_LENGTH_INVALID"
+        _mark_media_not_requested(letter)
         _persist_store_state()
         _safe_log("letter_failed", error_code="LLM_REPLY_LENGTH_INVALID")
         return False

--- a/original_client_letter_contract.py
+++ b/original_client_letter_contract.py
@@ -283,6 +283,7 @@ def serialize_letter_detail(
                 "reply_video_url": media_url,
                 "media_status": letter.get("media_status", "NOT_REQUESTED"),
                 "media_error_code": letter.get("media_error_code"),
+                "media_retryable": bool(letter.get("media_retryable", False)),
                 "scope": scope,
                 "read_only": scope == "legacy",
             }

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -244,11 +244,15 @@ def _adapt_mailbox_payload(
         letter = _find_letter(tuple(letter_collection(scope)), letter_id)
         if letter is None:
             return payload
-        payload["data"] = serialize_letter_detail(
+        serialized = serialize_letter_detail(
             letter,
             scope=scope,
             include_legacy_aliases=True,
         )
+        for field in ("error_code", "retryable"):
+            if field in data:
+                serialized[field] = data[field]
+        payload["data"] = serialized
         return payload
 
     if path == "/toy/letter/send":

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -682,6 +682,10 @@ def test_persisted_pending_reply_resumes_when_http_runtime_starts(
         "letter_id": "letter-restart-uncertain",
         "content": "synthetic uncertain provider input",
         "letter_status": "PROCESSING",
+        "reply_mode": "musical_video",
+        "media_status": "PENDING",
+        "media_error_code": "STALE_MEDIA_ERROR",
+        "media_retryable": True,
     })
     local_server.store.request_keys["restart-key"] = pending["letter_id"]
     local_server._persist_store_state()
@@ -712,10 +716,19 @@ def test_persisted_pending_reply_resumes_when_http_runtime_starts(
     assert detail["data"]["reply_text"] == "synthetic recovered reply"
     assert interrupted["data"]["letter_status"] == "FAILED"
     assert interrupted["data"]["error_code"] == "LLM_INTERRUPTED"
+    assert interrupted["data"]["media_status"] == "NOT_REQUESTED"
+    assert interrupted["data"]["media_error_code"] is None
+    assert interrupted["data"]["media_retryable"] is False
     assert generated_contents == ["synthetic persisted input"]
     persisted_by_id = {item["letter_id"]: item for item in persisted["letters"]}
     assert persisted_by_id[pending["letter_id"]]["letter_status"] == "COMPLETED"
     assert persisted_by_id["letter-restart-uncertain"]["letter_status"] == "FAILED"
+    assert (
+        persisted_by_id["letter-restart-uncertain"]["media_status"]
+        == "NOT_REQUESTED"
+    )
+    assert "media_error_code" not in persisted_by_id["letter-restart-uncertain"]
+    assert persisted_by_id["letter-restart-uncertain"]["media_retryable"] is False
     assert persisted["request_keys"]["restart-key"] == pending["letter_id"]
 
 

--- a/tests/http/test_original_client_mailbox_runtime.py
+++ b/tests/http/test_original_client_mailbox_runtime.py
@@ -65,6 +65,8 @@ def _letters() -> list[dict[str, object]]:
             "reply_mode": "text_letter",
             "reply_not_before": 0.0,
             "media_status": "NOT_REQUESTED",
+            "error_code": "REPLY_QUALITY_BLOCKED",
+            "retryable": False,
             "is_read": 1,
             "created_at": 1_700_000_004,
         },
@@ -142,6 +144,8 @@ def _fallback_factory(letters: list[dict[str, object]]):
                     "data": {
                         "letter_id": letter_id,
                         "reply_text": value.get("reply_text", ""),
+                        "error_code": value.get("error_code"),
+                        "retryable": value.get("retryable", False),
                     },
                 },
                 headers=common_headers,
@@ -238,6 +242,17 @@ def test_original_collection_detail_keeps_text_and_only_exposes_completed_local_
             assert pending_data["replyType"] == 0
             assert pending_data["replyText"] == ""
             assert pending_data["replyVideoUrl"] == ""
+
+            failed = await client.get(
+                "/toy/letter/detail?letter_id=letter.failed"
+            )
+            failed_data = (await failed.json())["data"]
+            assert failed_data["letterStatus"] == 5
+            assert failed_data["error_code"] == "REPLY_QUALITY_BLOCKED"
+            assert failed_data["retryable"] is False
+            assert failed_data["media_status"] == "NOT_REQUESTED"
+            assert failed_data["media_error_code"] is None
+            assert failed_data["media_retryable"] is False
 
     asyncio.run(scenario())
 

--- a/tests/persona/test_reply_pipeline.py
+++ b/tests/persona/test_reply_pipeline.py
@@ -581,6 +581,81 @@ def test_blocked_candidate_never_reaches_storage_or_media(
     assert letter["reply_text"] == ""
     assert letter["letter_status"] == "FAILED"
     assert letter["quality_status"] == "blocked"
+    assert letter["media_status"] == "NOT_REQUESTED"
+    assert letter.get("media_error_code") is None
     assert scheduled == []
     assert "review_prompt" not in letter
     assert "private_world" not in letter
+
+
+def test_video_reply_timeout_does_not_masquerade_as_a_media_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    class TimeoutPipeline:
+        async def run(self, request: object, context: ReplyContext) -> PipelineResult:
+            assert context.mode is ReplyMode.MUSICAL_VIDEO
+            raise asyncio.TimeoutError
+
+    letter = {
+        "letter_id": "letter-timeout",
+        "reply_text": "",
+        "letter_status": "PENDING",
+    }
+    monkeypatch.setattr(local_server.store, "letters", [letter])
+    monkeypatch.setattr(local_server, "emotion_triage", FakeTriageService())
+    monkeypatch.setattr(local_server, "_persist_store_state", lambda: None)
+    monkeypatch.setattr(
+        local_server, "_schedule_text_reply_delay", lambda *args: None
+    )
+    monkeypatch.setattr(local_server, "reply_pipeline", TimeoutPipeline())
+
+    assert (
+        asyncio.run(
+            local_server.generate_reply("letter-timeout", "candidate input")
+        )
+        is False
+    )
+    assert letter["letter_status"] == "FAILED"
+    assert letter["error_code"] == "LLM_TIMEOUT"
+    assert letter["media_status"] == "NOT_REQUESTED"
+    assert letter.get("media_error_code") is None
+
+
+def test_unexpected_video_reply_exception_does_not_leave_media_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    async def explode(*_args: object, **_kwargs: object) -> bool:
+        raise Exception("synthetic unexpected failure")
+
+    letter = {
+        "letter_id": "letter-unexpected",
+        "content": "candidate input",
+        "letter_status": "PROCESSING",
+        "reply_mode": "musical_video",
+        "media_status": "PENDING",
+        "media_error_code": "STALE_MEDIA_ERROR",
+        "media_retryable": True,
+    }
+    monkeypatch.setattr(local_server.store, "letters", [letter])
+    monkeypatch.setattr(local_server, "generate_reply", explode)
+    monkeypatch.setattr(local_server, "_persist_store_state", lambda: None)
+
+    assert (
+        asyncio.run(
+            local_server._run_reply_job(
+                "letter-unexpected",
+                "candidate input",
+                idempotency_key=None,
+            )
+        )
+        is False
+    )
+    assert letter["letter_status"] == "FAILED"
+    assert letter["error_code"] == "LLM_UNAVAILABLE"
+    assert letter["media_status"] == "NOT_REQUESTED"
+    assert letter.get("media_error_code") is None
+    assert letter["media_retryable"] is False


### PR DESCRIPTION
## Summary
- keep video media state pending only while canonical reply text is still being prepared
- reset media to not requested when text generation, quality review, restart recovery, or an unexpected pre-media failure ends the letter
- preserve letter and media retry metadata in the original-client detail response
- document the public state transition

## Focused validation
- 5 targeted pre-media failure/restart/client projection tests passed
- 3 adjacent original-client contract tests passed
- git diff --check passed

## Review evidence
- Standards round 1: BLOCK (2 P1, 1 P2); repaired with RED -> GREEN tests
- Standards round 2: PASS (P0/P1/P2 = 0)
- Spec round 2: PASS (P0/P1/P2 = 0)

## Boundaries
- no persona routing or reply-copy changes
- no Live changes
- no full test suite run