### PR TITLE
fix(video): keep letter receive responsive

### DIFF
--- a/letter_triage.py
+++ b/letter_triage.py
@@ -17,7 +17,7 @@ from typing import Any, Mapping, Protocol, Sequence
 
 from llm_gateway import GatewayError, GatewayToolCall
 from runtime.media.media_paths import configured_media_path
-from music_reply import musical_reply_configured, video_reply_dependency_status
+from music_reply import musical_reply_configured
 
 
 ROUTER_SYSTEM_PROMPT = """你负责决定林离这一封回信采用哪一种表达方式。
@@ -458,36 +458,15 @@ def routing_context_from_environment(
 ) -> RoutingContext:
     env = environ if environ is not None else os.environ
     try:
-        readiness = video_reply_dependency_status(
-            env,
-            performance_video_path=_current_music_performance(env),
-        )
+        # Video replies are one complete speech-plus-music capability.  Do not
+        # advertise a partial route when only the speech half is configured.
+        video_ready = _musical_video_configured(env)
     except Exception:
-        readiness = {"ready": False, "music_ready": False}
+        video_ready = False
     return RoutingContext(
-        spoken_video_available=readiness.get("ready") is True,
-        musical_video_available=readiness.get("music_ready") is True,
+        spoken_video_available=video_ready,
+        musical_video_available=video_ready,
         current_music_work=_context_items(env.get("OLIVIA_CURRENT_MUSIC_WORK", "")),
-    )
-
-
-def _spoken_video_configured(env: Mapping[str, str]) -> bool:
-    data_root = configured_media_path(env, "OLIVIA_LOCAL_DATA_ROOT")
-    tts_config = configured_media_path(env, "OLIVIA_TTS_CONFIG")
-    scene = configured_media_path(env, "OLIVIA_ORDINARY_ACTION_BASE")
-    latentsync_python = configured_media_path(env, "OLIVIA_LATENTSYNC_PYTHON")
-    latentsync_root = configured_media_path(env, "OLIVIA_LATENTSYNC_ROOT")
-    return bool(
-        data_root is not None
-        and data_root.is_absolute()
-        and tts_config is not None
-        and tts_config.is_file()
-        and scene is not None
-        and scene.is_file()
-        and latentsync_python is not None
-        and latentsync_python.is_file()
-        and latentsync_root is not None
-        and latentsync_root.is_dir()
     )
 
 

--- a/local_server.py
+++ b/local_server.py
@@ -52,7 +52,12 @@ from persona_provider import (
     persona_status,
 )
 from reply_orchestrator import ReplyOrchestrator, ReplyRequest, ReplyState
-from letter_triage import LetterEmotionTriage, TriageResult, _current_music_performance
+from letter_triage import (
+    LetterEmotionTriage,
+    TriageResult,
+    _current_music_performance,
+    _musical_video_configured,
+)
 from runtime.media.media_paths import configured_media_path
 from music_reply import (
     MusicReplyError,
@@ -803,13 +808,9 @@ def _open_video_capability_source(capability: object, source: object) -> bool:
 def _video_reply_dependencies_ready() -> bool:
     environment = MappingProxyType(dict(_os.environ))
     try:
-        readiness = video_reply_dependency_status(
-            environment,
-            performance_video_path=_current_music_performance(environment),
-        )
+        return _musical_video_configured(environment)
     except Exception:
         return False
-    return readiness.get("ready") is True
 
 
 private_world_runtime: PrivateWorldRuntime = create_private_world_runtime(

--- a/runtime/media/music_reply.py
+++ b/runtime/media/music_reply.py
@@ -148,6 +148,7 @@ def musical_reply_configured(
 
     minimax_root = configured_path("OLIVIA_MINIMAX_COMFY_ROOT")
     latentsync_root = configured_path("OLIVIA_LATENTSYNC_ROOT")
+    ordinary_scene = configured_path("OLIVIA_ORDINARY_ACTION_BASE")
     transition_reference = configured_path("OLIVIA_OFFICIAL_REPLY_REFERENCE")
     delivery_paths = (
         configured_path("OLIVIA_TTS_CONFIG"),
@@ -158,7 +159,7 @@ def musical_reply_configured(
     ):
         return False
     try:
-        assemble_latentsync_video_delivery(
+        delivery = assemble_latentsync_video_delivery(
             delivery_paths[0],
             delivery_paths[1],
             env,
@@ -176,7 +177,11 @@ def musical_reply_configured(
         configured_path("OLIVIA_MINIMAX_WORKER"),
         configured_path("OLIVIA_LATENTSYNC_PYTHON"),
     )
-    if transition_reference is None or any(path is None for path in configured_files):
+    if (
+        ordinary_scene is None
+        or transition_reference is None
+        or any(path is None for path in configured_files)
+    ):
         return False
     required = (
         transition_reference,
@@ -193,6 +198,8 @@ def musical_reply_configured(
     return bool(
         performance_video_path is not None
         and performance_video_path.is_file()
+        and ordinary_scene.is_file()
+        and (Path(delivery.tts.model_dir) / "llm.pt").is_file()
         and minimax_root.is_dir()
         and latentsync_root.is_dir()
         and all(path.is_file() for path in required)

--- a/tests/http/test_letter_triage_portable.py
+++ b/tests/http/test_letter_triage_portable.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -452,6 +453,23 @@ def test_environment_overrides_do_not_claim_video_availability_and_current_work_
     assert context.current_music_work == ("作品甲", "作品乙")
 
 
+def test_routing_context_does_not_wait_for_the_full_runtime_probe(monkeypatch):
+    import letter_triage
+
+    monkeypatch.setattr(
+        letter_triage,
+        "_musical_video_configured",
+        lambda _environment: True,
+    )
+
+    started = time.perf_counter()
+    context = routing_context_from_environment({})
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < 0.2
+    assert context == RoutingContext(True, True)
+
+
 def test_spoken_reason_is_unavailable_without_complete_video_pipeline():
     context = routing_context_from_environment(
         {
@@ -513,8 +531,7 @@ def test_complete_video_readiness_fails_closed_for_every_missing_renderer_depend
     env["OLIVIA_FFMPEG_EXE"] = str(ffmpeg)
     required = [
         tmp_path / "config/tts.json",
-        tmp_path / "config/visual.json",
-        tmp_path / "workers/visual.py",
+        tmp_path / "scenes/spoken.mp4",
         tmp_path / "official/reply.mp4",
         tmp_path / "roformer/roformer.exe",
         tmp_path / "roformer/model.ckpt",
@@ -584,6 +601,13 @@ def test_complete_video_readiness_fails_closed_for_every_missing_renderer_depend
 
     assert routing_context_from_environment(env) == RoutingContext(True, True)
 
+    # LiveTalking is optional and is not part of the LatentSync video-reply path.
+    Path(env["OLIVIA_VISUAL_CONFIG"]).unlink()
+    Path(env["OLIVIA_LIVETALKING_WORKER"]).unlink()
+    assert routing_context_from_environment(env) == RoutingContext(True, True)
+    Path(env["OLIVIA_VISUAL_CONFIG"]).write_bytes(b"synthetic")
+    Path(env["OLIVIA_LIVETALKING_WORKER"]).write_bytes(b"synthetic")
+
     env["OLIVIA_PROJECT_ROOT"] = str(tmp_path)
     for name, value in tuple(env.items()):
         if not name.startswith("OLIVIA_") or name in {
@@ -602,9 +626,10 @@ def test_complete_video_readiness_fails_closed_for_every_missing_renderer_depend
     quality_checkpoint.write_bytes(b"synthetic")
 
     for missing in required:
+        original = missing.read_bytes()
         missing.unlink()
-        assert routing_context_from_environment(env) == RoutingContext(False, False)
-        missing.write_bytes(b"synthetic")
+        assert routing_context_from_environment(env) == RoutingContext(False, False), missing
+        missing.write_bytes(original)
 
     monkeypatch.setitem(sys.modules, "imageio_ffmpeg", None)
     for resolved_ffmpeg in (None, write("runtime/ffmpeg.exe")):

--- a/tests/http/test_video_reply_settings.py
+++ b/tests/http/test_video_reply_settings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 import pytest
@@ -305,6 +306,57 @@ def test_route_and_receive_snapshot_off_are_server_enforced(tmp_path, monkeypatc
     try:
         assert asyncio.run(local_server.generate_reply(letter["letter_id"], letter["content"]))
         assert letter["video_reply_enabled"] is False and "media_status" not in letter
+    finally:
+        local_server.store.letters.remove(letter)
+
+
+def test_letter_send_does_not_wait_for_the_full_video_runtime_probe(
+    tmp_path, monkeypatch
+):
+    import local_server
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    settings = VideoReplySettingsStore.initialize(tmp_path)
+    settings.mutate("video_reply_setting:enabled", True)
+    monkeypatch.setattr(local_server, "video_reply_settings_store", settings)
+    monkeypatch.setattr(
+        local_server,
+        "_musical_video_configured",
+        lambda _environment: True,
+        raising=False,
+    )
+
+    def slow_full_probe(_environment, *, performance_video_path):
+        time.sleep(0.3)
+        return {"ready": False, "dependencies": []}
+
+    monkeypatch.setattr(local_server, "video_reply_dependency_status", slow_full_probe)
+    monkeypatch.setattr(local_server, "_schedule_reply_job", lambda *_a, **_k: None)
+
+    async def send() -> tuple[float, dict]:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            started = time.perf_counter()
+            response = await client.post(
+                "/toy/letter/send",
+                json={"content": "synthetic fast receive"},
+            )
+            elapsed = time.perf_counter() - started
+            payload = await response.json()
+            assert response.status == 200
+            return elapsed, payload
+
+    elapsed, payload = asyncio.run(send())
+    letter = next(
+        item
+        for item in local_server.store.letters
+        if item["letter_id"] == payload["data"]["letter_id"]
+    )
+    try:
+        assert elapsed < 0.2
+        assert letter["video_reply_enabled"] is True
     finally:
         local_server.store.letters.remove(letter)
 

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -198,6 +198,9 @@ def test_musical_reply_accepts_portable_roformer_python(
     ):
         _write(latentsync_root / relative)
     performance = _write(tmp_path / "private" / "performance.mp4")
+    ordinary_scene = _write(tmp_path / "private" / "spoken.mp4")
+    tts_model = tmp_path / "tts-model"
+    _write(tts_model / "llm.pt")
     environment = {
         "OLIVIA_TTS_CONFIG": str(_write(tmp_path / "config" / "tts.json")),
         "OLIVIA_LOCAL_DATA_ROOT": str(data_root),
@@ -210,11 +213,14 @@ def test_musical_reply_accepts_portable_roformer_python(
         "OLIVIA_ROFORMER_MODEL_PATH": str(_write(tmp_path / "roformer.ckpt")),
         "OLIVIA_ROFORMER_CONFIG_PATH": str(_write(tmp_path / "roformer.yaml")),
         "OLIVIA_OFFICIAL_REPLY_REFERENCE": str(_write(tmp_path / "private" / "reply.mp4")),
+        "OLIVIA_ORDINARY_ACTION_BASE": str(ordinary_scene),
     }
     monkeypatch.setattr(
         music_reply,
         "assemble_latentsync_video_delivery",
-        lambda *_args, **_kwargs: object(),
+        lambda *_args, **_kwargs: SimpleNamespace(
+            tts=SimpleNamespace(model_dir=str(tts_model))
+        ),
     )
 
     assert music_reply.musical_reply_configured(


### PR DESCRIPTION
Summary
- remove full Python/CUDA video runtime probes from the letter receive and routing hot paths
- keep video readiness fail-closed with the complete speech-plus-music file closure
- keep full runtime probes on Settings GET/enable, offloaded from the event loop
- keep LiveTalking optional and outside this LatentSync path

Focused validation
- 6 focused HTTP/routing tests passed in 0.74s
- git diff --check passed

Review evidence
- Standards: PASS, P0/P1/P2 = 0 after one P1 repair round
- Spec: PASS, P0/P1/P2 = 0 after one P1 repair round

Boundary
- no persona prompt or routing-selection policy changes
- no one-letter concurrency changes
- no LiveTalking changes
- full end-to-end video acceptance follows after patch installation