### PR TITLE
fix(video): retry invalid voice direction once

### DIFF
--- a/local_server.py
+++ b/local_server.py
@@ -1052,14 +1052,26 @@ async def _music_voice_plan_for_letter(
     if persisted_request_id is None:
         letter["voice_direction_request_id"] = request_id
         _persist_media_state()
-    plan = await asyncio.wait_for(
-        direct_music_voice_performance(
-            reply_text,
-            letters_adapter.gateway,
-            request_id=request_id,
-        ),
-        timeout=LLM_TIMEOUT_SECONDS,
-    )
+    try:
+        plan = await asyncio.wait_for(
+            direct_music_voice_performance(
+                reply_text,
+                letters_adapter.gateway,
+                request_id=request_id,
+            ),
+            timeout=LLM_TIMEOUT_SECONDS,
+        )
+    except VoiceDirectionError as exc:
+        if str(exc) != "VOICE_DIRECTION_INVALID":
+            raise
+        plan = await asyncio.wait_for(
+            direct_music_voice_performance(
+                reply_text,
+                letters_adapter.gateway,
+                request_id=f"{request_id}:repair",
+            ),
+            timeout=LLM_TIMEOUT_SECONDS,
+        )
     if plan.reply_text != reply_text:
         raise VoiceDirectionError("VOICE_DIRECTION_TEXT_MISMATCH")
     letter["voice_performance_plan"] = plan.to_dict()

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -575,6 +575,36 @@ def test_corrupt_persisted_voice_plan_fails_closed_without_redirection(monkeypat
     assert provider_calls == []
 
 
+def test_music_voice_direction_retries_one_invalid_tool_result(monkeypatch):
+    reply_text = "The frozen reply has two sentences. This is the second one."
+    letter = {"letter_id": "music-direction-repair"}
+    request_id = "letter-reply:music-direction-repair:voice-direction"
+    provider_calls = []
+    plan = VoicePerformancePlan(
+        reply_text=reply_text,
+        overall_emotion="gentle reassurance",
+        global_speed=1.03,
+        energy=0.42,
+        breath_before_sentences=(),
+        emphasize_sentences=(),
+        short_instruction="",
+        profile="legacy_music_global_direction_v1",
+    )
+
+    async def direct(_text, _gateway, *, request_id=None):
+        provider_calls.append(request_id)
+        if len(provider_calls) == 1:
+            raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
+        return plan
+
+    monkeypatch.setattr(local_server, "direct_music_voice_performance", direct)
+
+    assert asyncio.run(local_server._music_voice_plan_for_letter(letter, reply_text)) == plan
+    assert provider_calls == [request_id, f"{request_id}:repair"]
+    assert letter["voice_performance_plan"] == plan.to_dict()
+
+
+
 def test_voice_direction_retries_keep_a_persisted_provider_idempotency_key(monkeypatch):
     reply_text = "This reply is frozen before voice direction."
     request_id = "letter-reply:durable-direction:voice-direction"


### PR DESCRIPTION
Summary
- retry one malformed music voice-direction tool result with a stable repair request ID
- keep all other voice errors, network failures, and timeouts fail-closed
- preserve frozen reply text, routing choice, and persisted voice plan

Focused validation
- 4 focused voice/media tests passed in 0.51s
- git diff --check passed

Review evidence
- Standards: PASS, P0/P1/P2 = 0
- Spec: PASS, P0/P1/P2 = 0

Real acceptance evidence
- automatic musical_video routing completed
- canonical reply quality accepted and PrivateWorld committed
- first voice-direction call returned VOICE_DIRECTION_INVALID
- independent repair request returned a valid plan in about 15 seconds

Boundary
- no persona, reply text, routing, LiveTalking, or download changes