### PR TITLE
fix(video): use local musical voice plan

### DIFF
--- a/local_server.py
+++ b/local_server.py
@@ -75,7 +75,6 @@ from runtime.reply.reply_delivery import (
 from voice_direction import (
     VoiceDirectionError,
     VoicePerformancePlan,
-    direct_music_voice_performance,
     direct_voice_performance,
 )
 from runtime.video_reply_settings import (
@@ -1045,35 +1044,16 @@ async def _music_voice_plan_for_letter(
     letter_id = str(letter.get("letter_id", "")).strip()
     if not letter_id:
         raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_REQUEST_INVALID")
-    request_id = f"letter-reply:{letter_id}:voice-direction"
-    persisted_request_id = letter.get("voice_direction_request_id")
-    if persisted_request_id is not None and persisted_request_id != request_id:
-        raise VoiceDirectionError("VOICE_DIRECTION_PERSISTED_REQUEST_INVALID")
-    if persisted_request_id is None:
-        letter["voice_direction_request_id"] = request_id
-        _persist_media_state()
-    try:
-        plan = await asyncio.wait_for(
-            direct_music_voice_performance(
-                reply_text,
-                letters_adapter.gateway,
-                request_id=request_id,
-            ),
-            timeout=LLM_TIMEOUT_SECONDS,
-        )
-    except VoiceDirectionError as exc:
-        if str(exc) != "VOICE_DIRECTION_INVALID":
-            raise
-        plan = await asyncio.wait_for(
-            direct_music_voice_performance(
-                reply_text,
-                letters_adapter.gateway,
-                request_id=f"{request_id}:repair",
-            ),
-            timeout=LLM_TIMEOUT_SECONDS,
-        )
-    if plan.reply_text != reply_text:
-        raise VoiceDirectionError("VOICE_DIRECTION_TEXT_MISMATCH")
+    plan = VoicePerformancePlan(
+        reply_text=reply_text,
+        overall_emotion="自然、温柔、真诚地说完这封回信",
+        global_speed=1.03,
+        energy=0.45,
+        breath_before_sentences=(),
+        emphasize_sentences=(),
+        short_instruction="",
+        profile="legacy_music_global_direction_v1",
+    )
     letter["voice_performance_plan"] = plan.to_dict()
     _persist_media_state()
     return plan

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -455,11 +455,11 @@ def test_video_routes_use_separate_ordinary_and_musical_renderers(
     )
     music_plan = VoicePerformancePlan(
         reply_text=reply_text,
-        overall_emotion="restrained empathy becoming steady reassurance",
-        global_speed=1.06,
-        energy=0.62,
+        overall_emotion="自然、温柔、真诚地说完这封回信",
+        global_speed=1.03,
+        energy=0.45,
         breath_before_sentences=(),
-        emphasize_sentences=(1,),
+        emphasize_sentences=(),
         short_instruction="",
         profile="legacy_music_global_direction_v1",
     )
@@ -498,12 +498,6 @@ def test_video_routes_use_separate_ordinary_and_musical_renderers(
         directed_requests.append(request_id)
         return plan
 
-    async def direct_music_reply(text, gateway, *, request_id=None):
-        assert text == reply_text
-        assert gateway is local_server.letters_adapter.gateway
-        directed_requests.append(request_id)
-        return music_plan
-
     received = {}
 
     def render_spoken(_text, output, **kwargs):
@@ -525,11 +519,6 @@ def test_video_routes_use_separate_ordinary_and_musical_renderers(
         }
 
     monkeypatch.setattr(local_server, "direct_voice_performance", direct_frozen_reply)
-    monkeypatch.setattr(
-        local_server,
-        "direct_music_voice_performance",
-        direct_music_reply,
-    )
     monkeypatch.setattr(local_server, "render_reply_video", render_spoken)
     monkeypatch.setattr(local_server, "render_musical_reply", render_musical)
 
@@ -550,7 +539,6 @@ def test_video_routes_use_separate_ordinary_and_musical_renderers(
     assert all(letter["media_status"] == "COMPLETED" for letter in letters)
     assert directed_requests == [
         "letter-reply:spoken-entry:voice-direction",
-        "letter-reply:musical-entry:voice-direction",
     ]
     assert letters[0]["voice_performance_plan"] == plan.to_dict()
     assert letters[1]["voice_performance_plan"] == music_plan.to_dict()
@@ -575,32 +563,16 @@ def test_corrupt_persisted_voice_plan_fails_closed_without_redirection(monkeypat
     assert provider_calls == []
 
 
-def test_music_voice_direction_retries_one_invalid_tool_result(monkeypatch):
+def test_music_voice_plan_is_local_and_does_not_wait_for_provider(monkeypatch):
     reply_text = "The frozen reply has two sentences. This is the second one."
-    letter = {"letter_id": "music-direction-repair"}
-    request_id = "letter-reply:music-direction-repair:voice-direction"
-    provider_calls = []
-    plan = VoicePerformancePlan(
-        reply_text=reply_text,
-        overall_emotion="gentle reassurance",
-        global_speed=1.03,
-        energy=0.42,
-        breath_before_sentences=(),
-        emphasize_sentences=(),
-        short_instruction="",
-        profile="legacy_music_global_direction_v1",
-    )
+    letter = {"letter_id": "music-local-direction"}
 
-    async def direct(_text, _gateway, *, request_id=None):
-        provider_calls.append(request_id)
-        if len(provider_calls) == 1:
-            raise VoiceDirectionError("VOICE_DIRECTION_INVALID")
-        return plan
+    plan = asyncio.run(local_server._music_voice_plan_for_letter(letter, reply_text))
 
-    monkeypatch.setattr(local_server, "direct_music_voice_performance", direct)
-
-    assert asyncio.run(local_server._music_voice_plan_for_letter(letter, reply_text)) == plan
-    assert provider_calls == [request_id, f"{request_id}:repair"]
+    assert plan.reply_text == reply_text
+    assert plan.global_speed == 1.03
+    assert plan.energy == 0.45
+    assert plan.profile == "legacy_music_global_direction_v1"
     assert letter["voice_performance_plan"] == plan.to_dict()
 
 


### PR DESCRIPTION
Summary
- remove the extra music voice-direction LLM call from the media startup path
- derive a conservative non-spoken global voice plan locally from the already frozen reply
- preserve validated persisted plans and leave the spoken-video director path unchanged

Focused validation
- 4 focused voice/media tests passed in 0.53s
- git diff --check passed

Review evidence
- Standards: PASS, P0/P1/P2 = 0
- Spec: PASS, P0/P1/P2 = 0

Real acceptance evidence
- letter receive is 75ms on 0.1.17+
- automatic router selected musical_video
- text quality accepted and PrivateWorld committed
- extra music voice-direction call produced invalid controls and later exceeded 180 seconds before any GPU process started

Boundary
- no reply text, persona, routing, download, LiveTalking, or ordinary spoken-video changes