### PR TITLE
fix(video): unblock Windows musical reply pipeline

### DIFF
--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -123,6 +123,7 @@ RELEASE_INSTALLER_FILES = {
     "installer/video-capability-manifest.json",
     "installer/cosyvoice-windows-audio.patch.json",
     "installer/latentsync-windows-memmap.patch.json",
+    "installer/latentsync-windows-mp4-writer.patch.json",
     "installer/seed-vc-overlap-frames.patch",
 }
 RELEASE_TOOL_FILES = {

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -116,6 +116,7 @@ PAYLOAD_REQUIRED_RELATIVE_FILES = {
     "installer/video-capability-manifest.json",
     "installer/cosyvoice-windows-audio.patch.json",
     "installer/latentsync-windows-memmap.patch.json",
+    "installer/latentsync-windows-mp4-writer.patch.json",
     "installer/seed-vc-overlap-frames.patch",
     "installer/mem0-runtime-artifacts.json",
     "runtime/__init__.py",

--- a/installer/latentsync-windows-mp4-writer.patch.json
+++ b/installer/latentsync-windows-mp4-writer.patch.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "olivia.runtime-text-patch.v1",
+  "target": "latentsync/runtime/latentsync/utils/util.py",
+  "replacements": [
+    {
+      "before": "def write_video(video_output_path: str, video_frames: np.ndarray, fps: int):\n    with imageio.get_writer(\n        video_output_path,\n        fps=fps,\n        codec=\"libx264\",\n        macro_block_size=None,\n        ffmpeg_params=[\"-crf\", \"13\"],\n        ffmpeg_log_level=\"error\",\n    ) as writer:\n        for video_frame in video_frames:\n            writer.append_data(video_frame)",
+      "after": "def write_video(video_output_path: str, video_frames: np.ndarray, fps: int):\n    # The portable Windows runtime intentionally avoids imageio-ffmpeg.\n    # OpenCV writes the silent intermediate; the next stage muxes audio with FFmpeg.\n    write_video_cv2(video_output_path, video_frames, fps)"
+    }
+  ]
+}

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -74,7 +74,11 @@ def _load_video_environment(
     backend_tools = Path(__file__).resolve().parents[1] / "tools"
     minimax_worker = backend_tools / "minimax_music3_worker.py"
     minimax_profile = backend_tools / "minimax_profile.py"
-    if minimax_worker.is_file() and minimax_profile.is_file():
+    if (
+        "OLIVIA_MINIMAX_WORKER" not in environment
+        and minimax_worker.is_file()
+        and minimax_profile.is_file()
+    ):
         values["OLIVIA_MINIMAX_WORKER"] = str(minimax_worker)
     return values
 

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -71,6 +71,11 @@ def _load_video_environment(
         return values
     for key, value in persisted.items():
         values.setdefault(key, value)
+    backend_tools = Path(__file__).resolve().parents[1] / "tools"
+    minimax_worker = backend_tools / "minimax_music3_worker.py"
+    minimax_profile = backend_tools / "minimax_profile.py"
+    if minimax_worker.is_file() and minimax_profile.is_file():
+        values["OLIVIA_MINIMAX_WORKER"] = str(minimax_worker)
     return values
 
 

--- a/installer/video-capability-manifest.json
+++ b/installer/video-capability-manifest.json
@@ -22,7 +22,8 @@
       "runtime_environment": {"OLIVIA_COSYVOICE_PYTHON": "cosyvoice/runtime/python/python.exe", "OLIVIA_FFMPEG_EXE": "ffmpeg/runtime/bin/ffmpeg.exe", "OLIVIA_LATENTSYNC_PYTHON": "latentsync/runtime/python/python.exe", "OLIVIA_LATENTSYNC_ROOT": "latentsync/runtime", "OLIVIA_TTS_CONFIG": "cosyvoice/config/tts_local.json"},
       "runtime_patches": [
         {"id":"cosyvoice-windows-audio","path":"installer/cosyvoice-windows-audio.patch.json","target":"cosyvoice/runtime/cosyvoice/utils/file_utils.py","sha256":"019a0f163e397186c0a6d26c5eeaed1c56ba88462200662950c276ceb50c2d27"},
-        {"id":"latentsync-windows-memmap","path":"installer/latentsync-windows-memmap.patch.json","target":"latentsync/runtime/latentsync/pipelines/lipsync_pipeline.py","sha256":"a627cc639bd400c00466f683517afaf7adbac8b42088f128bd42e04d52b8e5b1"}
+        {"id":"latentsync-windows-memmap","path":"installer/latentsync-windows-memmap.patch.json","target":"latentsync/runtime/latentsync/pipelines/lipsync_pipeline.py","sha256":"a627cc639bd400c00466f683517afaf7adbac8b42088f128bd42e04d52b8e5b1"},
+        {"id":"latentsync-windows-mp4-writer","path":"installer/latentsync-windows-mp4-writer.patch.json","target":"latentsync/runtime/latentsync/utils/util.py","sha256":"bbeea2d143e756c0ba419b5299cd4b62731e619b155d3e308aa66920868ca516"}
       ],
       "files": [
         {"id":"cosyvoice-code","path":"sources/CosyVoice-074ca6dc.zip","size_bytes":1633232,"sha256":"4e7b1ce909f97abcc8afa0a890f92ccf2839ff435c698d4f04a1ba7aa71a022f","license":"Apache-2.0","sources":{"domestic":"https://codeload.github.com/FunAudioLLM/CosyVoice/zip/074ca6dc9e80a2f424f1f74b48bdd7d3fea531cc","official":"https://codeload.github.com/FunAudioLLM/CosyVoice/zip/074ca6dc9e80a2f424f1f74b48bdd7d3fea531cc"},"install":{"kind":"zip","destination":"cosyvoice/runtime","strip_components":1}},

--- a/runtime/media/music_reply.py
+++ b/runtime/media/music_reply.py
@@ -1234,7 +1234,13 @@ def _normal_stage_inputs_match(
         ("inputs", ("canonical_reply_sha256", "voice_performance_sha256")),
         (
             "assets",
-            ("official_reply_reference", "spoken_action_base", "tts_config"),
+            (
+                "official_reply_reference",
+                "spoken_action_base",
+                "tts_config",
+                "visual_config",
+                "visual_worker",
+            ),
         ),
         ("providers", ("face_sync",)),
     ):

--- a/runtime/media/music_reply.py
+++ b/runtime/media/music_reply.py
@@ -1207,9 +1207,44 @@ def _read_compatible_manifest(
         loaded.get(key) != expected.get(key)
         for key in ("schema_version", "inputs", "assets", "providers")
     ):
-        return {**expected, "artifacts": {}}
+        artifacts: dict[str, object] = {}
+        if isinstance(loaded, dict) and _normal_stage_inputs_match(loaded, expected):
+            loaded_artifacts = loaded.get("artifacts")
+            normal = (
+                loaded_artifacts.get("normal_video")
+                if isinstance(loaded_artifacts, dict)
+                else None
+            )
+            if isinstance(normal, dict):
+                artifacts["normal_video"] = normal
+        return {**expected, "artifacts": artifacts}
     artifacts = loaded.get("artifacts")
     return {**expected, "artifacts": artifacts if isinstance(artifacts, dict) else {}}
+
+
+def _normal_stage_inputs_match(
+    loaded: dict[str, object],
+    expected: dict[str, object],
+) -> bool:
+    """Keep completed speech when only song planning or music providers change."""
+
+    if loaded.get("schema_version") != expected.get("schema_version"):
+        return False
+    for section, keys in (
+        ("inputs", ("canonical_reply_sha256", "voice_performance_sha256")),
+        (
+            "assets",
+            ("official_reply_reference", "spoken_action_base", "tts_config"),
+        ),
+        ("providers", ("face_sync",)),
+    ):
+        old_values = loaded.get(section)
+        new_values = expected.get(section)
+        if not isinstance(old_values, dict) or not isinstance(new_values, dict):
+            return False
+        if any(old_values.get(key) != new_values.get(key) for key in keys):
+            return False
+    return True
 
 
 def _write_stage_manifest(manifest_path: Path, manifest: dict[str, object]) -> None:

--- a/runtime/media/song_content.py
+++ b/runtime/media/song_content.py
@@ -20,6 +20,7 @@ from runtime.media.music_duration import normalize_music_duration
 
 
 SONG_SEMANTIC_PLAN_SCHEMA_VERSION = "p03.song-semantic-plan.v1"
+_PLANNER_REPAIR_RESERVE_CHARS = 512
 
 
 class SongEmotionArc(StrEnum):
@@ -319,7 +320,9 @@ def _planning_messages(
             trusted_time=TrustedTime(datetime.now(timezone.utc)),
         ),
         user_input=user_input,
-        max_units=config.max_input_chars - len(prefix),
+        max_units=(
+            config.max_input_chars - len(prefix) - _PLANNER_REPAIR_RESERVE_CHARS
+        ),
     )
     return (
         {"role": "system", "content": prefix + assembly.system_content},
@@ -355,7 +358,27 @@ def plan_song_content(
     )
     messages = _planning_messages(user_input, duration, gateway_config)
     response = asyncio.run(active_gateway.complete(messages))
-    semantic_plan = parse_song_semantic_plan(response.text, duration)
+    try:
+        semantic_plan = parse_song_semantic_plan(response.text, duration)
+    except ValueError as exc:
+        error_code = str(exc)
+        if not error_code.startswith("SONG_SEMANTIC_PLAN_"):
+            raise
+        verse_count, chorus_count = _SECTION_LINE_COUNTS[duration]
+        repair_messages = (
+            *messages,
+            {
+                "role": "user",
+                "content": (
+                    f"Your previous JSON failed local validation with {error_code}. "
+                    "Return the corrected seven-key JSON object only. "
+                    f"Use exactly {verse_count} Verse lines and {chorus_count} "
+                    "Chorus lines; keep Intro and Outro empty."
+                ),
+            },
+        )
+        repaired = asyncio.run(active_gateway.complete(repair_messages))
+        semantic_plan = parse_song_semantic_plan(repaired.text, duration)
 
     # Imported lazily because music_caption imports the typed plan definitions
     # from this module. The production output remains compatible with the

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -244,6 +244,9 @@ def test_launcher_loads_persisted_video_runtime_environment(tmp_path: Path) -> N
     environment = start_local._load_video_environment({}, data_root)
 
     assert environment["OLIVIA_LATENTSYNC_ROOT"] == str(runtime_root)
+    assert environment["OLIVIA_MINIMAX_WORKER"] == str(
+        (Path(start_local.__file__).resolve().parents[1] / "tools" / "minimax_music3_worker.py")
+    )
     explicit = start_local._load_video_environment(
         {"OLIVIA_LATENTSYNC_ROOT": "D:/managed/latentsync"}, data_root
     )

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -248,9 +248,14 @@ def test_launcher_loads_persisted_video_runtime_environment(tmp_path: Path) -> N
         (Path(start_local.__file__).resolve().parents[1] / "tools" / "minimax_music3_worker.py")
     )
     explicit = start_local._load_video_environment(
-        {"OLIVIA_LATENTSYNC_ROOT": "D:/managed/latentsync"}, data_root
+        {
+            "OLIVIA_LATENTSYNC_ROOT": "D:/managed/latentsync",
+            "OLIVIA_MINIMAX_WORKER": "D:/managed/minimax-worker.py",
+        },
+        data_root,
     )
     assert explicit["OLIVIA_LATENTSYNC_ROOT"] == "D:/managed/latentsync"
+    assert explicit["OLIVIA_MINIMAX_WORKER"] == "D:/managed/minimax-worker.py"
 
 
 def test_launcher_uses_fixed_scene_assets_from_the_installed_client(tmp_path: Path) -> None:

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -107,6 +107,10 @@ def test_repository_bom_keeps_fixed_cosyvoice_and_license_boundaries() -> None:
             "latentsync/runtime/latentsync/pipelines/lipsync_pipeline.py",
             "a627cc639bd400c00466f683517afaf7adbac8b42088f128bd42e04d52b8e5b1",
         ),
+        "latentsync-windows-mp4-writer": (
+            "latentsync/runtime/latentsync/utils/util.py",
+            "bbeea2d143e756c0ba419b5299cd4b62731e619b155d3e308aa66920868ca516",
+        ),
     }
     music_file_ids = {item.identifier for item in music.files}
     assert "seed-vc-code" not in music_file_ids
@@ -180,6 +184,26 @@ def test_runtime_text_patch_is_hash_checked_and_fails_on_source_drift(
             expected_sha256=sha256,
             patch_id="fixture",
         )
+
+
+def test_latentsync_windows_mp4_writer_patch_uses_opencv(tmp_path: Path) -> None:
+    patch = Path("installer/latentsync-windows-mp4-writer.patch.json")
+    payload = json.loads(patch.read_text(encoding="utf-8"))
+    target = tmp_path / payload["target"]
+    target.parent.mkdir(parents=True)
+    target.write_text(payload["replacements"][0]["before"] + "\n", encoding="utf-8")
+
+    apply_runtime_text_patch(
+        bundle_root=tmp_path,
+        patch_path=patch,
+        target_path=payload["target"],
+        expected_sha256=hashlib.sha256(patch.read_bytes()).hexdigest(),
+        patch_id="latentsync-windows-mp4-writer",
+    )
+
+    patched = target.read_text(encoding="utf-8")
+    assert "write_video_cv2(video_output_path, video_frames, fps)" in patched
+    assert "imageio.get_writer" not in patched
 
 
 @pytest.mark.parametrize("unsafe", ["CON/file.bin", "asset:stream", "name./file.bin"])

--- a/tests/media/test_minimax_music3_worker.py
+++ b/tests/media/test_minimax_music3_worker.py
@@ -205,6 +205,23 @@ def test_worker_source_contains_no_music_fallback() -> None:
     assert "sparse percussion" not in source
 
 
+def test_comfy_command_bootstraps_embedded_python_import_path(tmp_path: Path) -> None:
+    comfy_root = tmp_path / "comfy"
+    command = worker._comfy_command(
+        comfy_root=comfy_root,
+        port=8899,
+        cache_lru=12,
+        reserve_vram=0.5,
+        generated_root=tmp_path / "output",
+        temp_root=tmp_path / "temp",
+        vram_mode="dynamic",
+    )
+
+    assert command[1:3] == ["-c", worker._COMFY_BOOTSTRAP]
+    assert command[3:5] == [str(comfy_root), str(comfy_root / "main.py")]
+    assert "sys.path.insert(0, root)" in worker._COMFY_BOOTSTRAP
+
+
 def test_118_second_generation_timeouts_cover_both_model_phases() -> None:
     adapter = MiniMaxMusic3Worker(
         python_path=Path("python.exe"),

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -699,6 +699,8 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     )
 
     official_reference = _write(tmp_path / "official-complete-reply.mp4")
+    visual_config = _write(tmp_path / "visual.json", b"visual-v1")
+    visual_worker = _write(tmp_path / "visual-worker.py", b"worker-v1")
     monkeypatch.setattr(
         music_reply,
         "prepare_official_spoken_base",
@@ -709,8 +711,8 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
         "official_reply_reference_path": official_reference,
         "song_video_path": song_video,
         "tts_config_path": tmp_path / "tts.json",
-        "visual_config_path": tmp_path / "visual.json",
-        "worker_path": tmp_path / "visual-worker.py",
+        "visual_config_path": visual_config,
+        "worker_path": visual_worker,
         "performance_video_path": tmp_path / "base-performance.mp4",
         "duration_seconds": 40,
     }
@@ -751,6 +753,16 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
 
     assert calls == {"spoken": 2, "minimax": 4, "separate": 5}
+
+    visual_config.write_bytes(b"visual-v2")
+    music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
+
+    assert calls == {"spoken": 3, "minimax": 5, "separate": 6}
+
+    visual_worker.write_bytes(b"worker-v2")
+    music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
+
+    assert calls == {"spoken": 4, "minimax": 6, "separate": 7}
 
 
 def test_render_musical_reply_rebuilds_downstream_stages_when_song_audio_is_rebuilt(

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -729,14 +729,28 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     assert result["music_stage"] == "reused"
     assert (stage_root / "manifest.json").is_file()
 
+    monkeypatch.setattr(
+        music_reply,
+        "plan_song_content",
+        lambda *_args: SongContentPlan(
+            emotion="warm_gratitude",
+            lyrics="[Verse]\nA different valid plan",
+            caption="different gentle piano ballad",
+            duration_seconds=40,
+        ),
+    )
+    music_reply.render_musical_reply("letter", "reply", output, **kwargs)
+
+    assert calls == {"spoken": 1, "minimax": 2, "separate": 3}
+
     music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
 
-    assert calls == {"spoken": 2, "minimax": 2, "separate": 3}
+    assert calls == {"spoken": 2, "minimax": 3, "separate": 4}
 
     minimax_worker.write_bytes(b"provider-v2")
     music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
 
-    assert calls == {"spoken": 3, "minimax": 3, "separate": 4}
+    assert calls == {"spoken": 2, "minimax": 4, "separate": 5}
 
 
 def test_render_musical_reply_rebuilds_downstream_stages_when_song_audio_is_rebuilt(

--- a/tests/media/test_song_content_pipeline.py
+++ b/tests/media/test_song_content_pipeline.py
@@ -78,6 +78,16 @@ class RecordingGateway:
         return Response(self.payload)
 
 
+class SequencedGateway(RecordingGateway):
+    def __init__(self, payloads: list[str]) -> None:
+        super().__init__(payloads[0])
+        self.payloads = list(payloads)
+
+    async def complete(self, messages, request_id=None):
+        self.calls.append((tuple(messages), request_id))
+        return Response(self.payloads.pop(0))
+
+
 def test_plan_song_content_switches_production_to_semantic_plan_and_fixed_caption() -> None:
     gateway = RecordingGateway(json.dumps(_payload(), ensure_ascii=False))
 
@@ -146,6 +156,26 @@ def test_invalid_planner_output_never_falls_back_to_a_free_caption() -> None:
 
     with pytest.raises(ValueError, match="SONG_SEMANTIC_PLAN_FIELDS_INVALID"):
         plan_song_content("synthetic", "synthetic", 40, gateway=gateway)
+
+
+def test_invalid_lyric_count_is_repaired_once_by_the_planner() -> None:
+    invalid = _payload()
+    invalid["lyrics"] = invalid["lyrics"].replace("副歌第6句慢慢收好\n", "")
+    gateway = SequencedGateway(
+        [
+            json.dumps(invalid, ensure_ascii=False),
+            json.dumps(_payload(), ensure_ascii=False),
+        ]
+    )
+
+    result = plan_song_content("synthetic", "synthetic", 40, gateway=gateway)
+
+    assert result.lyrics == _short_lyrics(40)
+    assert len(gateway.calls) == 2
+    repair_messages = gateway.calls[1][0]
+    assert repair_messages[-1]["role"] == "user"
+    assert "SONG_SEMANTIC_PLAN_LYRICS_LINE_COUNT_INVALID" in repair_messages[-1]["content"]
+    assert sum(len(message["content"]) for message in repair_messages) <= 10_000
 
 
 def test_song_planner_legacy_persona_requires_explicit_opt_in() -> None:

--- a/tools/minimax_music3_worker.py
+++ b/tools/minimax_music3_worker.py
@@ -276,6 +276,45 @@ def _stop(process: subprocess.Popen) -> None:
         process.wait(timeout=10)
 
 
+_COMFY_BOOTSTRAP = (
+    "import runpy,sys; "
+    "root,entry,*args=sys.argv[1:]; "
+    "sys.path.insert(0, root); "
+    "sys.argv=[entry,*args]; "
+    "runpy.run_path(entry,run_name='__main__')"
+)
+
+
+def _comfy_command(
+    *,
+    comfy_root: Path,
+    port: int,
+    cache_lru: int,
+    reserve_vram: float,
+    generated_root: Path,
+    temp_root: Path,
+    vram_mode: str,
+) -> list[str]:
+    command = [
+        str(Path(sys.executable)),
+        "-c",
+        _COMFY_BOOTSTRAP,
+        str(comfy_root),
+        str(comfy_root / "main.py"),
+        "--listen", "127.0.0.1",
+        "--port", str(port),
+        "--cache-lru", str(max(3, cache_lru)),
+        "--reserve-vram", str(max(0.25, reserve_vram)),
+        "--disable-auto-launch",
+        "--disable-all-custom-nodes",
+        "--output-directory", str(generated_root),
+        "--temp-directory", str(temp_root),
+    ]
+    if vram_mode == "low":
+        command.append("--lowvram")
+    return command
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     comfy_root = Path(args.comfy_root).resolve()
@@ -297,20 +336,15 @@ def main(argv: list[str] | None = None) -> int:
     generated_root.mkdir(parents=True, exist_ok=True)
     temp_root.mkdir(parents=True, exist_ok=True)
     port = _free_port()
-    command = [
-        str(Path(sys.executable)),
-        str(comfy_root / "main.py"),
-        "--listen", "127.0.0.1",
-        "--port", str(port),
-        "--cache-lru", str(max(3, args.cache_lru)),
-        "--reserve-vram", str(max(0.25, args.reserve_vram)),
-        "--disable-auto-launch",
-        "--disable-all-custom-nodes",
-        "--output-directory", str(generated_root),
-        "--temp-directory", str(temp_root),
-    ]
-    if args.vram_mode == "low":
-        command.append("--lowvram")
+    command = _comfy_command(
+        comfy_root=comfy_root,
+        port=port,
+        cache_lru=args.cache_lru,
+        reserve_vram=args.reserve_vram,
+        generated_root=generated_root,
+        temp_root=temp_root,
+        vram_mode=args.vram_mode,
+    )
     creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
     started_at = time.monotonic()
     metrics: dict[str, object] = {


### PR DESCRIPTION
## Summary

- patch LatentSync Windows MP4 writing to use the bundled OpenCV path instead of the unavailable imageio-ffmpeg plugin
- repair one invalid semantic song plan without repeating unrelated media stages
- retain the completed spoken-video stage when only music planning/provider inputs change
- use the backend-bundled MiniMax worker/profile pair and bootstrap ComfyUI's root for embedded Python

## Focused validation

- 7 focused regression tests passed
- modified Python modules passed `py_compile`
- `git diff --check` passed

## Real acceptance

- one naturally routed `musical_video` letter; no forced reply mode
- real CosyVoice speech, MiniMax Music 3, RoFormer separation, both LatentSync passes, and FFmpeg concat completed
- final MP4: 54.72 seconds, 8,479,532 bytes, H.264 1280x720 plus AAC audio
- manifest recorded present fingerprints for `normal_video`, `song_audio`, `vocals`, `song_video`, and `final_output`
- spoken and song frames were visually inspected; both audio sections were non-silent

The acceptance music segment was intentionally shortened to four seconds with an ignored local harness, matching the approved chain-connectivity acceptance scope. Production duration and routing remain unchanged.

## Scope boundary

No persona, intimacy, autonomous routing, Live, private-letter fixture, or credential changes.
