### PR TITLE
fix(persona): adjudicate evidence-bound hard findings

### DIFF
--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -85,6 +85,13 @@ one typed `hard_evidence` item with:
   `world_fact`, `known_continuation`, or `none`;
 - a short uppercase `reason_code` that contains no reply excerpt.
 
+Those two layer responses also require the boolean
+`independent_soft_issue`. It is `true` only when that layer has a separate,
+localized soft mismatch besides its hard claims. With no hard claim, `true`
+requires score 1 and no drift, while `false` requires score 2 and no drift. A
+hard claim cannot be used to infer this field. Missing, non-boolean, or
+score/drift-inconsistent values make the review unavailable.
+
 Missing, duplicate, mismatched, out-of-range, or schema-invalid evidence makes
 the whole enabled Letter review unavailable and therefore fails closed. A
 semantic duplicate is keyed by at least `(code, start, end)` across layers;
@@ -94,14 +101,21 @@ layers keep their existing response schema.
 Well-formed hard evidence conditionally spends at most one additional model
 call per candidate. The call uses the same configured quality Gateway and
 `deepseek-v4-flash`; it does not create a provider or retry path. The narrow
-adjudicator receives the candidate and a claim-specific support context:
+adjudicator receives the candidate, one shared context per trusted context
+class, and claims that refer to it by `context_id`. `claim_kind` and
+`support_source` remain descriptive output only; neither can select or expand
+disclosure. Trusted `(layer, code)` selects the context class:
 
-- identity claims receive only release and canonical world authority;
-- relationship, stage, acknowledged-feeling, and intimacy claims receive only
-  release authority, canonical relationship/private context, and typed
-  Linli-authored history;
-- ordinary `MEMORY_FABRICATION` factual claims may additionally use the bounded
-  current-user excerpt and bounded assembled memory.
+- `identity_boundary/IDENTITY_DRIFT` receives only release and canonical world
+  authority;
+- relationship, stage, acknowledged-feeling, intimacy, and relationship
+  retraction codes from `identity_boundary` receive only release authority,
+  canonical relationship/private context, and typed Linli-authored history;
+- `continuity_memory/MEMORY_FABRICATION` receives only the bounded factual
+  current-user excerpt and bounded assembled memory, even if the model labels
+  the claim as relationship or shared history;
+- every other allowed combination receives only its minimal layer release
+  authority.
 
 Current-user wishes, self-labels, and untyped assembled memory never establish
 a relationship. The adjudicator returns one candidate-bound `CONFIRM` or
@@ -109,12 +123,16 @@ a relationship. The adjudicator returns one candidate-bound `CONFIRM` or
 adjudication call. Malformed adjudication fails closed.
 
 Only confirmed claims remain hard violations, using their exact candidate
-spans. If every otherwise-hard claim is rejected and no independent issue
-remains, the original candidate is immediately `accepted_with_warnings` without
-using a rewriter. Independent soft or hard issues keep their existing flow. A
-rewritten candidate always runs all five layers again and, when needed,
-receives a fresh independent adjudication. No old claim, span, or decision is
-reused; a confirmed hard claim that persists after the rewrite blocks.
+spans. Up to 16 distinct `(code, span)` claims are accepted within the existing
+30,000-character fail-closed input budget; shared contexts are serialized once,
+not copied per claim. If every otherwise-hard claim is rejected and
+`independent_soft_issue` is false, the original Letter candidate is immediately
+`accepted_with_warnings` without using a rewriter. If it is true, the existing
+rewrite path remains mandatory. A rewritten candidate always runs all five
+layers again and, when needed, receives a fresh independent adjudication. No old
+claim, span, or decision is reused; a confirmed hard claim that persists after
+the rewrite blocks. `accepted_with_warnings` is a Letter-only quality status;
+non-Letter modes retain their prior `accepted` status for soft findings.
 
 Adjudication prompts and responses are transient. Candidate text is not added
 to quality status, audit records, evidence objects, or logs, and the typed

--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -46,8 +46,8 @@ pending/control-only continuation facts, databases, filesystem paths, provider
 configuration, or the complete archive. Review prompts and responses are not
 persisted.
 
-The existing `identity_boundary` layer owns the intimacy assessment in the
-same provider call. It may emit `STAGE_DRIFT`,
+The existing `identity_boundary` layer owns the intimacy assessment in its
+normal layer call. It may emit `STAGE_DRIFT`,
 `ACKNOWLEDGED_FEELING_REWRITE`, `INTIMACY_VIOLATION`,
 `UNSOLICITED_INTIMACY`, or `RELATIONSHIP_RETRACTION`. A user's wishes,
 self-labels, unilateral nicknames, repeated messages, or lack of refusal do
@@ -66,11 +66,51 @@ mode, a closing question is `STYLE_DRIFT` only when it adds no necessary
 information or choice and merely forces continuation; useful concrete
 questions remain allowed.
 
+## Evidence-bound hard findings and adjudication
+
+`identity_boundary` and `continuity_memory` cannot create a hard finding from
+a score or drift flag alone. Every hard code must have exactly one typed
+`hard_evidence` item with:
+
+- a unique stable `evidence_id` and the matching hard `code`;
+- zero-based, end-exclusive `start` and `end` offsets inside the current
+  candidate;
+- one bounded `claim_kind`: `identity_claim`, `current_fact`, `past_fact`,
+  `shared_history`, `habit`, `location`, `action`, or `relationship`;
+- one bounded `support_source`: `current_user`, `character_history`, `memory`,
+  `world_fact`, `known_continuation`, or `none`;
+- a short uppercase `reason_code` that contains no reply excerpt.
+
+Missing, duplicate, mismatched, out-of-range, or schema-invalid evidence makes
+the whole enabled review unavailable and therefore fails closed. Other review
+layers keep their existing response schema.
+
+Well-formed hard evidence conditionally spends at most one additional model
+call per candidate. The call uses the same configured quality Gateway and
+`deepseek-v4-flash`; it does not create a provider or retry path. The narrow
+adjudicator receives the candidate, bounded approved release authority and
+relationship context, the bounded current-user excerpt, bounded assembled
+memory, typed Linli-only history, and claim metadata, and returns one
+candidate-bound `CONFIRM` or `REJECT` decision per evidence id. A normal PASS
+candidate makes no adjudication call. Malformed adjudication fails closed.
+
+Only confirmed claims remain hard violations, using their exact candidate
+spans. Rejected claims become score-1, no-drift localized soft warnings; they
+may consume the existing single rewrite budget but cannot hard-block by the old
+score-0/whole-candidate fallback. A rewritten candidate always runs all five
+layers again and, when needed, receives a fresh independent adjudication. No
+old claim, span, or decision is reused.
+
+Adjudication prompts and responses are transient. Candidate text is not added
+to quality status, audit records, evidence objects, or logs, and the typed
+evidence contains offsets and machine reason codes rather than quoted text.
+
 Each candidate is reviewed independently. After the single permitted rewrite,
 the second identity review must return fresh spans and the same request
 classification. Stale spans, conflicting claim sources, changed request
 classification, or malformed metadata fail closed. This adds no sixth review
-layer and no extra provider call. An explicit hard `STYLE_DRIFT` that remains
+layer; only evidence-bound identity/continuity hard findings add the single
+conditional adjudication call described above. An explicit hard `STYLE_DRIFT` that remains
 after the rewrite is blocked; only a localized voice-style score of 1 with no
 hard code and no drift flag may remain an accepted warning.
 

--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -68,9 +68,13 @@ questions remain allowed.
 
 ## Evidence-bound hard findings and adjudication
 
-`identity_boundary` and `continuity_memory` cannot create a hard finding from
-a score or drift flag alone. Every hard code must have exactly one typed
-`hard_evidence` item with:
+This protocol is enabled only for `text_letter`. Spoken and musical-video
+reviews retain the pre-protocol response schema and call count: they neither
+require `hard_evidence` nor invoke adjudication.
+
+In `text_letter`, `identity_boundary` and `continuity_memory` cannot create a
+hard finding from a score or drift flag alone. Every hard code must have exactly
+one typed `hard_evidence` item with:
 
 - a unique stable `evidence_id` and the matching hard `code`;
 - zero-based, end-exclusive `start` and `end` offsets inside the current
@@ -82,24 +86,35 @@ a score or drift flag alone. Every hard code must have exactly one typed
 - a short uppercase `reason_code` that contains no reply excerpt.
 
 Missing, duplicate, mismatched, out-of-range, or schema-invalid evidence makes
-the whole enabled review unavailable and therefore fails closed. Other review
+the whole enabled Letter review unavailable and therefore fails closed. A
+semantic duplicate is keyed by at least `(code, start, end)` across layers;
+changing ids, kinds, sources, or reasons cannot make it distinct. Other review
 layers keep their existing response schema.
 
 Well-formed hard evidence conditionally spends at most one additional model
 call per candidate. The call uses the same configured quality Gateway and
 `deepseek-v4-flash`; it does not create a provider or retry path. The narrow
-adjudicator receives the candidate, bounded approved release authority and
-relationship context, the bounded current-user excerpt, bounded assembled
-memory, typed Linli-only history, and claim metadata, and returns one
-candidate-bound `CONFIRM` or `REJECT` decision per evidence id. A normal PASS
-candidate makes no adjudication call. Malformed adjudication fails closed.
+adjudicator receives the candidate and a claim-specific support context:
+
+- identity claims receive only release and canonical world authority;
+- relationship, stage, acknowledged-feeling, and intimacy claims receive only
+  release authority, canonical relationship/private context, and typed
+  Linli-authored history;
+- ordinary `MEMORY_FABRICATION` factual claims may additionally use the bounded
+  current-user excerpt and bounded assembled memory.
+
+Current-user wishes, self-labels, and untyped assembled memory never establish
+a relationship. The adjudicator returns one candidate-bound `CONFIRM` or
+`REJECT` decision per evidence id. A normal PASS candidate makes no
+adjudication call. Malformed adjudication fails closed.
 
 Only confirmed claims remain hard violations, using their exact candidate
-spans. Rejected claims become score-1, no-drift localized soft warnings; they
-may consume the existing single rewrite budget but cannot hard-block by the old
-score-0/whole-candidate fallback. A rewritten candidate always runs all five
-layers again and, when needed, receives a fresh independent adjudication. No
-old claim, span, or decision is reused.
+spans. If every otherwise-hard claim is rejected and no independent issue
+remains, the original candidate is immediately `accepted_with_warnings` without
+using a rewriter. Independent soft or hard issues keep their existing flow. A
+rewritten candidate always runs all five layers again and, when needed,
+receives a fresh independent adjudication. No old claim, span, or decision is
+reused; a confirmed hard claim that persists after the rewrite blocks.
 
 Adjudication prompts and responses are transient. Candidate text is not added
 to quality status, audit records, evidence objects, or logs, and the typed

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -17,6 +17,7 @@ from runtime.reply.reply_context import (
     IntimacyRequest,
     IntimacyTier,
     ReplyContext,
+    ReplyMode,
 )
 from runtime.reply.reply_policy import IntimacyClaim
 from runtime.reply.reply_reviewer import (
@@ -176,6 +177,15 @@ _HARD_EVIDENCE_SUPPORT_SOURCES = frozenset(
 )
 _HARD_EVIDENCE_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]{1,96}")
 _HARD_EVIDENCE_REASON_PATTERN = re.compile(r"[A-Z][A-Z0-9_]{0,63}")
+_RELATIONSHIP_EVIDENCE_CODES = frozenset(
+    {
+        "STAGE_DRIFT",
+        "ACKNOWLEDGED_FEELING_REWRITE",
+        "INTIMACY_VIOLATION",
+        "UNSOLICITED_INTIMACY",
+        "RELATIONSHIP_RETRACTION",
+    }
+)
 _LAYER_RELEASE_FACETS = {
     "identity_boundary": frozenset(
         {"IDENTITY", "KNOWLEDGE_BOUNDARY", "RELATIONSHIP_STYLE", "SAFETY"}
@@ -297,6 +307,7 @@ class GatewayReviewTransport:
         timeout_seconds: float,
     ) -> object:
         mode = str(request.get("mode", ""))
+        evidence_bound = mode == ReplyMode.TEXT_LETTER.value
         authorities = _build_release_layer_authorities(
             load_persona(self.persona_path).snapshot,
             mode=mode,
@@ -344,26 +355,29 @@ class GatewayReviewTransport:
                 else {}
             ),
             mode=mode,
+            evidence_bound=evidence_bound,
             timeout_seconds=timeout_seconds,
         )
-        results = _adjudicate_hard_evidence(
-            self.gateway,
-            results,
-            authorities=authorities,
-            candidate=str(request.get("candidate", "")),
-            current_user_input=current_user_input,
-            character_reply_history=character_reply_history,
-            memory_evidence=memory_evidence,
-            relationship_context=(
-                request.get("relationship_context", {})
-                if isinstance(request.get("relationship_context"), Mapping)
-                else {}
-            ),
-            timeout_seconds=timeout_seconds,
-        )
+        if evidence_bound:
+            results = _adjudicate_hard_evidence(
+                self.gateway,
+                results,
+                authorities=authorities,
+                candidate=str(request.get("candidate", "")),
+                current_user_input=current_user_input,
+                character_reply_history=character_reply_history,
+                memory_evidence=memory_evidence,
+                relationship_context=(
+                    request.get("relationship_context", {})
+                    if isinstance(request.get("relationship_context"), Mapping)
+                    else {}
+                ),
+                timeout_seconds=timeout_seconds,
+            )
         return _aggregate_layer_results(
             results,
             candidate=str(request.get("candidate", "")),
+            evidence_bound=evidence_bound,
         )
 
 
@@ -740,16 +754,18 @@ def _layer_messages(
     memory_evidence: Mapping[str, str],
     relationship_context: Mapping[str, object],
     mode: str,
+    evidence_bound: bool,
 ) -> tuple[dict[str, str], dict[str, str]]:
     allowed = ", ".join(layer.allowed_codes)
+    evidence_contract = ',"hard_evidence":[]' if evidence_bound else ""
     response_contract = (
         f'{{"layer":"{layer.name}","score":0,"hard_violations":[],'
         '"drift_detected":false,"intimacy_request":"none",'
-        '"intimacy_claims":[],"hard_evidence":[]}}'
+        f'"intimacy_claims":[]{evidence_contract}}}'
         if layer.name == "identity_boundary"
         else (
             f'{{"layer":"{layer.name}","score":0,'
-            '"hard_violations":[],"drift_detected":false,"hard_evidence":[]}}'
+            f'"hard_violations":[],"drift_detected":false{evidence_contract}}}'
             if layer.name == "continuity_memory"
             else (
                 f'{{"layer":"{layer.name}","score":0,'
@@ -777,7 +793,7 @@ def _layer_messages(
         "character_history,memory,world_fact,known_continuation,none. reason_code "
         "is a short uppercase machine code, never quoted candidate text. Return no "
         "hard_evidence when hard_violations is empty."
-        if layer.name in _EVIDENCE_BOUND_LAYERS
+        if evidence_bound and layer.name in _EVIDENCE_BOUND_LAYERS
         else ""
     )
     system = (
@@ -836,6 +852,7 @@ def _parse_layer_result(
     text: str,
     *,
     candidate: str,
+    evidence_bound: bool,
 ) -> _LayerResult:
     try:
         raw = json.loads(text.strip())
@@ -844,7 +861,7 @@ def _parse_layer_result(
     expected = {"layer", "score", "hard_violations", "drift_detected"}
     if layer.name == "identity_boundary":
         expected.update({"intimacy_request", "intimacy_claims"})
-    if layer.name in _EVIDENCE_BOUND_LAYERS:
+    if evidence_bound and layer.name in _EVIDENCE_BOUND_LAYERS:
         expected.add("hard_evidence")
     violations = raw.get("hard_violations") if isinstance(raw, Mapping) else None
     score = raw.get("score") if isinstance(raw, Mapping) else None
@@ -860,19 +877,21 @@ def _parse_layer_result(
         or len(violations) > len(layer.allowed_codes)
         or any(code not in layer.allowed_codes for code in violations)
         or (
-            layer.name in _EVIDENCE_BOUND_LAYERS
+            evidence_bound
+            and layer.name in _EVIDENCE_BOUND_LAYERS
             and len(set(violations)) != len(violations)
         )
         or type(drift) is not bool
         or (
-            layer.name in _EVIDENCE_BOUND_LAYERS
+            evidence_bound
+            and layer.name in _EVIDENCE_BOUND_LAYERS
             and (score == 0 or drift)
             and not violations
         )
     ):
         raise RuntimeError("LAYER_REVIEW_INVALID")
     hard_evidence: tuple[_HardReviewEvidence, ...] = ()
-    if layer.name in _EVIDENCE_BOUND_LAYERS:
+    if evidence_bound and layer.name in _EVIDENCE_BOUND_LAYERS:
         hard_evidence = _parse_hard_evidence(
             raw.get("hard_evidence"),
             violations=tuple(violations),
@@ -1029,6 +1048,7 @@ def _complete_layer_reviews(
     memory_evidence: Mapping[str, str],
     relationship_context: Mapping[str, object],
     mode: str,
+    evidence_bound: bool,
     timeout_seconds: float,
 ) -> tuple[_LayerResult, ...]:
     async def invoke(
@@ -1050,6 +1070,7 @@ def _complete_layer_reviews(
                 layer,
                 text,
                 candidate=candidate,
+                evidence_bound=evidence_bound,
             )
 
         return tuple(
@@ -1070,6 +1091,7 @@ def _complete_layer_reviews(
                     memory_evidence=memory_evidence,
                     relationship_context=relationship_context,
                     mode=mode,
+                    evidence_bound=evidence_bound,
                 ),
             )
             for layer in authorities
@@ -1105,9 +1127,6 @@ def _adjudicate_hard_evidence(
             evidence.code,
             evidence.start,
             evidence.end,
-            evidence.claim_kind,
-            evidence.support_source,
-            evidence.reason_code,
         )
         for _, evidence in claims
     )
@@ -1116,6 +1135,12 @@ def _adjudicate_hard_evidence(
         or len(set(evidence_signatures)) != len(evidence_signatures)
     ):
         raise RuntimeError("ADJUDICATION_EVIDENCE_DUPLICATE")
+    target_authorities = tuple(
+        item for item in authorities if item.name in _EVIDENCE_BOUND_LAYERS
+    )
+    if len(target_authorities) != len(_EVIDENCE_BOUND_LAYERS):
+        raise RuntimeError("ADJUDICATION_AUTHORITY_UNAVAILABLE")
+    authority_by_layer = {item.name: item for item in target_authorities}
     claim_payloads = [
         {
             "layer": layer,
@@ -1126,21 +1151,20 @@ def _adjudicate_hard_evidence(
             "claim_kind": evidence.claim_kind,
             "support_source": evidence.support_source,
             "reason_code": evidence.reason_code,
+            "support_context": _adjudication_support_context(
+                layer,
+                evidence,
+                authority=authority_by_layer[
+                    _adjudication_authority_layer(layer, evidence)
+                ],
+                current_user_input=current_user_input,
+                character_reply_history=character_reply_history,
+                memory_evidence=memory_evidence,
+                relationship_context=relationship_context,
+            ),
         }
         for layer, evidence in claims
     ]
-    target_authorities = tuple(
-        item for item in authorities if item.name in _EVIDENCE_BOUND_LAYERS
-    )
-    if len(target_authorities) != len(_EVIDENCE_BOUND_LAYERS):
-        raise RuntimeError("ADJUDICATION_AUTHORITY_UNAVAILABLE")
-    adjudication_authority = {
-        "global": _safe_text(target_authorities[0].global_authority, 3000),
-        "layers": {
-            item.name: _safe_text(item.layer_authority, 3000)
-            for item in target_authorities
-        },
-    }
     messages = (
         {
             "role": "system",
@@ -1150,9 +1174,12 @@ def _adjudicate_hard_evidence(
                 "hard claims. Use no outside knowledge. CONFIRM only when the exact "
                 "candidate span makes the coded claim and the bounded evidence does "
                 "not support it (or it directly violates identity/relationship "
-                "authority). REJECT false positives, emotional acknowledgments, and "
-                "claims supported by the current user, typed Linli history, or bounded "
-                "memory. Return only compact JSON with exactly {\"decisions\":[...]}. "
+                "authority). Use only each claim's support_context: current-user text "
+                "can support ordinary factual MEMORY_FABRICATION claims but never a "
+                "relationship or acknowledged-feeling claim; untyped assembled memory "
+                "never establishes a relationship; identity uses release/world authority "
+                "only. REJECT false positives and supported ordinary factual claims. "
+                "Return only compact JSON with exactly {\"decisions\":[...]}. "
                 "Each decision must contain exactly evidence_id, code, start, end, "
                 "decision; decision is CONFIRM or REJECT. Preserve every identifier "
                 "and offset exactly, once, and do not include candidate text."
@@ -1163,11 +1190,6 @@ def _adjudicate_hard_evidence(
             "content": json.dumps(
                 {
                     "candidate_reply": candidate,
-                    "current_user_input": current_user_input,
-                    "character_reply_history": character_reply_history,
-                    "memory_evidence": dict(memory_evidence),
-                    "relationship_context": dict(relationship_context),
-                    "release_authority": adjudication_authority,
                     "claims": claim_payloads,
                 },
                 ensure_ascii=False,
@@ -1204,6 +1226,63 @@ def _adjudicate_hard_evidence(
     return tuple(revised)
 
 
+def _adjudication_authority_layer(
+    layer: str,
+    evidence: _HardReviewEvidence,
+) -> str:
+    if (
+        evidence.code in _RELATIONSHIP_EVIDENCE_CODES
+        or evidence.claim_kind in {"identity_claim", "relationship"}
+    ):
+        return "identity_boundary"
+    return layer
+
+
+def _adjudication_support_context(
+    layer: str,
+    evidence: _HardReviewEvidence,
+    *,
+    authority: _LayerAuthority,
+    current_user_input: str,
+    character_reply_history: str,
+    memory_evidence: Mapping[str, str],
+    relationship_context: Mapping[str, object],
+) -> dict[str, object]:
+    release_authority = {
+        "global": _safe_text(authority.global_authority, 3000),
+        "layer": _safe_text(authority.layer_authority, 3000),
+    }
+    if (
+        evidence.code in _RELATIONSHIP_EVIDENCE_CODES
+        or evidence.claim_kind == "relationship"
+    ):
+        return {
+            "release_authority": release_authority,
+            "character_reply_history": character_reply_history,
+            "relationship_context": dict(relationship_context),
+        }
+    if layer == "identity_boundary" and (
+        evidence.code == "IDENTITY_DRIFT"
+        or evidence.claim_kind == "identity_claim"
+    ):
+        return {
+            "release_authority": release_authority,
+            "world_facts": memory_evidence.get("world_facts", ""),
+        }
+    if layer == "continuity_memory" and evidence.code == "MEMORY_FABRICATION":
+        return {
+            "release_authority": release_authority,
+            "current_user_input": current_user_input,
+            "memory_evidence": dict(memory_evidence),
+            "character_reply_history": character_reply_history,
+        }
+    return {
+        "release_authority": release_authority,
+        "world_facts": memory_evidence.get("world_facts", ""),
+        "known_continuations": memory_evidence.get("known_continuations", ""),
+    }
+
+
 def _parse_adjudication_result(
     text: str,
     *,
@@ -1227,6 +1306,8 @@ def _parse_adjudication_result(
             or set(raw_item) != fields
             or raw_item.get("evidence_id") != evidence.evidence_id
             or raw_item.get("code") != evidence.code
+            or type(raw_item.get("start")) is not int
+            or type(raw_item.get("end")) is not int
             or raw_item.get("start") != evidence.start
             or raw_item.get("end") != evidence.end
             or raw_item.get("decision") not in {"CONFIRM", "REJECT"}
@@ -1270,6 +1351,7 @@ def _aggregate_layer_results(
     results: Sequence[_LayerResult],
     *,
     candidate: str,
+    evidence_bound: bool,
 ) -> dict[str, object]:
     by_name = {item.layer: item for item in results}
     expected = tuple(_LAYER_SPECS)
@@ -1284,21 +1366,33 @@ def _aggregate_layer_results(
         and not by_name["voice_style"].hard_violations
         and not by_name["voice_style"].drift_detected
     )
+    adjudication_warnings = frozenset(
+        name
+        for name in expected
+        if evidence_bound
+        and by_name[name].soft_evidence
+        and not by_name[name].hard_violations
+        and not by_name[name].drift_detected
+    )
     failed = tuple(
         name
         for name in expected
         if not by_name[name].passed
         and not (name == "voice_style" and warning_only)
+        and name not in adjudication_warnings
     )
     violations: list[dict[str, object]] = []
-    seen: set[tuple[str, str, int, int]] = set()
-    for name in failed:
+    seen: set[object] = set()
+    for name in (
+        *failed,
+        *(name for name in expected if name in adjudication_warnings),
+    ):
         item = by_name[name]
         evidence_by_code = {evidence.code: evidence for evidence in item.hard_evidence}
         soft_by_code = {evidence.code: evidence for evidence in item.soft_evidence}
-        codes = item.hard_violations or tuple(soft_by_code) or (
-            str(_LAYER_SPECS[name]["codes"][0]),
-        )
+        codes = (*item.hard_violations, *soft_by_code)
+        if not codes:
+            codes = (str(_LAYER_SPECS[name]["codes"][0]),)
         for code in codes:
             evidence = evidence_by_code.get(code) or soft_by_code.get(code)
             severity = (
@@ -1309,7 +1403,9 @@ def _aggregate_layer_results(
             )
             start = evidence.start if evidence is not None else 0
             end = evidence.end if evidence is not None else len(candidate)
-            key = (code, severity, start, end)
+            key: tuple[str, str, int, int] | str = (
+                (code, severity, start, end) if evidence_bound else code
+            )
             if key in seen:
                 continue
             seen.add(key)

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -280,6 +280,7 @@ class _LayerResult:
     intimacy_claims: tuple[IntimacyClaim, ...] = ()
     hard_evidence: tuple[_HardReviewEvidence, ...] = ()
     soft_evidence: tuple[_HardReviewEvidence, ...] = ()
+    independent_soft_issue: bool = False
 
     @property
     def passed(self) -> bool:
@@ -757,7 +758,11 @@ def _layer_messages(
     evidence_bound: bool,
 ) -> tuple[dict[str, str], dict[str, str]]:
     allowed = ", ".join(layer.allowed_codes)
-    evidence_contract = ',"hard_evidence":[]' if evidence_bound else ""
+    evidence_contract = (
+        ',"hard_evidence":[],"independent_soft_issue":false'
+        if evidence_bound
+        else ""
+    )
     response_contract = (
         f'{{"layer":"{layer.name}","score":0,"hard_violations":[],'
         '"drift_detected":false,"intimacy_request":"none",'
@@ -792,7 +797,11 @@ def _layer_messages(
         "habit,location,action,relationship. support_source is one of current_user,"
         "character_history,memory,world_fact,known_continuation,none. reason_code "
         "is a short uppercase machine code, never quoted candidate text. Return no "
-        "hard_evidence when hard_violations is empty."
+        "hard_evidence when hard_violations is empty. independent_soft_issue is "
+        "true only when this same layer has a separate localized soft mismatch "
+        "besides the listed hard claims; it is never inferred from a hard claim. "
+        "With no hard claims, true requires score 1 and drift_detected false; false "
+        "requires score 2 and drift_detected false."
         if evidence_bound and layer.name in _EVIDENCE_BOUND_LAYERS
         else ""
     )
@@ -862,10 +871,14 @@ def _parse_layer_result(
     if layer.name == "identity_boundary":
         expected.update({"intimacy_request", "intimacy_claims"})
     if evidence_bound and layer.name in _EVIDENCE_BOUND_LAYERS:
-        expected.add("hard_evidence")
+        expected.update({"hard_evidence", "independent_soft_issue"})
     violations = raw.get("hard_violations") if isinstance(raw, Mapping) else None
     score = raw.get("score") if isinstance(raw, Mapping) else None
     drift = raw.get("drift_detected") if isinstance(raw, Mapping) else None
+    independent_soft = (
+        raw.get("independent_soft_issue") if isinstance(raw, Mapping) else None
+    )
+    evidence_layer = evidence_bound and layer.name in _EVIDENCE_BOUND_LAYERS
     if (
         not isinstance(raw, Mapping)
         or set(raw) != expected
@@ -874,20 +887,29 @@ def _parse_layer_result(
         or not isinstance(score, int)
         or score not in {0, 1, 2}
         or not isinstance(violations, list)
-        or len(violations) > len(layer.allowed_codes)
+        or len(violations) > (16 if evidence_layer else len(layer.allowed_codes))
         or any(code not in layer.allowed_codes for code in violations)
         or (
-            evidence_bound
-            and layer.name in _EVIDENCE_BOUND_LAYERS
-            and len(set(violations)) != len(violations)
+            evidence_layer
+            and (
+                type(independent_soft) is not bool
+                or (violations and score == 2)
+                or (
+                    not violations
+                    and (
+                        (
+                            independent_soft is True
+                            and (score != 1 or drift is not False)
+                        )
+                        or (
+                            independent_soft is False
+                            and (score != 2 or drift is not False)
+                        )
+                    )
+                )
+            )
         )
         or type(drift) is not bool
-        or (
-            evidence_bound
-            and layer.name in _EVIDENCE_BOUND_LAYERS
-            and (score == 0 or drift)
-            and not violations
-        )
     ):
         raise RuntimeError("LAYER_REVIEW_INVALID")
     hard_evidence: tuple[_HardReviewEvidence, ...] = ()
@@ -904,6 +926,7 @@ def _parse_layer_result(
             tuple(violations),
             drift,
             hard_evidence=hard_evidence,
+            independent_soft_issue=bool(independent_soft),
         )
     raw_claims = raw.get("intimacy_claims")
     try:
@@ -945,6 +968,7 @@ def _parse_layer_result(
         intimacy_request,
         intimacy_claims,
         hard_evidence,
+        independent_soft_issue=bool(independent_soft),
     )
 
 
@@ -1141,6 +1165,28 @@ def _adjudicate_hard_evidence(
     if len(target_authorities) != len(_EVIDENCE_BOUND_LAYERS):
         raise RuntimeError("ADJUDICATION_AUTHORITY_UNAVAILABLE")
     authority_by_layer = {item.name: item for item in target_authorities}
+    context_ids = tuple(
+        _adjudication_context_id(layer, evidence.code)
+        for layer, evidence in claims
+    )
+    contexts: dict[str, dict[str, object]] = {}
+    for (layer, evidence), context_id in zip(
+        claims,
+        context_ids,
+        strict=True,
+    ):
+        if context_id in contexts:
+            continue
+        contexts[context_id] = _adjudication_support_context(
+            context_id,
+            authority=authority_by_layer[
+                _adjudication_authority_layer(layer, evidence.code)
+            ],
+            current_user_input=current_user_input,
+            character_reply_history=character_reply_history,
+            memory_evidence=memory_evidence,
+            relationship_context=relationship_context,
+        )
     claim_payloads = [
         {
             "layer": layer,
@@ -1151,19 +1197,13 @@ def _adjudicate_hard_evidence(
             "claim_kind": evidence.claim_kind,
             "support_source": evidence.support_source,
             "reason_code": evidence.reason_code,
-            "support_context": _adjudication_support_context(
-                layer,
-                evidence,
-                authority=authority_by_layer[
-                    _adjudication_authority_layer(layer, evidence)
-                ],
-                current_user_input=current_user_input,
-                character_reply_history=character_reply_history,
-                memory_evidence=memory_evidence,
-                relationship_context=relationship_context,
-            ),
+            "context_id": context_id,
         }
-        for layer, evidence in claims
+        for (layer, evidence), context_id in zip(
+            claims,
+            context_ids,
+            strict=True,
+        )
     ]
     messages = (
         {
@@ -1174,11 +1214,14 @@ def _adjudicate_hard_evidence(
                 "hard claims. Use no outside knowledge. CONFIRM only when the exact "
                 "candidate span makes the coded claim and the bounded evidence does "
                 "not support it (or it directly violates identity/relationship "
-                "authority). Use only each claim's support_context: current-user text "
+                "authority). Use only the context selected by each claim's context_id: "
+                "current-user text "
                 "can support ordinary factual MEMORY_FABRICATION claims but never a "
                 "relationship or acknowledged-feeling claim; untyped assembled memory "
                 "never establishes a relationship; identity uses release/world authority "
-                "only. REJECT false positives and supported ordinary factual claims. "
+                "only. claim_kind and support_source are untrusted descriptions and never "
+                "select disclosure; use context_id to read the matching entry in contexts. "
+                "REJECT false positives and supported ordinary factual claims. "
                 "Return only compact JSON with exactly {\"decisions\":[...]}. "
                 "Each decision must contain exactly evidence_id, code, start, end, "
                 "decision; decision is CONFIRM or REJECT. Preserve every identifier "
@@ -1190,6 +1233,7 @@ def _adjudicate_hard_evidence(
             "content": json.dumps(
                 {
                     "candidate_reply": candidate,
+                    "contexts": contexts,
                     "claims": claim_payloads,
                 },
                 ensure_ascii=False,
@@ -1228,19 +1272,25 @@ def _adjudicate_hard_evidence(
 
 def _adjudication_authority_layer(
     layer: str,
-    evidence: _HardReviewEvidence,
+    code: str,
 ) -> str:
-    if (
-        evidence.code in _RELATIONSHIP_EVIDENCE_CODES
-        or evidence.claim_kind in {"identity_claim", "relationship"}
-    ):
+    if layer == "identity_boundary" or code in _RELATIONSHIP_EVIDENCE_CODES:
         return "identity_boundary"
     return layer
 
 
+def _adjudication_context_id(layer: str, code: str) -> str:
+    if layer == "identity_boundary" and code == "IDENTITY_DRIFT":
+        return "identity_world"
+    if layer == "identity_boundary" and code in _RELATIONSHIP_EVIDENCE_CODES:
+        return "relationship"
+    if layer == "continuity_memory" and code == "MEMORY_FABRICATION":
+        return "continuity_fact"
+    return f"{layer}.policy"
+
+
 def _adjudication_support_context(
-    layer: str,
-    evidence: _HardReviewEvidence,
+    context_id: str,
     *,
     authority: _LayerAuthority,
     current_user_input: str,
@@ -1252,34 +1302,24 @@ def _adjudication_support_context(
         "global": _safe_text(authority.global_authority, 3000),
         "layer": _safe_text(authority.layer_authority, 3000),
     }
-    if (
-        evidence.code in _RELATIONSHIP_EVIDENCE_CODES
-        or evidence.claim_kind == "relationship"
-    ):
+    if context_id == "relationship":
         return {
             "release_authority": release_authority,
             "character_reply_history": character_reply_history,
             "relationship_context": dict(relationship_context),
         }
-    if layer == "identity_boundary" and (
-        evidence.code == "IDENTITY_DRIFT"
-        or evidence.claim_kind == "identity_claim"
-    ):
+    if context_id == "identity_world":
         return {
             "release_authority": release_authority,
             "world_facts": memory_evidence.get("world_facts", ""),
         }
-    if layer == "continuity_memory" and evidence.code == "MEMORY_FABRICATION":
+    if context_id == "continuity_fact":
         return {
-            "release_authority": release_authority,
             "current_user_input": current_user_input,
             "memory_evidence": dict(memory_evidence),
-            "character_reply_history": character_reply_history,
         }
     return {
         "release_authority": release_authority,
-        "world_facts": memory_evidence.get("world_facts", ""),
-        "known_continuations": memory_evidence.get("known_continuations", ""),
     }
 
 
@@ -1373,6 +1413,7 @@ def _aggregate_layer_results(
         and by_name[name].soft_evidence
         and not by_name[name].hard_violations
         and not by_name[name].drift_detected
+        and not by_name[name].independent_soft_issue
     )
     failed = tuple(
         name
@@ -1388,19 +1429,27 @@ def _aggregate_layer_results(
         *(name for name in expected if name in adjudication_warnings),
     ):
         item = by_name[name]
-        evidence_by_code = {evidence.code: evidence for evidence in item.hard_evidence}
-        soft_by_code = {evidence.code: evidence for evidence in item.soft_evidence}
-        codes = (*item.hard_violations, *soft_by_code)
-        if not codes:
-            codes = (str(_LAYER_SPECS[name]["codes"][0]),)
-        for code in codes:
-            evidence = evidence_by_code.get(code) or soft_by_code.get(code)
-            severity = (
-                "hard"
-                if code in evidence_by_code
-                or (not soft_by_code and (item.hard_violations or item.score == 0))
-                else "soft"
+        entries: list[tuple[str, str, _HardReviewEvidence | None]] = []
+        if evidence_bound and name in _EVIDENCE_BOUND_LAYERS:
+            entries.extend(
+                (evidence.code, "hard", evidence)
+                for evidence in item.hard_evidence
             )
+            entries.extend(
+                (evidence.code, "soft", evidence)
+                for evidence in item.soft_evidence
+            )
+            if item.independent_soft_issue:
+                entries.append(
+                    (str(_LAYER_SPECS[name]["codes"][0]), "soft", None)
+                )
+        else:
+            codes = item.hard_violations or (
+                str(_LAYER_SPECS[name]["codes"][0]),
+            )
+            severity = "hard" if item.hard_violations or item.score == 0 else "soft"
+            entries.extend((code, severity, None) for code in codes)
+        for code, severity, evidence in entries:
             start = evidence.start if evidence is not None else 0
             end = evidence.end if evidence is not None else len(candidate)
             key: tuple[str, str, int, int] | str = (

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -1145,6 +1145,8 @@ def _adjudicate_hard_evidence(
     )
     if not claims:
         return tuple(results)
+    if len(claims) > 16:
+        raise RuntimeError("ADJUDICATION_EVIDENCE_LIMIT")
     evidence_ids = tuple(evidence.evidence_id for _, evidence in claims)
     evidence_signatures = tuple(
         (

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -29,6 +29,7 @@ from runtime.reply.reply_reviewer import (
 
 
 _REVIEW_MARKER = "P02_REPLY_REVIEW_JSON"
+_ADJUDICATION_MARKER = "P02_REPLY_EVIDENCE_ADJUDICATION_JSON"
 _REWRITE_MARKER = "P02_REPLY_REWRITE_TEXT"
 _REVIEW_MODEL = "deepseek-v4-flash"
 _GLOBAL_HEADINGS = (
@@ -150,6 +151,31 @@ _LAYER_SPECS = {
     },
 }
 _MEMORY_EVIDENCE_LAYERS = frozenset({"continuity_memory"})
+_EVIDENCE_BOUND_LAYERS = frozenset({"identity_boundary", "continuity_memory"})
+_HARD_EVIDENCE_CLAIM_KINDS = frozenset(
+    {
+        "identity_claim",
+        "current_fact",
+        "past_fact",
+        "shared_history",
+        "habit",
+        "location",
+        "action",
+        "relationship",
+    }
+)
+_HARD_EVIDENCE_SUPPORT_SOURCES = frozenset(
+    {
+        "current_user",
+        "character_history",
+        "memory",
+        "world_fact",
+        "known_continuation",
+        "none",
+    }
+)
+_HARD_EVIDENCE_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]{1,96}")
+_HARD_EVIDENCE_REASON_PATTERN = re.compile(r"[A-Z][A-Z0-9_]{0,63}")
 _LAYER_RELEASE_FACETS = {
     "identity_boundary": frozenset(
         {"IDENTITY", "KNOWLEDGE_BOUNDARY", "RELATIONSHIP_STYLE", "SAFETY"}
@@ -215,6 +241,26 @@ class _LayerAuthority:
 
 
 @dataclass(frozen=True)
+class _HardReviewEvidence:
+    evidence_id: str
+    code: str
+    start: int
+    end: int
+    claim_kind: str
+    support_source: str
+    reason_code: str
+
+
+@dataclass(frozen=True)
+class _AdjudicationDecision:
+    evidence_id: str
+    code: str
+    start: int
+    end: int
+    confirmed: bool
+
+
+@dataclass(frozen=True)
 class _LayerResult:
     layer: str
     score: int
@@ -222,6 +268,8 @@ class _LayerResult:
     drift_detected: bool
     intimacy_request: IntimacyRequest | None = None
     intimacy_claims: tuple[IntimacyClaim, ...] = ()
+    hard_evidence: tuple[_HardReviewEvidence, ...] = ()
+    soft_evidence: tuple[_HardReviewEvidence, ...] = ()
 
     @property
     def passed(self) -> bool:
@@ -296,6 +344,21 @@ class GatewayReviewTransport:
                 else {}
             ),
             mode=mode,
+            timeout_seconds=timeout_seconds,
+        )
+        results = _adjudicate_hard_evidence(
+            self.gateway,
+            results,
+            authorities=authorities,
+            candidate=str(request.get("candidate", "")),
+            current_user_input=current_user_input,
+            character_reply_history=character_reply_history,
+            memory_evidence=memory_evidence,
+            relationship_context=(
+                request.get("relationship_context", {})
+                if isinstance(request.get("relationship_context"), Mapping)
+                else {}
+            ),
             timeout_seconds=timeout_seconds,
         )
         return _aggregate_layer_results(
@@ -682,11 +745,16 @@ def _layer_messages(
     response_contract = (
         f'{{"layer":"{layer.name}","score":0,"hard_violations":[],'
         '"drift_detected":false,"intimacy_request":"none",'
-        '"intimacy_claims":[]}}'
+        '"intimacy_claims":[],"hard_evidence":[]}}'
         if layer.name == "identity_boundary"
         else (
             f'{{"layer":"{layer.name}","score":0,'
-            '"hard_violations":[],"drift_detected":false}}'
+            '"hard_violations":[],"drift_detected":false,"hard_evidence":[]}}'
+            if layer.name == "continuity_memory"
+            else (
+                f'{{"layer":"{layer.name}","score":0,'
+                '"hard_violations":[],"drift_detected":false}}'
+            )
         )
     )
     intimacy_instructions = (
@@ -698,6 +766,18 @@ def _layer_messages(
         "end-exclusive Python character offsets into candidate_reply. Return an "
         "empty list when there is no completed contact."
         if layer.name == "identity_boundary"
+        else ""
+    )
+    hard_evidence_instructions = (
+        " For every hard_violations entry return exactly one hard_evidence item "
+        "with evidence_id, matching code, zero-based end-exclusive start/end "
+        "offsets into candidate_reply, claim_kind, support_source, and reason_code. "
+        "claim_kind is one of identity_claim,current_fact,past_fact,shared_history,"
+        "habit,location,action,relationship. support_source is one of current_user,"
+        "character_history,memory,world_fact,known_continuation,none. reason_code "
+        "is a short uppercase machine code, never quoted candidate text. Return no "
+        "hard_evidence when hard_violations is empty."
+        if layer.name in _EVIDENCE_BOUND_LAYERS
         else ""
     )
     system = (
@@ -712,7 +792,7 @@ def _layer_messages(
         "mismatch. Never lower the score for uncertainty, preference, or the "
         "absence of an optional trait. Set drift_detected=true only for "
         "substantive persona drift. Return ONLY compact JSON with exactly: "
-        f"{response_contract}.{intimacy_instructions} "
+        f"{response_contract}.{intimacy_instructions}{hard_evidence_instructions} "
         f"hard_violations may contain only: {allowed}. Do not explain.\n"
         f"GLOBAL_AUTHORITY:\n{layer.global_authority}\n"
         f"LAYER_AUTHORITY:\n{layer.layer_authority}"
@@ -764,6 +844,8 @@ def _parse_layer_result(
     expected = {"layer", "score", "hard_violations", "drift_detected"}
     if layer.name == "identity_boundary":
         expected.update({"intimacy_request", "intimacy_claims"})
+    if layer.name in _EVIDENCE_BOUND_LAYERS:
+        expected.add("hard_evidence")
     violations = raw.get("hard_violations") if isinstance(raw, Mapping) else None
     score = raw.get("score") if isinstance(raw, Mapping) else None
     drift = raw.get("drift_detected") if isinstance(raw, Mapping) else None
@@ -777,11 +859,33 @@ def _parse_layer_result(
         or not isinstance(violations, list)
         or len(violations) > len(layer.allowed_codes)
         or any(code not in layer.allowed_codes for code in violations)
+        or (
+            layer.name in _EVIDENCE_BOUND_LAYERS
+            and len(set(violations)) != len(violations)
+        )
         or type(drift) is not bool
+        or (
+            layer.name in _EVIDENCE_BOUND_LAYERS
+            and (score == 0 or drift)
+            and not violations
+        )
     ):
         raise RuntimeError("LAYER_REVIEW_INVALID")
+    hard_evidence: tuple[_HardReviewEvidence, ...] = ()
+    if layer.name in _EVIDENCE_BOUND_LAYERS:
+        hard_evidence = _parse_hard_evidence(
+            raw.get("hard_evidence"),
+            violations=tuple(violations),
+            candidate=candidate,
+        )
     if layer.name != "identity_boundary":
-        return _LayerResult(layer.name, score, tuple(violations), drift)
+        return _LayerResult(
+            layer.name,
+            score,
+            tuple(violations),
+            drift,
+            hard_evidence=hard_evidence,
+        )
     raw_claims = raw.get("intimacy_claims")
     try:
         intimacy_request = IntimacyRequest(str(raw.get("intimacy_request")))
@@ -821,7 +925,76 @@ def _parse_layer_result(
         drift,
         intimacy_request,
         intimacy_claims,
+        hard_evidence,
     )
+
+
+def _parse_hard_evidence(
+    raw_evidence: object,
+    *,
+    violations: tuple[str, ...],
+    candidate: str,
+) -> tuple[_HardReviewEvidence, ...]:
+    expected_fields = {
+        "evidence_id",
+        "code",
+        "start",
+        "end",
+        "claim_kind",
+        "support_source",
+        "reason_code",
+    }
+    if (
+        not isinstance(raw_evidence, list)
+        or len(raw_evidence) > 16
+        or len(raw_evidence) != len(violations)
+    ):
+        raise RuntimeError("LAYER_REVIEW_INVALID")
+    parsed: list[_HardReviewEvidence] = []
+    for raw in raw_evidence:
+        if not isinstance(raw, Mapping) or set(raw) != expected_fields:
+            raise RuntimeError("LAYER_REVIEW_INVALID")
+        evidence_id = raw.get("evidence_id")
+        code = raw.get("code")
+        start = raw.get("start")
+        end = raw.get("end")
+        claim_kind = raw.get("claim_kind")
+        support_source = raw.get("support_source")
+        reason_code = raw.get("reason_code")
+        if (
+            not isinstance(evidence_id, str)
+            or _HARD_EVIDENCE_ID_PATTERN.fullmatch(evidence_id) is None
+            or not isinstance(code, str)
+            or not isinstance(start, int)
+            or isinstance(start, bool)
+            or not isinstance(end, int)
+            or isinstance(end, bool)
+            or start < 0
+            or end <= start
+            or end > len(candidate)
+            or claim_kind not in _HARD_EVIDENCE_CLAIM_KINDS
+            or support_source not in _HARD_EVIDENCE_SUPPORT_SOURCES
+            or not isinstance(reason_code, str)
+            or _HARD_EVIDENCE_REASON_PATTERN.fullmatch(reason_code) is None
+        ):
+            raise RuntimeError("LAYER_REVIEW_INVALID")
+        parsed.append(
+            _HardReviewEvidence(
+                evidence_id,
+                code,
+                start,
+                end,
+                str(claim_kind),
+                str(support_source),
+                reason_code,
+            )
+        )
+    if (
+        len({item.evidence_id for item in parsed}) != len(parsed)
+        or tuple(item.code for item in parsed) != violations
+    ):
+        raise RuntimeError("LAYER_REVIEW_INVALID")
+    return tuple(parsed)
 
 
 async def _complete_layer_text(
@@ -906,6 +1079,171 @@ def _complete_layer_reviews(
         raise RuntimeError("quality model unavailable") from None
 
 
+def _adjudicate_hard_evidence(
+    gateway: Gateway,
+    results: Sequence[_LayerResult],
+    *,
+    authorities: Sequence[_LayerAuthority],
+    candidate: str,
+    current_user_input: str,
+    character_reply_history: str,
+    memory_evidence: Mapping[str, str],
+    relationship_context: Mapping[str, object],
+    timeout_seconds: float,
+) -> tuple[_LayerResult, ...]:
+    claims = tuple(
+        (item.layer, evidence)
+        for item in results
+        if item.layer in _EVIDENCE_BOUND_LAYERS
+        for evidence in item.hard_evidence
+    )
+    if not claims:
+        return tuple(results)
+    evidence_ids = tuple(evidence.evidence_id for _, evidence in claims)
+    evidence_signatures = tuple(
+        (
+            evidence.code,
+            evidence.start,
+            evidence.end,
+            evidence.claim_kind,
+            evidence.support_source,
+            evidence.reason_code,
+        )
+        for _, evidence in claims
+    )
+    if (
+        len(set(evidence_ids)) != len(evidence_ids)
+        or len(set(evidence_signatures)) != len(evidence_signatures)
+    ):
+        raise RuntimeError("ADJUDICATION_EVIDENCE_DUPLICATE")
+    claim_payloads = [
+        {
+            "layer": layer,
+            "evidence_id": evidence.evidence_id,
+            "code": evidence.code,
+            "start": evidence.start,
+            "end": evidence.end,
+            "claim_kind": evidence.claim_kind,
+            "support_source": evidence.support_source,
+            "reason_code": evidence.reason_code,
+        }
+        for layer, evidence in claims
+    ]
+    target_authorities = tuple(
+        item for item in authorities if item.name in _EVIDENCE_BOUND_LAYERS
+    )
+    if len(target_authorities) != len(_EVIDENCE_BOUND_LAYERS):
+        raise RuntimeError("ADJUDICATION_AUTHORITY_UNAVAILABLE")
+    adjudication_authority = {
+        "global": _safe_text(target_authorities[0].global_authority, 3000),
+        "layers": {
+            item.name: _safe_text(item.layer_authority, 3000)
+            for item in target_authorities
+        },
+    }
+    messages = (
+        {
+            "role": "system",
+            "content": (
+                f"{_ADJUDICATION_MARKER}\n"
+                "Independently adjudicate only the supplied identity/continuity "
+                "hard claims. Use no outside knowledge. CONFIRM only when the exact "
+                "candidate span makes the coded claim and the bounded evidence does "
+                "not support it (or it directly violates identity/relationship "
+                "authority). REJECT false positives, emotional acknowledgments, and "
+                "claims supported by the current user, typed Linli history, or bounded "
+                "memory. Return only compact JSON with exactly {\"decisions\":[...]}. "
+                "Each decision must contain exactly evidence_id, code, start, end, "
+                "decision; decision is CONFIRM or REJECT. Preserve every identifier "
+                "and offset exactly, once, and do not include candidate text."
+            ),
+        },
+        {
+            "role": "user",
+            "content": json.dumps(
+                {
+                    "candidate_reply": candidate,
+                    "current_user_input": current_user_input,
+                    "character_reply_history": character_reply_history,
+                    "memory_evidence": dict(memory_evidence),
+                    "relationship_context": dict(relationship_context),
+                    "release_authority": adjudication_authority,
+                    "claims": claim_payloads,
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+        },
+    )
+    if sum(len(item["content"]) for item in messages) > _REVIEW_INPUT_CHARACTER_LIMIT:
+        raise RuntimeError("ADJUDICATION_INPUT_TOO_LARGE")
+    text = _complete_text(gateway, messages, timeout_seconds)
+    decisions = _parse_adjudication_result(text, claims=claims)
+    by_id = {item.evidence_id: item for item in decisions}
+    revised: list[_LayerResult] = []
+    for result in results:
+        if result.layer not in _EVIDENCE_BOUND_LAYERS or not result.hard_evidence:
+            revised.append(result)
+            continue
+        confirmed = tuple(
+            item for item in result.hard_evidence if by_id[item.evidence_id].confirmed
+        )
+        rejected = tuple(
+            item for item in result.hard_evidence if not by_id[item.evidence_id].confirmed
+        )
+        revised.append(
+            replace(
+                result,
+                score=result.score if confirmed else 1,
+                hard_violations=tuple(item.code for item in confirmed),
+                drift_detected=result.drift_detected if confirmed else False,
+                hard_evidence=confirmed,
+                soft_evidence=rejected,
+            )
+        )
+    return tuple(revised)
+
+
+def _parse_adjudication_result(
+    text: str,
+    *,
+    claims: Sequence[tuple[str, _HardReviewEvidence]],
+) -> tuple[_AdjudicationDecision, ...]:
+    try:
+        raw = json.loads(text.strip())
+    except (AttributeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("ADJUDICATION_INVALID") from exc
+    raw_decisions = raw.get("decisions") if isinstance(raw, Mapping) else None
+    if set(raw) != {"decisions"} or not isinstance(raw_decisions, list):
+        raise RuntimeError("ADJUDICATION_INVALID")
+    expected = tuple(evidence for _, evidence in claims)
+    if len(raw_decisions) != len(expected):
+        raise RuntimeError("ADJUDICATION_INVALID")
+    parsed: list[_AdjudicationDecision] = []
+    fields = {"evidence_id", "code", "start", "end", "decision"}
+    for raw_item, evidence in zip(raw_decisions, expected, strict=True):
+        if (
+            not isinstance(raw_item, Mapping)
+            or set(raw_item) != fields
+            or raw_item.get("evidence_id") != evidence.evidence_id
+            or raw_item.get("code") != evidence.code
+            or raw_item.get("start") != evidence.start
+            or raw_item.get("end") != evidence.end
+            or raw_item.get("decision") not in {"CONFIRM", "REJECT"}
+        ):
+            raise RuntimeError("ADJUDICATION_INVALID")
+        parsed.append(
+            _AdjudicationDecision(
+                evidence.evidence_id,
+                evidence.code,
+                evidence.start,
+                evidence.end,
+                raw_item["decision"] == "CONFIRM",
+            )
+        )
+    return tuple(parsed)
+
+
 def _reference_text(request: Mapping[str, object], reference_id: str) -> str:
     references = request.get("references", [])
     if not isinstance(references, list):
@@ -953,23 +1291,36 @@ def _aggregate_layer_results(
         and not (name == "voice_style" and warning_only)
     )
     violations: list[dict[str, object]] = []
-    seen: set[str] = set()
+    seen: set[tuple[str, str, int, int]] = set()
     for name in failed:
         item = by_name[name]
-        codes = item.hard_violations or (str(_LAYER_SPECS[name]["codes"][0]),)
+        evidence_by_code = {evidence.code: evidence for evidence in item.hard_evidence}
+        soft_by_code = {evidence.code: evidence for evidence in item.soft_evidence}
+        codes = item.hard_violations or tuple(soft_by_code) or (
+            str(_LAYER_SPECS[name]["codes"][0]),
+        )
         for code in codes:
-            if code in seen:
+            evidence = evidence_by_code.get(code) or soft_by_code.get(code)
+            severity = (
+                "hard"
+                if code in evidence_by_code
+                or (not soft_by_code and (item.hard_violations or item.score == 0))
+                else "soft"
+            )
+            start = evidence.start if evidence is not None else 0
+            end = evidence.end if evidence is not None else len(candidate)
+            key = (code, severity, start, end)
+            if key in seen:
                 continue
-            seen.add(code)
+            seen.add(key)
             violations.append(
                 {
                     "code": code,
-                    "severity": (
-                        "hard"
-                        if item.hard_violations or item.score == 0
-                        else "soft"
-                    ),
-                    "evidence": {"start": 0, "end": len(candidate)},
+                    "severity": severity,
+                    "evidence": {
+                        "start": start,
+                        "end": end,
+                    },
                 }
             )
     if warning_only:

--- a/runtime/reply/reply_quality_gate.py
+++ b/runtime/reply/reply_quality_gate.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import Any, Mapping, Protocol, Sequence
 
-from runtime.reply.reply_context import ReplyContext, ReplyMode
+from runtime.reply.reply_context import ReplyContext
 from runtime.reply.reply_policy import IntimacyClaim, scan_reply
 from runtime.reply.reply_reviewer import ReviewResult, ReviewStatus, ReviewVerdict
 from runtime.reply.reply_reviewer import TrustedReviewEvidence
@@ -56,16 +56,6 @@ def _stable_codes(*groups: Sequence[str]) -> tuple[str, ...]:
                 seen.add(code)
                 ordered.append(code)
     return tuple(ordered)
-
-
-def _accepted_status(
-    context: ReplyContext,
-    *,
-    has_warnings: bool,
-) -> QualityGateStatus:
-    if has_warnings and context.mode is ReplyMode.TEXT_LETTER:
-        return QualityGateStatus.ACCEPTED_WITH_WARNINGS
-    return QualityGateStatus.ACCEPTED
 
 
 def run_reply_quality_gate(
@@ -148,7 +138,11 @@ def run_reply_quality_gate(
     }
     if not rewrite_required:
         return QualityGateResult(
-            _accepted_status(context, has_warnings=bool(review.violations)),
+            (
+                QualityGateStatus.ACCEPTED_WITH_WARNINGS
+                if review.violations
+                else QualityGateStatus.ACCEPTED
+            ),
             candidate,
             initial_codes,
             deterministic_checks=1,
@@ -266,13 +260,10 @@ def run_reply_quality_gate(
         status = (
             QualityGateStatus.BLOCKED
             if has_hard_review
-            else _accepted_status(context, has_warnings=True)
+            else QualityGateStatus.ACCEPTED_WITH_WARNINGS
         )
     else:
-        status = _accepted_status(
-            context,
-            has_warnings=bool(final_review.violations),
-        )
+        status = QualityGateStatus.ACCEPTED
     return QualityGateResult(
         status,
         rewritten,

--- a/runtime/reply/reply_quality_gate.py
+++ b/runtime/reply/reply_quality_gate.py
@@ -263,7 +263,11 @@ def run_reply_quality_gate(
             else QualityGateStatus.ACCEPTED_WITH_WARNINGS
         )
     else:
-        status = QualityGateStatus.ACCEPTED
+        status = (
+            QualityGateStatus.ACCEPTED_WITH_WARNINGS
+            if final_review.violations
+            else QualityGateStatus.ACCEPTED
+        )
     return QualityGateResult(
         status,
         rewritten,

--- a/runtime/reply/reply_quality_gate.py
+++ b/runtime/reply/reply_quality_gate.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import Any, Mapping, Protocol, Sequence
 
-from runtime.reply.reply_context import ReplyContext
+from runtime.reply.reply_context import ReplyContext, ReplyMode
 from runtime.reply.reply_policy import IntimacyClaim, scan_reply
 from runtime.reply.reply_reviewer import ReviewResult, ReviewStatus, ReviewVerdict
 from runtime.reply.reply_reviewer import TrustedReviewEvidence
@@ -56,6 +56,16 @@ def _stable_codes(*groups: Sequence[str]) -> tuple[str, ...]:
                 seen.add(code)
                 ordered.append(code)
     return tuple(ordered)
+
+
+def _accepted_status(
+    context: ReplyContext,
+    *,
+    has_warnings: bool,
+) -> QualityGateStatus:
+    if has_warnings and context.mode is ReplyMode.TEXT_LETTER:
+        return QualityGateStatus.ACCEPTED_WITH_WARNINGS
+    return QualityGateStatus.ACCEPTED
 
 
 def run_reply_quality_gate(
@@ -138,11 +148,7 @@ def run_reply_quality_gate(
     }
     if not rewrite_required:
         return QualityGateResult(
-            (
-                QualityGateStatus.ACCEPTED_WITH_WARNINGS
-                if review.violations
-                else QualityGateStatus.ACCEPTED
-            ),
+            _accepted_status(context, has_warnings=bool(review.violations)),
             candidate,
             initial_codes,
             deterministic_checks=1,
@@ -260,13 +266,12 @@ def run_reply_quality_gate(
         status = (
             QualityGateStatus.BLOCKED
             if has_hard_review
-            else QualityGateStatus.ACCEPTED_WITH_WARNINGS
+            else _accepted_status(context, has_warnings=True)
         )
     else:
-        status = (
-            QualityGateStatus.ACCEPTED_WITH_WARNINGS
-            if final_review.violations
-            else QualityGateStatus.ACCEPTED
+        status = _accepted_status(
+            context,
+            has_warnings=bool(final_review.violations),
         )
     return QualityGateResult(
         status,

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -94,6 +94,38 @@ def _passing_layer_payloads() -> list[str]:
     ]
 
 
+def _legacy_layer_payload(
+    layer: str,
+    *,
+    score: int = 2,
+    hard_violations: list[str] | None = None,
+    drift_detected: bool = False,
+) -> str:
+    payload: dict[str, object] = {
+        "layer": layer,
+        "score": score,
+        "hard_violations": hard_violations or [],
+        "drift_detected": drift_detected,
+    }
+    if layer == "identity_boundary":
+        payload["intimacy_request"] = "none"
+        payload["intimacy_claims"] = []
+    return json.dumps(payload)
+
+
+def _legacy_passing_layer_payloads() -> list[str]:
+    return [
+        _legacy_layer_payload(layer)
+        for layer in (
+            "identity_boundary",
+            "voice_style",
+            "focus_response",
+            "continuity_memory",
+            "autonomy_life",
+        )
+    ]
+
+
 def _claim_payload(candidate: str, claim_id: str) -> dict[str, object]:
     return {
         "claim_id": claim_id,
@@ -247,9 +279,13 @@ def _pipeline(
     monkeypatch: pytest.MonkeyPatch,
     *,
     memory: NullMemoryPort | None = None,
+    rewrite_enabled: bool = True,
 ) -> ReplyPipeline:
     monkeypatch.setenv("OLIVIA_REPLY_REVIEW_ENABLED", "true")
-    monkeypatch.setenv("OLIVIA_REPLY_REWRITE_ENABLED", "true")
+    monkeypatch.setenv(
+        "OLIVIA_REPLY_REWRITE_ENABLED",
+        "true" if rewrite_enabled else "false",
+    )
     monkeypatch.setenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", "1")
     memory = memory or NullMemoryPort()
     adapter = SimpleNamespace(
@@ -636,6 +672,51 @@ def test_identity_layer_accepts_each_intimacy_rubric_code(code: str) -> None:
     assert tuple(item.code for item in result.violations) == (code,)
 
 
+@pytest.mark.parametrize(
+    "mode",
+    (ReplyMode.SPOKEN_VIDEO, ReplyMode.MUSICAL_VIDEO),
+)
+def test_non_letter_hard_findings_keep_legacy_schema_without_adjudication(
+    mode: ReplyMode,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = _legacy_passing_layer_payloads()
+    first[0] = _legacy_layer_payload(
+        "identity_boundary",
+        score=0,
+        hard_violations=["IDENTITY_DRIFT"],
+        drift_detected=True,
+    )
+    gateway = SequencedQualityGateway(
+        candidate="x" * 190,
+        reviews=[*first, *_legacy_passing_layer_payloads()],
+        rewritten="y" * 190,
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(content="Synthetic request.", request_id=f"legacy-{mode.value}"),
+            _context(mode),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.text == "y" * 190
+    assert result.reviewer_calls == 2
+    assert result.rewrite_calls == 1
+    assert gateway.call_kinds == [
+        "generation",
+        *("review",) * 5,
+        "rewrite",
+        *("review",) * 5,
+    ]
+    assert gateway.adjudication_requests == []
+    assert all(
+        "hard_evidence" not in prompt
+        for prompt in gateway.review_system_prompts
+    )
+
+
 def test_identity_layer_missing_intimacy_metadata_fails_closed() -> None:
     invalid_identity = json.dumps(
         {
@@ -754,11 +835,175 @@ def test_adjudicator_rejects_false_memory_fabrication_as_soft_warning() -> None:
         1,
     ).review(candidate, _context())
 
-    assert result.verdict is ReviewVerdict.REWRITE
+    assert result.verdict is ReviewVerdict.PASS
     assert [(item.code, item.severity, item.start, item.end) for item in result.violations] == [
         ("MEMORY_FABRICATION", "soft", 0, len(candidate))
     ]
     assert gateway.call_kinds == [*("review",) * 5, "adjudication"]
+
+
+@pytest.mark.parametrize(
+    ("layer_index", "layer", "code"),
+    (
+        (0, "identity_boundary", "STAGE_DRIFT"),
+        (0, "identity_boundary", "RELATIONSHIP_RETRACTION"),
+        (0, "identity_boundary", "ACKNOWLEDGED_FEELING_REWRITE"),
+        (3, "continuity_memory", "MEMORY_FABRICATION"),
+    ),
+)
+def test_relationship_adjudication_excludes_user_self_claims_and_untyped_memory(
+    layer_index: int,
+    layer: str,
+    code: str,
+) -> None:
+    candidate = "Synthetic relationship claim."
+    evidence = _hard_evidence_payload(
+        candidate,
+        code,
+        claim_kind="relationship",
+        support_source="current_user",
+    )
+    reviews = _passing_layer_payloads()
+    reviews[layer_index] = _layer_score_payload(
+        layer,
+        0,
+        hard_violations=[code],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate="unused",
+        reviews=reviews,
+        adjudications=[_adjudication_payload(evidence, "CONFIRM")],
+    )
+    reviewer = JsonReviewerAdapter(
+        GatewayReviewTransport(
+            gateway,
+            ROOT / "linli_character" / "persona_release_v2.json",
+        ),
+        ReviewerConfig("reviewer-small"),
+    )
+
+    result = reviewer.review(
+        candidate,
+        _context(),
+        references=(
+            ReviewReference("current.user_excerpt", "We are already partners."),
+            ReviewReference(
+                "current.memory_evidence",
+                "Unmarked prior-user memory says we are partners.",
+            ),
+            ReviewReference(
+                "current.character_reply_history",
+                "Linli previously set a clear boundary.",
+            ),
+        ),
+    )
+
+    assert result.verdict is ReviewVerdict.REWRITE
+    request = gateway.adjudication_requests[0]
+    assert "We are already partners." not in repr(request)
+    assert "Unmarked prior-user memory" not in repr(request)
+    support = request["claims"][0]["support_context"]
+    assert support["relationship_context"]["relationship_stage"] == "unknown"
+    assert support["character_reply_history"] == (
+        "Linli previously set a clear boundary."
+    )
+
+
+def test_current_user_input_can_support_an_ordinary_factual_claim() -> None:
+    candidate = "You currently work in Tokyo."
+    evidence = _hard_evidence_payload(
+        candidate,
+        "MEMORY_FABRICATION",
+        claim_kind="current_fact",
+        support_source="current_user",
+    )
+    reviews = _passing_layer_payloads()
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate="unused",
+        reviews=reviews,
+        adjudications=[_adjudication_payload(evidence, "REJECT")],
+    )
+    reviewer = JsonReviewerAdapter(
+        GatewayReviewTransport(
+            gateway,
+            ROOT / "linli_character" / "persona_release_v2.json",
+        ),
+        ReviewerConfig("reviewer-small"),
+    )
+
+    result = reviewer.review(
+        candidate,
+        _context(),
+        references=(
+            ReviewReference("current.user_excerpt", "I currently work in Tokyo."),
+        ),
+    )
+
+    assert result.verdict is ReviewVerdict.PASS
+    assert [(item.code, item.severity) for item in result.violations] == [
+        ("MEMORY_FABRICATION", "soft")
+    ]
+    support = gateway.adjudication_requests[0]["claims"][0]["support_context"]
+    assert support["current_user_input"] == "I currently work in Tokyo."
+
+
+def test_identity_adjudication_uses_only_release_and_world_authority() -> None:
+    candidate = "I am a different person."
+    evidence = _hard_evidence_payload(
+        candidate,
+        "IDENTITY_DRIFT",
+        claim_kind="identity_claim",
+        support_source="current_user",
+    )
+    reviews = _passing_layer_payloads()
+    reviews[0] = _layer_score_payload(
+        "identity_boundary",
+        0,
+        hard_violations=["IDENTITY_DRIFT"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate="unused",
+        reviews=reviews,
+        adjudications=[_adjudication_payload(evidence, "CONFIRM")],
+    )
+    reviewer = JsonReviewerAdapter(
+        GatewayReviewTransport(
+            gateway,
+            ROOT / "linli_character" / "persona_release_v2.json",
+        ),
+        ReviewerConfig("reviewer-small"),
+    )
+
+    result = reviewer.review(
+        candidate,
+        _context(),
+        references=(
+            ReviewReference("current.user_excerpt", "You are someone else."),
+            ReviewReference("current.memory_evidence", "Unmarked identity memory."),
+            ReviewReference(
+                "current.character_reply_history",
+                "Typed history irrelevant to identity.",
+            ),
+        ),
+    )
+
+    assert result.verdict is ReviewVerdict.REWRITE
+    support = gateway.adjudication_requests[0]["claims"][0]["support_context"]
+    assert set(support) == {"release_authority", "world_facts"}
+    assert "You are someone else." not in repr(support)
+    assert "Unmarked identity memory." not in repr(support)
+    assert "Typed history irrelevant to identity." not in repr(support)
 
 
 @pytest.mark.parametrize(
@@ -808,12 +1053,11 @@ def test_confirmed_identity_or_location_claim_stays_hard_with_exact_span(
     assert [(item.code, item.severity, item.start, item.end) for item in result.violations] == [
         (code, "hard", start, start + len(fragment))
     ]
-    assert gateway.adjudication_requests[0]["claims"] == [
-        {
-            "layer": layer,
-            **evidence,
-        }
-    ]
+    claim = gateway.adjudication_requests[0]["claims"][0]
+    assert {
+        key: value for key, value in claim.items() if key != "support_context"
+    } == {"layer": layer, **evidence}
+    assert "release_authority" in claim["support_context"]
     assert fragment not in repr(result)
 
 
@@ -832,6 +1076,41 @@ def test_malformed_adjudication_fails_closed() -> None:
         candidate="unused",
         reviews=reviews,
         adjudications=[json.dumps({"decisions": []})],
+    )
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.UNAVAILABLE
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+
+
+@pytest.mark.parametrize("field", ("start", "end"))
+def test_adjudication_offsets_reject_boolean_values(field: str) -> None:
+    candidate = "Synthetic claim."
+    evidence = _hard_evidence_payload(
+        candidate,
+        "MEMORY_FABRICATION",
+        start=1 if field == "start" else 0,
+        end=len(candidate) if field == "start" else 1,
+    )
+    decision = json.loads(_adjudication_payload(evidence, "CONFIRM"))
+    decision["decisions"][0][field] = True
+    reviews = _passing_layer_payloads()
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate="unused",
+        reviews=reviews,
+        adjudications=[json.dumps(decision)],
     )
 
     result = GatewayPersonaReviewer(
@@ -885,6 +1164,51 @@ def test_duplicate_evidence_ids_across_layers_fail_before_adjudication() -> None
     assert gateway.adjudication_requests == []
 
 
+def test_semantically_duplicate_cross_layer_evidence_fails_before_adjudication() -> None:
+    candidate = "Synthetic duplicate claim."
+    identity_evidence = _hard_evidence_payload(
+        candidate,
+        "BOUNDARY_BREACH",
+        evidence_id="evidence.identity",
+        claim_kind="relationship",
+        support_source="character_history",
+        reason_code="RELATIONSHIP_BOUNDARY",
+    )
+    continuity_evidence = _hard_evidence_payload(
+        candidate,
+        "BOUNDARY_BREACH",
+        evidence_id="evidence.continuity",
+        claim_kind="shared_history",
+        support_source="memory",
+        reason_code="PRIVATE_BOUNDARY",
+    )
+    reviews = _passing_layer_payloads()
+    reviews[0] = _layer_score_payload(
+        "identity_boundary",
+        0,
+        hard_violations=["BOUNDARY_BREACH"],
+        drift_detected=True,
+        hard_evidence=[identity_evidence],
+    )
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["BOUNDARY_BREACH"],
+        drift_detected=True,
+        hard_evidence=[continuity_evidence],
+    )
+    gateway = SequencedQualityGateway(candidate="unused", reviews=reviews)
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.UNAVAILABLE
+    assert gateway.adjudication_requests == []
+
+
 def test_rejected_false_memory_claim_does_not_block_pipeline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -907,23 +1231,112 @@ def test_rejected_false_memory_claim_does_not_block_pipeline(
     )
 
     result = asyncio.run(
-        _pipeline(gateway, monkeypatch).run(
+        _pipeline(gateway, monkeypatch, rewrite_enabled=False).run(
             ReplyRequest(content="Synthetic current input.", request_id="false-memory"),
             _context(),
         )
     )
 
     assert result.state is ReplyState.COMPLETED
-    assert result.text == rewritten
-    assert result.reviewer_calls == 2
-    assert result.rewrite_calls == 1
+    assert result.text == candidate
+    assert result.quality_status == "accepted_with_warnings"
+    assert result.violation_codes == ("MEMORY_FABRICATION",)
+    assert result.reviewer_calls == 1
+    assert result.rewrite_calls == 0
     assert gateway.call_kinds == [
         "generation",
         *("review",) * 5,
         "adjudication",
-        "rewrite",
-        *("review",) * 5,
     ]
+
+
+def test_rejected_hard_evidence_does_not_hide_an_independent_hard_issue() -> None:
+    candidate = "Synthetic candidate with another hard issue."
+    evidence = _hard_evidence_payload(candidate, "MEMORY_FABRICATION")
+    reviews = _passing_layer_payloads()
+    reviews[2] = _layer_score_payload(
+        "focus_response",
+        0,
+        hard_violations=["GENERIC_COUNSELOR"],
+        drift_detected=True,
+    )
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate="unused",
+        reviews=reviews,
+        adjudications=[_adjudication_payload(evidence, "REJECT")],
+    )
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.REWRITE
+    assert {(item.code, item.severity) for item in result.violations} == {
+        ("GENERIC_COUNSELOR", "hard"),
+        ("MEMORY_FABRICATION", "soft"),
+    }
+
+
+def test_rejected_and_confirmed_claims_in_one_layer_are_both_reported() -> None:
+    candidate = "Synthetic relationship claims."
+    confirmed = _hard_evidence_payload(
+        candidate,
+        "STAGE_DRIFT",
+        evidence_id="evidence.confirmed",
+        claim_kind="relationship",
+    )
+    rejected = _hard_evidence_payload(
+        candidate,
+        "RELATIONSHIP_RETRACTION",
+        evidence_id="evidence.rejected",
+        claim_kind="relationship",
+    )
+    decisions = {
+        "decisions": [
+            {
+                "evidence_id": item["evidence_id"],
+                "code": item["code"],
+                "start": item["start"],
+                "end": item["end"],
+                "decision": decision,
+            }
+            for item, decision in ((confirmed, "CONFIRM"), (rejected, "REJECT"))
+        ]
+    }
+    reviews = _passing_layer_payloads()
+    reviews[0] = _layer_score_payload(
+        "identity_boundary",
+        0,
+        hard_violations=["STAGE_DRIFT", "RELATIONSHIP_RETRACTION"],
+        drift_detected=True,
+        hard_evidence=[confirmed, rejected],
+    )
+    gateway = SequencedQualityGateway(
+        candidate="unused",
+        reviews=reviews,
+        adjudications=[json.dumps(decisions)],
+    )
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.REWRITE
+    assert {(item.code, item.severity) for item in result.violations} == {
+        ("STAGE_DRIFT", "hard"),
+        ("RELATIONSHIP_RETRACTION", "soft"),
+    }
 
 
 def test_rewrite_uses_fresh_candidate_evidence_and_adjudication(
@@ -996,6 +1409,61 @@ def test_rewrite_uses_fresh_candidate_evidence_and_adjudication(
         "evidence.old",
         "evidence.new",
     ]
+
+
+def test_persistent_confirmed_hard_evidence_blocks_after_one_rewrite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = "Synthetic claim at old location."
+    rewritten = "Synthetic claim at new location."
+    old_evidence = _hard_evidence_payload(
+        candidate,
+        "MEMORY_FABRICATION",
+        evidence_id="evidence.old.confirmed",
+    )
+    new_evidence = _hard_evidence_payload(
+        rewritten,
+        "MEMORY_FABRICATION",
+        evidence_id="evidence.new.confirmed",
+    )
+    first = _passing_layer_payloads()
+    first[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[old_evidence],
+    )
+    second = _passing_layer_payloads()
+    second[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[new_evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate=candidate,
+        reviews=[*first, *second],
+        rewritten=rewritten,
+        adjudications=[
+            _adjudication_payload(old_evidence, "CONFIRM"),
+            _adjudication_payload(new_evidence, "CONFIRM"),
+        ],
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(content="Synthetic current input.", request_id="persistent-hard"),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.FAILED
+    assert result.quality_status == "blocked"
+    assert result.violation_codes == ("MEMORY_FABRICATION",)
+    assert result.reviewer_calls == 2
+    assert result.rewrite_calls == 1
 
 
 def test_reviewer_uses_release_declarations_without_source_document(
@@ -1466,7 +1934,7 @@ def test_video_length_rewrite_receives_the_exact_delivery_contract(
 ) -> None:
     gateway = SequencedQualityGateway(
         candidate="太短。",
-        reviews=[*_passing_layer_payloads(), *_passing_layer_payloads()],
+        reviews=[*_legacy_passing_layer_payloads(), *_legacy_passing_layer_payloads()],
         rewritten="林" * 190,
     )
     pipeline = _pipeline(gateway, monkeypatch)

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -227,6 +227,9 @@ class SequencedQualityGateway(Gateway):
         self.rewrite_requests: list[dict[str, object]] = []
         self.review_input_sizes: list[int] = []
         self.adjudication_requests: list[dict[str, object]] = []
+        self.adjudication_message_roles: list[tuple[str, ...]] = []
+        self.adjudication_system_prompts: list[str] = []
+        self.adjudication_input_sizes: list[int] = []
 
     async def complete(
         self,
@@ -239,6 +242,13 @@ class SequencedQualityGateway(Gateway):
         if "P02_REPLY_EVIDENCE_ADJUDICATION_JSON" in system:
             self.call_kinds.append("adjudication")
             self.adjudication_requests.append(json.loads(user))
+            self.adjudication_message_roles.append(
+                tuple(str(message.get("role", "")) for message in messages)
+            )
+            self.adjudication_system_prompts.append(system)
+            self.adjudication_input_sizes.append(
+                sum(len(str(message.get("content", ""))) for message in messages)
+            )
             text = self.adjudications.pop(0)
         elif "P02_REPLY_REVIEW_JSON" in system:
             self.call_kinds.append("review")
@@ -1197,20 +1207,88 @@ def test_semantically_duplicate_cross_layer_evidence_fails_before_adjudication()
     assert gateway.adjudication_requests == []
 
 
-def test_sixteen_claims_share_one_context_within_the_input_budget() -> None:
-    candidate = "abcdefghijklmnop"
-    evidence_items = [
+def test_seventeen_cross_layer_claims_fail_before_adjudication() -> None:
+    candidate = "abcdefghijklmnopq"
+    identity_evidence = [
+        _hard_evidence_payload(
+            candidate,
+            "IDENTITY_DRIFT",
+            evidence_id=f"evidence.identity.{index}",
+            start=index,
+            end=index + 1,
+            claim_kind="identity_claim",
+            support_source="world_fact",
+        )
+        for index in range(8)
+    ]
+    continuity_evidence = [
         _hard_evidence_payload(
             candidate,
             "MEMORY_FABRICATION",
-            evidence_id=f"evidence.synthetic.{index}",
+            evidence_id=f"evidence.continuity.{index}",
             start=index,
             end=index + 1,
             claim_kind="past_fact",
             support_source="memory",
         )
-        for index in range(16)
+        for index in range(8, 17)
     ]
+    reviews = _passing_layer_payloads()
+    reviews[0] = _layer_score_payload(
+        "identity_boundary",
+        0,
+        hard_violations=["IDENTITY_DRIFT"] * len(identity_evidence),
+        drift_detected=True,
+        hard_evidence=identity_evidence,
+    )
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"] * len(continuity_evidence),
+        drift_detected=True,
+        hard_evidence=continuity_evidence,
+    )
+    gateway = SequencedQualityGateway(candidate="unused", reviews=reviews)
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.UNAVAILABLE
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert gateway.call_kinds == ["review"] * 5
+    assert gateway.adjudication_requests == []
+
+
+def test_sixteen_cross_context_claims_preserve_full_bounded_adjudication() -> None:
+    candidate = "abcdefghijklmnop"
+    identity_evidence = [
+        _hard_evidence_payload(
+            candidate,
+            "IDENTITY_DRIFT" if index == 0 else "STAGE_DRIFT",
+            evidence_id=f"evidence.identity.{index}",
+            start=index,
+            end=index + 1,
+            claim_kind="identity_claim" if index == 0 else "relationship",
+            support_source="world_fact" if index == 0 else "character_history",
+        )
+        for index in range(8)
+    ]
+    continuity_evidence = [
+        _hard_evidence_payload(
+            candidate,
+            "MEMORY_FABRICATION",
+            evidence_id=f"evidence.continuity.{index}",
+            start=index,
+            end=index + 1,
+            claim_kind="past_fact",
+            support_source="memory",
+        )
+        for index in range(8, 16)
+    ]
+    evidence_items = [*identity_evidence, *continuity_evidence]
     decisions = {
         "decisions": [
             {
@@ -1224,12 +1302,19 @@ def test_sixteen_claims_share_one_context_within_the_input_budget() -> None:
         ]
     }
     reviews = _passing_layer_payloads()
+    reviews[0] = _layer_score_payload(
+        "identity_boundary",
+        0,
+        hard_violations=[item["code"] for item in identity_evidence],
+        drift_detected=True,
+        hard_evidence=identity_evidence,
+    )
     reviews[3] = _layer_score_payload(
         "continuity_memory",
         0,
-        hard_violations=["MEMORY_FABRICATION"] * 16,
+        hard_violations=["MEMORY_FABRICATION"] * len(continuity_evidence),
         drift_detected=True,
-        hard_evidence=evidence_items,
+        hard_evidence=continuity_evidence,
     )
     gateway = SequencedQualityGateway(
         candidate="unused",
@@ -1249,10 +1334,20 @@ def test_sixteen_claims_share_one_context_within_the_input_budget() -> None:
         (index, index + 1) for index in range(16)
     }
     request = gateway.adjudication_requests[0]
-    assert set(request["contexts"]) == {"continuity_fact"}
+    assert tuple(request["contexts"]) == (
+        "identity_world",
+        "relationship",
+        "continuity_fact",
+    )
     assert len(request["claims"]) == 16
-    assert all(item["context_id"] == "continuity_fact" for item in request["claims"])
-    assert len(json.dumps(request, separators=(",", ":"))) < 30_000
+    assert {item["context_id"] for item in request["claims"]} == set(request["contexts"])
+    assert len(decisions["decisions"]) == len(request["claims"]) == 16
+    assert gateway.adjudication_message_roles == [("system", "user")]
+    assert (
+        "P02_REPLY_EVIDENCE_ADJUDICATION_JSON"
+        in gateway.adjudication_system_prompts[0]
+    )
+    assert gateway.adjudication_input_sizes[0] < 30_000
 
 
 def test_rejected_false_memory_claim_does_not_block_pipeline(
@@ -1507,7 +1602,7 @@ def test_rewrite_uses_fresh_candidate_evidence_and_adjudication(
     )
 
     assert result.state is ReplyState.COMPLETED
-    assert result.quality_status == "accepted_with_warnings"
+    assert result.quality_status == "accepted"
     assert result.reviewer_calls == 2
     assert result.rewrite_calls == 1
     assert [request["candidate_reply"] for request in gateway.adjudication_requests] == [

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -52,6 +52,8 @@ def _layer_payload(layer: str) -> str:
     if layer == "identity_boundary":
         payload["intimacy_request"] = "none"
         payload["intimacy_claims"] = []
+    if layer in {"identity_boundary", "continuity_memory"}:
+        payload["hard_evidence"] = []
     return json.dumps(payload)
 
 
@@ -63,6 +65,7 @@ def _layer_score_payload(
     drift_detected: bool = False,
     intimacy_request: str = "none",
     intimacy_claims: list[dict[str, object]] | None = None,
+    hard_evidence: list[dict[str, object]] | None = None,
 ) -> str:
     payload: dict[str, object] = {
         "layer": layer,
@@ -73,6 +76,8 @@ def _layer_score_payload(
     if layer == "identity_boundary":
         payload["intimacy_request"] = intimacy_request
         payload["intimacy_claims"] = intimacy_claims or []
+    if layer in {"identity_boundary", "continuity_memory"}:
+        payload["hard_evidence"] = hard_evidence or []
     return json.dumps(payload)
 
 
@@ -98,6 +103,47 @@ def _claim_payload(candidate: str, claim_id: str) -> dict[str, object]:
     }
 
 
+def _hard_evidence_payload(
+    candidate: str,
+    code: str,
+    *,
+    evidence_id: str = "evidence.synthetic.1",
+    start: int = 0,
+    end: int | None = None,
+    claim_kind: str = "past_fact",
+    support_source: str = "none",
+    reason_code: str = "UNSUPPORTED_CLAIM",
+) -> dict[str, object]:
+    return {
+        "evidence_id": evidence_id,
+        "code": code,
+        "start": start,
+        "end": len(candidate) if end is None else end,
+        "claim_kind": claim_kind,
+        "support_source": support_source,
+        "reason_code": reason_code,
+    }
+
+
+def _adjudication_payload(
+    evidence: Mapping[str, object],
+    decision: str,
+) -> str:
+    return json.dumps(
+        {
+            "decisions": [
+                {
+                    "evidence_id": evidence["evidence_id"],
+                    "code": evidence["code"],
+                    "start": evidence["start"],
+                    "end": evidence["end"],
+                    "decision": decision,
+                }
+            ]
+        }
+    )
+
+
 def _intimacy_context() -> ReplyContext:
     return ReplyContext.create(
         ReplyMode.TEXT_LETTER,
@@ -117,16 +163,19 @@ class SequencedQualityGateway(Gateway):
         candidate: str,
         reviews: list[str],
         rewritten: str = "我听见了。先不用急着给自己一个结论。",
+        adjudications: list[str] | None = None,
     ) -> None:
         self.candidate = candidate
         self.reviews = list(reviews)
         self.rewritten = rewritten
+        self.adjudications = list(adjudications or [])
         self.call_kinds: list[str] = []
         self.review_system_prompts: list[str] = []
         self.review_requests: list[dict[str, object]] = []
         self.rewrite_system_prompts: list[str] = []
         self.rewrite_requests: list[dict[str, object]] = []
         self.review_input_sizes: list[int] = []
+        self.adjudication_requests: list[dict[str, object]] = []
 
     async def complete(
         self,
@@ -136,7 +185,11 @@ class SequencedQualityGateway(Gateway):
     ) -> GatewayResponse:
         system = str(messages[0].get("content", ""))
         user = str(messages[-1].get("content", ""))
-        if "P02_REPLY_REVIEW_JSON" in system:
+        if "P02_REPLY_EVIDENCE_ADJUDICATION_JSON" in system:
+            self.call_kinds.append("adjudication")
+            self.adjudication_requests.append(json.loads(user))
+            text = self.adjudications.pop(0)
+        elif "P02_REPLY_REVIEW_JSON" in system:
             self.call_kinds.append("review")
             self.review_system_prompts.append(system)
             self.review_requests.append(json.loads(user))
@@ -258,6 +311,7 @@ def test_configured_provider_runs_structured_persona_review(
     assert result.reviewer_calls == 1
     assert result.rewrite_calls == 0
     assert gateway.call_kinds == ["generation", *("review",) * 5]
+    assert gateway.adjudication_requests == []
     assert [request["layer"] for request in gateway.review_requests] == [
         "identity_boundary",
         "voice_style",
@@ -554,18 +608,29 @@ def test_production_reviewer_request_allows_only_tier_within_ceiling(
     ),
 )
 def test_identity_layer_accepts_each_intimacy_rubric_code(code: str) -> None:
+    candidate = "Synthetic candidate."
+    evidence = _hard_evidence_payload(
+        candidate,
+        code,
+        claim_kind="relationship",
+    )
     reviews = _passing_layer_payloads()
     reviews[0] = _layer_score_payload(
         "identity_boundary",
         0,
         hard_violations=[code],
         drift_detected=True,
+        hard_evidence=[evidence],
     )
     result = GatewayPersonaReviewer(
-        SequencedQualityGateway(candidate="unused", reviews=reviews),
+        SequencedQualityGateway(
+            candidate="unused",
+            reviews=reviews,
+            adjudications=[_adjudication_payload(evidence, "CONFIRM")],
+        ),
         ROOT / "linli_character" / "persona_release_v2.json",
         1,
-    ).review("Synthetic candidate.", _context())
+    ).review(candidate, _context())
 
     assert result.verdict is ReviewVerdict.REWRITE
     assert tuple(item.code for item in result.violations) == (code,)
@@ -593,6 +658,344 @@ def test_identity_layer_missing_intimacy_metadata_fails_closed() -> None:
 
     assert result.verdict is ReviewVerdict.UNAVAILABLE
     assert result.error_code == "REVIEWER_UNAVAILABLE"
+
+
+def test_continuity_hard_violation_without_evidence_fails_closed() -> None:
+    reviews = _passing_layer_payloads()
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+    )
+
+    result = GatewayPersonaReviewer(
+        SequencedQualityGateway(candidate="unused", reviews=reviews),
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review("Synthetic unsupported memory claim.", _context())
+
+    assert result.verdict is ReviewVerdict.UNAVAILABLE
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+
+
+@pytest.mark.parametrize(
+    ("layer_index", "layer"),
+    ((0, "identity_boundary"), (3, "continuity_memory")),
+)
+def test_evidence_bound_layer_cannot_imply_hard_failure_without_a_code(
+    layer_index: int,
+    layer: str,
+) -> None:
+    reviews = _passing_layer_payloads()
+    reviews[layer_index] = _layer_score_payload(
+        layer,
+        0,
+        drift_detected=True,
+    )
+
+    result = GatewayPersonaReviewer(
+        SequencedQualityGateway(candidate="unused", reviews=reviews),
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review("Synthetic candidate.", _context())
+
+    assert result.verdict is ReviewVerdict.UNAVAILABLE
+
+
+@pytest.mark.parametrize("invalid_kind", ("range", "code"))
+def test_hard_evidence_must_match_code_and_candidate_offsets(
+    invalid_kind: str,
+) -> None:
+    candidate = "Synthetic unsupported memory claim."
+    evidence = _hard_evidence_payload(candidate, "MEMORY_FABRICATION")
+    if invalid_kind == "range":
+        evidence["end"] = len(candidate) + 1
+    else:
+        evidence["code"] = "BOUNDARY_BREACH"
+    reviews = _passing_layer_payloads()
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+
+    result = GatewayPersonaReviewer(
+        SequencedQualityGateway(candidate="unused", reviews=reviews),
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.UNAVAILABLE
+
+
+def test_adjudicator_rejects_false_memory_fabrication_as_soft_warning() -> None:
+    candidate = "Synthetic emotional acknowledgment."
+    evidence = _hard_evidence_payload(candidate, "MEMORY_FABRICATION")
+    reviews = _passing_layer_payloads()
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate="unused",
+        reviews=reviews,
+        adjudications=[_adjudication_payload(evidence, "REJECT")],
+    )
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.REWRITE
+    assert [(item.code, item.severity, item.start, item.end) for item in result.violations] == [
+        ("MEMORY_FABRICATION", "soft", 0, len(candidate))
+    ]
+    assert gateway.call_kinds == [*("review",) * 5, "adjudication"]
+
+
+@pytest.mark.parametrize(
+    ("layer_index", "layer", "code", "claim_kind", "fragment"),
+    (
+        (3, "continuity_memory", "MEMORY_FABRICATION", "location", "at the station"),
+        (0, "identity_boundary", "IDENTITY_DRIFT", "identity_claim", "I am Olivia"),
+    ),
+)
+def test_confirmed_identity_or_location_claim_stays_hard_with_exact_span(
+    layer_index: int,
+    layer: str,
+    code: str,
+    claim_kind: str,
+    fragment: str,
+) -> None:
+    candidate = f"Synthetic prefix; {fragment}; synthetic suffix."
+    start = candidate.index(fragment)
+    evidence = _hard_evidence_payload(
+        candidate,
+        code,
+        start=start,
+        end=start + len(fragment),
+        claim_kind=claim_kind,
+    )
+    reviews = _passing_layer_payloads()
+    reviews[layer_index] = _layer_score_payload(
+        layer,
+        0,
+        hard_violations=[code],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate="unused",
+        reviews=reviews,
+        adjudications=[_adjudication_payload(evidence, "CONFIRM")],
+    )
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.REWRITE
+    assert [(item.code, item.severity, item.start, item.end) for item in result.violations] == [
+        (code, "hard", start, start + len(fragment))
+    ]
+    assert gateway.adjudication_requests[0]["claims"] == [
+        {
+            "layer": layer,
+            **evidence,
+        }
+    ]
+    assert fragment not in repr(result)
+
+
+def test_malformed_adjudication_fails_closed() -> None:
+    candidate = "Synthetic unsupported memory claim."
+    evidence = _hard_evidence_payload(candidate, "MEMORY_FABRICATION")
+    reviews = _passing_layer_payloads()
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate="unused",
+        reviews=reviews,
+        adjudications=[json.dumps({"decisions": []})],
+    )
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.UNAVAILABLE
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+
+
+def test_duplicate_evidence_ids_across_layers_fail_before_adjudication() -> None:
+    candidate = "Synthetic boundary claim."
+    identity_evidence = _hard_evidence_payload(
+        candidate,
+        "BOUNDARY_BREACH",
+        evidence_id="evidence.duplicate",
+        claim_kind="relationship",
+    )
+    continuity_evidence = _hard_evidence_payload(
+        candidate,
+        "BOUNDARY_BREACH",
+        evidence_id="evidence.duplicate",
+        claim_kind="shared_history",
+    )
+    reviews = _passing_layer_payloads()
+    reviews[0] = _layer_score_payload(
+        "identity_boundary",
+        0,
+        hard_violations=["BOUNDARY_BREACH"],
+        drift_detected=True,
+        hard_evidence=[identity_evidence],
+    )
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["BOUNDARY_BREACH"],
+        drift_detected=True,
+        hard_evidence=[continuity_evidence],
+    )
+    gateway = SequencedQualityGateway(candidate="unused", reviews=reviews)
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.UNAVAILABLE
+    assert gateway.adjudication_requests == []
+
+
+def test_rejected_false_memory_claim_does_not_block_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = "Synthetic emotional acknowledgment."
+    rewritten = "Synthetic restrained acknowledgment."
+    evidence = _hard_evidence_payload(candidate, "MEMORY_FABRICATION")
+    first = _passing_layer_payloads()
+    first[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate=candidate,
+        reviews=[*first, *_passing_layer_payloads()],
+        rewritten=rewritten,
+        adjudications=[_adjudication_payload(evidence, "REJECT")],
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(content="Synthetic current input.", request_id="false-memory"),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.text == rewritten
+    assert result.reviewer_calls == 2
+    assert result.rewrite_calls == 1
+    assert gateway.call_kinds == [
+        "generation",
+        *("review",) * 5,
+        "adjudication",
+        "rewrite",
+        *("review",) * 5,
+    ]
+
+
+def test_rewrite_uses_fresh_candidate_evidence_and_adjudication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = "Synthetic claim at old location."
+    rewritten = "Synthetic claim at new location."
+    old_fragment = "old location"
+    new_fragment = "new location"
+    old_start = candidate.index(old_fragment)
+    new_start = rewritten.index(new_fragment)
+    old_evidence = _hard_evidence_payload(
+        candidate,
+        "MEMORY_FABRICATION",
+        evidence_id="evidence.old",
+        start=old_start,
+        end=old_start + len(old_fragment),
+        claim_kind="location",
+    )
+    new_evidence = _hard_evidence_payload(
+        rewritten,
+        "MEMORY_FABRICATION",
+        evidence_id="evidence.new",
+        start=new_start,
+        end=new_start + len(new_fragment),
+        claim_kind="location",
+    )
+    first = _passing_layer_payloads()
+    first[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[old_evidence],
+    )
+    second = _passing_layer_payloads()
+    second[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[new_evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate=candidate,
+        reviews=[*first, *second],
+        rewritten=rewritten,
+        adjudications=[
+            _adjudication_payload(old_evidence, "CONFIRM"),
+            _adjudication_payload(new_evidence, "REJECT"),
+        ],
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(content="Synthetic current input.", request_id="fresh-evidence"),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.quality_status == "accepted_with_warnings"
+    assert result.reviewer_calls == 2
+    assert result.rewrite_calls == 1
+    assert [request["candidate_reply"] for request in gateway.adjudication_requests] == [
+        candidate,
+        rewritten,
+    ]
+    assert [request["claims"][0]["evidence_id"] for request in gateway.adjudication_requests] == [
+        "evidence.old",
+        "evidence.new",
+    ]
 
 
 def test_reviewer_uses_release_declarations_without_source_document(

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -54,6 +54,7 @@ def _layer_payload(layer: str) -> str:
         payload["intimacy_claims"] = []
     if layer in {"identity_boundary", "continuity_memory"}:
         payload["hard_evidence"] = []
+        payload["independent_soft_issue"] = False
     return json.dumps(payload)
 
 
@@ -78,6 +79,7 @@ def _layer_score_payload(
         payload["intimacy_claims"] = intimacy_claims or []
     if layer in {"identity_boundary", "continuity_memory"}:
         payload["hard_evidence"] = hard_evidence or []
+        payload["independent_soft_issue"] = False
     return json.dumps(payload)
 
 
@@ -155,6 +157,23 @@ def _hard_evidence_payload(
         "support_source": support_source,
         "reason_code": reason_code,
     }
+
+
+def _independent_soft_memory_review(
+    candidate: str,
+) -> tuple[dict[str, object], str]:
+    evidence = _hard_evidence_payload(candidate, "MEMORY_FABRICATION")
+    payload = json.loads(
+        _layer_score_payload(
+            "continuity_memory",
+            0,
+            hard_violations=["MEMORY_FABRICATION"],
+            drift_detected=True,
+            hard_evidence=[evidence],
+        )
+    )
+    payload["independent_soft_issue"] = True
+    return evidence, json.dumps(payload)
 
 
 def _adjudication_payload(
@@ -812,6 +831,50 @@ def test_hard_evidence_must_match_code_and_candidate_offsets(
     assert result.verdict is ReviewVerdict.UNAVAILABLE
 
 
+@pytest.mark.parametrize(
+    "mutate",
+    (
+        lambda payload: payload.pop("independent_soft_issue"),
+        lambda payload: payload.__setitem__("independent_soft_issue", "false"),
+        lambda payload: payload.update(score=1, independent_soft_issue=False),
+        lambda payload: payload.update(score=2, independent_soft_issue=True),
+        lambda payload: payload.update(
+            score=1,
+            drift_detected=True,
+            independent_soft_issue=True,
+        ),
+        lambda payload: payload.update(
+            score=2,
+            hard_violations=["MEMORY_FABRICATION"],
+            hard_evidence=[
+                _hard_evidence_payload(
+                    "Synthetic candidate.",
+                    "MEMORY_FABRICATION",
+                )
+            ],
+        ),
+    ),
+)
+def test_evidence_bound_independent_soft_contract_is_strict(
+    mutate: Any,
+) -> None:
+    reviews = _passing_layer_payloads()
+    payload = json.loads(reviews[3])
+    mutate(payload)
+    reviews[3] = json.dumps(payload)
+    gateway = SequencedQualityGateway(candidate="unused", reviews=reviews)
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review("Synthetic candidate.", _context())
+
+    assert result.verdict is ReviewVerdict.UNAVAILABLE
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert gateway.adjudication_requests == []
+
+
 def test_adjudicator_rejects_false_memory_fabrication_as_soft_warning() -> None:
     candidate = "Synthetic emotional acknowledgment."
     evidence = _hard_evidence_payload(candidate, "MEMORY_FABRICATION")
@@ -843,25 +906,27 @@ def test_adjudicator_rejects_false_memory_fabrication_as_soft_warning() -> None:
 
 
 @pytest.mark.parametrize(
-    ("layer_index", "layer", "code"),
+    ("layer_index", "layer", "code", "claim_kind", "support_source", "context_id"),
     (
-        (0, "identity_boundary", "STAGE_DRIFT"),
-        (0, "identity_boundary", "RELATIONSHIP_RETRACTION"),
-        (0, "identity_boundary", "ACKNOWLEDGED_FEELING_REWRITE"),
-        (3, "continuity_memory", "MEMORY_FABRICATION"),
+        (0, "identity_boundary", "IDENTITY_DRIFT", "relationship", "character_history", "identity_world"),
+        (0, "identity_boundary", "STAGE_DRIFT", "current_fact", "current_user", "relationship"),
+        (3, "continuity_memory", "MEMORY_FABRICATION", "relationship", "character_history", "continuity_fact"),
     ),
 )
-def test_relationship_adjudication_excludes_user_self_claims_and_untyped_memory(
+def test_adjudication_disclosure_ignores_untrusted_claim_routing_metadata(
     layer_index: int,
     layer: str,
     code: str,
+    claim_kind: str,
+    support_source: str,
+    context_id: str,
 ) -> None:
-    candidate = "Synthetic relationship claim."
+    candidate = "Synthetic claim."
     evidence = _hard_evidence_payload(
         candidate,
         code,
-        claim_kind="relationship",
-        support_source="current_user",
+        claim_kind=claim_kind,
+        support_source=support_source,
     )
     reviews = _passing_layer_payloads()
     reviews[layer_index] = _layer_score_payload(
@@ -888,122 +953,41 @@ def test_relationship_adjudication_excludes_user_self_claims_and_untyped_memory(
         candidate,
         _context(),
         references=(
-            ReviewReference("current.user_excerpt", "We are already partners."),
-            ReviewReference(
-                "current.memory_evidence",
-                "Unmarked prior-user memory says we are partners.",
-            ),
+            ReviewReference("current.user_excerpt", "Sensitive current user fact."),
+            ReviewReference("current.memory_evidence", "Sensitive untyped memory."),
             ReviewReference(
                 "current.character_reply_history",
-                "Linli previously set a clear boundary.",
+                "Typed Linli relationship history.",
             ),
         ),
     )
 
     assert result.verdict is ReviewVerdict.REWRITE
     request = gateway.adjudication_requests[0]
-    assert "We are already partners." not in repr(request)
-    assert "Unmarked prior-user memory" not in repr(request)
-    support = request["claims"][0]["support_context"]
-    assert support["relationship_context"]["relationship_stage"] == "unknown"
-    assert support["character_reply_history"] == (
-        "Linli previously set a clear boundary."
-    )
-
-
-def test_current_user_input_can_support_an_ordinary_factual_claim() -> None:
-    candidate = "You currently work in Tokyo."
-    evidence = _hard_evidence_payload(
-        candidate,
-        "MEMORY_FABRICATION",
-        claim_kind="current_fact",
-        support_source="current_user",
-    )
-    reviews = _passing_layer_payloads()
-    reviews[3] = _layer_score_payload(
-        "continuity_memory",
-        0,
-        hard_violations=["MEMORY_FABRICATION"],
-        drift_detected=True,
-        hard_evidence=[evidence],
-    )
-    gateway = SequencedQualityGateway(
-        candidate="unused",
-        reviews=reviews,
-        adjudications=[_adjudication_payload(evidence, "REJECT")],
-    )
-    reviewer = JsonReviewerAdapter(
-        GatewayReviewTransport(
-            gateway,
-            ROOT / "linli_character" / "persona_release_v2.json",
-        ),
-        ReviewerConfig("reviewer-small"),
-    )
-
-    result = reviewer.review(
-        candidate,
-        _context(),
-        references=(
-            ReviewReference("current.user_excerpt", "I currently work in Tokyo."),
-        ),
-    )
-
-    assert result.verdict is ReviewVerdict.PASS
-    assert [(item.code, item.severity) for item in result.violations] == [
-        ("MEMORY_FABRICATION", "soft")
-    ]
-    support = gateway.adjudication_requests[0]["claims"][0]["support_context"]
-    assert support["current_user_input"] == "I currently work in Tokyo."
-
-
-def test_identity_adjudication_uses_only_release_and_world_authority() -> None:
-    candidate = "I am a different person."
-    evidence = _hard_evidence_payload(
-        candidate,
-        "IDENTITY_DRIFT",
-        claim_kind="identity_claim",
-        support_source="current_user",
-    )
-    reviews = _passing_layer_payloads()
-    reviews[0] = _layer_score_payload(
-        "identity_boundary",
-        0,
-        hard_violations=["IDENTITY_DRIFT"],
-        drift_detected=True,
-        hard_evidence=[evidence],
-    )
-    gateway = SequencedQualityGateway(
-        candidate="unused",
-        reviews=reviews,
-        adjudications=[_adjudication_payload(evidence, "CONFIRM")],
-    )
-    reviewer = JsonReviewerAdapter(
-        GatewayReviewTransport(
-            gateway,
-            ROOT / "linli_character" / "persona_release_v2.json",
-        ),
-        ReviewerConfig("reviewer-small"),
-    )
-
-    result = reviewer.review(
-        candidate,
-        _context(),
-        references=(
-            ReviewReference("current.user_excerpt", "You are someone else."),
-            ReviewReference("current.memory_evidence", "Unmarked identity memory."),
-            ReviewReference(
-                "current.character_reply_history",
-                "Typed history irrelevant to identity.",
-            ),
-        ),
-    )
-
-    assert result.verdict is ReviewVerdict.REWRITE
-    support = gateway.adjudication_requests[0]["claims"][0]["support_context"]
-    assert set(support) == {"release_authority", "world_facts"}
-    assert "You are someone else." not in repr(support)
-    assert "Unmarked identity memory." not in repr(support)
-    assert "Typed history irrelevant to identity." not in repr(support)
+    assert set(request) == {"candidate_reply", "contexts", "claims"}
+    assert set(request["contexts"]) == {context_id}
+    claim = request["claims"][0]
+    assert claim["context_id"] == context_id
+    assert "support_context" not in claim
+    context = request["contexts"][context_id]
+    expected_keys = {
+        "identity_world": {"release_authority", "world_facts"},
+        "relationship": {"release_authority", "character_reply_history", "relationship_context"},
+        "continuity_fact": {"current_user_input", "memory_evidence"},
+    }
+    assert set(context) == expected_keys[context_id]
+    forbidden = {
+        "identity_world": ("Sensitive current user", "Sensitive untyped", "Typed Linli"),
+        "relationship": ("Sensitive current user", "Sensitive untyped"),
+        "continuity_fact": ("Typed Linli",),
+    }
+    assert all(text not in repr(context) for text in forbidden[context_id])
+    required = {
+        "identity_world": ("release_authority",),
+        "relationship": ("Typed Linli", "unknown"),
+        "continuity_fact": ("Sensitive current user", "Sensitive untyped"),
+    }
+    assert all(text in repr(context) for text in required[context_id])
 
 
 @pytest.mark.parametrize(
@@ -1055,9 +1039,13 @@ def test_confirmed_identity_or_location_claim_stays_hard_with_exact_span(
     ]
     claim = gateway.adjudication_requests[0]["claims"][0]
     assert {
-        key: value for key, value in claim.items() if key != "support_context"
+        key: value for key, value in claim.items() if key != "context_id"
     } == {"layer": layer, **evidence}
-    assert "release_authority" in claim["support_context"]
+    context = gateway.adjudication_requests[0]["contexts"][claim["context_id"]]
+    if claim["context_id"] == "identity_world":
+        assert "release_authority" in context
+    else:
+        assert set(context) == {"current_user_input", "memory_evidence"}
     assert fragment not in repr(result)
 
 
@@ -1209,6 +1197,64 @@ def test_semantically_duplicate_cross_layer_evidence_fails_before_adjudication()
     assert gateway.adjudication_requests == []
 
 
+def test_sixteen_claims_share_one_context_within_the_input_budget() -> None:
+    candidate = "abcdefghijklmnop"
+    evidence_items = [
+        _hard_evidence_payload(
+            candidate,
+            "MEMORY_FABRICATION",
+            evidence_id=f"evidence.synthetic.{index}",
+            start=index,
+            end=index + 1,
+            claim_kind="past_fact",
+            support_source="memory",
+        )
+        for index in range(16)
+    ]
+    decisions = {
+        "decisions": [
+            {
+                "evidence_id": item["evidence_id"],
+                "code": item["code"],
+                "start": item["start"],
+                "end": item["end"],
+                "decision": "CONFIRM",
+            }
+            for item in evidence_items
+        ]
+    }
+    reviews = _passing_layer_payloads()
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"] * 16,
+        drift_detected=True,
+        hard_evidence=evidence_items,
+    )
+    gateway = SequencedQualityGateway(
+        candidate="unused",
+        reviews=reviews,
+        adjudications=[json.dumps(decisions)],
+    )
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.REWRITE
+    assert len(result.violations) == 16
+    assert {(item.start, item.end) for item in result.violations} == {
+        (index, index + 1) for index in range(16)
+    }
+    request = gateway.adjudication_requests[0]
+    assert set(request["contexts"]) == {"continuity_fact"}
+    assert len(request["claims"]) == 16
+    assert all(item["context_id"] == "continuity_fact" for item in request["claims"])
+    assert len(json.dumps(request, separators=(",", ":"))) < 30_000
+
+
 def test_rejected_false_memory_claim_does_not_block_pipeline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1247,6 +1293,69 @@ def test_rejected_false_memory_claim_does_not_block_pipeline(
         "generation",
         *("review",) * 5,
         "adjudication",
+    ]
+
+
+def test_rejected_false_memory_with_independent_soft_issue_keeps_rewrite_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = "Synthetic acknowledgment with a separate local mismatch."
+    evidence, continuity = _independent_soft_memory_review(candidate)
+    reviews = _passing_layer_payloads()
+    reviews[3] = continuity
+    gateway = SequencedQualityGateway(
+        candidate=candidate,
+        reviews=reviews,
+        adjudications=[_adjudication_payload(evidence, "REJECT")],
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch, rewrite_enabled=False).run(
+            ReplyRequest(content="Synthetic current input.", request_id="soft-rewrite"),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.FAILED
+    assert result.quality_status == "blocked"
+    assert result.error_code == "REWRITE_FAILED"
+    assert result.reviewer_calls == 1
+    assert result.rewrite_calls == 1
+
+
+def test_rejected_false_memory_with_independent_soft_issue_gets_fresh_review(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = "Synthetic acknowledgment with a separate local mismatch."
+    rewritten = "Synthetic restrained acknowledgment."
+    evidence, continuity = _independent_soft_memory_review(candidate)
+    first = _passing_layer_payloads()
+    first[3] = continuity
+    gateway = SequencedQualityGateway(
+        candidate=candidate,
+        reviews=[*first, *_passing_layer_payloads()],
+        rewritten=rewritten,
+        adjudications=[_adjudication_payload(evidence, "REJECT")],
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(content="Synthetic current input.", request_id="soft-fresh"),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.text == rewritten
+    assert result.quality_status == "accepted"
+    assert result.reviewer_calls == 2
+    assert result.rewrite_calls == 1
+    assert gateway.call_kinds == [
+        "generation",
+        *("review",) * 5,
+        "adjudication",
+        "rewrite",
+        *("review",) * 5,
     ]
 
 

--- a/tests/persona/test_reply_pipeline.py
+++ b/tests/persona/test_reply_pipeline.py
@@ -341,6 +341,7 @@ class RecordingLayerReviewGateway(Gateway):
             response["intimacy_claims"] = []
         if request["layer"] in {"identity_boundary", "continuity_memory"}:
             response["hard_evidence"] = []
+            response["independent_soft_issue"] = False
         return GatewayResponse(
             text=json.dumps(response),
             request_id=request_id or "review",

--- a/tests/persona/test_reply_pipeline.py
+++ b/tests/persona/test_reply_pipeline.py
@@ -339,6 +339,8 @@ class RecordingLayerReviewGateway(Gateway):
         if request["layer"] == "identity_boundary":
             response["intimacy_request"] = "none"
             response["intimacy_claims"] = []
+        if request["layer"] in {"identity_boundary", "continuity_memory"}:
+            response["hard_evidence"] = []
         return GatewayResponse(
             text=json.dumps(response),
             request_id=request_id or "review",

--- a/tests/persona/test_reply_quality_gate.py
+++ b/tests/persona/test_reply_quality_gate.py
@@ -370,3 +370,39 @@ def test_final_soft_review_issue_is_accepted_with_warnings_after_one_rewrite() -
     assert result.accepted is True
     assert result.violation_codes == ("STYLE_DRIFT",)
     assert result.rewrite_calls == 1
+
+
+def test_non_letter_soft_issues_keep_legacy_accepted_status() -> None:
+    soft = ReviewResult(
+        ReviewStatus.COMPLETED,
+        ReviewVerdict.PASS,
+        (ReviewerViolation("STYLE_DRIFT", "soft", 0, 5),),
+        ReviewerScores(90, 90, 90, 90),
+        IntimacyRequest.NONE,
+        (),
+    )
+    initial = run_reply_quality_gate(
+        "x" * 190,
+        _video_context(),
+        reviewer=_Reviewer(soft),
+        rewriter=_Rewriter("unused"),
+    )
+    rewrite = ReviewResult(
+        ReviewStatus.COMPLETED,
+        ReviewVerdict.REWRITE,
+        (),
+        ReviewerScores(80, 80, 80, 80),
+        IntimacyRequest.NONE,
+        (),
+    )
+    final = run_reply_quality_gate(
+        "short",
+        _video_context(),
+        reviewer=_Reviewer(rewrite, soft),
+        rewriter=_Rewriter("x" * 190),
+    )
+
+    assert [(item.status, item.violation_codes, item.rewrite_calls) for item in (initial, final)] == [
+        (QualityGateStatus.ACCEPTED, ("STYLE_DRIFT",), 0),
+        (QualityGateStatus.ACCEPTED, ("STYLE_DRIFT",), 1),
+    ]

--- a/tests/persona/test_reply_quality_gate.py
+++ b/tests/persona/test_reply_quality_gate.py
@@ -372,37 +372,51 @@ def test_final_soft_review_issue_is_accepted_with_warnings_after_one_rewrite() -
     assert result.rewrite_calls == 1
 
 
-def test_non_letter_soft_issues_keep_legacy_accepted_status() -> None:
-    soft = ReviewResult(
-        ReviewStatus.COMPLETED,
-        ReviewVerdict.PASS,
-        (ReviewerViolation("STYLE_DRIFT", "soft", 0, 5),),
-        ReviewerScores(90, 90, 90, 90),
-        IntimacyRequest.NONE,
-        (),
+@pytest.mark.parametrize("mode", tuple(ReplyMode))
+@pytest.mark.parametrize(
+    ("initial_verdict", "final_verdict", "expected_status"),
+    (
+        (ReviewVerdict.PASS, None, QualityGateStatus.ACCEPTED_WITH_WARNINGS),
+        (ReviewVerdict.REWRITE, ReviewVerdict.PASS, QualityGateStatus.ACCEPTED),
+        (
+            ReviewVerdict.REWRITE,
+            ReviewVerdict.REWRITE,
+            QualityGateStatus.ACCEPTED_WITH_WARNINGS,
+        ),
+    ),
+    ids=("initial-pass-soft", "post-rewrite-pass", "post-rewrite-soft"),
+)
+def test_quality_status_matrix_matches_frozen_base_across_modes(
+    mode: ReplyMode,
+    initial_verdict: ReviewVerdict,
+    final_verdict: ReviewVerdict | None,
+    expected_status: QualityGateStatus,
+) -> None:
+    def review(verdict: ReviewVerdict) -> ReviewResult:
+        return ReviewResult(
+            ReviewStatus.COMPLETED,
+            verdict,
+            (ReviewerViolation("STYLE_DRIFT", "soft", 0, 5),),
+            ReviewerScores(90, 90, 90, 90),
+            IntimacyRequest.NONE,
+            (),
+        )
+
+    reviewer = _Reviewer(
+        review(initial_verdict),
+        *(() if final_verdict is None else (review(final_verdict),)),
     )
-    initial = run_reply_quality_gate(
+    result = run_reply_quality_gate(
         "x" * 190,
-        _video_context(),
-        reviewer=_Reviewer(soft),
-        rewriter=_Rewriter("unused"),
-    )
-    rewrite = ReviewResult(
-        ReviewStatus.COMPLETED,
-        ReviewVerdict.REWRITE,
-        (),
-        ReviewerScores(80, 80, 80, 80),
-        IntimacyRequest.NONE,
-        (),
-    )
-    final = run_reply_quality_gate(
-        "short",
-        _video_context(),
-        reviewer=_Reviewer(rewrite, soft),
-        rewriter=_Rewriter("x" * 190),
+        ReplyContext.create(
+            mode,
+            trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+            future_im_enabled=mode is ReplyMode.FUTURE_IM,
+        ),
+        reviewer=reviewer,
+        rewriter=_Rewriter("y" * 190),
     )
 
-    assert [(item.status, item.violation_codes, item.rewrite_calls) for item in (initial, final)] == [
-        (QualityGateStatus.ACCEPTED, ("STYLE_DRIFT",), 0),
-        (QualityGateStatus.ACCEPTED, ("STYLE_DRIFT",), 1),
-    ]
+    assert result.status is expected_status
+    assert result.violation_codes == ("STYLE_DRIFT",)
+    assert result.rewrite_calls == (0 if final_verdict is None else 1)


### PR DESCRIPTION
## Scope

Release P0 follow-up after real private holdout exposed an ungrounded MEMORY_FABRICATION false positive. TEXT_LETTER identity/continuity hard findings now require candidate-bound typed evidence and one conditional independent adjudication on the same configured deepseek-v4-flash quality gateway.

## Contract

- Only TEXT_LETTER uses the new evidence schema/adjudication. Spoken and musical-video retain their frozen-base schema, five layer calls, zero adjudication calls, and exact quality-status matrix.
- Identity/continuity hard codes require matching evidence with stable id, exact candidate offsets, bounded metadata, and non-text reason code. The response explicitly marks any separate same-layer soft issue; rejected hard claims cannot erase it.
- Missing, duplicate, inconsistent, out-of-range, bool-typed, or malformed evidence/adjudication is REVIEWER_UNAVAILABLE and fails closed. Cross-layer semantic duplicates are keyed by code+span. At most 16 claims are accepted globally across both layers; claim 17 fails before adjudication.
- Disclosure is selected only by trusted layer+code, never model-selected claim_kind/support_source. Identity gets release/world context; relationship codes get typed Linli history plus canonical relationship context; continuity factual memory gets bounded current input/memory. Current-user wishes and untyped memory never establish a relationship.
- Shared contexts are serialized once and claims reference context_id. A maximum legal 16-claim, three-context adjudication retains every claim/decision and its complete messages remain below the 30k budget.
- CONFIRM retains exact-span hard violations. If every hard claim is REJECT, no independent issue remains, and mode is Letter, the original candidate follows the frozen base PASS+warning behavior without a rewriter. A same-layer independent soft issue keeps the old rewrite path; confirmed hard findings that persist after rewrite block.
- Rewrite reruns five layers and fresh evidence/adjudication. Candidate text is not persisted in evidence, quality status, audit, or logs.

## Necessary compatibility fixtures

Only response fixtures directly requiring the TEXT_LETTER schema add empty hard_evidence and independent_soft_issue/context fields. A full mode-by-branch regression matrix locks the original quality-gate status behavior. No prior safety assertion is relaxed.

## Non-goals

- [x] No Live, media, client, routing, installer, or PrivateWorld change.
- [x] No new provider, dependency, retry path, automatic relationship evidence collector, or global archive scan.
- [x] No weakening of deterministic intimacy scans or confirmed identity/current/past/shared-history fabrication blocks.
- [x] No private corpus, key, path, raw candidate, or model output in code/tests/PR evidence.
- [x] No fixed four-part reply, uplift, question, or length rule.

## Compatibility and migration

No persistence/schema migration. Non-Letter modes retain the prior model response contract and observable status. Letter PASS stays at five layer calls; a Letter candidate with well-formed identity/continuity hard evidence conditionally adds one call per scan.

## Rollback

Revert this PR's merge commit. There is no data migration or persisted schema to undo; rollback restores the previous reviewer response schema/aggregation atomically. If provider output is temporarily incompatible before rollback, disable model quality review using the existing runtime control so generation does not consume the new response contract.

## Size rationale

5 files, 1846 insertions and 147 deletions (1993 changed) exceeds the default 500-line target but remains below the 2000-line absolute boundary. Schema/parser, disclosure routing, conditional adjudicator, aggregation semantics, privacy docs, and RED/GREEN regressions form one fail-closed unit. 1382 changed lines are synthetic tests; splitting parsing from its rejection/compatibility matrix would create an unsafe intermediate contract.

## Validation

- Focused: 114 passed.
- Persona suite: 234 passed.
- Full: 1511 passed, 1 skipped, 1 deselected.
- baseline_hardening_scan.py --mode all: PASS, matches=0.
- compileall: PASS.
- git diff --check: PASS.

Real fold0 is already consumed and will be rerun only as regression after merge, not relabeled as an independent holdout.