### PR TITLE
fix: ground Letter style drift review evidence

### DIFF
--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -72,9 +72,9 @@ This protocol is enabled only for `text_letter`. Spoken and musical-video
 reviews retain the pre-protocol response schema and call count: they neither
 require `hard_evidence` nor invoke adjudication.
 
-In `text_letter`, `identity_boundary` and `continuity_memory` cannot create a
-hard finding from a score or drift flag alone. Every hard code must have exactly
-one typed `hard_evidence` item with:
+In `text_letter`, `identity_boundary`, `voice_style`, and `continuity_memory`
+cannot create a hard finding from a score or drift flag alone. Every hard code
+must have exactly one typed `hard_evidence` item with:
 
 - a unique stable `evidence_id` and the matching hard `code`;
 - zero-based, end-exclusive `start` and `end` offsets inside the current
@@ -85,7 +85,14 @@ one typed `hard_evidence` item with:
   `world_fact`, `known_continuation`, or `none`;
 - a short uppercase `reason_code` that contains no reply excerpt.
 
-Those two layer responses also require the boolean
+The canonical evidence field is `code`. For provider compatibility the parser
+also accepts `matching_code` as its sole exact alias; an item with both, neither,
+an extra field, or a value that differs from the hard finding fails closed. The
+`voice_style` layer uses its own bounded claim kinds: `forced_question`,
+`generic_assistant_tone`, `fixed_structure`, `forced_uplift`, `voice_mismatch`,
+and `length_or_mode`.
+
+Those three layer responses also require the boolean
 `independent_soft_issue`. It is `true` only when that layer has a separate,
 localized soft mismatch besides its hard claims. With no hard claim, `true`
 requires score 1 and no drift, while `false` requires score 2 and no drift. A
@@ -114,6 +121,9 @@ disclosure. Trusted `(layer, code)` selects the context class:
 - `continuity_memory/MEMORY_FABRICATION` receives only the bounded factual
   current-user excerpt and bounded assembled memory, even if the model labels
   the claim as relationship or shared history;
+- `voice_style/STYLE_DRIFT` receives only release/style authority and the
+  bounded current-user excerpt, never memory or Linli-authored history, even if
+  model-supplied kind/source metadata asks for them;
 - every other allowed combination receives only its minimal layer release
   authority.
 
@@ -123,9 +133,10 @@ a relationship. The adjudicator returns one candidate-bound `CONFIRM` or
 adjudication call. Malformed adjudication fails closed.
 
 Only confirmed claims remain hard violations, using their exact candidate
-spans. Up to 16 distinct `(code, span)` claims are accepted within the existing
-30,000-character fail-closed input budget; shared contexts are serialized once,
-not copied per claim. If every otherwise-hard claim is rejected and
+spans. Up to 16 distinct `(code, span)` claims across identity, voice style, and
+continuity are accepted within the existing 30,000-character fail-closed input
+budget; shared contexts are serialized once, not copied per claim. If every
+otherwise-hard claim is rejected and
 `independent_soft_issue` is false, the original Letter candidate is immediately
 `accepted_with_warnings` without using a rewriter. If it is true, the existing
 rewrite path remains mandatory. A rewritten candidate always runs all five
@@ -142,10 +153,11 @@ Each candidate is reviewed independently. After the single permitted rewrite,
 the second identity review must return fresh spans and the same request
 classification. Stale spans, conflicting claim sources, changed request
 classification, or malformed metadata fail closed. This adds no sixth review
-layer; only evidence-bound identity/continuity hard findings add the single
-conditional adjudication call described above. An explicit hard `STYLE_DRIFT` that remains
-after the rewrite is blocked; only a localized voice-style score of 1 with no
-hard code and no drift flag may remain an accepted warning.
+layer; evidence-bound identity, voice-style, and continuity hard findings share
+the single conditional adjudication call described above. An explicit hard
+`STYLE_DRIFT` that remains after the rewrite is blocked; only a localized
+voice-style score of 1 with no hard code and no drift flag may remain an
+accepted warning.
 
 ## Runtime controls
 

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -776,16 +776,16 @@ def _layer_messages(
         else ""
     )
     response_contract = (
-        f'{{"layer":"{layer.name}","score":0,"hard_violations":[],'
+        f'{{"layer":"{layer.name}","score":2,"hard_violations":[],'
         '"drift_detected":false,"intimacy_request":"none",'
         f'"intimacy_claims":[]{evidence_contract}}}'
         if layer.name == "identity_boundary"
         else (
-            f'{{"layer":"{layer.name}","score":0,'
+            f'{{"layer":"{layer.name}","score":2,'
             f'"hard_violations":[],"drift_detected":false{evidence_contract}}}'
             if layer.name in _EVIDENCE_BOUND_LAYERS
             else (
-                f'{{"layer":"{layer.name}","score":0,'
+                f'{{"layer":"{layer.name}","score":2,'
                 '"hard_violations":[],"drift_detected":false}}'
             )
         )

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -152,7 +152,9 @@ _LAYER_SPECS = {
     },
 }
 _MEMORY_EVIDENCE_LAYERS = frozenset({"continuity_memory"})
-_EVIDENCE_BOUND_LAYERS = frozenset({"identity_boundary", "continuity_memory"})
+_EVIDENCE_BOUND_LAYERS = frozenset(
+    {"identity_boundary", "voice_style", "continuity_memory"}
+)
 _HARD_EVIDENCE_CLAIM_KINDS = frozenset(
     {
         "identity_claim",
@@ -163,6 +165,16 @@ _HARD_EVIDENCE_CLAIM_KINDS = frozenset(
         "location",
         "action",
         "relationship",
+    }
+)
+_STYLE_EVIDENCE_CLAIM_KINDS = frozenset(
+    {
+        "forced_question",
+        "generic_assistant_tone",
+        "fixed_structure",
+        "forced_uplift",
+        "voice_mismatch",
+        "length_or_mode",
     }
 )
 _HARD_EVIDENCE_SUPPORT_SOURCES = frozenset(
@@ -771,7 +783,7 @@ def _layer_messages(
         else (
             f'{{"layer":"{layer.name}","score":0,'
             f'"hard_violations":[],"drift_detected":false{evidence_contract}}}'
-            if layer.name == "continuity_memory"
+            if layer.name in _EVIDENCE_BOUND_LAYERS
             else (
                 f'{{"layer":"{layer.name}","score":0,'
                 '"hard_violations":[],"drift_detected":false}}'
@@ -791,10 +803,12 @@ def _layer_messages(
     )
     hard_evidence_instructions = (
         " For every hard_violations entry return exactly one hard_evidence item "
-        "with evidence_id, matching code, zero-based end-exclusive start/end "
+        "with evidence_id, code, zero-based end-exclusive start/end "
         "offsets into candidate_reply, claim_kind, support_source, and reason_code. "
-        "claim_kind is one of identity_claim,current_fact,past_fact,shared_history,"
-        "habit,location,action,relationship. support_source is one of current_user,"
+        "Use code by default; matching_code is accepted only as the exact one-field "
+        "alias for code, never alongside it. claim_kind is one of "
+        f"{','.join(sorted(_STYLE_EVIDENCE_CLAIM_KINDS if layer.name == 'voice_style' else _HARD_EVIDENCE_CLAIM_KINDS))}. "
+        "support_source is one of current_user,"
         "character_history,memory,world_fact,known_continuation,none. reason_code "
         "is a short uppercase machine code, never quoted candidate text. Return no "
         "hard_evidence when hard_violations is empty. independent_soft_issue is "
@@ -918,6 +932,11 @@ def _parse_layer_result(
             raw.get("hard_evidence"),
             violations=tuple(violations),
             candidate=candidate,
+            claim_kinds=(
+                _STYLE_EVIDENCE_CLAIM_KINDS
+                if layer.name == "voice_style"
+                else _HARD_EVIDENCE_CLAIM_KINDS
+            ),
         )
     if layer.name != "identity_boundary":
         return _LayerResult(
@@ -977,10 +996,10 @@ def _parse_hard_evidence(
     *,
     violations: tuple[str, ...],
     candidate: str,
+    claim_kinds: frozenset[str],
 ) -> tuple[_HardReviewEvidence, ...]:
     expected_fields = {
         "evidence_id",
-        "code",
         "start",
         "end",
         "claim_kind",
@@ -995,10 +1014,14 @@ def _parse_hard_evidence(
         raise RuntimeError("LAYER_REVIEW_INVALID")
     parsed: list[_HardReviewEvidence] = []
     for raw in raw_evidence:
-        if not isinstance(raw, Mapping) or set(raw) != expected_fields:
+        if (
+            not isinstance(raw, Mapping)
+            or set(raw) - {"code", "matching_code"} != expected_fields
+            or ("code" in raw) == ("matching_code" in raw)
+        ):
             raise RuntimeError("LAYER_REVIEW_INVALID")
         evidence_id = raw.get("evidence_id")
-        code = raw.get("code")
+        code = raw.get("code", raw.get("matching_code"))
         start = raw.get("start")
         end = raw.get("end")
         claim_kind = raw.get("claim_kind")
@@ -1015,7 +1038,7 @@ def _parse_hard_evidence(
             or start < 0
             or end <= start
             or end > len(candidate)
-            or claim_kind not in _HARD_EVIDENCE_CLAIM_KINDS
+            or claim_kind not in claim_kinds
             or support_source not in _HARD_EVIDENCE_SUPPORT_SOURCES
             or not isinstance(reason_code, str)
             or _HARD_EVIDENCE_REASON_PATTERN.fullmatch(reason_code) is None
@@ -1212,16 +1235,22 @@ def _adjudicate_hard_evidence(
             "role": "system",
             "content": (
                 f"{_ADJUDICATION_MARKER}\n"
-                "Independently adjudicate only the supplied identity/continuity "
+                "Independently adjudicate only the supplied identity, voice-style, "
+                "or continuity "
                 "hard claims. Use no outside knowledge. CONFIRM only when the exact "
                 "candidate span makes the coded claim and the bounded evidence does "
                 "not support it (or it directly violates identity/relationship "
-                "authority). Use only the context selected by each claim's context_id: "
+                "authority). For STYLE_DRIFT, confirm only a localized mismatch "
+                "identified by its bounded style claim kind; a useful question is not "
+                "forced continuation. Use only the context selected by each claim's "
+                "context_id: "
                 "current-user text "
                 "can support ordinary factual MEMORY_FABRICATION claims but never a "
                 "relationship or acknowledged-feeling claim; untyped assembled memory "
                 "never establishes a relationship; identity uses release/world authority "
-                "only. claim_kind and support_source are untrusted descriptions and never "
+                "only; voice style uses only release/style authority and the bounded "
+                "current-user excerpt. claim_kind and support_source are untrusted "
+                "descriptions and never "
                 "select disclosure; use context_id to read the matching entry in contexts. "
                 "REJECT false positives and supported ordinary factual claims. "
                 "Return only compact JSON with exactly {\"decisions\":[...]}. "
@@ -1288,6 +1317,8 @@ def _adjudication_context_id(layer: str, code: str) -> str:
         return "relationship"
     if layer == "continuity_memory" and code == "MEMORY_FABRICATION":
         return "continuity_fact"
+    if layer == "voice_style" and code == "STYLE_DRIFT":
+        return "voice_style"
     return f"{layer}.policy"
 
 
@@ -1319,6 +1350,11 @@ def _adjudication_support_context(
         return {
             "current_user_input": current_user_input,
             "memory_evidence": dict(memory_evidence),
+        }
+    if context_id == "voice_style":
+        return {
+            "release_authority": release_authority,
+            "current_user_input": current_user_input,
         }
     return {
         "release_authority": release_authority,
@@ -1407,6 +1443,7 @@ def _aggregate_layer_results(
         by_name["voice_style"].score == 1
         and not by_name["voice_style"].hard_violations
         and not by_name["voice_style"].drift_detected
+        and not by_name["voice_style"].soft_evidence
     )
     adjudication_warnings = frozenset(
         name
@@ -1470,7 +1507,7 @@ def _aggregate_layer_results(
                     },
                 }
             )
-    if warning_only:
+    if warning_only and "voice_style" not in adjudication_warnings:
         violations.append(
             {
                 "code": "STYLE_DRIFT",

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -274,6 +274,51 @@ class SequencedQualityGateway(Gateway):
         )
 
 
+class PromptContractQualityGateway(Gateway):
+    stream_enabled = False
+
+    def __init__(self, candidate: str) -> None:
+        self.candidate = candidate
+        self.call_kinds: list[str] = []
+        self.contract_layers: list[str] = []
+
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None = None,
+    ) -> GatewayResponse:
+        system = str(messages[0].get("content", ""))
+        if "P02_REPLY_REVIEW_JSON" in system:
+            request = json.loads(str(messages[-1].get("content", "")))
+            layer = str(request["layer"])
+            self.call_kinds.append("review")
+            if layer in {
+                "identity_boundary",
+                "voice_style",
+                "continuity_memory",
+            }:
+                marker = "Return ONLY compact JSON with exactly: "
+                text = system.split(marker, 1)[1].split(".", 1)[0]
+                self.contract_layers.append(layer)
+            else:
+                text = _layer_payload(layer)
+        elif (
+            "P02_REPLY_EVIDENCE_ADJUDICATION_JSON" in system
+            or "P02_REPLY_REWRITE_TEXT" in system
+        ):
+            raise AssertionError("a clean exact response contract must pass directly")
+        else:
+            self.call_kinds.append("generation")
+            text = self.candidate
+        return GatewayResponse(
+            text=text,
+            request_id=request_id or "synthetic",
+            provider="synthetic",
+            model="synthetic",
+        )
+
+
 class CompatibilityBridge(Gateway):
     stream_enabled = False
 
@@ -390,6 +435,33 @@ def test_configured_provider_runs_structured_persona_review(
         and request["mode"] == "text_letter"
         for request in gateway.review_requests
     )
+
+
+def test_provider_exact_clean_response_contract_is_accepted_by_the_same_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = PromptContractQualityGateway("Synthetic clean candidate.")
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(
+                content="Synthetic current input.",
+                request_id="exact-clean-contract",
+            ),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.quality_status == "accepted"
+    assert result.reviewer_calls == 1
+    assert result.rewrite_calls == 0
+    assert gateway.call_kinds == ["generation", *("review",) * 5]
+    assert gateway.contract_layers == [
+        "identity_boundary",
+        "voice_style",
+        "continuity_memory",
+    ]
 
 
 def test_identity_review_receives_only_bounded_relationship_evidence() -> None:

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -52,7 +52,7 @@ def _layer_payload(layer: str) -> str:
     if layer == "identity_boundary":
         payload["intimacy_request"] = "none"
         payload["intimacy_claims"] = []
-    if layer in {"identity_boundary", "continuity_memory"}:
+    if layer in {"identity_boundary", "voice_style", "continuity_memory"}:
         payload["hard_evidence"] = []
         payload["independent_soft_issue"] = False
     return json.dumps(payload)
@@ -77,7 +77,7 @@ def _layer_score_payload(
     if layer == "identity_boundary":
         payload["intimacy_request"] = intimacy_request
         payload["intimacy_claims"] = intimacy_claims or []
-    if layer in {"identity_boundary", "continuity_memory"}:
+    if layer in {"identity_boundary", "voice_style", "continuity_memory"}:
         payload["hard_evidence"] = hard_evidence or []
         payload["independent_soft_issue"] = False
     return json.dumps(payload)
@@ -517,6 +517,19 @@ def test_text_letter_rubrics_separate_support_from_memory_and_forced_questions()
     assert "does not assert a past or current event" in prompts["continuity_memory"]
     assert "closing question" in prompts["voice_style"]
     assert "necessary information or choice" in prompts["voice_style"]
+    assert '"hard_evidence":[]' in prompts["voice_style"]
+    assert all(
+        claim_kind in prompts["voice_style"]
+        for claim_kind in (
+            "forced_question",
+            "generic_assistant_tone",
+            "fixed_structure",
+            "forced_uplift",
+            "voice_mismatch",
+            "length_or_mode",
+        )
+    )
+    assert "matching_code" in prompts["voice_style"]
 
 
 def test_continuity_rubric_has_typed_current_fact_decision_cases() -> None:
@@ -571,6 +584,263 @@ def test_useful_text_letter_question_has_no_automatic_style_violation(
     assert result.quality_status == "accepted"
     assert result.violation_codes == ()
     assert result.rewrite_calls == 0
+
+
+def test_text_letter_hard_style_without_candidate_evidence_fails_closed() -> None:
+    reviews = _passing_layer_payloads()
+    voice = json.loads(reviews[1])
+    voice.update(
+        score=0,
+        hard_violations=["STYLE_DRIFT"],
+        drift_detected=True,
+    )
+    reviews[1] = json.dumps(voice)
+    gateway = SequencedQualityGateway(candidate="unused", reviews=reviews)
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review("Synthetic forced continuation?", _context())
+
+    assert result.verdict is ReviewVerdict.UNAVAILABLE
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert gateway.adjudication_requests == []
+
+
+def test_hard_evidence_accepts_matching_code_as_the_only_code_alias() -> None:
+    candidate = "Synthetic unsupported memory claim."
+    evidence = _hard_evidence_payload(candidate, "MEMORY_FABRICATION")
+    evidence["matching_code"] = evidence.pop("code")
+    reviews = _passing_layer_payloads()
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    normalized = {**evidence, "code": evidence["matching_code"]}
+    normalized.pop("matching_code")
+    gateway = SequencedQualityGateway(
+        candidate="unused",
+        reviews=reviews,
+        adjudications=[_adjudication_payload(normalized, "CONFIRM")],
+    )
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.REWRITE
+    assert gateway.adjudication_requests[0]["claims"][0]["code"] == (
+        "MEMORY_FABRICATION"
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    ("both", "neither", "wrong_type", "mismatch", "extra"),
+)
+def test_hard_evidence_code_alias_remains_fail_closed(case: str) -> None:
+    candidate = "Synthetic unsupported memory claim."
+    evidence = _hard_evidence_payload(candidate, "MEMORY_FABRICATION")
+    if case == "both":
+        evidence["matching_code"] = "MEMORY_FABRICATION"
+    elif case == "neither":
+        evidence.pop("code")
+    elif case == "wrong_type":
+        evidence["code"] = 1
+    elif case == "mismatch":
+        evidence["code"] = "BOUNDARY_BREACH"
+    else:
+        evidence["extra"] = "forbidden"
+    reviews = _passing_layer_payloads()
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    gateway = SequencedQualityGateway(candidate="unused", reviews=reviews)
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.UNAVAILABLE
+    assert gateway.adjudication_requests == []
+
+
+def test_voice_style_evidence_rejects_non_style_claim_kind() -> None:
+    candidate = "Synthetic forced continuation?"
+    evidence = _hard_evidence_payload(
+        candidate,
+        "STYLE_DRIFT",
+        claim_kind="past_fact",
+    )
+    reviews = _passing_layer_payloads()
+    reviews[1] = _layer_score_payload(
+        "voice_style",
+        0,
+        hard_violations=["STYLE_DRIFT"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    gateway = SequencedQualityGateway(candidate="unused", reviews=reviews)
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.UNAVAILABLE
+    assert gateway.adjudication_requests == []
+
+
+def test_adjudicator_rejects_false_style_drift_as_direct_soft_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = "Synthetic useful choice question?"
+    evidence = _hard_evidence_payload(
+        candidate,
+        "STYLE_DRIFT",
+        claim_kind="forced_question",
+    )
+    reviews = _passing_layer_payloads()
+    reviews[1] = _layer_score_payload(
+        "voice_style",
+        0,
+        hard_violations=["STYLE_DRIFT"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate=candidate,
+        reviews=reviews,
+        adjudications=[_adjudication_payload(evidence, "REJECT")],
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(content="Synthetic current input.", request_id="false-style"),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.quality_status == "accepted_with_warnings"
+    assert result.violation_codes == ("STYLE_DRIFT",)
+    assert result.rewrite_calls == 0
+    assert gateway.call_kinds == ["generation", *('review',) * 5, "adjudication"]
+
+
+def test_confirmed_forced_question_rewrites_then_persistent_style_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = "Synthetic forced continuation?"
+    rewritten = "Synthetic rewritten forced continuation?"
+    old_evidence = _hard_evidence_payload(
+        candidate,
+        "STYLE_DRIFT",
+        evidence_id="evidence.style.old",
+        claim_kind="forced_question",
+    )
+    new_evidence = _hard_evidence_payload(
+        rewritten,
+        "STYLE_DRIFT",
+        evidence_id="evidence.style.new",
+        claim_kind="forced_question",
+    )
+    first = _passing_layer_payloads()
+    first[1] = _layer_score_payload(
+        "voice_style",
+        0,
+        hard_violations=["STYLE_DRIFT"],
+        drift_detected=True,
+        hard_evidence=[old_evidence],
+    )
+    second = _passing_layer_payloads()
+    second[1] = _layer_score_payload(
+        "voice_style",
+        0,
+        hard_violations=["STYLE_DRIFT"],
+        drift_detected=True,
+        hard_evidence=[new_evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate=candidate,
+        reviews=[*first, *second],
+        rewritten=rewritten,
+        adjudications=[
+            _adjudication_payload(old_evidence, "CONFIRM"),
+            _adjudication_payload(new_evidence, "CONFIRM"),
+        ],
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(content="Synthetic current input.", request_id="style-hard"),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.FAILED
+    assert result.quality_status == "blocked"
+    assert result.violation_codes == ("STYLE_DRIFT",)
+    assert candidate not in repr(result)
+    assert result.reviewer_calls == 2
+    assert result.rewrite_calls == 1
+    assert [request["candidate_reply"] for request in gateway.adjudication_requests] == [
+        candidate,
+        rewritten,
+    ]
+
+
+def test_rejected_style_claim_preserves_same_layer_independent_soft_issue() -> None:
+    candidate = "Synthetic forced question plus separate generic tone."
+    evidence = _hard_evidence_payload(
+        candidate,
+        "STYLE_DRIFT",
+        start=0,
+        end=9,
+        claim_kind="forced_question",
+    )
+    voice = json.loads(
+        _layer_score_payload(
+            "voice_style",
+            0,
+            hard_violations=["STYLE_DRIFT"],
+            drift_detected=True,
+            hard_evidence=[evidence],
+        )
+    )
+    voice["independent_soft_issue"] = True
+    reviews = _passing_layer_payloads()
+    reviews[1] = json.dumps(voice)
+    gateway = SequencedQualityGateway(
+        candidate="unused",
+        reviews=reviews,
+        adjudications=[_adjudication_payload(evidence, "REJECT")],
+    )
+
+    result = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    ).review(candidate, _context())
+
+    assert result.verdict is ReviewVerdict.REWRITE
+    assert [(item.code, item.severity, item.start, item.end) for item in result.violations] == [
+        ("STYLE_DRIFT", "soft", 0, 9),
+        ("STYLE_DRIFT", "soft", 0, len(candidate)),
+    ]
 
 
 def test_reassembled_current_user_reference_is_capped_at_600_characters() -> None:
@@ -920,6 +1190,7 @@ def test_adjudicator_rejects_false_memory_fabrication_as_soft_warning() -> None:
     (
         (0, "identity_boundary", "IDENTITY_DRIFT", "relationship", "character_history", "identity_world"),
         (0, "identity_boundary", "STAGE_DRIFT", "current_fact", "current_user", "relationship"),
+        (1, "voice_style", "STYLE_DRIFT", "forced_question", "memory", "voice_style"),
         (3, "continuity_memory", "MEMORY_FABRICATION", "relationship", "character_history", "continuity_fact"),
     ),
 )
@@ -983,18 +1254,21 @@ def test_adjudication_disclosure_ignores_untrusted_claim_routing_metadata(
     expected_keys = {
         "identity_world": {"release_authority", "world_facts"},
         "relationship": {"release_authority", "character_reply_history", "relationship_context"},
+        "voice_style": {"release_authority", "current_user_input"},
         "continuity_fact": {"current_user_input", "memory_evidence"},
     }
     assert set(context) == expected_keys[context_id]
     forbidden = {
         "identity_world": ("Sensitive current user", "Sensitive untyped", "Typed Linli"),
         "relationship": ("Sensitive current user", "Sensitive untyped"),
+        "voice_style": ("Sensitive untyped", "Typed Linli"),
         "continuity_fact": ("Typed Linli",),
     }
     assert all(text not in repr(context) for text in forbidden[context_id])
     required = {
         "identity_world": ("release_authority",),
         "relationship": ("Typed Linli", "unknown"),
+        "voice_style": ("release_authority", "Sensitive current user"),
         "continuity_fact": ("Sensitive current user", "Sensitive untyped"),
     }
     assert all(text in repr(context) for text in required[context_id])
@@ -1219,7 +1493,18 @@ def test_seventeen_cross_layer_claims_fail_before_adjudication() -> None:
             claim_kind="identity_claim",
             support_source="world_fact",
         )
-        for index in range(8)
+        for index in range(6)
+    ]
+    style_evidence = [
+        _hard_evidence_payload(
+            candidate,
+            "STYLE_DRIFT",
+            evidence_id=f"evidence.style.{index}",
+            start=index,
+            end=index + 1,
+            claim_kind="voice_mismatch",
+        )
+        for index in range(6, 11)
     ]
     continuity_evidence = [
         _hard_evidence_payload(
@@ -1231,7 +1516,7 @@ def test_seventeen_cross_layer_claims_fail_before_adjudication() -> None:
             claim_kind="past_fact",
             support_source="memory",
         )
-        for index in range(8, 17)
+        for index in range(11, 17)
     ]
     reviews = _passing_layer_payloads()
     reviews[0] = _layer_score_payload(
@@ -1240,6 +1525,13 @@ def test_seventeen_cross_layer_claims_fail_before_adjudication() -> None:
         hard_violations=["IDENTITY_DRIFT"] * len(identity_evidence),
         drift_detected=True,
         hard_evidence=identity_evidence,
+    )
+    reviews[1] = _layer_score_payload(
+        "voice_style",
+        0,
+        hard_violations=["STYLE_DRIFT"] * len(style_evidence),
+        drift_detected=True,
+        hard_evidence=style_evidence,
     )
     reviews[3] = _layer_score_payload(
         "continuity_memory",
@@ -1274,7 +1566,18 @@ def test_sixteen_cross_context_claims_preserve_full_bounded_adjudication() -> No
             claim_kind="identity_claim" if index == 0 else "relationship",
             support_source="world_fact" if index == 0 else "character_history",
         )
-        for index in range(8)
+        for index in range(6)
+    ]
+    style_evidence = [
+        _hard_evidence_payload(
+            candidate,
+            "STYLE_DRIFT",
+            evidence_id=f"evidence.style.{index}",
+            start=index,
+            end=index + 1,
+            claim_kind="voice_mismatch",
+        )
+        for index in range(6, 11)
     ]
     continuity_evidence = [
         _hard_evidence_payload(
@@ -1286,9 +1589,9 @@ def test_sixteen_cross_context_claims_preserve_full_bounded_adjudication() -> No
             claim_kind="past_fact",
             support_source="memory",
         )
-        for index in range(8, 16)
+        for index in range(11, 16)
     ]
-    evidence_items = [*identity_evidence, *continuity_evidence]
+    evidence_items = [*identity_evidence, *style_evidence, *continuity_evidence]
     decisions = {
         "decisions": [
             {
@@ -1308,6 +1611,13 @@ def test_sixteen_cross_context_claims_preserve_full_bounded_adjudication() -> No
         hard_violations=[item["code"] for item in identity_evidence],
         drift_detected=True,
         hard_evidence=identity_evidence,
+    )
+    reviews[1] = _layer_score_payload(
+        "voice_style",
+        0,
+        hard_violations=["STYLE_DRIFT"] * len(style_evidence),
+        drift_detected=True,
+        hard_evidence=style_evidence,
     )
     reviews[3] = _layer_score_payload(
         "continuity_memory",
@@ -1337,6 +1647,7 @@ def test_sixteen_cross_context_claims_preserve_full_bounded_adjudication() -> No
     assert tuple(request["contexts"]) == (
         "identity_world",
         "relationship",
+        "voice_style",
         "continuity_fact",
     )
     assert len(request["claims"]) == 16
@@ -1822,7 +2133,9 @@ def test_localized_voice_mismatch_is_warning_without_rewrite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     reviews = _passing_layer_payloads()
-    reviews[1] = _layer_score_payload("voice_style", 1)
+    voice = json.loads(_layer_score_payload("voice_style", 1))
+    voice["independent_soft_issue"] = True
+    reviews[1] = json.dumps(voice)
     gateway = SequencedQualityGateway(
         candidate="先别急着替今天下结论。",
         reviews=reviews,
@@ -1845,12 +2158,27 @@ def test_localized_voice_mismatch_is_warning_without_rewrite(
 def test_hard_voice_style_blocks_after_the_single_rewrite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    candidate = "A polished but overly generic reply."
+    rewritten = "A direct, concrete, restrained reply."
+    first_evidence = _hard_evidence_payload(
+        candidate,
+        "STYLE_DRIFT",
+        evidence_id="evidence.style.generic.old",
+        claim_kind="generic_assistant_tone",
+    )
+    second_evidence = _hard_evidence_payload(
+        rewritten,
+        "STYLE_DRIFT",
+        evidence_id="evidence.style.generic.new",
+        claim_kind="generic_assistant_tone",
+    )
     first_pass = _passing_layer_payloads()
     first_pass[1] = _layer_score_payload(
         "voice_style",
         0,
         hard_violations=["STYLE_DRIFT"],
         drift_detected=True,
+        hard_evidence=[first_evidence],
     )
     second_pass = _passing_layer_payloads()
     second_pass[1] = _layer_score_payload(
@@ -1858,11 +2186,16 @@ def test_hard_voice_style_blocks_after_the_single_rewrite(
         0,
         hard_violations=["STYLE_DRIFT"],
         drift_detected=True,
+        hard_evidence=[second_evidence],
     )
     gateway = SequencedQualityGateway(
-        candidate="A polished but overly generic reply.",
+        candidate=candidate,
         reviews=[*first_pass, *second_pass],
-        rewritten="A direct, concrete, restrained reply.",
+        rewritten=rewritten,
+        adjudications=[
+            _adjudication_payload(first_evidence, "CONFIRM"),
+            _adjudication_payload(second_evidence, "CONFIRM"),
+        ],
     )
 
     result = asyncio.run(
@@ -1915,17 +2248,25 @@ def test_text_letter_forced_question_is_rewritten_then_freshly_reviewed(
 ) -> None:
     candidate = "你好呀，今天也要照顾好自己。最近怎么样？"
     rewritten = "你好。今天倒是安静得有点过分。"
+    evidence = _hard_evidence_payload(
+        candidate,
+        "STYLE_DRIFT",
+        evidence_id="evidence.style.forced.old",
+        claim_kind="forced_question",
+    )
     first_pass = _passing_layer_payloads()
     first_pass[1] = _layer_score_payload(
         "voice_style",
         0,
         hard_violations=["STYLE_DRIFT"],
         drift_detected=True,
+        hard_evidence=[evidence],
     )
     gateway = SequencedQualityGateway(
         candidate=candidate,
         reviews=[*first_pass, *_passing_layer_payloads()],
         rewritten=rewritten,
+        adjudications=[_adjudication_payload(evidence, "CONFIRM")],
     )
 
     result = asyncio.run(
@@ -1955,12 +2296,27 @@ def test_text_letter_forced_question_is_rewritten_then_freshly_reviewed(
 def test_persistent_hard_forced_question_is_blocked_after_single_rewrite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    candidate = "你好呀，最近怎么样？"
+    rewritten = "我看见你的问候了。你今天过得好吗？"
+    first_evidence = _hard_evidence_payload(
+        candidate,
+        "STYLE_DRIFT",
+        evidence_id="evidence.style.forced.old",
+        claim_kind="forced_question",
+    )
+    second_evidence = _hard_evidence_payload(
+        rewritten,
+        "STYLE_DRIFT",
+        evidence_id="evidence.style.forced.new",
+        claim_kind="forced_question",
+    )
     first_pass = _passing_layer_payloads()
     first_pass[1] = _layer_score_payload(
         "voice_style",
         0,
         hard_violations=["STYLE_DRIFT"],
         drift_detected=True,
+        hard_evidence=[first_evidence],
     )
     second_pass = _passing_layer_payloads()
     second_pass[1] = _layer_score_payload(
@@ -1968,11 +2324,16 @@ def test_persistent_hard_forced_question_is_blocked_after_single_rewrite(
         0,
         hard_violations=["STYLE_DRIFT"],
         drift_detected=True,
+        hard_evidence=[second_evidence],
     )
     gateway = SequencedQualityGateway(
-        candidate="你好呀，最近怎么样？",
+        candidate=candidate,
         reviews=[*first_pass, *second_pass],
-        rewritten="我看见你的问候了。你今天过得好吗？",
+        rewritten=rewritten,
+        adjudications=[
+            _adjudication_payload(first_evidence, "CONFIRM"),
+            _adjudication_payload(second_evidence, "CONFIRM"),
+        ],
     )
 
     result = asyncio.run(

--- a/tests/persona/test_reply_pipeline.py
+++ b/tests/persona/test_reply_pipeline.py
@@ -339,7 +339,11 @@ class RecordingLayerReviewGateway(Gateway):
         if request["layer"] == "identity_boundary":
             response["intimacy_request"] = "none"
             response["intimacy_claims"] = []
-        if request["layer"] in {"identity_boundary", "continuity_memory"}:
+        if request["layer"] in {
+            "identity_boundary",
+            "voice_style",
+            "continuity_memory",
+        }:
             response["hard_evidence"] = []
             response["independent_soft_issue"] = False
         return GatewayResponse(


### PR DESCRIPTION
## Scope
- Require candidate-bound typed evidence for hard `STYLE_DRIFT` in the Letter `voice_style` layer.
- Route only bounded release/style authority plus the current-user excerpt to conditional adjudication; never disclose memory or Linli history for style review.
- Accept `matching_code` as the sole exact provider alias for `code`, normalize it internally, and fail closed for ambiguous or malformed objects.
- Preserve the global 16-claim budget across identity, voice style, and continuity; keep non-Letter behavior unchanged.
- Align every provider-facing clean JSON skeleton with the parser (`score:2`) and prove the exact emitted contract is accepted by the same public ReplyPipeline.

## TDD evidence
- Focused: 80 passed.
- Persona: 247 passed.
- Full: 1527 passed, 1 skipped, 1 deselected.
- Hardening, compileall, and diff-check: PASS.
- `runtime/reply/reply_quality_gate.py` is byte-identical to base.

## Frozen pair (round 2)
- Base: `89703b4941bb0b20288b83fb4af13be2f3f3748a`
- Head: `7004a4a0009b1e886cfd2d1cb089d99368400244`

## Size and split rationale
- 4 files, 566 changed lines (526 additions, 40 deletions): below the absolute 40-file / 2,000-line limit but 66 lines above the default 500-line target.
- The excess is synthetic public-pipeline regression coverage added to close the round-1 P0. The provider schema, parser, adjudication behavior, documentation, and exact-contract regression are one atomic compatibility boundary; splitting the tests from the parser/prompt change would make either PR unverifiable or temporarily inconsistent.

## Boundaries
- Synthetic tests only. No private corpus, key, Live, client, video, or media changes.