### PR TITLE
fix: classify reviewer unavailability safely

### DIFF
--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -174,6 +174,10 @@ schema-invalid output become sanitized `REVIEWER_UNAVAILABLE` or
 as `accepted_degraded`; a hard violation cannot bypass the single-rewrite gate.
 
 The configured gateway transport also keeps an ephemeral in-memory diagnostic tuple
-for the most recent review. It contains only bounded stage, reason, and optional layer
-enums; never candidate text, raw Provider output, exception text, or request identifiers.
-It changes neither public schemas nor external codes and is cleared at every review.
+for the most recently completed review. Every completion atomically replaces the tuple;
+a successful completion publishes an empty tuple. It contains only bounded stage,
+reason, and optional layer enums; never candidate text, raw Provider output, exception
+text, or request identifiers. Known Provider invocation failures are `transport`, known
+aggregation failures are `aggregation_contract`, and unexpected construction or
+programming failures are `internal`. It changes neither public schemas nor external
+codes and does not serialize concurrent Provider calls.

--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -172,3 +172,8 @@ Provider absence, timeout, transport errors, non-JSON output, and
 schema-invalid output become sanitized `REVIEWER_UNAVAILABLE` or
 `REVIEWER_RESPONSE_INVALID` results. A clean deterministic reply may then pass
 as `accepted_degraded`; a hard violation cannot bypass the single-rewrite gate.
+
+The configured gateway transport also keeps an ephemeral in-memory diagnostic tuple
+for the most recent review. It contains only bounded stage, reason, and optional layer
+enums; never candidate text, raw Provider output, exception text, or request identifiers.
+It changes neither public schemas nor external codes and is cleared at every review.

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, replace
+from enum import StrEnum
 import json
 import os
 import re
@@ -253,6 +254,54 @@ _CONTINUITY_DECISION_CASES = (
 )
 
 
+class ReviewFailureStage(StrEnum):
+    LAYER = "layer"
+    ADJUDICATION = "adjudication"
+    AGGREGATION = "aggregation"
+
+
+class ReviewFailureReason(StrEnum):
+    TRANSPORT = "transport"
+    EMPTY_TEXT = "empty_text"
+    JSON = "json"
+    TOP_LEVEL_SCHEMA = "top_level_schema"
+    LAYER_CONTRACT = "layer_contract"
+    EVIDENCE_CONTRACT = "evidence_contract"
+    ADJUDICATION_CONTRACT = "adjudication_contract"
+    AGGREGATION_CONTRACT = "aggregation_contract"
+
+
+@dataclass(frozen=True)
+class ReviewFailureDiagnostic:
+    stage: ReviewFailureStage
+    reason: ReviewFailureReason
+    layer: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.layer is not None and self.layer not in _LAYER_SPECS:
+            raise ValueError("diagnostic layer is not bounded")
+
+
+class _ReviewContractFailure(RuntimeError):
+    def __init__(self, reason: ReviewFailureReason) -> None:
+        super().__init__(reason.value)
+        self.reason = reason
+
+
+class _ReviewDiagnosticsError(RuntimeError):
+    def __init__(self, diagnostics: tuple[ReviewFailureDiagnostic, ...]) -> None:
+        super().__init__("quality model unavailable")
+        self.diagnostics = diagnostics
+
+
+def _diagnostic_error(
+    stage: ReviewFailureStage,
+    reason: ReviewFailureReason,
+    layer: str | None = None,
+) -> _ReviewDiagnosticsError:
+    return _ReviewDiagnosticsError((ReviewFailureDiagnostic(stage, reason, layer),))
+
+
 @dataclass(frozen=True)
 class _LayerAuthority:
     name: str
@@ -311,12 +360,37 @@ class GatewayReviewTransport:
     ) -> None:
         self.gateway = gateway
         self.persona_path = persona_path
+        self._last_failure_diagnostics: tuple[ReviewFailureDiagnostic, ...] = ()
+
+    @property
+    def last_failure_diagnostics(self) -> tuple[ReviewFailureDiagnostic, ...]:
+        return self._last_failure_diagnostics
 
     def review_json(
         self,
         request: dict[str, object],
         *,
         model: str,
+        timeout_seconds: float,
+    ) -> object:
+        self._last_failure_diagnostics = ()
+        try:
+            return self._review_json(request, timeout_seconds=timeout_seconds)
+        except _ReviewDiagnosticsError as exc:
+            self._last_failure_diagnostics = exc.diagnostics
+            raise RuntimeError("quality model unavailable") from None
+        except Exception:
+            failure = _diagnostic_error(
+                ReviewFailureStage.AGGREGATION,
+                ReviewFailureReason.AGGREGATION_CONTRACT,
+            )
+            self._last_failure_diagnostics = failure.diagnostics
+            raise RuntimeError("quality model unavailable") from None
+
+    def _review_json(
+        self,
+        request: dict[str, object],
+        *,
         timeout_seconds: float,
     ) -> object:
         mode = str(request.get("mode", ""))
@@ -372,21 +446,31 @@ class GatewayReviewTransport:
             timeout_seconds=timeout_seconds,
         )
         if evidence_bound:
-            results = _adjudicate_hard_evidence(
-                self.gateway,
-                results,
-                authorities=authorities,
-                candidate=str(request.get("candidate", "")),
-                current_user_input=current_user_input,
-                character_reply_history=character_reply_history,
-                memory_evidence=memory_evidence,
-                relationship_context=(
-                    request.get("relationship_context", {})
-                    if isinstance(request.get("relationship_context"), Mapping)
-                    else {}
-                ),
-                timeout_seconds=timeout_seconds,
-            )
+            try:
+                results = _adjudicate_hard_evidence(
+                    self.gateway,
+                    results,
+                    authorities=authorities,
+                    candidate=str(request.get("candidate", "")),
+                    current_user_input=current_user_input,
+                    character_reply_history=character_reply_history,
+                    memory_evidence=memory_evidence,
+                    relationship_context=(
+                        request.get("relationship_context", {})
+                        if isinstance(request.get("relationship_context"), Mapping)
+                        else {}
+                    ),
+                    timeout_seconds=timeout_seconds,
+                )
+            except _ReviewContractFailure as exc:
+                raise _diagnostic_error(
+                    ReviewFailureStage.ADJUDICATION, exc.reason
+                ) from None
+            except Exception:
+                raise _diagnostic_error(
+                    ReviewFailureStage.ADJUDICATION,
+                    ReviewFailureReason.ADJUDICATION_CONTRACT,
+                ) from None
         return _aggregate_layer_results(
             results,
             candidate=str(request.get("candidate", "")),
@@ -401,17 +485,19 @@ class GatewayPersonaReviewer:
         persona_path: Path,
         timeout_seconds: float,
     ) -> None:
+        self._transport = GatewayReviewTransport(gateway, persona_path)
         self.adapter = JsonReviewerAdapter(
-            GatewayReviewTransport(
-                gateway,
-                persona_path,
-            ),
+            self._transport,
             ReviewerConfig(
                 model=_REVIEW_MODEL,
                 timeout_seconds=timeout_seconds,
                 enabled=True,
             ),
         )
+
+    @property
+    def last_failure_diagnostics(self) -> tuple[ReviewFailureDiagnostic, ...]:
+        return self._transport.last_failure_diagnostics
 
     def review(
         self,
@@ -880,7 +966,7 @@ def _parse_layer_result(
     try:
         raw = json.loads(text.strip())
     except (AttributeError, json.JSONDecodeError) as exc:
-        raise RuntimeError("LAYER_REVIEW_INVALID") from exc
+        raise _ReviewContractFailure(ReviewFailureReason.JSON) from exc
     expected = {"layer", "score", "hard_violations", "drift_detected"}
     if layer.name == "identity_boundary":
         expected.update({"intimacy_request", "intimacy_claims"})
@@ -897,7 +983,10 @@ def _parse_layer_result(
         not isinstance(raw, Mapping)
         or set(raw) != expected
         or raw.get("layer") != layer.name
-        or isinstance(score, bool)
+    ):
+        raise _ReviewContractFailure(ReviewFailureReason.TOP_LEVEL_SCHEMA)
+    if (
+        isinstance(score, bool)
         or not isinstance(score, int)
         or score not in {0, 1, 2}
         or not isinstance(violations, list)
@@ -925,7 +1014,7 @@ def _parse_layer_result(
         )
         or type(drift) is not bool
     ):
-        raise RuntimeError("LAYER_REVIEW_INVALID")
+        raise _ReviewContractFailure(ReviewFailureReason.LAYER_CONTRACT)
     hard_evidence: tuple[_HardReviewEvidence, ...] = ()
     if evidence_bound and layer.name in _EVIDENCE_BOUND_LAYERS:
         hard_evidence = _parse_hard_evidence(
@@ -972,13 +1061,13 @@ def _parse_layer_result(
             for item in raw_claims
         )
     except (KeyError, TypeError, ValueError) as exc:
-        raise RuntimeError("LAYER_REVIEW_INVALID") from exc
+        raise _ReviewContractFailure(ReviewFailureReason.LAYER_CONTRACT) from exc
     if (
         len({claim.claim_id for claim in intimacy_claims})
         != len(intimacy_claims)
         or any(claim.end > len(candidate) for claim in intimacy_claims)
     ):
-        raise RuntimeError("LAYER_REVIEW_INVALID")
+        raise _ReviewContractFailure(ReviewFailureReason.LAYER_CONTRACT)
     return _LayerResult(
         layer.name,
         score,
@@ -1011,7 +1100,7 @@ def _parse_hard_evidence(
         or len(raw_evidence) > 16
         or len(raw_evidence) != len(violations)
     ):
-        raise RuntimeError("LAYER_REVIEW_INVALID")
+        raise _ReviewContractFailure(ReviewFailureReason.EVIDENCE_CONTRACT)
     parsed: list[_HardReviewEvidence] = []
     for raw in raw_evidence:
         if (
@@ -1019,7 +1108,7 @@ def _parse_hard_evidence(
             or set(raw) - {"code", "matching_code"} != expected_fields
             or ("code" in raw) == ("matching_code" in raw)
         ):
-            raise RuntimeError("LAYER_REVIEW_INVALID")
+            raise _ReviewContractFailure(ReviewFailureReason.EVIDENCE_CONTRACT)
         evidence_id = raw.get("evidence_id")
         code = raw.get("code", raw.get("matching_code"))
         start = raw.get("start")
@@ -1043,7 +1132,7 @@ def _parse_hard_evidence(
             or not isinstance(reason_code, str)
             or _HARD_EVIDENCE_REASON_PATTERN.fullmatch(reason_code) is None
         ):
-            raise RuntimeError("LAYER_REVIEW_INVALID")
+            raise _ReviewContractFailure(ReviewFailureReason.EVIDENCE_CONTRACT)
         parsed.append(
             _HardReviewEvidence(
                 evidence_id,
@@ -1059,7 +1148,7 @@ def _parse_hard_evidence(
         len({item.evidence_id for item in parsed}) != len(parsed)
         or tuple(item.code for item in parsed) != violations
     ):
-        raise RuntimeError("LAYER_REVIEW_INVALID")
+        raise _ReviewContractFailure(ReviewFailureReason.EVIDENCE_CONTRACT)
     return tuple(parsed)
 
 
@@ -1107,24 +1196,59 @@ def _complete_layer_reviews(
             layer: _LayerAuthority,
             messages: tuple[dict[str, str], dict[str, str]],
         ) -> _LayerResult:
-            text = await _complete_layer_text(
-                gateway,
-                messages,
-                timeout_seconds,
-                f"quality-{uuid.uuid4().hex}:{layer.name}",
-            )
-            return _parse_layer_result(
-                layer,
-                text,
-                candidate=candidate,
-                evidence_bound=evidence_bound,
-            )
+            try:
+                text = await _complete_layer_text(
+                    gateway,
+                    messages,
+                    timeout_seconds,
+                    f"quality-{uuid.uuid4().hex}:{layer.name}",
+                )
+            except Exception:
+                raise _diagnostic_error(
+                    ReviewFailureStage.LAYER,
+                    ReviewFailureReason.TRANSPORT,
+                    layer.name,
+                ) from None
+            if not isinstance(text, str) or not text.strip():
+                raise _diagnostic_error(
+                    ReviewFailureStage.LAYER,
+                    ReviewFailureReason.EMPTY_TEXT,
+                    layer.name,
+                )
+            try:
+                return _parse_layer_result(
+                    layer,
+                    text,
+                    candidate=candidate,
+                    evidence_bound=evidence_bound,
+                )
+            except _ReviewContractFailure as exc:
+                raise _diagnostic_error(
+                    ReviewFailureStage.LAYER, exc.reason, layer.name
+                ) from None
 
-        return tuple(
-            await asyncio.gather(
-                *(run_one(layer, messages) for layer, messages in requests)
-            )
+        outcomes = await asyncio.gather(
+            *(run_one(layer, messages) for layer, messages in requests),
+            return_exceptions=True,
         )
+        diagnostics: list[ReviewFailureDiagnostic] = []
+        completed: list[_LayerResult] = []
+        for (layer, _), outcome in zip(requests, outcomes, strict=True):
+            if isinstance(outcome, _ReviewDiagnosticsError):
+                diagnostics.extend(outcome.diagnostics)
+            elif isinstance(outcome, BaseException):
+                diagnostics.append(
+                    ReviewFailureDiagnostic(
+                        ReviewFailureStage.LAYER,
+                        ReviewFailureReason.TRANSPORT,
+                        layer.name,
+                    )
+                )
+            else:
+                completed.append(outcome)
+        if diagnostics:
+            raise _ReviewDiagnosticsError(tuple(diagnostics))
+        return tuple(completed)
 
     try:
         requests = tuple(
@@ -1144,6 +1268,8 @@ def _complete_layer_reviews(
             for layer in authorities
         )
         return asyncio.run(invoke(requests))
+    except _ReviewDiagnosticsError:
+        raise
     except Exception:
         raise RuntimeError("quality model unavailable") from None
 
@@ -1274,7 +1400,12 @@ def _adjudicate_hard_evidence(
     )
     if sum(len(item["content"]) for item in messages) > _REVIEW_INPUT_CHARACTER_LIMIT:
         raise RuntimeError("ADJUDICATION_INPUT_TOO_LARGE")
-    text = _complete_text(gateway, messages, timeout_seconds)
+    text = _complete_text(
+        gateway,
+        messages,
+        timeout_seconds,
+        diagnostic=True,
+    )
     decisions = _parse_adjudication_result(text, claims=claims)
     by_id = {item.evidence_id: item for item in decisions}
     revised: list[_LayerResult] = []
@@ -1369,13 +1500,13 @@ def _parse_adjudication_result(
     try:
         raw = json.loads(text.strip())
     except (AttributeError, json.JSONDecodeError) as exc:
-        raise RuntimeError("ADJUDICATION_INVALID") from exc
+        raise _ReviewContractFailure(ReviewFailureReason.JSON) from exc
     raw_decisions = raw.get("decisions") if isinstance(raw, Mapping) else None
     if set(raw) != {"decisions"} or not isinstance(raw_decisions, list):
-        raise RuntimeError("ADJUDICATION_INVALID")
+        raise _ReviewContractFailure(ReviewFailureReason.ADJUDICATION_CONTRACT)
     expected = tuple(evidence for _, evidence in claims)
     if len(raw_decisions) != len(expected):
-        raise RuntimeError("ADJUDICATION_INVALID")
+        raise _ReviewContractFailure(ReviewFailureReason.ADJUDICATION_CONTRACT)
     parsed: list[_AdjudicationDecision] = []
     fields = {"evidence_id", "code", "start", "end", "decision"}
     for raw_item, evidence in zip(raw_decisions, expected, strict=True):
@@ -1390,7 +1521,9 @@ def _parse_adjudication_result(
             or raw_item.get("end") != evidence.end
             or raw_item.get("decision") not in {"CONFIRM", "REJECT"}
         ):
-            raise RuntimeError("ADJUDICATION_INVALID")
+            raise _ReviewContractFailure(
+                ReviewFailureReason.ADJUDICATION_CONTRACT
+            )
         parsed.append(
             _AdjudicationDecision(
                 evidence.evidence_id,
@@ -1717,6 +1850,8 @@ def _complete_text(
         Mapping[str, Any]
     ],
     timeout_seconds: float,
+    *,
+    diagnostic: bool = False,
 ) -> str:
     async def invoke() -> str:
         request_id = f"quality-{uuid.uuid4().hex}"
@@ -1747,6 +1882,8 @@ def _complete_text(
     try:
         text = asyncio.run(invoke())
     except Exception:
+        if diagnostic:
+            raise _ReviewContractFailure(ReviewFailureReason.TRANSPORT) from None
         raise RuntimeError(
             "quality model unavailable"
         ) from None
@@ -1754,6 +1891,8 @@ def _complete_text(
         not isinstance(text, str)
         or not text.strip()
     ):
+        if diagnostic:
+            raise _ReviewContractFailure(ReviewFailureReason.EMPTY_TEXT)
         raise RuntimeError(
             "quality model returned empty text"
         )

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 import json
 import os
 import re
+from threading import Lock
 import uuid
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -261,6 +262,7 @@ class ReviewFailureStage(StrEnum):
 
 
 class ReviewFailureReason(StrEnum):
+    INTERNAL = "internal"
     TRANSPORT = "transport"
     EMPTY_TEXT = "empty_text"
     JSON = "json"
@@ -278,6 +280,10 @@ class ReviewFailureDiagnostic:
     layer: str | None = None
 
     def __post_init__(self) -> None:
+        if type(self.stage) is not ReviewFailureStage:
+            raise TypeError("diagnostic stage must be ReviewFailureStage")
+        if type(self.reason) is not ReviewFailureReason:
+            raise TypeError("diagnostic reason must be ReviewFailureReason")
         if self.layer is not None and self.layer not in _LAYER_SPECS:
             raise ValueError("diagnostic layer is not bounded")
 
@@ -292,6 +298,10 @@ class _ReviewDiagnosticsError(RuntimeError):
     def __init__(self, diagnostics: tuple[ReviewFailureDiagnostic, ...]) -> None:
         super().__init__("quality model unavailable")
         self.diagnostics = diagnostics
+
+
+class _GatewayInvocationFailure(RuntimeError):
+    pass
 
 
 def _diagnostic_error(
@@ -361,10 +371,19 @@ class GatewayReviewTransport:
         self.gateway = gateway
         self.persona_path = persona_path
         self._last_failure_diagnostics: tuple[ReviewFailureDiagnostic, ...] = ()
+        self._diagnostics_lock = Lock()
 
     @property
     def last_failure_diagnostics(self) -> tuple[ReviewFailureDiagnostic, ...]:
-        return self._last_failure_diagnostics
+        with self._diagnostics_lock:
+            return self._last_failure_diagnostics
+
+    def _publish_failure_diagnostics(
+        self,
+        diagnostics: tuple[ReviewFailureDiagnostic, ...],
+    ) -> None:
+        with self._diagnostics_lock:
+            self._last_failure_diagnostics = diagnostics
 
     def review_json(
         self,
@@ -373,19 +392,20 @@ class GatewayReviewTransport:
         model: str,
         timeout_seconds: float,
     ) -> object:
-        self._last_failure_diagnostics = ()
         try:
-            return self._review_json(request, timeout_seconds=timeout_seconds)
+            result = self._review_json(request, timeout_seconds=timeout_seconds)
         except _ReviewDiagnosticsError as exc:
-            self._last_failure_diagnostics = exc.diagnostics
+            self._publish_failure_diagnostics(exc.diagnostics)
             raise RuntimeError("quality model unavailable") from None
         except Exception:
             failure = _diagnostic_error(
                 ReviewFailureStage.AGGREGATION,
-                ReviewFailureReason.AGGREGATION_CONTRACT,
+                ReviewFailureReason.INTERNAL,
             )
-            self._last_failure_diagnostics = failure.diagnostics
+            self._publish_failure_diagnostics(failure.diagnostics)
             raise RuntimeError("quality model unavailable") from None
+        self._publish_failure_diagnostics(())
+        return result
 
     def _review_json(
         self,
@@ -469,13 +489,19 @@ class GatewayReviewTransport:
             except Exception:
                 raise _diagnostic_error(
                     ReviewFailureStage.ADJUDICATION,
-                    ReviewFailureReason.ADJUDICATION_CONTRACT,
+                    ReviewFailureReason.INTERNAL,
                 ) from None
-        return _aggregate_layer_results(
-            results,
-            candidate=str(request.get("candidate", "")),
-            evidence_bound=evidence_bound,
-        )
+        try:
+            return _aggregate_layer_results(
+                results,
+                candidate=str(request.get("candidate", "")),
+                evidence_bound=evidence_bound,
+            )
+        except Exception:
+            raise _diagnostic_error(
+                ReviewFailureStage.AGGREGATION,
+                ReviewFailureReason.AGGREGATION_CONTRACT,
+            ) from None
 
 
 class GatewayPersonaReviewer:
@@ -1166,11 +1192,17 @@ async def _complete_layer_text(
                     chunks.append(delta.text)
             return "".join(chunks)
 
-        return await asyncio.wait_for(collect(), timeout_seconds)
-    response = await asyncio.wait_for(
-        gateway.complete(messages, request_id=request_id),
-        timeout_seconds,
-    )
+        try:
+            return await asyncio.wait_for(collect(), timeout_seconds)
+        except Exception as exc:
+            raise _GatewayInvocationFailure from exc
+    try:
+        response = await asyncio.wait_for(
+            gateway.complete(messages, request_id=request_id),
+            timeout_seconds,
+        )
+    except Exception as exc:
+        raise _GatewayInvocationFailure from exc
     return response.text
 
 
@@ -1203,7 +1235,7 @@ def _complete_layer_reviews(
                     timeout_seconds,
                     f"quality-{uuid.uuid4().hex}:{layer.name}",
                 )
-            except Exception:
+            except _GatewayInvocationFailure:
                 raise _diagnostic_error(
                     ReviewFailureStage.LAYER,
                     ReviewFailureReason.TRANSPORT,
@@ -1236,14 +1268,16 @@ def _complete_layer_reviews(
         for (layer, _), outcome in zip(requests, outcomes, strict=True):
             if isinstance(outcome, _ReviewDiagnosticsError):
                 diagnostics.extend(outcome.diagnostics)
-            elif isinstance(outcome, BaseException):
+            elif isinstance(outcome, Exception):
                 diagnostics.append(
                     ReviewFailureDiagnostic(
                         ReviewFailureStage.LAYER,
-                        ReviewFailureReason.TRANSPORT,
+                        ReviewFailureReason.INTERNAL,
                         layer.name,
                     )
                 )
+            elif isinstance(outcome, BaseException):
+                raise outcome
             else:
                 completed.append(outcome)
         if diagnostics:
@@ -1251,10 +1285,12 @@ def _complete_layer_reviews(
         return tuple(completed)
 
     try:
-        requests = tuple(
-            (
-                layer,
-                _layer_messages(
+        requests: list[
+            tuple[_LayerAuthority, tuple[dict[str, str], dict[str, str]]]
+        ] = []
+        for layer in authorities:
+            try:
+                messages = _layer_messages(
                     layer,
                     candidate=candidate,
                     current_user_input=current_user_input,
@@ -1263,10 +1299,14 @@ def _complete_layer_reviews(
                     relationship_context=relationship_context,
                     mode=mode,
                     evidence_bound=evidence_bound,
-                ),
-            )
-            for layer in authorities
-        )
+                )
+            except Exception:
+                raise _diagnostic_error(
+                    ReviewFailureStage.LAYER,
+                    ReviewFailureReason.INTERNAL,
+                    layer.name,
+                ) from None
+            requests.append((layer, messages))
         return asyncio.run(invoke(requests))
     except _ReviewDiagnosticsError:
         raise
@@ -1853,40 +1893,25 @@ def _complete_text(
     *,
     diagnostic: bool = False,
 ) -> str:
-    async def invoke() -> str:
-        request_id = f"quality-{uuid.uuid4().hex}"
-        if bool(getattr(gateway, "stream_enabled", False)):
-            async def collect_stream() -> str:
-                chunks: list[str] = []
-                async for delta in gateway.stream(
-                    messages,
-                    request_id=request_id,
-                ):
-                    if delta.text:
-                        chunks.append(delta.text)
-                return "".join(chunks)
-
-            return await asyncio.wait_for(
-                collect_stream(),
-                timeout_seconds,
-            )
-        response = await asyncio.wait_for(
-            gateway.complete(
-                messages,
-                request_id=request_id,
-            ),
-            timeout_seconds,
-        )
-        return response.text
-
     try:
-        text = asyncio.run(invoke())
-    except Exception:
+        text = asyncio.run(
+            _complete_layer_text(
+                gateway,
+                messages,
+                timeout_seconds,
+                f"quality-{uuid.uuid4().hex}",
+            )
+        )
+    except _GatewayInvocationFailure:
         if diagnostic:
             raise _ReviewContractFailure(ReviewFailureReason.TRANSPORT) from None
         raise RuntimeError(
             "quality model unavailable"
         ) from None
+    except Exception:
+        if diagnostic:
+            raise _ReviewContractFailure(ReviewFailureReason.INTERNAL) from None
+        raise RuntimeError("quality model unavailable") from None
     if (
         not isinstance(text, str)
         or not text.strip()

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import asdict, fields
 from datetime import datetime, timezone
 import json
 from pathlib import Path
@@ -8,6 +9,8 @@ from types import SimpleNamespace
 from typing import Any, Mapping, Sequence
 
 import pytest
+
+import runtime.reply.reply_model_quality as quality_module
 
 from llm_gateway import Gateway, GatewayConfig, GatewayDelta, GatewayResponse
 from memory_port import CONVERSATION_MEMORY, MemoryRecord, NullMemoryPort
@@ -28,6 +31,9 @@ from reply_model_quality import (
     GatewayPersonaReviewer,
     GatewayPersonaRewriter,
     GatewayReviewTransport,
+    ReviewFailureDiagnostic,
+    ReviewFailureReason,
+    ReviewFailureStage,
     create_model_quality_ports,
 )
 from runtime.reply.reply_reviewer import (
@@ -40,6 +46,13 @@ from runtime.reply.reply_reviewer import (
 
 
 ROOT = Path(__file__).resolve().parents[2]
+_REVIEW_LAYERS = (
+    "identity_boundary",
+    "voice_style",
+    "focus_response",
+    "continuity_memory",
+    "autonomy_life",
+)
 
 
 def _layer_payload(layer: str) -> str:
@@ -84,16 +97,198 @@ def _layer_score_payload(
 
 
 def _passing_layer_payloads() -> list[str]:
-    return [
-        _layer_payload(layer)
-        for layer in (
-            "identity_boundary",
-            "voice_style",
-            "focus_response",
-            "continuity_memory",
-            "autonomy_life",
+    return [_layer_payload(layer) for layer in _REVIEW_LAYERS]
+
+
+def _run_diagnostic_review(
+    gateway: Gateway,
+    candidate: str = "Synthetic candidate.",
+    context: ReplyContext | None = None,
+) -> tuple[object, GatewayPersonaReviewer]:
+    reviewer = GatewayPersonaReviewer(
+        gateway, ROOT / "linli_character" / "persona_release_v2.json", 2.0
+    )
+    return reviewer.review(candidate, context or _intimacy_context()), reviewer
+
+
+@pytest.mark.parametrize(
+    ("case", "reason", "layer"),
+    (
+        ("transport", ReviewFailureReason.TRANSPORT, "continuity_memory"),
+        ("json", ReviewFailureReason.JSON, "identity_boundary"),
+        ("empty", ReviewFailureReason.EMPTY_TEXT, "voice_style"),
+        ("envelope", ReviewFailureReason.TOP_LEVEL_SCHEMA, "focus_response"),
+        ("layer_mismatch", ReviewFailureReason.TOP_LEVEL_SCHEMA, "continuity_memory"),
+        ("score", ReviewFailureReason.LAYER_CONTRACT, "autonomy_life"),
+        ("identity", ReviewFailureReason.LAYER_CONTRACT, "identity_boundary"),
+        ("evidence", ReviewFailureReason.EVIDENCE_CONTRACT, "identity_boundary"),
+    ),
+)
+def test_reviewer_classifies_layer_failure(
+    case: str,
+    reason: ReviewFailureReason,
+    layer: str,
+) -> None:
+    candidate = "Synthetic candidate."
+    reviews = _passing_layer_payloads()
+    index = _REVIEW_LAYERS.index(layer)
+    if case == "transport":
+        pass
+    elif case == "json":
+        reviews[index] = "{"
+    elif case == "empty":
+        reviews[index] = ""
+    elif case in {"envelope", "layer_mismatch", "score", "identity"}:
+        payload = json.loads(reviews[index])
+        if case == "envelope":
+            payload["unexpected"] = True
+        elif case == "layer_mismatch":
+            payload["layer"] = "autonomy_life"
+        elif case == "score":
+            payload["score"] = True
+        else:
+            payload["intimacy_request"] = "invented"
+        reviews[index] = json.dumps(payload)
+    else:
+        evidence = _hard_evidence_payload(
+            candidate, "IDENTITY_DRIFT", claim_kind="identity_claim"
         )
-    ]
+        evidence["start"] = True
+        reviews[index] = _layer_score_payload(
+            layer,
+            0,
+            hard_violations=["IDENTITY_DRIFT"],
+            drift_detected=True,
+            hard_evidence=[evidence],
+        )
+    gateway = (
+        FailingQualityGateway(failure="layer", failing_layer=layer)
+        if case == "transport"
+        else SequencedQualityGateway(candidate=candidate, reviews=reviews)
+    )
+    result, reviewer = _run_diagnostic_review(gateway, candidate)
+
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert reviewer.last_failure_diagnostics == (
+        ReviewFailureDiagnostic(ReviewFailureStage.LAYER, reason, layer),
+    )
+
+
+def test_reviewer_orders_multiple_layer_failures_by_authority() -> None:
+    reviews = _passing_layer_payloads()
+    reviews[0] = "{"
+    reviews[1] = ""
+    result, reviewer = _run_diagnostic_review(
+        SequencedQualityGateway(candidate="Synthetic candidate.", reviews=reviews)
+    )
+
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert reviewer.last_failure_diagnostics == (
+        ReviewFailureDiagnostic(ReviewFailureStage.LAYER, ReviewFailureReason.JSON, "identity_boundary"),
+        ReviewFailureDiagnostic(ReviewFailureStage.LAYER, ReviewFailureReason.EMPTY_TEXT, "voice_style"),
+    )
+
+
+def _reviews_requiring_adjudication(candidate: str) -> list[str]:
+    reviews = _passing_layer_payloads()
+    evidence = _hard_evidence_payload(candidate, "MEMORY_FABRICATION")
+    reviews[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    return reviews
+
+
+@pytest.mark.parametrize(
+    ("case", "response", "reason"),
+    (
+        ("transport", None, ReviewFailureReason.TRANSPORT),
+        ("empty", "", ReviewFailureReason.EMPTY_TEXT),
+        ("json", "{", ReviewFailureReason.JSON),
+        ("contract", json.dumps({"decisions": []}), ReviewFailureReason.ADJUDICATION_CONTRACT),
+    ),
+)
+def test_reviewer_classifies_adjudication_failure(
+    case: str,
+    response: str | None,
+    reason: ReviewFailureReason,
+) -> None:
+    candidate = "Synthetic unsupported past claim."
+    reviews = _reviews_requiring_adjudication(candidate)
+    gateway = (
+        FailingQualityGateway(failure="adjudication", candidate=candidate, reviews=reviews)
+        if case == "transport"
+        else SequencedQualityGateway(
+            candidate=candidate,
+            reviews=reviews,
+            adjudications=[str(response)],
+        )
+    )
+    result, reviewer = _run_diagnostic_review(gateway, candidate)
+
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert reviewer.last_failure_diagnostics == (
+        ReviewFailureDiagnostic(ReviewFailureStage.ADJUDICATION, reason),
+    )
+    assert "private adjudication detail" not in repr(
+        reviewer.last_failure_diagnostics
+    )
+
+
+def test_reviewer_classifies_aggregation_failure_without_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_aggregation(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("private aggregation detail")
+
+    monkeypatch.setattr(
+        quality_module,
+        "_aggregate_layer_results",
+        fail_aggregation,
+    )
+    result, reviewer = _run_diagnostic_review(
+        SequencedQualityGateway(
+            candidate="Synthetic candidate.",
+            reviews=_passing_layer_payloads(),
+        )
+    )
+
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    diagnostic = reviewer.last_failure_diagnostics[0]
+    assert diagnostic == ReviewFailureDiagnostic(
+        ReviewFailureStage.AGGREGATION, ReviewFailureReason.AGGREGATION_CONTRACT
+    )
+    assert {item.name for item in fields(diagnostic)} == {"stage", "reason", "layer"}
+    assert set(asdict(diagnostic)) == {"stage", "reason", "layer"}
+    assert "private aggregation detail" not in repr(
+        reviewer.last_failure_diagnostics
+    )
+
+
+def test_passing_review_clears_diagnostics_and_keeps_five_calls() -> None:
+    reviews = _passing_layer_payloads()
+    first = list(reviews)
+    first[0] = "{"
+    gateway = SequencedQualityGateway(
+        candidate="Synthetic candidate.",
+        reviews=[*first, *reviews],
+    )
+    reviewer = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        2.0,
+    )
+
+    failed = reviewer.review("Synthetic candidate.", _intimacy_context())
+    completed = reviewer.review("Synthetic candidate.", _intimacy_context())
+
+    assert failed.error_code == "REVIEWER_UNAVAILABLE"
+    assert completed.verdict is ReviewVerdict.PASS
+    assert reviewer.last_failure_diagnostics == ()
+    assert gateway.call_kinds == [*("review",) * 10]
 
 
 def _legacy_layer_payload(
@@ -272,6 +467,45 @@ class SequencedQualityGateway(Gateway):
             provider="synthetic",
             model="synthetic",
         )
+
+
+class FailingQualityGateway(SequencedQualityGateway):
+    def __init__(
+        self,
+        *,
+        failure: str,
+        candidate: str = "Synthetic candidate.",
+        failing_layer: str | None = None,
+        reviews: list[str] | None = None,
+    ) -> None:
+        super().__init__(candidate=candidate, reviews=[])
+        self.failure = failure
+        self.failing_layer = failing_layer
+        self.review_by_layer = dict(zip(_REVIEW_LAYERS, reviews or _passing_layer_payloads(), strict=True))
+
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None = None,
+    ) -> GatewayResponse:
+        system = str(messages[0].get("content", ""))
+        if (
+            self.failure == "adjudication"
+            and "P02_REPLY_EVIDENCE_ADJUDICATION_JSON" in system
+        ):
+            raise TimeoutError("private adjudication detail")
+        if "P02_REPLY_REVIEW_JSON" in system:
+            layer = str(json.loads(str(messages[-1]["content"]))["layer"])
+            if self.failure == "layer" and layer == self.failing_layer:
+                raise TimeoutError("private upstream detail")
+            return GatewayResponse(
+                text=self.review_by_layer[layer],
+                request_id=request_id or "synthetic",
+                provider="synthetic",
+                model="synthetic",
+            )
+        return await super().complete(messages, request_id=request_id)
 
 
 class PromptContractQualityGateway(Gateway):
@@ -1063,9 +1297,10 @@ def test_non_letter_hard_findings_keep_legacy_schema_without_adjudication(
         reviews=[*first, *_legacy_passing_layer_payloads()],
         rewritten="y" * 190,
     )
+    pipeline = _pipeline(gateway, monkeypatch)
 
     result = asyncio.run(
-        _pipeline(gateway, monkeypatch).run(
+        pipeline.run(
             ReplyRequest(content="Synthetic request.", request_id=f"legacy-{mode.value}"),
             _context(mode),
         )
@@ -1082,6 +1317,7 @@ def test_non_letter_hard_findings_keep_legacy_schema_without_adjudication(
         *("review",) * 5,
     ]
     assert gateway.adjudication_requests == []
+    assert pipeline.reviewer.last_failure_diagnostics == ()
     assert all(
         "hard_evidence" not in prompt
         for prompt in gateway.review_system_prompts

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, fields
 from datetime import datetime, timezone
 import json
 from pathlib import Path
+from threading import Event
 from types import SimpleNamespace
 from typing import Any, Mapping, Sequence
 
@@ -268,6 +270,145 @@ def test_reviewer_classifies_aggregation_failure_without_details(
     )
 
 
+def test_unexpected_layer_parser_error_is_internal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = quality_module._parse_layer_result
+
+    def fail_identity_parser(layer: object, *args: object, **kwargs: object) -> object:
+        if getattr(layer, "name", None) == "identity_boundary":
+            raise RuntimeError("private parser detail")
+        return original(layer, *args, **kwargs)
+
+    monkeypatch.setattr(quality_module, "_parse_layer_result", fail_identity_parser)
+    result, reviewer = _run_diagnostic_review(
+        SequencedQualityGateway(
+            candidate="Synthetic candidate.",
+            reviews=_passing_layer_payloads(),
+        )
+    )
+
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert reviewer.last_failure_diagnostics == (
+        ReviewFailureDiagnostic(
+            ReviewFailureStage.LAYER,
+            ReviewFailureReason.INTERNAL,
+            "identity_boundary",
+        ),
+    )
+    assert "private parser detail" not in repr(reviewer.last_failure_diagnostics)
+
+
+def test_layer_cancellation_is_not_converted_to_reviewer_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = quality_module._parse_layer_result
+
+    def cancel_identity_parser(
+        layer: object,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        if getattr(layer, "name", None) == "identity_boundary":
+            raise asyncio.CancelledError
+        return original(layer, *args, **kwargs)
+
+    monkeypatch.setattr(quality_module, "_parse_layer_result", cancel_identity_parser)
+    reviewer = GatewayPersonaReviewer(
+        SequencedQualityGateway(
+            candidate="Synthetic candidate.",
+            reviews=_passing_layer_payloads(),
+        ),
+        ROOT / "linli_character" / "persona_release_v2.json",
+        2.0,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        reviewer.review("Synthetic candidate.", _intimacy_context())
+    assert reviewer.last_failure_diagnostics == ()
+
+
+@pytest.mark.parametrize("control_flow", (KeyboardInterrupt, SystemExit))
+def test_transport_does_not_swallow_process_control_flow(
+    monkeypatch: pytest.MonkeyPatch,
+    control_flow: type[BaseException],
+) -> None:
+    transport = GatewayReviewTransport(
+        SequencedQualityGateway(candidate="unused", reviews=[]),
+        ROOT / "linli_character" / "persona_release_v2.json",
+    )
+
+    def stop_review(*args: object, **kwargs: object) -> object:
+        raise control_flow
+
+    monkeypatch.setattr(transport, "_review_json", stop_review)
+    with pytest.raises(control_flow):
+        transport.review_json({}, model="synthetic", timeout_seconds=2.0)
+    assert transport.last_failure_diagnostics == ()
+
+
+def test_layer_input_construction_error_is_internal_before_gateway_call() -> None:
+    gateway = SequencedQualityGateway(candidate="unused", reviews=[])
+    result, reviewer = _run_diagnostic_review(gateway, "x" * 30_000)
+
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert reviewer.last_failure_diagnostics == (
+        ReviewFailureDiagnostic(
+            ReviewFailureStage.LAYER,
+            ReviewFailureReason.INTERNAL,
+            "identity_boundary",
+        ),
+    )
+    assert gateway.call_kinds == []
+
+
+def test_unexpected_adjudication_parser_error_is_internal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = "Synthetic unsupported past claim."
+
+    def fail_parser(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("private adjudication parser detail")
+
+    monkeypatch.setattr(quality_module, "_parse_adjudication_result", fail_parser)
+    result, reviewer = _run_diagnostic_review(
+        SequencedQualityGateway(
+            candidate=candidate,
+            reviews=_reviews_requiring_adjudication(candidate),
+            adjudications=[json.dumps({"decisions": []})],
+        ),
+        candidate,
+    )
+
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert reviewer.last_failure_diagnostics == (
+        ReviewFailureDiagnostic(
+            ReviewFailureStage.ADJUDICATION,
+            ReviewFailureReason.INTERNAL,
+        ),
+    )
+    assert "private adjudication parser detail" not in repr(
+        reviewer.last_failure_diagnostics
+    )
+
+
+@pytest.mark.parametrize(
+    ("stage", "reason"),
+    (
+        (ReviewFailureStage.LAYER.value, ReviewFailureReason.JSON),
+        (ReviewFailureStage.LAYER, ReviewFailureReason.JSON.value),
+        (object(), ReviewFailureReason.JSON),
+        (ReviewFailureStage.LAYER, object()),
+    ),
+)
+def test_failure_diagnostic_rejects_non_enum_stage_and_reason(
+    stage: object,
+    reason: object,
+) -> None:
+    with pytest.raises(TypeError):
+        ReviewFailureDiagnostic(stage, reason)  # type: ignore[arg-type]
+
+
 def test_passing_review_clears_diagnostics_and_keeps_five_calls() -> None:
     reviews = _passing_layer_payloads()
     first = list(reviews)
@@ -289,6 +430,45 @@ def test_passing_review_clears_diagnostics_and_keeps_five_calls() -> None:
     assert completed.verdict is ReviewVerdict.PASS
     assert reviewer.last_failure_diagnostics == ()
     assert gateway.call_kinds == [*("review",) * 10]
+
+
+@pytest.mark.parametrize("delayed_fails", (False, True))
+def test_most_recently_completed_review_publishes_diagnostics(
+    delayed_fails: bool,
+) -> None:
+    delayed_candidate = "slow failure" if delayed_fails else "slow success"
+    immediate_candidate = "fast success" if delayed_fails else "fast failure"
+    gateway = InterleavedDiagnosticGateway(
+        delayed_candidate=delayed_candidate,
+        failing_candidate="slow failure" if delayed_fails else "fast failure",
+    )
+    reviewer = GatewayPersonaReviewer(
+        gateway,
+        ROOT / "linli_character" / "persona_release_v2.json",
+        2.0,
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        delayed = pool.submit(reviewer.review, delayed_candidate, _intimacy_context())
+        assert gateway.delayed_started.wait(2.0)
+        immediate = reviewer.review(immediate_candidate, _intimacy_context())
+        gateway.release_delayed.set()
+        completed = delayed.result(timeout=2.0)
+
+    if delayed_fails:
+        assert immediate.verdict is ReviewVerdict.PASS
+        assert completed.error_code == "REVIEWER_UNAVAILABLE"
+        assert reviewer.last_failure_diagnostics == (
+            ReviewFailureDiagnostic(
+                ReviewFailureStage.LAYER,
+                ReviewFailureReason.JSON,
+                "identity_boundary",
+            ),
+        )
+    else:
+        assert immediate.error_code == "REVIEWER_UNAVAILABLE"
+        assert completed.verdict is ReviewVerdict.PASS
+        assert reviewer.last_failure_diagnostics == ()
 
 
 def _legacy_layer_payload(
@@ -506,6 +686,41 @@ class FailingQualityGateway(SequencedQualityGateway):
                 model="synthetic",
             )
         return await super().complete(messages, request_id=request_id)
+
+
+class InterleavedDiagnosticGateway(Gateway):
+    stream_enabled = False
+
+    def __init__(self, *, delayed_candidate: str, failing_candidate: str) -> None:
+        self.delayed_candidate = delayed_candidate
+        self.failing_candidate = failing_candidate
+        self.delayed_started = Event()
+        self.release_delayed = Event()
+
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None = None,
+    ) -> GatewayResponse:
+        request = json.loads(str(messages[-1]["content"]))
+        candidate = str(request["candidate_reply"])
+        layer = str(request["layer"])
+        if candidate == self.delayed_candidate:
+            self.delayed_started.set()
+            released = await asyncio.to_thread(self.release_delayed.wait, 2.0)
+            assert released
+        text = (
+            "{"
+            if candidate == self.failing_candidate and layer == "identity_boundary"
+            else _layer_payload(layer)
+        )
+        return GatewayResponse(
+            text=text,
+            request_id=request_id or "synthetic",
+            provider="synthetic",
+            model="synthetic",
+        )
 
 
 class PromptContractQualityGateway(Gateway):


### PR DESCRIPTION
## Scope
- Preserve the public `REVIEWER_UNAVAILABLE` fail-closed contract while retaining only ephemeral bounded failure diagnostics in memory.
- Classify layer, adjudication, aggregation, and unknown internal failures by finite stage/reason enums; optional layer is restricted to the five existing reviewer layers.
- Publish diagnostics atomically by review completion order: every successful completion publishes an empty tuple, while failures publish only bounded values. Provider calls remain concurrent.
- Distinguish known gateway invocation failures from unknown programming/input-construction failures; do not swallow cancellation or process-control exceptions.
- Never retain candidate text, raw provider output, exception text, field values, or request ids.

## Why
A real post-PR-D regression produced two `REVIEWER_UNAVAILABLE` outcomes with five layer calls started but no semantic violation. Existing code collapsed transport, JSON, layer-contract, evidence-contract, adjudication, and aggregation failures into one code, so a privacy-safe report could not distinguish the repair boundary without blind retries.

## TDD evidence
- Diagnostic/control-flow slices: 26 passed.
- `test_reply_model_quality.py`: 107 passed.
- Persona: 274 passed.
- Full exact head tree: 1554 passed, 1 skipped, 1 deselected (7 existing aiohttp warnings), using a unique repository `.evidence` basetemp.
- Hardening, compileall, and diff-check: PASS.

## Frozen pair (round 2)
- Base: `27a6a060acd7db5c60719c8734863b8675b17703`
- Head: `86f4b73f5cc090f65b803b4e45e82af979e41a3d`

## Size and split rationale
- 3 files, 824 changed lines (724 additions, 100 deletions): below the absolute 40-file / 2,000-line limit but above the default 500-line target.
- The first frozen head was exactly 500 lines. Round-1 review required deterministic concurrent-completion tests, honest `internal` classification, exact enum validation, and control-flow propagation tests. The runtime diagnostic contract, public-path concurrency/privacy evidence, and documentation are one lifecycle responsibility; splitting tests or concurrency semantics from the diagnostic seam would make one PR unverifiable or temporarily misleading.

## Boundaries
- Public ReviewResult/quality/pipeline schemas and external error codes are unchanged.
- Passing call counts and non-Letter behavior are frozen by synthetic public-path tests.
- No private corpus, key, Live, client, video, media, logger, database, or persistent telemetry changes.