### PR TITLE
fix: enable max reasoning for Letter Persona

### DIFF
--- a/contracts/llm_config.schema.json
+++ b/contracts/llm_config.schema.json
@@ -12,6 +12,7 @@
     "api_key_env": {"type": "string"},
     "api_style": {"enum": ["chat_completions", "responses"]},
     "timeout_seconds": {"type": "number", "exclusiveMinimum": 0, "maximum": 600},
+    "reasoning_timeout_seconds": {"type": "number", "minimum": 0.05, "maximum": 1800, "default": 600},
     "max_retries": {"type": "integer", "minimum": 0, "maximum": 8},
     "retry_backoff_seconds": {"type": "number", "minimum": 0, "maximum": 30},
     "stream": {"type": "boolean"},

--- a/docs/B03_LLM_GATEWAY.md
+++ b/docs/B03_LLM_GATEWAY.md
@@ -29,7 +29,7 @@ rtk python tools/healthcheck.py --profile core
 rtk python tools/healthcheck.py --profile llm
 ```
 
-也可用环境变量覆盖配置：`OLIVIA_LLM_BASE_URL`、`OLIVIA_LLM_MODEL`、`OLIVIA_LLM_API_STYLE`、`OLIVIA_LLM_TIMEOUT_SECONDS`、`OLIVIA_LLM_MAX_RETRIES`、`OLIVIA_LLM_RETRY_BACKOFF_SECONDS`、`OLIVIA_LLM_STREAM`、`OLIVIA_LLM_MAX_INPUT_CHARS`、`OLIVIA_LLM_MAX_OUTPUT_CHARS`、`OLIVIA_LLM_FALLBACK_PROVIDER`、`OLIVIA_PERSONA_FILE`。
+也可用环境变量覆盖配置：`OLIVIA_LLM_BASE_URL`、`OLIVIA_LLM_MODEL`、`OLIVIA_LLM_API_STYLE`、`OLIVIA_LLM_TIMEOUT_SECONDS`、`OLIVIA_LLM_REASONING_TIMEOUT_SECONDS`、`OLIVIA_LLM_MAX_RETRIES`、`OLIVIA_LLM_RETRY_BACKOFF_SECONDS`、`OLIVIA_LLM_STREAM`、`OLIVIA_LLM_MAX_INPUT_CHARS`、`OLIVIA_LLM_MAX_OUTPUT_CHARS`、`OLIVIA_LLM_FALLBACK_PROVIDER`、`OLIVIA_PERSONA_FILE`。
 
 ## 配置与自定义 provider
 
@@ -42,12 +42,15 @@ rtk python tools/healthcheck.py --profile llm
 | `api_key_env` / `requires_api_key` | 只保存环境变量名，不保存密钥 |
 | `api_style` | `chat_completions` 或 `responses` |
 | `timeout_seconds` / `max_retries` / `retry_backoff_seconds` | 单次请求超时、429/5xx/网络失败重试预算 |
+| `reasoning_timeout_seconds` | 文本信件使用 `deepseek-v4-flash` max thinking 时的单阶段超时；默认 600 秒，范围 0.05-1800 秒 |
 | `stream` | 内部事件编排是否消费 provider 流；HTTP `/toy` 仍是非 SSE 响应 |
 | `max_input_chars` / `max_output_chars` | 输入消息总长度和输出长度上限 |
 | `fallback_provider` | 显式降级登记；默认 `none`，不会无提示生成占位回信 |
 | persona_v2_file / persona_v2_enabled | 默认 Persona 2.0 release 文件与开关；关闭该开关才进入 legacy 路径 |
 | persona_file / feature_enabled | 可选 legacy DRAFT 文件和总开关；默认配置不再引用该文件 |
 | persona_config / persona_evidence_file | 候选结构化配置与短 provenance/evidence 索引；候选包默认独立关闭，不会替换 DRAFT |
+
+仅 `text_letter` 的生成、五层 review、条件 adjudication、一次 rewrite 与 recheck 使用可信的进程内 scope，向 OpenAI-compatible Chat Completions（OpenCode Go 或 DeepSeek 官方同形端点）发送 `thinking={"type":"enabled"}` 与 `reasoning_effort="max"`。scope 不写入 `Idempotency-Key` 或 `X-Request-ID`；视频、音乐、Live、历史导入和 tool call 保持原 payload 与 `timeout_seconds`。Provider 返回的 `reasoning_content` 只在传输层丢弃，不进入回复、日志或记忆。
 
 代码可通过 `llm_gateway.register_provider("name", factory)` 注册 provider。factory 接收 `GatewayConfig`，返回实现 `Gateway.complete()` 与可选 `Gateway.stream()` 的对象；异常只能使用 `GatewayError` 的稳定 code/retryable 分类，不能把响应 body、header、key 或 prompt 放入异常文本。
 

--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -165,8 +165,20 @@ accepted warning.
   existing deterministic-clean degraded path;
 - `OLIVIA_REPLY_REWRITE_ENABLED=false` leaves review enabled but disables model
   rewrite;
-- `OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS` sets a bounded 0.1-120 second timeout;
-  the default is the smaller of 12 seconds and the configured Provider timeout.
+- for OpenAI-compatible Chat Completions with `deepseek-v4-flash`, only durable
+  `letter-reply:` generation and `quality-` review requests explicitly enable
+  thinking with `reasoning_effort=max`; tool calls and unscoped, historical,
+  Live, or song requests retain their previous payload and timeout;
+- `reasoning_content` is consumed only as Provider transport and is discarded;
+  it never enters reply text, review text, logs, or memory;
+- `OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS` remains an explicit override. For
+  the max-reasoning Flash quality transport it is bounded to 0.1-600 seconds and
+  defaults to 600 seconds; other transports retain the 0.1-120 second bound and
+  the smaller of 60 seconds and their configured Provider timeout;
+- the Flash Letter outer deadline covers every paid stage: text Letter allows
+  generation, review plus optional adjudication, one rewrite, and a fresh review
+  plus optional adjudication (3,605 seconds including slack). Non-text Letter
+  modes retain the three-quality-stage budget (2,405 seconds including slack).
 
 Provider absence, timeout, transport errors, non-JSON output, and
 schema-invalid output become sanitized `REVIEWER_UNAVAILABLE` or

--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -165,20 +165,11 @@ accepted warning.
   existing deterministic-clean degraded path;
 - `OLIVIA_REPLY_REWRITE_ENABLED=false` leaves review enabled but disables model
   rewrite;
-- for OpenAI-compatible Chat Completions with `deepseek-v4-flash`, only durable
-  `letter-reply:` generation and `quality-` review requests explicitly enable
-  thinking with `reasoning_effort=max`; tool calls and unscoped, historical,
-  Live, or song requests retain their previous payload and timeout;
-- `reasoning_content` is consumed only as Provider transport and is discarded;
-  it never enters reply text, review text, logs, or memory;
-- `OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS` remains an explicit override. For
-  the max-reasoning Flash quality transport it is bounded to 0.1-600 seconds and
-  defaults to 600 seconds; other transports retain the 0.1-120 second bound and
-  the smaller of 60 seconds and their configured Provider timeout;
-- the Flash Letter outer deadline covers every paid stage: text Letter allows
-  generation, review plus optional adjudication, one rewrite, and a fresh review
-  plus optional adjudication (3,605 seconds including slack). Non-text Letter
-  modes retain the three-quality-stage budget (2,405 seconds including slack).
+- `OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS` sets a bounded 0.1-120 second timeout;
+  the default is the smaller of 12 seconds and the configured Provider timeout.
+  This control applies only to non-max review, including video modes. A scoped
+  `deepseek-v4-flash` text Letter review instead uses the public
+  `reasoning_timeout_seconds` setting shared by its max-reasoning stages.
 
 Provider absence, timeout, transport errors, non-JSON output, and
 schema-invalid output become sanitized `REVIEWER_UNAVAILABLE` or

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -13,6 +13,7 @@ import json
 import os
 import uuid
 from dataclasses import dataclass, field, replace
+from enum import Enum
 from pathlib import Path
 from typing import Any, AsyncIterator, Callable, Mapping, Sequence
 
@@ -24,6 +25,12 @@ PROVIDER_USER_AGENT = "Olivia-Community/0.1"
 
 ALLOWED_ROLES = frozenset({"system", "user", "assistant"})
 SUPPORTED_API_STYLES = frozenset({"chat_completions", "responses"})
+
+
+class GatewayRequestScope(str, Enum):
+    """Trusted in-process call scope; never serialized into provider request ids."""
+
+    TEXT_LETTER_MAX_REASONING = "text_letter_max_reasoning"
 
 
 class GatewayError(RuntimeError):
@@ -86,6 +93,7 @@ class GatewayConfig:
     api_key_env: str = ""
     api_style: str = "chat_completions"
     timeout_seconds: float = 30.0
+    reasoning_timeout_seconds: float = 600.0
     max_retries: int = 2
     retry_backoff_seconds: float = 0.0
     stream: bool = False
@@ -141,6 +149,12 @@ class GatewayConfig:
             api_key_env=str(api_key_env or "").strip(),
             api_style=_normalize_api_style(api_style),
             timeout_seconds=_bounded_float(data.get("timeout_seconds", 30.0), 30.0, 0.05, 600.0),
+            reasoning_timeout_seconds=_bounded_float(
+                data.get("reasoning_timeout_seconds", 600.0),
+                600.0,
+                0.05,
+                1800.0,
+            ),
             max_retries=_bounded_int(data.get("max_retries", 2), 2, 0, 8),
             retry_backoff_seconds=_bounded_float(
                 data.get("retry_backoff_seconds", 0.0), 0.0, 0.0, 30.0
@@ -173,6 +187,7 @@ class GatewayConfig:
             "api_key_env_configured": bool(self.api_key_env),
             "api_style": self.api_style,
             "timeout_seconds": self.timeout_seconds,
+            "reasoning_timeout_seconds": self.reasoning_timeout_seconds,
             "max_retries": self.max_retries,
             "stream": self.stream,
             "max_input_chars": self.max_input_chars,
@@ -254,6 +269,7 @@ def _env_overlay(environ: Mapping[str, str]) -> dict[str, Any]:
         "OLIVIA_LLM_API_KEY_ENV": "api_key_env",
         "OLIVIA_LLM_API_STYLE": "api_style",
         "OLIVIA_LLM_TIMEOUT_SECONDS": "timeout_seconds",
+        "OLIVIA_LLM_REASONING_TIMEOUT_SECONDS": "reasoning_timeout_seconds",
         "OLIVIA_LLM_MAX_RETRIES": "max_retries",
         "OLIVIA_LLM_RETRY_BACKOFF_SECONDS": "retry_backoff_seconds",
         "OLIVIA_LLM_STREAM": "stream",
@@ -350,6 +366,14 @@ class Gateway:
 
         self.network_call_count = int(getattr(self, "network_call_count", 0)) + 1
 
+    def timeout_seconds_for_scope(
+        self,
+        scope: GatewayRequestScope,
+        *,
+        default: float,
+    ) -> float:
+        return default
+
     async def complete(
         self,
         messages: Sequence[Mapping[str, Any]],
@@ -357,6 +381,15 @@ class Gateway:
         request_id: str | None = None,
     ) -> GatewayResponse:
         raise NotImplementedError
+
+    async def complete_scoped(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None = None,
+        scope: GatewayRequestScope,
+    ) -> GatewayResponse:
+        return await self.complete(messages, request_id=request_id)
 
     async def complete_with_tools(
         self,
@@ -376,6 +409,16 @@ class Gateway:
     ) -> AsyncIterator[GatewayDelta]:
         response = await self.complete(messages, request_id=request_id)
         yield GatewayDelta(response.text, response.request_id, finish_reason="stop")
+
+    async def stream_scoped(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None = None,
+        scope: GatewayRequestScope,
+    ) -> AsyncIterator[GatewayDelta]:
+        async for delta in self.stream(messages, request_id=request_id):
+            yield delta
 
 
 class UnconfiguredAdapter(Gateway):
@@ -397,6 +440,14 @@ class FallbackAdapter(Gateway):
             getattr(self.fallback, "network_call_count", 0)
         )
 
+    def timeout_seconds_for_scope(
+        self,
+        scope: GatewayRequestScope,
+        *,
+        default: float,
+    ) -> float:
+        return self.primary.timeout_seconds_for_scope(scope, default=default)
+
     async def complete(self, messages: Sequence[Mapping[str, Any]], *, request_id: str | None = None) -> GatewayResponse:
         try:
             return await self.primary.complete(messages, request_id=request_id)
@@ -404,6 +455,28 @@ class FallbackAdapter(Gateway):
             if not exc.retryable:
                 raise
             return await self.fallback.complete(messages, request_id=request_id)
+
+    async def complete_scoped(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None = None,
+        scope: GatewayRequestScope,
+    ) -> GatewayResponse:
+        try:
+            return await self.primary.complete_scoped(
+                messages,
+                request_id=request_id,
+                scope=scope,
+            )
+        except GatewayError as exc:
+            if not exc.retryable:
+                raise
+            return await self.fallback.complete_scoped(
+                messages,
+                request_id=request_id,
+                scope=scope,
+            )
 
     async def complete_with_tools(
         self,
@@ -442,6 +515,34 @@ class FallbackAdapter(Gateway):
             if emitted or not exc.retryable:
                 raise
         async for delta in self.fallback.stream(messages, request_id=request_id):
+            yield delta
+
+    async def stream_scoped(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None = None,
+        scope: GatewayRequestScope,
+    ) -> AsyncIterator[GatewayDelta]:
+        emitted = False
+        try:
+            async for delta in self.primary.stream_scoped(
+                messages,
+                request_id=request_id,
+                scope=scope,
+            ):
+                if delta.text:
+                    emitted = True
+                yield delta
+            return
+        except GatewayError as exc:
+            if emitted or not exc.retryable:
+                raise
+        async for delta in self.fallback.stream_scoped(
+            messages,
+            request_id=request_id,
+            scope=scope,
+        ):
             yield delta
 
 
@@ -564,18 +665,28 @@ class OpenAICompatibleAdapter(Gateway):
         headers["X-Request-ID"] = request_id
         return headers
 
-    def _uses_max_reasoning(self, request_id: str) -> bool:
+    def _uses_max_reasoning(self, scope: GatewayRequestScope | None) -> bool:
         return (
             self.config.provider == "openai_compatible"
             and self.config.api_style == "chat_completions"
             and self.config.model.casefold() == "deepseek-v4-flash"
-            and request_id.startswith(("letter-reply:", "quality-"))
+            and scope is GatewayRequestScope.TEXT_LETTER_MAX_REASONING
         )
 
     def _request_timeout_seconds(self, *, max_reasoning: bool) -> float:
         if max_reasoning:
-            return max(self.config.timeout_seconds, 600.0)
+            return self.config.reasoning_timeout_seconds
         return self.config.timeout_seconds
+
+    def timeout_seconds_for_scope(
+        self,
+        scope: GatewayRequestScope,
+        *,
+        default: float,
+    ) -> float:
+        if self._uses_max_reasoning(scope):
+            return self.config.reasoning_timeout_seconds
+        return default
 
     def _body(
         self,
@@ -659,8 +770,34 @@ class OpenAICompatibleAdapter(Gateway):
         raise ProviderUnavailable()
 
     async def complete(self, messages: Sequence[Mapping[str, Any]], *, request_id: str | None = None) -> GatewayResponse:
+        return await self._complete(
+            messages,
+            request_id=request_id,
+            scope=None,
+        )
+
+    async def complete_scoped(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None = None,
+        scope: GatewayRequestScope,
+    ) -> GatewayResponse:
+        return await self._complete(
+            messages,
+            request_id=request_id,
+            scope=scope,
+        )
+
+    async def _complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None,
+        scope: GatewayRequestScope | None,
+    ) -> GatewayResponse:
         request = request_id or uuid.uuid4().hex
-        max_reasoning = self._uses_max_reasoning(request)
+        max_reasoning = self._uses_max_reasoning(scope)
         body = self._body(
             messages,
             stream=False,
@@ -716,8 +853,36 @@ class OpenAICompatibleAdapter(Gateway):
         return calls
 
     async def stream(self, messages: Sequence[Mapping[str, Any]], *, request_id: str | None = None) -> AsyncIterator[GatewayDelta]:
+        async for delta in self._stream(
+            messages,
+            request_id=request_id,
+            scope=None,
+        ):
+            yield delta
+
+    async def stream_scoped(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None = None,
+        scope: GatewayRequestScope,
+    ) -> AsyncIterator[GatewayDelta]:
+        async for delta in self._stream(
+            messages,
+            request_id=request_id,
+            scope=scope,
+        ):
+            yield delta
+
+    async def _stream(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None,
+        scope: GatewayRequestScope | None,
+    ) -> AsyncIterator[GatewayDelta]:
         request = request_id or uuid.uuid4().hex
-        max_reasoning = self._uses_max_reasoning(request)
+        max_reasoning = self._uses_max_reasoning(scope)
         body = self._body(
             messages,
             stream=True,
@@ -970,6 +1135,7 @@ __all__ = [
     "GatewayToolCall",
     "FallbackAdapter",
     "GatewayResponse",
+    "GatewayRequestScope",
     "InvalidGatewayInput",
     "LLMConfig",
     "MockAdapter",

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -564,7 +564,26 @@ class OpenAICompatibleAdapter(Gateway):
         headers["X-Request-ID"] = request_id
         return headers
 
-    def _body(self, messages: Sequence[Mapping[str, Any]], *, stream: bool) -> dict[str, Any]:
+    def _uses_max_reasoning(self, request_id: str) -> bool:
+        return (
+            self.config.provider == "openai_compatible"
+            and self.config.api_style == "chat_completions"
+            and self.config.model.casefold() == "deepseek-v4-flash"
+            and request_id.startswith(("letter-reply:", "quality-"))
+        )
+
+    def _request_timeout_seconds(self, *, max_reasoning: bool) -> float:
+        if max_reasoning:
+            return max(self.config.timeout_seconds, 600.0)
+        return self.config.timeout_seconds
+
+    def _body(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        stream: bool,
+        max_reasoning: bool = False,
+    ) -> dict[str, Any]:
         normalized = validate_messages(messages, max_input_chars=self.config.max_input_chars)
         if self.config.api_style == "responses":
             request_input = [
@@ -572,16 +591,36 @@ class OpenAICompatibleAdapter(Gateway):
                 for message in normalized
             ]
             return {"model": self.config.model, "input": request_input, "stream": stream}
-        return {"model": self.config.model, "messages": list(normalized), "stream": stream}
+        body: dict[str, Any] = {
+            "model": self.config.model,
+            "messages": list(normalized),
+            "stream": stream,
+        }
+        if (
+            max_reasoning
+            and self.config.provider == "openai_compatible"
+            and self.config.model.casefold() == "deepseek-v4-flash"
+        ):
+            body["thinking"] = {"type": "enabled"}
+            body["reasoning_effort"] = "max"
+        return body
 
     async def _retry_wait(self, attempt: int) -> None:
         delay = self.config.retry_backoff_seconds * (attempt + 1)
         if delay:
             await asyncio.sleep(delay)
 
-    async def _post_json(self, body: dict[str, Any], request_id: str) -> dict[str, Any]:
+    async def _post_json(
+        self,
+        body: dict[str, Any],
+        request_id: str,
+        *,
+        max_reasoning: bool = False,
+    ) -> dict[str, Any]:
         key = self._ensure_configured()
-        timeout = aiohttp.ClientTimeout(total=self.config.timeout_seconds)
+        timeout = aiohttp.ClientTimeout(
+            total=self._request_timeout_seconds(max_reasoning=max_reasoning)
+        )
         for attempt in range(self.config.max_retries + 1):
             try:
                 async with aiohttp.ClientSession(timeout=timeout) as session:
@@ -621,8 +660,13 @@ class OpenAICompatibleAdapter(Gateway):
 
     async def complete(self, messages: Sequence[Mapping[str, Any]], *, request_id: str | None = None) -> GatewayResponse:
         request = request_id or uuid.uuid4().hex
-        body = self._body(messages, stream=False)
-        data = await self._post_json(body, request)
+        max_reasoning = self._uses_max_reasoning(request)
+        body = self._body(
+            messages,
+            stream=False,
+            max_reasoning=max_reasoning,
+        )
+        data = await self._post_json(body, request, max_reasoning=max_reasoning)
         text = _extract_response_text(data)
         if not text:
             raise ProviderProtocolError()
@@ -673,9 +717,16 @@ class OpenAICompatibleAdapter(Gateway):
 
     async def stream(self, messages: Sequence[Mapping[str, Any]], *, request_id: str | None = None) -> AsyncIterator[GatewayDelta]:
         request = request_id or uuid.uuid4().hex
-        body = self._body(messages, stream=True)
+        max_reasoning = self._uses_max_reasoning(request)
+        body = self._body(
+            messages,
+            stream=True,
+            max_reasoning=max_reasoning,
+        )
         key = self._ensure_configured()
-        timeout = aiohttp.ClientTimeout(total=self.config.timeout_seconds)
+        timeout = aiohttp.ClientTimeout(
+            total=self._request_timeout_seconds(max_reasoning=max_reasoning)
+        )
         emitted = False
         for attempt in range(self.config.max_retries + 1):
             try:

--- a/local_server.py
+++ b/local_server.py
@@ -219,6 +219,20 @@ LLM_CFG = LLM_CONFIG.public_dict()
 LLM_CFG["persona_file"] = LLM_CONFIG.persona_file
 
 
+def _deepseek_max_reasoning_enabled(config: GatewayConfig) -> bool:
+    return (
+        config.provider == "openai_compatible"
+        and config.api_style == "chat_completions"
+        and config.model.casefold() == "deepseek-v4-flash"
+    )
+
+
+def _letter_reply_timeout_seconds(config: GatewayConfig) -> float:
+    if _deepseek_max_reasoning_enabled(config):
+        return max(config.timeout_seconds, 600.0)
+    return config.timeout_seconds
+
+
 def apply_runtime_llm_config(base_url: str, model: str, api_key: str | None) -> None:
     """Atomically switch future reply requests to freshly saved local settings."""
 
@@ -251,7 +265,7 @@ def apply_runtime_llm_config(base_url: str, model: str, api_key: str | None) -> 
         private_world_candidate_analyzer.gateway = gateway
         private_world_candidate_analyzer.timeout_seconds = candidate.timeout_seconds
     emotion_triage.gateway = gateway
-    reply_engine.timeout_seconds = candidate.timeout_seconds
+    reply_engine.timeout_seconds = _letter_reply_timeout_seconds(candidate)
     LLM_CONFIG = candidate
     LLM_TIMEOUT_SECONDS = candidate.timeout_seconds
     LLM_CFG = candidate.public_dict()
@@ -1062,7 +1076,7 @@ async def _music_voice_plan_for_letter(
 music_adapter = MusicAdapter()
 reply_engine = ReplyOrchestrator(
     _LetterGateway(letters_adapter),
-    timeout_seconds=LLM_CONFIG.timeout_seconds,
+    timeout_seconds=_letter_reply_timeout_seconds(LLM_CONFIG),
 )
 reply_pipeline = ReplyPipeline(
     reply_engine,
@@ -1980,10 +1994,14 @@ def _schedule_text_reply_delay(letter: dict, reply_mode: str) -> None:
     letter["reply_not_before"] = time.time() + delay * 60.0
 
 
-def _reply_pipeline_timeout_seconds() -> float:
+def _reply_pipeline_timeout_seconds(exact_mode: str) -> float:
     """Cover generation plus review, one rewrite, and the final recheck."""
 
-    default_quality_timeout = min(float(LLM_TIMEOUT_SECONDS), 60.0)
+    max_reasoning = _deepseek_max_reasoning_enabled(LLM_CONFIG)
+    generation_timeout = _letter_reply_timeout_seconds(LLM_CONFIG)
+    default_quality_timeout = (
+        600.0 if max_reasoning else min(float(LLM_TIMEOUT_SECONDS), 60.0)
+    )
     try:
         quality_timeout = float(
             _os.environ.get(
@@ -1993,8 +2011,16 @@ def _reply_pipeline_timeout_seconds() -> float:
         )
     except (TypeError, ValueError):
         quality_timeout = default_quality_timeout
-    quality_timeout = max(1.0, min(quality_timeout, 300.0))
-    return float(LLM_TIMEOUT_SECONDS) + 3.0 * quality_timeout + 5.0
+    quality_timeout = max(
+        1.0,
+        min(quality_timeout, 600.0 if max_reasoning else 300.0),
+    )
+    quality_stages = (
+        5.0
+        if max_reasoning and exact_mode == ReplyMode.TEXT_LETTER.value
+        else 3.0
+    )
+    return generation_timeout + quality_stages * quality_timeout + 5.0
 
 
 def _send_result_for_letter(letter: dict) -> dict:
@@ -3167,7 +3193,7 @@ async def _run_reply_pipeline_for_letter(
                 request,
                 letters_adapter.build_reply_context(ReplyMode(exact_mode)),
             ),
-            timeout=_reply_pipeline_timeout_seconds(),
+            timeout=_reply_pipeline_timeout_seconds(exact_mode),
         )
     finally:
         _CURRENT_LETTER_MEMORY_SOURCE.reset(source_token)

--- a/local_server.py
+++ b/local_server.py
@@ -35,6 +35,7 @@ from llm_gateway import (
     GatewayConfig,
     GatewayDelta,
     GatewayError,
+    GatewayRequestScope,
     GatewayResponse,
     ProviderTimeout,
     ProviderUnavailable,
@@ -229,7 +230,7 @@ def _deepseek_max_reasoning_enabled(config: GatewayConfig) -> bool:
 
 def _letter_reply_timeout_seconds(config: GatewayConfig) -> float:
     if _deepseek_max_reasoning_enabled(config):
-        return max(config.timeout_seconds, 600.0)
+        return config.reasoning_timeout_seconds
     return config.timeout_seconds
 
 
@@ -265,7 +266,7 @@ def apply_runtime_llm_config(base_url: str, model: str, api_key: str | None) -> 
         private_world_candidate_analyzer.gateway = gateway
         private_world_candidate_analyzer.timeout_seconds = candidate.timeout_seconds
     emotion_triage.gateway = gateway
-    reply_engine.timeout_seconds = _letter_reply_timeout_seconds(candidate)
+    reply_engine.timeout_seconds = candidate.timeout_seconds
     LLM_CONFIG = candidate
     LLM_TIMEOUT_SECONDS = candidate.timeout_seconds
     LLM_CFG = candidate.public_dict()
@@ -307,7 +308,27 @@ class _LetterGateway(Gateway):
         self.adapter = adapter
         self.stream_enabled = bool(adapter.config.stream)
 
+    def timeout_seconds_for_scope(
+        self,
+        scope: GatewayRequestScope,
+        *,
+        default: float,
+    ) -> float:
+        return self.adapter.gateway.timeout_seconds_for_scope(scope, default=default)
+
     async def complete(self, messages, *, request_id=None) -> GatewayResponse:
+        return await self._complete(messages, request_id=request_id, scope=None)
+
+    async def complete_scoped(
+        self,
+        messages,
+        *,
+        request_id=None,
+        scope: GatewayRequestScope,
+    ) -> GatewayResponse:
+        return await self._complete(messages, request_id=request_id, scope=scope)
+
+    async def _complete(self, messages, *, request_id, scope) -> GatewayResponse:
         content = next(
             (
                 message.get("content", "")
@@ -322,6 +343,7 @@ class _LetterGateway(Gateway):
                 content,
                 "",
                 request_id=request_id,
+                gateway_scope=scope,
             )
         except LLMError as exc:
             if exc.code == "LLM_TIMEOUT":
@@ -339,6 +361,20 @@ class _LetterGateway(Gateway):
         )
 
     async def stream(self, messages, *, request_id=None):
+        async for delta in self._stream(messages, request_id=request_id, scope=None):
+            yield delta
+
+    async def stream_scoped(
+        self,
+        messages,
+        *,
+        request_id=None,
+        scope: GatewayRequestScope,
+    ):
+        async for delta in self._stream(messages, request_id=request_id, scope=scope):
+            yield delta
+
+    async def _stream(self, messages, *, request_id, scope):
         content = next(
             (
                 message.get("content", "")
@@ -348,7 +384,16 @@ class _LetterGateway(Gateway):
             "",
         )
         built_messages = await asyncio.to_thread(self.adapter._messages, content)
-        async for delta in self.adapter.gateway.stream(built_messages, request_id=request_id):
+        stream = (
+            self.adapter.gateway.stream_scoped(
+                built_messages,
+                request_id=request_id,
+                scope=scope,
+            )
+            if scope is not None
+            else self.adapter.gateway.stream(built_messages, request_id=request_id)
+        )
+        async for delta in stream:
             yield GatewayDelta(
                 delta.text,
                 delta.request_id,
@@ -622,13 +667,21 @@ class LetterAdapter:
         context: str = "",
         *,
         request_id: str | None = None,
+        gateway_scope: GatewayRequestScope | None = None,
     ) -> str:
         config, gateway = self._runtime
         try:
             messages = self._messages(content, context)
-            return asyncio.run(
-                gateway.complete(messages, request_id=request_id)
-            ).text
+            completion = (
+                gateway.complete_scoped(
+                    messages,
+                    request_id=request_id,
+                    scope=gateway_scope,
+                )
+                if gateway_scope is not None
+                else gateway.complete(messages, request_id=request_id)
+            )
+            return asyncio.run(completion).text
         except GatewayError as exc:
             code = "LLM_TIMEOUT" if isinstance(exc, ProviderTimeout) else "LLM_UNAVAILABLE"
             if exc.code == "PROVIDER_REJECTED":
@@ -1076,7 +1129,7 @@ async def _music_voice_plan_for_letter(
 music_adapter = MusicAdapter()
 reply_engine = ReplyOrchestrator(
     _LetterGateway(letters_adapter),
-    timeout_seconds=_letter_reply_timeout_seconds(LLM_CONFIG),
+    timeout_seconds=LLM_CONFIG.timeout_seconds,
 )
 reply_pipeline = ReplyPipeline(
     reply_engine,
@@ -1997,29 +2050,40 @@ def _schedule_text_reply_delay(letter: dict, reply_mode: str) -> None:
 def _reply_pipeline_timeout_seconds(exact_mode: str) -> float:
     """Cover generation plus review, one rewrite, and the final recheck."""
 
-    max_reasoning = _deepseek_max_reasoning_enabled(LLM_CONFIG)
-    generation_timeout = _letter_reply_timeout_seconds(LLM_CONFIG)
-    default_quality_timeout = (
-        600.0 if max_reasoning else min(float(LLM_TIMEOUT_SECONDS), 60.0)
+    max_reasoning = (
+        exact_mode == ReplyMode.TEXT_LETTER.value
+        and _deepseek_max_reasoning_enabled(LLM_CONFIG)
     )
-    try:
-        quality_timeout = float(
-            _os.environ.get(
-                "OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS",
-                str(default_quality_timeout),
-            )
-        )
-    except (TypeError, ValueError):
+    generation_timeout = (
+        _letter_reply_timeout_seconds(LLM_CONFIG)
+        if max_reasoning
+        else float(LLM_TIMEOUT_SECONDS)
+    )
+    default_quality_timeout = (
+        LLM_CONFIG.reasoning_timeout_seconds
+        if max_reasoning
+        else min(float(LLM_TIMEOUT_SECONDS), 60.0)
+    )
+    if max_reasoning:
         quality_timeout = default_quality_timeout
+    else:
+        try:
+            quality_timeout = float(
+                _os.environ.get(
+                    "OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS",
+                    str(default_quality_timeout),
+                )
+            )
+        except (TypeError, ValueError):
+            quality_timeout = default_quality_timeout
     quality_timeout = max(
         1.0,
-        min(quality_timeout, 600.0 if max_reasoning else 300.0),
+        min(
+            quality_timeout,
+            LLM_CONFIG.reasoning_timeout_seconds if max_reasoning else 300.0,
+        ),
     )
-    quality_stages = (
-        5.0
-        if max_reasoning and exact_mode == ReplyMode.TEXT_LETTER.value
-        else 3.0
-    )
+    quality_stages = 5.0 if max_reasoning else 3.0
     return generation_timeout + quality_stages * quality_timeout + 5.0
 
 
@@ -3187,6 +3251,12 @@ async def _run_reply_pipeline_for_letter(
                 else None
             ),
             max_input_chars=LLM_CONFIG.max_input_chars,
+            gateway_scope=(
+                GatewayRequestScope.TEXT_LETTER_MAX_REASONING
+                if exact_mode == ReplyMode.TEXT_LETTER.value
+                and _deepseek_max_reasoning_enabled(LLM_CONFIG)
+                else None
+            ),
         )
         return await asyncio.wait_for(
             reply_pipeline.run(

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -788,9 +788,18 @@ def create_model_quality_ports(
             30.0,
         )
     )
+    max_reasoning = (
+        isinstance(config, GatewayConfig)
+        and config.provider == "openai_compatible"
+        and config.api_style == "chat_completions"
+        and _REVIEW_MODEL.casefold() == "deepseek-v4-flash"
+    )
     timeout = _env_timeout(
         "OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS",
-        min(configured_timeout, 60.0),
+        max(configured_timeout, 600.0)
+        if max_reasoning
+        else min(configured_timeout, 60.0),
+        maximum=600.0 if max_reasoning else 120.0,
     )
     reviewer = GatewayPersonaReviewer(
         quality_gateway,
@@ -1942,6 +1951,8 @@ def _env_bool(
 def _env_timeout(
     name: str,
     default: float,
+    *,
+    maximum: float,
 ) -> float:
     try:
         value = float(
@@ -1955,7 +1966,7 @@ def _env_timeout(
     return max(
         0.1,
         min(
-            120.0,
+            maximum,
             value,
         ),
     )

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -13,7 +13,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-from llm_gateway import Gateway, GatewayConfig, create_gateway
+from llm_gateway import Gateway, GatewayConfig, GatewayRequestScope, create_gateway
 from persona_loader import PersonaDeclaration, PersonaSnapshot, load_persona
 from runtime.reply.reply_context import (
     IntimacyRequest,
@@ -367,9 +367,11 @@ class GatewayReviewTransport:
         self,
         gateway: Gateway,
         persona_path: Path,
+        reasoning_timeout_seconds: float | None = None,
     ) -> None:
         self.gateway = gateway
         self.persona_path = persona_path
+        self.reasoning_timeout_seconds = reasoning_timeout_seconds
         self._last_failure_diagnostics: tuple[ReviewFailureDiagnostic, ...] = ()
         self._diagnostics_lock = Lock()
 
@@ -415,6 +417,16 @@ class GatewayReviewTransport:
     ) -> object:
         mode = str(request.get("mode", ""))
         evidence_bound = mode == ReplyMode.TEXT_LETTER.value
+        reasoning_scope = (
+            GatewayRequestScope.TEXT_LETTER_MAX_REASONING
+            if evidence_bound and self.reasoning_timeout_seconds is not None
+            else None
+        )
+        effective_timeout = (
+            self.reasoning_timeout_seconds
+            if reasoning_scope is not None
+            else timeout_seconds
+        )
         authorities = _build_release_layer_authorities(
             load_persona(self.persona_path).snapshot,
             mode=mode,
@@ -463,7 +475,8 @@ class GatewayReviewTransport:
             ),
             mode=mode,
             evidence_bound=evidence_bound,
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=effective_timeout,
+            gateway_scope=reasoning_scope,
         )
         if evidence_bound:
             try:
@@ -480,7 +493,8 @@ class GatewayReviewTransport:
                         if isinstance(request.get("relationship_context"), Mapping)
                         else {}
                     ),
-                    timeout_seconds=timeout_seconds,
+                    timeout_seconds=effective_timeout,
+                    gateway_scope=reasoning_scope,
                 )
             except _ReviewContractFailure as exc:
                 raise _diagnostic_error(
@@ -510,8 +524,13 @@ class GatewayPersonaReviewer:
         gateway: Gateway,
         persona_path: Path,
         timeout_seconds: float,
+        reasoning_timeout_seconds: float | None = None,
     ) -> None:
-        self._transport = GatewayReviewTransport(gateway, persona_path)
+        self._transport = GatewayReviewTransport(
+            gateway,
+            persona_path,
+            reasoning_timeout_seconds,
+        )
         self.adapter = JsonReviewerAdapter(
             self._transport,
             ReviewerConfig(
@@ -578,10 +597,12 @@ class GatewayPersonaRewriter:
         gateway: Gateway,
         persona_path: Path,
         timeout_seconds: float,
+        reasoning_timeout_seconds: float | None = None,
     ) -> None:
         self.gateway = gateway
         self.persona_path = persona_path
         self.timeout_seconds = timeout_seconds
+        self.reasoning_timeout_seconds = reasoning_timeout_seconds
 
     def rewrite(
         self,
@@ -705,10 +726,21 @@ class GatewayPersonaRewriter:
                 ),
             },
         )
+        reasoning_scope = (
+            GatewayRequestScope.TEXT_LETTER_MAX_REASONING
+            if context.mode is ReplyMode.TEXT_LETTER
+            and self.reasoning_timeout_seconds is not None
+            else None
+        )
         return _complete_text(
             self.gateway,
             messages,
-            self.timeout_seconds,
+            (
+                self.reasoning_timeout_seconds
+                if reasoning_scope is not None
+                else self.timeout_seconds
+            ),
+            gateway_scope=reasoning_scope,
         ).strip()
 
 
@@ -796,21 +828,26 @@ def create_model_quality_ports(
     )
     timeout = _env_timeout(
         "OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS",
-        max(configured_timeout, 600.0)
-        if max_reasoning
-        else min(configured_timeout, 60.0),
-        maximum=600.0 if max_reasoning else 120.0,
+        min(configured_timeout, 60.0),
+        maximum=120.0,
+    )
+    reasoning_timeout = (
+        config.reasoning_timeout_seconds
+        if max_reasoning and isinstance(config, GatewayConfig)
+        else None
     )
     reviewer = GatewayPersonaReviewer(
         quality_gateway,
         persona_path,
         timeout,
+        reasoning_timeout,
     )
     rewriter = (
         GatewayPersonaRewriter(
             quality_gateway,
             persona_path,
             timeout,
+            reasoning_timeout,
         )
         if _env_bool(
             "OLIVIA_REPLY_REWRITE_ENABLED",
@@ -1192,11 +1229,21 @@ async def _complete_layer_text(
     messages: Sequence[Mapping[str, Any]],
     timeout_seconds: float,
     request_id: str,
+    gateway_scope: GatewayRequestScope | None = None,
 ) -> str:
     if bool(getattr(gateway, "stream_enabled", False)):
         async def collect() -> str:
             chunks: list[str] = []
-            async for delta in gateway.stream(messages, request_id=request_id):
+            stream = (
+                gateway.stream_scoped(
+                    messages,
+                    request_id=request_id,
+                    scope=gateway_scope,
+                )
+                if gateway_scope is not None
+                else gateway.stream(messages, request_id=request_id)
+            )
+            async for delta in stream:
                 if delta.text:
                     chunks.append(delta.text)
             return "".join(chunks)
@@ -1206,10 +1253,16 @@ async def _complete_layer_text(
         except Exception as exc:
             raise _GatewayInvocationFailure from exc
     try:
-        response = await asyncio.wait_for(
-            gateway.complete(messages, request_id=request_id),
-            timeout_seconds,
+        completion = (
+            gateway.complete_scoped(
+                messages,
+                request_id=request_id,
+                scope=gateway_scope,
+            )
+            if gateway_scope is not None
+            else gateway.complete(messages, request_id=request_id)
         )
+        response = await asyncio.wait_for(completion, timeout_seconds)
     except Exception as exc:
         raise _GatewayInvocationFailure from exc
     return response.text
@@ -1227,6 +1280,7 @@ def _complete_layer_reviews(
     mode: str,
     evidence_bound: bool,
     timeout_seconds: float,
+    gateway_scope: GatewayRequestScope | None,
 ) -> tuple[_LayerResult, ...]:
     async def invoke(
         requests: Sequence[
@@ -1243,6 +1297,7 @@ def _complete_layer_reviews(
                     messages,
                     timeout_seconds,
                     f"quality-{uuid.uuid4().hex}:{layer.name}",
+                    gateway_scope,
                 )
             except _GatewayInvocationFailure:
                 raise _diagnostic_error(
@@ -1334,6 +1389,7 @@ def _adjudicate_hard_evidence(
     memory_evidence: Mapping[str, str],
     relationship_context: Mapping[str, object],
     timeout_seconds: float,
+    gateway_scope: GatewayRequestScope | None,
 ) -> tuple[_LayerResult, ...]:
     claims = tuple(
         (item.layer, evidence)
@@ -1454,6 +1510,7 @@ def _adjudicate_hard_evidence(
         messages,
         timeout_seconds,
         diagnostic=True,
+        gateway_scope=gateway_scope,
     )
     decisions = _parse_adjudication_result(text, claims=claims)
     by_id = {item.evidence_id: item for item in decisions}
@@ -1901,6 +1958,7 @@ def _complete_text(
     timeout_seconds: float,
     *,
     diagnostic: bool = False,
+    gateway_scope: GatewayRequestScope | None = None,
 ) -> str:
     try:
         text = asyncio.run(
@@ -1909,6 +1967,7 @@ def _complete_text(
                 messages,
                 timeout_seconds,
                 f"quality-{uuid.uuid4().hex}",
+                gateway_scope,
             )
         )
     except _GatewayInvocationFailure:

--- a/runtime/reply/reply_orchestrator.py
+++ b/runtime/reply/reply_orchestrator.py
@@ -9,7 +9,14 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, AsyncIterator, Mapping, Sequence
 
-from llm_gateway import Gateway, GatewayDelta, GatewayError, GatewayResponse, validate_messages
+from llm_gateway import (
+    Gateway,
+    GatewayDelta,
+    GatewayError,
+    GatewayRequestScope,
+    GatewayResponse,
+    validate_messages,
+)
 
 
 class ReplyEventType(str, Enum):
@@ -46,6 +53,7 @@ class ReplyRequest:
     request_id: str = field(default_factory=lambda: uuid.uuid4().hex)
     idempotency_key: str | None = None
     max_input_chars: int = 10000
+    gateway_scope: GatewayRequestScope | None = None
 
     def normalized_messages(self) -> tuple[dict[str, str], ...]:
         if self.messages is not None:
@@ -207,21 +215,42 @@ class ReplyOrchestrator:
             return
 
         provider_gateway = _provider_gateway(self.gateway, request)
+        provider_timeout = self.timeout_seconds
+        if request.gateway_scope is not None:
+            provider_timeout = provider_gateway.timeout_seconds_for_scope(
+                request.gateway_scope,
+                default=self.timeout_seconds,
+            )
         try:
             await self._publish(
                 run, ReplyEventType.REQUEST_ACCEPTED, ReplyState.ACCEPTED
             )
             if getattr(provider_gateway, "stream_enabled", False):
                 result = await asyncio.wait_for(
-                    self._consume_stream(run, messages, provider_gateway),
-                    self.timeout_seconds,
+                    self._consume_stream(
+                        run,
+                        messages,
+                        provider_gateway,
+                        scope=request.gateway_scope,
+                    ),
+                    provider_timeout,
                 )
             else:
+                completion = (
+                    provider_gateway.complete_scoped(
+                        messages,
+                        request_id=request.request_id,
+                        scope=request.gateway_scope,
+                    )
+                    if request.gateway_scope is not None
+                    else provider_gateway.complete(
+                        messages,
+                        request_id=request.request_id,
+                    )
+                )
                 response = await asyncio.wait_for(
-                    provider_gateway.complete(
-                        messages, request_id=request.request_id
-                    ),
-                    self.timeout_seconds,
+                    completion,
+                    provider_timeout,
                 )
                 result = await self._complete_response(run, response)
             self._set_result(run, result)
@@ -309,11 +338,20 @@ class ReplyOrchestrator:
         run: ReplyRun,
         messages: Sequence[Mapping[str, Any]],
         gateway: Gateway,
+        *,
+        scope: GatewayRequestScope | None,
     ) -> ReplyResult:
         chunks: list[str] = []
-        async for delta in gateway.stream(
-            messages, request_id=run.request.request_id
-        ):
+        stream = (
+            gateway.stream_scoped(
+                messages,
+                request_id=run.request.request_id,
+                scope=scope,
+            )
+            if scope is not None
+            else gateway.stream(messages, request_id=run.request.request_id)
+        )
+        async for delta in stream:
             if delta.text:
                 chunks.append(delta.text)
                 await self._publish(
@@ -393,7 +431,10 @@ def _request_fingerprint(request: ReplyRequest) -> str:
         payload: Any = list(request.messages)
     else:
         payload = [{"role": "user", "content": request.content or ""}]
-    return uuid.uuid5(uuid.NAMESPACE_URL, repr(payload)).hex
+    return uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        repr((payload, request.gateway_scope)),
+    ).hex
 
 
 __all__ = [

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -10,6 +10,7 @@ from aiohttp.test_utils import make_mocked_request
 
 import local_server
 from letter_triage import TriageResult
+from llm_gateway import GatewayConfig
 from runtime.reply.reply_context import ReplyMode
 from reply_orchestrator import ReplyState
 from runtime.reply.reply_pipeline import PipelineResult
@@ -689,13 +690,41 @@ def test_shutdown_cancels_and_releases_owned_media_jobs():
 
 
 def test_reply_pipeline_total_timeout_covers_all_quality_stages(monkeypatch):
+    config = GatewayConfig(
+        provider="openai_compatible",
+        api_style="chat_completions",
+        model="synthetic-model",
+        timeout_seconds=90.0,
+    )
+    monkeypatch.setattr(local_server, "LLM_CONFIG", config)
     monkeypatch.setattr(local_server, "LLM_TIMEOUT_SECONDS", 90.0)
     monkeypatch.delenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", raising=False)
 
-    assert local_server._reply_pipeline_timeout_seconds() == 275.0
+    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.TEXT_LETTER.value) == 275.0
 
     monkeypatch.setenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", "20")
-    assert local_server._reply_pipeline_timeout_seconds() == 155.0
+    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.TEXT_LETTER.value) == 155.0
+
+
+def test_deepseek_flash_reply_pipeline_timeout_covers_reasoning_and_adjudication(
+    monkeypatch,
+):
+    config = GatewayConfig(
+        provider="openai_compatible",
+        api_style="chat_completions",
+        model="deepseek-v4-flash",
+        timeout_seconds=180.0,
+    )
+    monkeypatch.setattr(local_server, "LLM_CONFIG", config)
+    monkeypatch.setattr(local_server, "LLM_TIMEOUT_SECONDS", 180.0)
+    monkeypatch.delenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", raising=False)
+
+    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.TEXT_LETTER.value) == 3605.0
+    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.SPOKEN_VIDEO.value) == 2405.0
+
+    monkeypatch.setenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", "20")
+    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.TEXT_LETTER.value) == 705.0
+    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.SPOKEN_VIDEO.value) == 665.0
 
 
 @pytest.mark.parametrize(

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -10,7 +10,7 @@ from aiohttp.test_utils import make_mocked_request
 
 import local_server
 from letter_triage import TriageResult
-from llm_gateway import GatewayConfig
+from llm_gateway import GatewayConfig, GatewayRequestScope
 from runtime.reply.reply_context import ReplyMode
 from reply_orchestrator import ReplyState
 from runtime.reply.reply_pipeline import PipelineResult
@@ -714,17 +714,65 @@ def test_deepseek_flash_reply_pipeline_timeout_covers_reasoning_and_adjudication
         api_style="chat_completions",
         model="deepseek-v4-flash",
         timeout_seconds=180.0,
+        reasoning_timeout_seconds=720.0,
     )
     monkeypatch.setattr(local_server, "LLM_CONFIG", config)
     monkeypatch.setattr(local_server, "LLM_TIMEOUT_SECONDS", 180.0)
     monkeypatch.delenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", raising=False)
 
-    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.TEXT_LETTER.value) == 3605.0
-    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.SPOKEN_VIDEO.value) == 2405.0
+    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.TEXT_LETTER.value) == 4325.0
+    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.SPOKEN_VIDEO.value) == 365.0
 
     monkeypatch.setenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", "20")
-    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.TEXT_LETTER.value) == 705.0
-    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.SPOKEN_VIDEO.value) == 665.0
+    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.TEXT_LETTER.value) == 4325.0
+    assert local_server._reply_pipeline_timeout_seconds(ReplyMode.SPOKEN_VIDEO.value) == 245.0
+
+
+def test_run_reply_pipeline_scopes_only_text_letter_generation_for_max_reasoning(
+    monkeypatch,
+):
+    seen = []
+
+    class RecordingPipeline:
+        async def run(self, request, context):
+            seen.append((request, context.mode))
+            return object()
+
+    config = GatewayConfig(
+        provider="openai_compatible",
+        api_style="chat_completions",
+        model="deepseek-v4-flash",
+        timeout_seconds=180.0,
+        reasoning_timeout_seconds=720.0,
+    )
+    monkeypatch.setattr(local_server, "LLM_CONFIG", config)
+    monkeypatch.setattr(local_server, "LLM_TIMEOUT_SECONDS", 180.0)
+    monkeypatch.setattr(local_server, "reply_pipeline", RecordingPipeline())
+
+    async def exercise():
+        await local_server._run_reply_pipeline_for_letter(
+            {"letter_id": "text-fixture"},
+            "synthetic text letter",
+            ReplyMode.TEXT_LETTER.value,
+            idempotency_key="stable",
+        )
+        await local_server._run_reply_pipeline_for_letter(
+            {"letter_id": "video-fixture"},
+            "synthetic video request",
+            ReplyMode.SPOKEN_VIDEO.value,
+            idempotency_key="stable",
+        )
+
+    asyncio.run(exercise())
+
+    assert seen[0][0].gateway_scope is GatewayRequestScope.TEXT_LETTER_MAX_REASONING
+    assert seen[0][0].request_id == "letter-reply:text-fixture"
+    assert seen[0][0].idempotency_key == "stable:text-fixture"
+    assert seen[0][1] is ReplyMode.TEXT_LETTER
+    assert seen[1][0].gateway_scope is None
+    assert seen[1][0].request_id == "letter-reply:video-fixture"
+    assert seen[1][0].idempotency_key == "stable:video-fixture"
+    assert seen[1][1] is ReplyMode.SPOKEN_VIDEO
 
 
 @pytest.mark.parametrize(

--- a/tests/llm/test_b03_integration.py
+++ b/tests/llm/test_b03_integration.py
@@ -73,6 +73,54 @@ def test_saved_llm_config_replaces_the_next_reply_gateway_without_restart(
     assert "synthetic-runtime-key" not in repr(local_server.LLM_CFG)
 
 
+def test_deepseek_flash_runtime_extends_only_the_letter_reply_timeout(
+    monkeypatch,
+) -> None:
+    import local_server
+
+    previous = GatewayConfig(
+        provider="openai_compatible",
+        base_url="https://old.example/v1",
+        model="old-model",
+    )
+    marker = object()
+    candidate_analyzer = type(
+        "CandidateAnalyzer",
+        (),
+        {"gateway": object(), "timeout_seconds": 1.0},
+    )()
+    monkeypatch.setattr(local_server, "LLM_CONFIG", previous)
+    monkeypatch.setattr(local_server, "LLM_TIMEOUT_SECONDS", previous.timeout_seconds)
+    monkeypatch.setattr(local_server, "LLM_CFG", previous.public_dict())
+    monkeypatch.setattr(local_server.letters_adapter, "config", previous)
+    monkeypatch.setattr(local_server.letters_adapter, "gateway", object())
+    monkeypatch.setattr(
+        local_server,
+        "GatewayPrivateWorldCandidateAnalyzer",
+        type(candidate_analyzer),
+    )
+    monkeypatch.setattr(
+        local_server,
+        "private_world_candidate_analyzer",
+        candidate_analyzer,
+    )
+    monkeypatch.setattr(local_server.reply_engine, "timeout_seconds", 1.0)
+    monkeypatch.setattr(local_server, "create_gateway", lambda *_args, **_kwargs: marker)
+    monkeypatch.setattr(local_server.emotion_triage, "gateway", object())
+    monkeypatch.delenv("OLIVIA_LLM_RUNTIME_KEY_CONFIGURED", raising=False)
+
+    local_server.apply_runtime_llm_config(
+        "https://gateway.example/v1",
+        "deepseek-v4-flash",
+        "synthetic-runtime-key",
+    )
+
+    assert local_server.LLM_CONFIG.timeout_seconds == 180.0
+    assert local_server.LLM_TIMEOUT_SECONDS == 180.0
+    assert candidate_analyzer.timeout_seconds == 180.0
+    assert local_server.reply_engine.timeout_seconds == 600.0
+
+
 def test_failed_llm_runtime_replacement_keeps_the_previous_gateway(monkeypatch) -> None:
     import local_server
 

--- a/tests/llm/test_b03_integration.py
+++ b/tests/llm/test_b03_integration.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import asyncio
 
-from llm_gateway import GatewayConfig, OfflineDeterministicAdapter, UnconfiguredAdapter
+from llm_gateway import (
+    Gateway,
+    GatewayConfig,
+    GatewayRequestScope,
+    GatewayResponse,
+    OfflineDeterministicAdapter,
+    UnconfiguredAdapter,
+)
 
 
 def test_saved_llm_config_replaces_the_next_reply_gateway_without_restart(
@@ -73,7 +80,7 @@ def test_saved_llm_config_replaces_the_next_reply_gateway_without_restart(
     assert "synthetic-runtime-key" not in repr(local_server.LLM_CFG)
 
 
-def test_deepseek_flash_runtime_extends_only_the_letter_reply_timeout(
+def test_deepseek_flash_runtime_keeps_generic_engine_timeout_for_non_scoped_calls(
     monkeypatch,
 ) -> None:
     import local_server
@@ -118,7 +125,40 @@ def test_deepseek_flash_runtime_extends_only_the_letter_reply_timeout(
     assert local_server.LLM_CONFIG.timeout_seconds == 180.0
     assert local_server.LLM_TIMEOUT_SECONDS == 180.0
     assert candidate_analyzer.timeout_seconds == 180.0
-    assert local_server.reply_engine.timeout_seconds == 600.0
+    assert local_server.reply_engine.timeout_seconds == 180.0
+
+
+def test_letter_gateway_preserves_scoped_text_call_without_changing_request_id() -> None:
+    import local_server
+
+    seen = []
+
+    class RecordingGateway(Gateway):
+        async def complete(self, messages, *, request_id=None):
+            raise AssertionError("text Letter scope was dropped")
+
+        async def complete_scoped(self, messages, *, request_id=None, scope):
+            seen.append((tuple(messages), request_id, scope))
+            return GatewayResponse("scoped reply", request_id or "", "mock", "mock")
+
+    config = GatewayConfig(provider="mock", persona_v2_enabled=False)
+    adapter = local_server.LetterAdapter(config)
+    adapter.replace_runtime(config, RecordingGateway())
+    bridge = local_server._LetterGateway(adapter)
+
+    response = asyncio.run(
+        bridge.complete_scoped(
+            ({"role": "user", "content": "synthetic letter"},),
+            request_id="letter-reply:stable",
+            scope=GatewayRequestScope.TEXT_LETTER_MAX_REASONING,
+        )
+    )
+
+    assert response.request_id == "letter-reply:stable"
+    assert seen[0][1:] == (
+        "letter-reply:stable",
+        GatewayRequestScope.TEXT_LETTER_MAX_REASONING,
+    )
 
 
 def test_failed_llm_runtime_replacement_keeps_the_previous_gateway(monkeypatch) -> None:

--- a/tests/llm/test_gateway.py
+++ b/tests/llm/test_gateway.py
@@ -156,6 +156,124 @@ def test_chat_completion_adapter_uses_local_mock_server_and_env_key(monkeypatch:
     assert seen["body"]["messages"] == list(ROOT_MESSAGES)
 
 
+@pytest.mark.parametrize("endpoint", ["opencode-go", "official-deepseek"])
+@pytest.mark.parametrize("request_id", ["letter-reply:fixture", "quality-fixture"])
+def test_deepseek_v4_flash_release_text_requests_max_reasoning(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    endpoint: str,
+    request_id: str,
+) -> None:
+    async def exercise():
+        seen: dict[str, object] = {}
+
+        async def handler(request: web.Request) -> web.Response:
+            seen.update(await request.json())
+            return web.json_response(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "reasoning_content": "private chain",
+                                "content": "mock reply",
+                            }
+                        }
+                    ]
+                }
+            )
+
+        app = web.Application()
+        app.router.add_post(f"/{endpoint}/v1/chat/completions", handler)
+        async with TestClient(TestServer(app)) as client:
+            adapter = OpenAICompatibleAdapter(
+                make_config(
+                    str(client.make_url(f"/{endpoint}/v1")),
+                    model="DeepSeek-V4-Flash",
+                )
+            )
+            response = await adapter.complete(ROOT_MESSAGES, request_id=request_id)
+        return response, seen
+
+    monkeypatch.setenv("B03_TEST_KEY", "TEST")
+    response, body = run(exercise())
+
+    assert response.text == "mock reply"
+    assert body["thinking"] == {"type": "enabled"}
+    assert body["reasoning_effort"] == "max"
+    captured = capsys.readouterr()
+    assert "private chain" not in captured.out
+    assert "private chain" not in captured.err
+
+
+@pytest.mark.parametrize(
+    "request_id",
+    [None, "historical-import", "live-turn", "song-plan"],
+)
+def test_deepseek_v4_flash_nonrelease_text_requests_keep_legacy_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    request_id: str | None,
+) -> None:
+    async def exercise() -> dict[str, object]:
+        seen: dict[str, object] = {}
+
+        async def handler(request: web.Request) -> web.Response:
+            seen.update(await request.json())
+            return web.json_response(
+                {"choices": [{"message": {"content": "mock reply"}}]}
+            )
+
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", handler)
+        async with TestClient(TestServer(app)) as client:
+            adapter = OpenAICompatibleAdapter(
+                make_config(
+                    str(client.make_url("/v1")),
+                    model="deepseek-v4-flash",
+                )
+            )
+            await adapter.complete(ROOT_MESSAGES, request_id=request_id)
+        return seen
+
+    monkeypatch.setenv("B03_TEST_KEY", "TEST")
+    body = run(exercise())
+
+    assert "thinking" not in body
+    assert "reasoning_effort" not in body
+
+
+def test_deepseek_v4_flash_release_reasoning_has_a_compatible_http_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def exercise() -> tuple[str, str]:
+        async def handler(_request: web.Request) -> web.Response:
+            await asyncio.sleep(0.05)
+            return web.json_response(
+                {"choices": [{"message": {"content": "mock reply"}}]}
+            )
+
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", handler)
+        async with TestClient(TestServer(app)) as client:
+            adapter = OpenAICompatibleAdapter(
+                make_config(
+                    str(client.make_url("/v1")),
+                    model="deepseek-v4-flash",
+                    timeout_seconds=0.01,
+                )
+            )
+            release = await adapter.complete(
+                ROOT_MESSAGES,
+                request_id="letter-reply:fixture",
+            )
+            with pytest.raises(ProviderTimeout) as nonrelease:
+                await adapter.complete(ROOT_MESSAGES, request_id="live-turn")
+        return release.text, nonrelease.value.code
+
+    monkeypatch.setenv("B03_TEST_KEY", "TEST")
+
+    assert run(exercise()) == ("mock reply", "PROVIDER_TIMEOUT")
+
+
 def test_openai_compatible_adapter_returns_required_tool_calls(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -391,6 +509,69 @@ def test_responses_style_and_sse_stream_are_supported(monkeypatch: pytest.Monkey
     response, stream = run(exercise())
     assert response.text == "responses reply"
     assert "".join(delta.text for delta in stream) == "first second"
+
+
+def test_deepseek_v4_flash_release_stream_hides_reasoning_content(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def exercise():
+        seen: list[dict[str, object]] = []
+
+        async def handler(request: web.Request) -> web.StreamResponse:
+            seen.append(await request.json())
+            response = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+            await response.prepare(request)
+            await response.write(
+                b'data: {"choices":[{"delta":{"reasoning_content":"private stream chain"}}]}\n\n'
+            )
+            await response.write(
+                b'data: {"choices":[{"delta":{"content":"visible reply"}}]}\n\n'
+            )
+            await response.write(
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+            )
+            await response.write_eof()
+            return response
+
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", handler)
+        async with TestClient(TestServer(app)) as client:
+            adapter = OpenAICompatibleAdapter(
+                make_config(
+                    str(client.make_url("/v1")),
+                    model="deepseek-v4-flash",
+                    stream=True,
+                )
+            )
+            release_deltas = [
+                delta
+                async for delta in adapter.stream(
+                    ROOT_MESSAGES,
+                    request_id="quality-fixture",
+                )
+            ]
+            live_deltas = [
+                delta
+                async for delta in adapter.stream(
+                    ROOT_MESSAGES,
+                    request_id="live-turn",
+                )
+            ]
+        return release_deltas, live_deltas, seen
+
+    monkeypatch.setenv("B03_TEST_KEY", "TEST")
+    release_deltas, live_deltas, bodies = run(exercise())
+
+    assert "".join(delta.text for delta in release_deltas) == "visible reply"
+    assert "".join(delta.text for delta in live_deltas) == "visible reply"
+    assert bodies[0]["thinking"] == {"type": "enabled"}
+    assert bodies[0]["reasoning_effort"] == "max"
+    assert "thinking" not in bodies[1]
+    assert "reasoning_effort" not in bodies[1]
+    captured = capsys.readouterr()
+    assert "private stream chain" not in captured.out
+    assert "private stream chain" not in captured.err
 
 
 @pytest.mark.parametrize("status", [429, 503])

--- a/tests/llm/test_gateway.py
+++ b/tests/llm/test_gateway.py
@@ -8,6 +8,7 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from llm_gateway import (
     GatewayConfig,
+    GatewayRequestScope,
     InvalidGatewayInput,
     OfflineDeterministicAdapter,
     OpenAICompatibleAdapter,
@@ -17,6 +18,7 @@ from llm_gateway import (
     ProviderUnavailable,
     UnconfiguredAdapter,
     create_gateway,
+    load_gateway_config,
     validate_messages,
 )
 
@@ -64,6 +66,26 @@ def make_config(base_url: str, **overrides) -> GatewayConfig:
     }
     values.update(overrides)
     return GatewayConfig(**values)
+
+
+def test_reasoning_timeout_is_an_explicit_bounded_public_config() -> None:
+    default = GatewayConfig.from_mapping({})
+    configured = GatewayConfig.from_mapping({"reasoning_timeout_seconds": 720})
+    bounded = GatewayConfig.from_mapping({"reasoning_timeout_seconds": 99_999})
+
+    assert default.reasoning_timeout_seconds == 600.0
+    assert configured.reasoning_timeout_seconds == 720.0
+    assert bounded.reasoning_timeout_seconds == 1800.0
+    assert configured.public_dict()["reasoning_timeout_seconds"] == 720.0
+
+
+def test_reasoning_timeout_environment_override_is_loaded(tmp_path) -> None:
+    config = load_gateway_config(
+        tmp_path / "missing.json",
+        environ={"OLIVIA_LLM_REASONING_TIMEOUT_SECONDS": "840"},
+    )
+
+    assert config.reasoning_timeout_seconds == 840.0
 
 
 def test_input_roles_and_lengths_are_rejected_before_provider_call() -> None:
@@ -168,7 +190,9 @@ def test_deepseek_v4_flash_release_text_requests_max_reasoning(
         seen: dict[str, object] = {}
 
         async def handler(request: web.Request) -> web.Response:
-            seen.update(await request.json())
+            seen["body"] = await request.json()
+            seen["request_id"] = request.headers.get("X-Request-ID")
+            seen["idempotency_key"] = request.headers.get("Idempotency-Key")
             return web.json_response(
                 {
                     "choices": [
@@ -191,15 +215,25 @@ def test_deepseek_v4_flash_release_text_requests_max_reasoning(
                     model="DeepSeek-V4-Flash",
                 )
             )
-            response = await adapter.complete(ROOT_MESSAGES, request_id=request_id)
+            response = await adapter.complete_scoped(
+                ROOT_MESSAGES,
+                request_id=request_id,
+                scope=GatewayRequestScope.TEXT_LETTER_MAX_REASONING,
+            )
         return response, seen
 
     monkeypatch.setenv("B03_TEST_KEY", "TEST")
-    response, body = run(exercise())
+    response, seen = run(exercise())
 
     assert response.text == "mock reply"
+    assert response.request_id == request_id
+    body = seen["body"]
     assert body["thinking"] == {"type": "enabled"}
     assert body["reasoning_effort"] == "max"
+    assert seen["request_id"] == request_id
+    assert seen["idempotency_key"] == (
+        request_id if request_id.startswith("letter-reply:") else None
+    )
     captured = capsys.readouterr()
     assert "private chain" not in captured.out
     assert "private chain" not in captured.err
@@ -207,7 +241,7 @@ def test_deepseek_v4_flash_release_text_requests_max_reasoning(
 
 @pytest.mark.parametrize(
     "request_id",
-    [None, "historical-import", "live-turn", "song-plan"],
+    [None, "letter-reply:video", "quality-video", "historical-import", "live-turn", "song-plan"],
 )
 def test_deepseek_v4_flash_nonrelease_text_requests_keep_legacy_payload(
     monkeypatch: pytest.MonkeyPatch,
@@ -261,9 +295,10 @@ def test_deepseek_v4_flash_release_reasoning_has_a_compatible_http_timeout(
                     timeout_seconds=0.01,
                 )
             )
-            release = await adapter.complete(
+            release = await adapter.complete_scoped(
                 ROOT_MESSAGES,
                 request_id="letter-reply:fixture",
+                scope=GatewayRequestScope.TEXT_LETTER_MAX_REASONING,
             )
             with pytest.raises(ProviderTimeout) as nonrelease:
                 await adapter.complete(ROOT_MESSAGES, request_id="live-turn")
@@ -546,9 +581,10 @@ def test_deepseek_v4_flash_release_stream_hides_reasoning_content(
             )
             release_deltas = [
                 delta
-                async for delta in adapter.stream(
+                async for delta in adapter.stream_scoped(
                     ROOT_MESSAGES,
                     request_id="quality-fixture",
+                    scope=GatewayRequestScope.TEXT_LETTER_MAX_REASONING,
                 )
             ]
             live_deltas = [

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -3169,7 +3169,7 @@ def test_quality_model_default_timeout_allows_slow_configured_provider(
                     base_url="https://example.invalid/v1",
                     model="forbidden-review-model",
                     api_key_env="SYNTHETIC_KEY",
-                    timeout_seconds=90.0,
+                    timeout_seconds=180.0,
                     max_input_chars=10_000,
                     fallback_provider="mock",
                 ),
@@ -3185,11 +3185,19 @@ def test_quality_model_default_timeout_allows_slow_configured_provider(
 
     assert reviewer is not None
     assert rewriter is not None
-    assert reviewer.adapter.config.timeout_seconds == 60.0
-    assert rewriter.timeout_seconds == 60.0
+    assert reviewer.adapter.config.timeout_seconds == 600.0
+    assert rewriter.timeout_seconds == 600.0
     review_gateway = reviewer.adapter.transport.gateway
     assert review_gateway is rewriter.gateway
     assert review_gateway is not gateway
     assert review_gateway.config.model == "deepseek-v4-flash"
     assert review_gateway.config.max_input_chars == 30_000
     assert review_gateway.config.fallback_provider == "none"
+
+    monkeypatch.setenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", "20")
+    overridden_reviewer, overridden_rewriter = create_model_quality_ports(orchestrator)
+
+    assert overridden_reviewer is not None
+    assert overridden_rewriter is not None
+    assert overridden_reviewer.adapter.config.timeout_seconds == 20.0
+    assert overridden_rewriter.timeout_seconds == 20.0

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -14,7 +14,13 @@ import pytest
 
 import runtime.reply.reply_model_quality as quality_module
 
-from llm_gateway import Gateway, GatewayConfig, GatewayDelta, GatewayResponse
+from llm_gateway import (
+    Gateway,
+    GatewayConfig,
+    GatewayDelta,
+    GatewayRequestScope,
+    GatewayResponse,
+)
 from memory_port import CONVERSATION_MEMORY, MemoryRecord, NullMemoryPort
 from memory_prompt import MemoryPromptBuilder
 from runtime.reply.reply_context import (
@@ -605,6 +611,17 @@ class SequencedQualityGateway(Gateway):
         self.adjudication_message_roles: list[tuple[str, ...]] = []
         self.adjudication_system_prompts: list[str] = []
         self.adjudication_input_sizes: list[int] = []
+        self.scopes: list[GatewayRequestScope] = []
+
+    async def complete_scoped(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        request_id: str | None = None,
+        scope: GatewayRequestScope,
+    ) -> GatewayResponse:
+        self.scopes.append(scope)
+        return await self.complete(messages, request_id=request_id)
 
     async def complete(
         self,
@@ -803,6 +820,7 @@ def _pipeline(
     *,
     memory: NullMemoryPort | None = None,
     rewrite_enabled: bool = True,
+    max_reasoning: bool = False,
 ) -> ReplyPipeline:
     monkeypatch.setenv("OLIVIA_REPLY_REVIEW_ENABLED", "true")
     monkeypatch.setenv(
@@ -811,12 +829,26 @@ def _pipeline(
     )
     monkeypatch.setenv("OLIVIA_REPLY_REVIEW_TIMEOUT_SECONDS", "1")
     memory = memory or NullMemoryPort()
-    adapter = SimpleNamespace(
-        config=SimpleNamespace(
+    config = (
+        GatewayConfig(
+            provider="openai_compatible",
+            api_style="chat_completions",
+            model="deepseek-v4-flash",
+            persona_v2_enabled=True,
+            timeout_seconds=3.0,
+            reasoning_timeout_seconds=5.0,
+        )
+        if max_reasoning
+        else SimpleNamespace(
             provider="openai_compatible",
             persona_v2_enabled=True,
             timeout_seconds=3.0,
-        ),
+        )
+    )
+    if max_reasoning:
+        monkeypatch.setattr(quality_module, "create_gateway", lambda _config: gateway)
+    adapter = SimpleNamespace(
+        config=config,
         persona_v2_path=(
             ROOT / "linli_character" / "persona_release_v2.json"
         ),
@@ -853,7 +885,7 @@ def test_configured_provider_runs_structured_persona_review(
         candidate="我听见了。今晚先做一件小事就好。",
         reviews=_passing_layer_payloads(),
     )
-    pipeline = _pipeline(gateway, monkeypatch)
+    pipeline = _pipeline(gateway, monkeypatch, max_reasoning=True)
 
     result = asyncio.run(
         pipeline.run(
@@ -1249,8 +1281,12 @@ def test_adjudicator_rejects_false_style_drift_as_direct_soft_warning(
     )
 
     result = asyncio.run(
-        _pipeline(gateway, monkeypatch).run(
-            ReplyRequest(content="Synthetic current input.", request_id="false-style"),
+        _pipeline(gateway, monkeypatch, max_reasoning=True).run(
+            ReplyRequest(
+                content="Synthetic current input.",
+                request_id="false-style",
+                gateway_scope=GatewayRequestScope.TEXT_LETTER_MAX_REASONING,
+            ),
             _context(),
         )
     )
@@ -1260,6 +1296,7 @@ def test_adjudicator_rejects_false_style_drift_as_direct_soft_warning(
     assert result.violation_codes == ("STYLE_DRIFT",)
     assert result.rewrite_calls == 0
     assert gateway.call_kinds == ["generation", *('review',) * 5, "adjudication"]
+    assert gateway.scopes == [GatewayRequestScope.TEXT_LETTER_MAX_REASONING] * 7
 
 
 def test_confirmed_forced_question_rewrites_then_persistent_style_blocks(
@@ -1512,7 +1549,7 @@ def test_non_letter_hard_findings_keep_legacy_schema_without_adjudication(
         reviews=[*first, *_legacy_passing_layer_payloads()],
         rewritten="y" * 190,
     )
-    pipeline = _pipeline(gateway, monkeypatch)
+    pipeline = _pipeline(gateway, monkeypatch, max_reasoning=True)
 
     result = asyncio.run(
         pipeline.run(
@@ -2989,13 +3026,14 @@ def test_deterministic_violation_uses_original_model_for_one_rewrite(
         reviews=[*_passing_layer_payloads(), *_passing_layer_payloads()],
         rewritten="谁让你一个人把事情都扛着的。今晚先停一下。",
     )
-    pipeline = _pipeline(gateway, monkeypatch)
+    pipeline = _pipeline(gateway, monkeypatch, max_reasoning=True)
 
     result = asyncio.run(
         pipeline.run(
             ReplyRequest(
                 content="我又把事情搞砸了。",
                 request_id="rewrite-once",
+                gateway_scope=GatewayRequestScope.TEXT_LETTER_MAX_REASONING,
             ),
             _context(),
         )
@@ -3011,6 +3049,7 @@ def test_deterministic_violation_uses_original_model_for_one_rewrite(
         "rewrite",
         *("review",) * 5,
     ]
+    assert gateway.scopes == [GatewayRequestScope.TEXT_LETTER_MAX_REASONING] * 12
     rewrite = gateway.rewrite_requests[0]
     assert rewrite["user_message"] == "我又把事情搞砸了。"
     assert rewrite["violation_codes"] == ["INTERNAL_CONTROL_MARKUP"]
@@ -3044,6 +3083,7 @@ def test_video_length_rewrite_receives_the_exact_delivery_contract(
         "target_compact_characters": 190,
         "priority": "required_over_concise_style",
     }
+    assert gateway.scopes == []
 
 
 def test_quality_rewriter_uses_configured_streaming_transport() -> None:
@@ -3185,8 +3225,10 @@ def test_quality_model_default_timeout_allows_slow_configured_provider(
 
     assert reviewer is not None
     assert rewriter is not None
-    assert reviewer.adapter.config.timeout_seconds == 600.0
-    assert rewriter.timeout_seconds == 600.0
+    assert reviewer.adapter.config.timeout_seconds == 60.0
+    assert reviewer.adapter.transport.reasoning_timeout_seconds == 600.0
+    assert rewriter.timeout_seconds == 60.0
+    assert rewriter.reasoning_timeout_seconds == 600.0
     review_gateway = reviewer.adapter.transport.gateway
     assert review_gateway is rewriter.gateway
     assert review_gateway is not gateway
@@ -3201,3 +3243,5 @@ def test_quality_model_default_timeout_allows_slow_configured_provider(
     assert overridden_rewriter is not None
     assert overridden_reviewer.adapter.config.timeout_seconds == 20.0
     assert overridden_rewriter.timeout_seconds == 20.0
+    assert overridden_reviewer.adapter.transport.reasoning_timeout_seconds == 600.0
+    assert overridden_rewriter.reasoning_timeout_seconds == 600.0


### PR DESCRIPTION
## Summary
- Explicitly enable DeepSeek V4 Flash thinking with reasoning_effort=max only for trusted TEXT_LETTER generation and Persona quality stages.
- Apply the same host-independent Chat Completions payload to OpenCode Go and official DeepSeek endpoints.
- Expose reasoning_timeout_seconds (default 600 seconds) through GatewayConfig, environment loading, public status, schema, and documentation.
- Carry a typed in-process request scope through the orchestrator and quality reviewer; provider request IDs and idempotency headers remain unchanged.
- Discard reasoning_content so chain-of-thought never becomes reply text, review text, logs, or memory.

## Release rationale and size
This PR is 11 files and 985 changed lines, above the default 10-file/500-line target but below the absolute 40-file/2000-line limit. It is intentionally atomic: one release control must span the public timeout contract, HTTP payload, ReplyOrchestrator and Letter bridge, five-layer review/adjudication/rewrite/recheck, and the outer paid-call deadline. Splitting would create an unsafe intermediate state where max thinking is enabled but still cut off by the old 180/60-second limits, or where video requests inherit the Letter policy.

## Compatibility boundaries
- Only trusted TEXT_LETTER scope receives max thinking and reasoning_timeout_seconds.
- Spoken-video, musical-video, Live, historical import, song planning, Responses API, and generic calls retain their prior payload and timeout.
- complete_with_tools and automatic routing remain unchanged.
- Provider Idempotency-Key, X-Request-ID, and response request IDs are stable.
- No Live, client, video, media, or private-corpus files are changed.

## Verification
- Focused exact-head suite: 210 passed.
- Full exact-head pytest: 1556 passed, 1 skipped, 1 deselected; 7 existing aiohttp warnings.
- git diff --check passed.
- Real private-corpus provider acceptance is intentionally post-merge and will use only the configured OpenCode Go key; this PR contains synthetic fixtures only.