### PR TITLE
fix: bind Persona rewrite evidence to adjudication

### DIFF
--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -145,6 +145,17 @@ claim, span, or decision is reused; a confirmed hard claim that persists after
 the rewrite blocks. `accepted_with_warnings` is a Letter-only quality status;
 non-Letter modes retain their prior `accepted` status for soft findings.
 
+For the one permitted Letter rewrite, the configured rewriter receives the
+initial adjudication's confirmed hard findings as bounded machine evidence:
+only `code`, `start`, and `end`, with the same global limit of 16. It receives no
+evidence id, reason, decision payload, quoted excerpt, or reasoning trace. The
+rewriter must repair or qualify those candidate spans without replacing an
+unsupported current or past fact, location, action, or habit with another one.
+Invalid, non-hard, out-of-candidate, over-limit, or code-inconsistent repair
+evidence fails before the rewriter. Rewriters without this optional typed entry
+retain the legacy violation-code call. Non-Letter reviews never claim that
+their legacy findings were adjudicated and therefore pass no repair evidence.
+
 Adjudication prompts and responses are transient. Candidate text is not added
 to quality status, audit records, evidence objects, or logs, and the typed
 evidence contains offsets and machine reason codes rather than quoted text.

--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -145,16 +145,12 @@ claim, span, or decision is reused; a confirmed hard claim that persists after
 the rewrite blocks. `accepted_with_warnings` is a Letter-only quality status;
 non-Letter modes retain their prior `accepted` status for soft findings.
 
-For the one permitted Letter rewrite, the configured rewriter receives the
-initial adjudication's confirmed hard findings as bounded machine evidence:
-only `code`, `start`, and `end`, with the same global limit of 16. It receives no
-evidence id, reason, decision payload, quoted excerpt, or reasoning trace. The
-rewriter must repair or qualify those candidate spans without replacing an
-unsupported current or past fact, location, action, or habit with another one.
-Invalid, non-hard, out-of-candidate, over-limit, or code-inconsistent repair
-evidence fails before the rewriter. Rewriters without this optional typed entry
-retain the legacy violation-code call. Non-Letter reviews never claim that
-their legacy findings were adjudicated and therefore pass no repair evidence.
+For the one permitted Letter rewrite, the configured rewriter receives only actual
+`CONFIRM` results as candidate-bound, single-use `code`/`start`/`end` evidence
+(limit 16), never evidence ids, reasons, decisions, excerpts, or reasoning.
+It must repair those spans without substituting unsupported facts or actions.
+Invalid or inconsistent evidence fails before the rewriter; legacy code-only
+calls remain, while non-Letter findings are not treated as adjudicated evidence.
 
 Adjudication prompts and responses are transient. Candidate text is not added
 to quality status, audit records, evidence objects, or logs, and the typed

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -25,7 +25,9 @@ from runtime.reply.reply_policy import IntimacyClaim
 from runtime.reply.reply_reviewer import (
     JsonReviewerAdapter,
     ReviewReference,
+    ReviewerViolation,
     ReviewResult,
+    ReviewStatus,
     ReviewerConfig,
     TrustedReviewEvidence,
 )
@@ -590,6 +592,23 @@ class GatewayPersonaReviewer:
             references=references,
         )
 
+    def confirmed_rewrite_evidence(
+        self,
+        _candidate: str,
+        context: ReplyContext,
+        review: ReviewResult,
+    ) -> tuple[ReviewerViolation, ...]:
+        if (
+            context.mode is not ReplyMode.TEXT_LETTER
+            or review.status is not ReviewStatus.COMPLETED
+        ):
+            return ()
+        return tuple(
+            item
+            for item in review.violations
+            if item.severity == "hard"
+        )
+
 
 class GatewayPersonaRewriter:
     def __init__(
@@ -635,6 +654,26 @@ class GatewayPersonaRewriter:
             ),
         )
 
+    def rewrite_with_evidence(
+        self,
+        candidate: str,
+        context: ReplyContext,
+        violation_codes: tuple[str, ...],
+        generation_messages: Sequence[
+            Mapping[str, Any]
+        ],
+        confirmed_violations: tuple[ReviewerViolation, ...],
+    ) -> str:
+        return self._rewrite(
+            candidate,
+            context,
+            violation_codes,
+            user_text=_last_user_text(
+                generation_messages
+            ),
+            confirmed_violations=confirmed_violations,
+        )
+
     def _rewrite(
         self,
         candidate: str,
@@ -642,7 +681,13 @@ class GatewayPersonaRewriter:
         violation_codes: tuple[str, ...],
         *,
         user_text: str,
+        confirmed_violations: tuple[ReviewerViolation, ...] = (),
     ) -> str:
+        confirmed_violation_evidence = _confirmed_violation_evidence_payload(
+            candidate,
+            violation_codes,
+            confirmed_violations,
+        )
         delivery_length_contract = None
         if "VIDEO_REPLY_LENGTH_OUT_OF_RANGE" in violation_codes:
             delivery_length_contract = {
@@ -690,6 +735,7 @@ class GatewayPersonaRewriter:
             "violation_codes": list(
                 violation_codes
             ),
+            "confirmed_violation_evidence": confirmed_violation_evidence,
         }
         if delivery_length_contract is not None:
             payload["delivery_length_contract"] = delivery_length_contract
@@ -697,6 +743,14 @@ class GatewayPersonaRewriter:
             " In text_letter, do not add a question just to create a closing; "
             "keep one only when it obtains necessary information or choice."
             if context.mode.value == "text_letter"
+            else ""
+        )
+        evidence_repair = (
+            " confirmed_violation_evidence contains adjudicated hard spans in "
+            "the candidate. Repair or qualify those exact spans. Do not replace "
+            "one unsupported current or past fact, location, action, or habit "
+            "with another unsupported claim."
+            if confirmed_violation_evidence
             else ""
         )
         messages = (
@@ -711,6 +765,7 @@ class GatewayPersonaRewriter:
                     "plain-text reply: no analysis, JSON, Markdown heading, stage direction, "
                     "speaker prefix, or control markup."
                     f"{text_letter_repair}"
+                    f"{evidence_repair}"
                     " When delivery_length_contract is present, it overrides the usual "
                     "concise style: rewrite to its target length and verify the compact "
                     "character count is within the inclusive range before returning. "
@@ -742,6 +797,42 @@ class GatewayPersonaRewriter:
             ),
             gateway_scope=reasoning_scope,
         ).strip()
+
+
+def _confirmed_violation_evidence_payload(
+    candidate: str,
+    violation_codes: tuple[str, ...],
+    confirmed_violations: tuple[ReviewerViolation, ...],
+) -> list[dict[str, object]]:
+    if not isinstance(confirmed_violations, tuple) or any(
+        not isinstance(item, ReviewerViolation)
+        for item in confirmed_violations
+    ):
+        raise TypeError("confirmed violations must be a typed tuple")
+    if len(confirmed_violations) > 16:
+        raise ValueError("confirmed violation evidence exceeds limit")
+    payload: list[dict[str, object]] = []
+    for item in confirmed_violations:
+        if (
+            item.severity != "hard"
+            or item.code not in violation_codes
+            or isinstance(item.start, bool)
+            or not isinstance(item.start, int)
+            or isinstance(item.end, bool)
+            or not isinstance(item.end, int)
+            or item.start < 0
+            or item.end <= item.start
+            or item.end > len(candidate)
+        ):
+            raise ValueError("confirmed violation evidence is invalid")
+        payload.append(
+            {
+                "code": item.code,
+                "start": item.start,
+                "end": item.end,
+            }
+        )
+    return payload
 
 
 def create_model_quality_ports(

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+from contextvars import ContextVar
 from dataclasses import dataclass, replace
 from enum import StrEnum
+from hashlib import sha256
 import json
 import os
 import re
@@ -364,6 +366,22 @@ class _LayerResult:
         )
 
 
+@dataclass(frozen=True)
+class _ConfirmedRewriteEvidence:
+    candidate_digest: str
+    violations: tuple[ReviewerViolation, ...]
+
+
+@dataclass(frozen=True)
+class _AdjudicationOutcome:
+    results: tuple[_LayerResult, ...]
+    confirmed_evidence: tuple[ReviewerViolation, ...]
+
+
+def _candidate_digest(candidate: str) -> str:
+    return sha256(candidate.encode("utf-8", errors="surrogatepass")).hexdigest()
+
+
 class GatewayReviewTransport:
     def __init__(
         self,
@@ -376,6 +394,12 @@ class GatewayReviewTransport:
         self.reasoning_timeout_seconds = reasoning_timeout_seconds
         self._last_failure_diagnostics: tuple[ReviewFailureDiagnostic, ...] = ()
         self._diagnostics_lock = Lock()
+        self._confirmed_rewrite_evidence: ContextVar[
+            _ConfirmedRewriteEvidence | None
+        ] = ContextVar(
+            f"confirmed_rewrite_evidence_{id(self)}",
+            default=None,
+        )
 
     @property
     def last_failure_diagnostics(self) -> tuple[ReviewFailureDiagnostic, ...]:
@@ -396,12 +420,15 @@ class GatewayReviewTransport:
         model: str,
         timeout_seconds: float,
     ) -> object:
+        self._confirmed_rewrite_evidence.set(None)
         try:
             result = self._review_json(request, timeout_seconds=timeout_seconds)
         except _ReviewDiagnosticsError as exc:
+            self._confirmed_rewrite_evidence.set(None)
             self._publish_failure_diagnostics(exc.diagnostics)
             raise RuntimeError("quality model unavailable") from None
         except Exception:
+            self._confirmed_rewrite_evidence.set(None)
             failure = _diagnostic_error(
                 ReviewFailureStage.AGGREGATION,
                 ReviewFailureReason.INTERNAL,
@@ -410,6 +437,22 @@ class GatewayReviewTransport:
             raise RuntimeError("quality model unavailable") from None
         self._publish_failure_diagnostics(())
         return result
+
+    def consume_confirmed_rewrite_evidence(
+        self,
+        candidate: str,
+        *,
+        required: bool = True,
+    ) -> tuple[ReviewerViolation, ...]:
+        batch = self._confirmed_rewrite_evidence.get()
+        self._confirmed_rewrite_evidence.set(None)
+        if batch is None:
+            if required:
+                raise ValueError("confirmed rewrite evidence unavailable")
+            return ()
+        if batch.candidate_digest != _candidate_digest(candidate):
+            raise ValueError("confirmed rewrite evidence candidate mismatch")
+        return batch.violations
 
     def _review_json(
         self,
@@ -482,7 +525,7 @@ class GatewayReviewTransport:
         )
         if evidence_bound:
             try:
-                results = _adjudicate_hard_evidence(
+                adjudication = _adjudicate_hard_evidence(
                     self.gateway,
                     results,
                     authorities=authorities,
@@ -498,6 +541,7 @@ class GatewayReviewTransport:
                     timeout_seconds=effective_timeout,
                     gateway_scope=reasoning_scope,
                 )
+                results = adjudication.results
             except _ReviewContractFailure as exc:
                 raise _diagnostic_error(
                     ReviewFailureStage.ADJUDICATION, exc.reason
@@ -508,7 +552,7 @@ class GatewayReviewTransport:
                     ReviewFailureReason.INTERNAL,
                 ) from None
         try:
-            return _aggregate_layer_results(
+            aggregate = _aggregate_layer_results(
                 results,
                 candidate=str(request.get("candidate", "")),
                 evidence_bound=evidence_bound,
@@ -518,6 +562,14 @@ class GatewayReviewTransport:
                 ReviewFailureStage.AGGREGATION,
                 ReviewFailureReason.AGGREGATION_CONTRACT,
             ) from None
+        if evidence_bound:
+            self._confirmed_rewrite_evidence.set(
+                _ConfirmedRewriteEvidence(
+                    _candidate_digest(str(request.get("candidate", ""))),
+                    adjudication.confirmed_evidence,
+                )
+            )
+        return aggregate
 
 
 class GatewayPersonaReviewer:
@@ -594,7 +646,7 @@ class GatewayPersonaReviewer:
 
     def confirmed_rewrite_evidence(
         self,
-        _candidate: str,
+        candidate: str,
         context: ReplyContext,
         review: ReviewResult,
     ) -> tuple[ReviewerViolation, ...]:
@@ -602,12 +654,11 @@ class GatewayPersonaReviewer:
             context.mode is not ReplyMode.TEXT_LETTER
             or review.status is not ReviewStatus.COMPLETED
         ):
+            self._transport.consume_confirmed_rewrite_evidence(
+                candidate, required=False
+            )
             return ()
-        return tuple(
-            item
-            for item in review.violations
-            if item.severity == "hard"
-        )
+        return self._transport.consume_confirmed_rewrite_evidence(candidate)
 
 
 class GatewayPersonaRewriter:
@@ -1481,7 +1532,7 @@ def _adjudicate_hard_evidence(
     relationship_context: Mapping[str, object],
     timeout_seconds: float,
     gateway_scope: GatewayRequestScope | None,
-) -> tuple[_LayerResult, ...]:
+) -> _AdjudicationOutcome:
     claims = tuple(
         (item.layer, evidence)
         for item in results
@@ -1489,7 +1540,7 @@ def _adjudicate_hard_evidence(
         for evidence in item.hard_evidence
     )
     if not claims:
-        return tuple(results)
+        return _AdjudicationOutcome(tuple(results), ())
     if len(claims) > 16:
         raise RuntimeError("ADJUDICATION_EVIDENCE_LIMIT")
     evidence_ids = tuple(evidence.evidence_id for _, evidence in claims)
@@ -1626,7 +1677,12 @@ def _adjudicate_hard_evidence(
                 soft_evidence=rejected,
             )
         )
-    return tuple(revised)
+    confirmed_evidence = tuple(
+        ReviewerViolation(item.code, "hard", item.start, item.end)
+        for item in decisions
+        if item.confirmed
+    )
+    return _AdjudicationOutcome(tuple(revised), confirmed_evidence)
 
 
 def _adjudication_authority_layer(

--- a/runtime/reply/reply_quality_gate.py
+++ b/runtime/reply/reply_quality_gate.py
@@ -155,19 +155,31 @@ def run_reply_quality_gate(
             rewrite_calls=0,
         )
     try:
+        confirmed_evidence = _confirmed_rewrite_evidence(
+            reviewer,
+            candidate,
+            reviewed_context,
+            review,
+            initial_codes,
+        )
+    except Exception:
+        return QualityGateResult(
+            QualityGateStatus.BLOCKED,
+            candidate,
+            initial_codes,
+            deterministic_checks=1,
+            reviewer_calls=1,
+            rewrite_calls=0,
+            error_code="REWRITE_FAILED",
+        )
+    try:
         rewritten = _rewrite_candidate(
             rewriter,
             candidate,
             reviewed_context,
             initial_codes,
             generation_messages,
-            _confirmed_rewrite_evidence(
-                reviewer,
-                candidate,
-                reviewed_context,
-                review,
-                initial_codes,
-            ),
+            confirmed_evidence,
         )
     except Exception:
         return QualityGateResult(

--- a/runtime/reply/reply_quality_gate.py
+++ b/runtime/reply/reply_quality_gate.py
@@ -8,7 +8,12 @@ from typing import Any, Mapping, Protocol, Sequence
 
 from runtime.reply.reply_context import ReplyContext
 from runtime.reply.reply_policy import IntimacyClaim, scan_reply
-from runtime.reply.reply_reviewer import ReviewResult, ReviewStatus, ReviewVerdict
+from runtime.reply.reply_reviewer import (
+    ReviewerViolation,
+    ReviewResult,
+    ReviewStatus,
+    ReviewVerdict,
+)
 from runtime.reply.reply_reviewer import TrustedReviewEvidence
 
 
@@ -156,6 +161,13 @@ def run_reply_quality_gate(
             reviewed_context,
             initial_codes,
             generation_messages,
+            _confirmed_rewrite_evidence(
+                reviewer,
+                candidate,
+                reviewed_context,
+                review,
+                initial_codes,
+            ),
         )
     except Exception:
         return QualityGateResult(
@@ -301,7 +313,17 @@ def _rewrite_candidate(
     context: ReplyContext,
     violation_codes: tuple[str, ...],
     generation_messages: Sequence[Mapping[str, Any]],
+    confirmed_violations: tuple[ReviewerViolation, ...],
 ) -> str:
+    evidence_aware = getattr(rewriter, "rewrite_with_evidence", None)
+    if callable(evidence_aware):
+        return evidence_aware(
+            candidate,
+            context,
+            violation_codes,
+            generation_messages,
+            confirmed_violations,
+        )
     extended = getattr(rewriter, "rewrite_with_messages", None)
     if callable(extended):
         return extended(
@@ -311,3 +333,42 @@ def _rewrite_candidate(
             generation_messages,
         )
     return rewriter.rewrite(candidate, context, violation_codes)
+
+
+def _confirmed_rewrite_evidence(
+    reviewer: ReviewerPort,
+    candidate: str,
+    context: ReplyContext,
+    review: ReviewResult,
+    violation_codes: tuple[str, ...],
+) -> tuple[ReviewerViolation, ...]:
+    source = getattr(reviewer, "confirmed_rewrite_evidence", None)
+    if not callable(source):
+        return ()
+    evidence = source(candidate, context, review)
+    if not isinstance(evidence, tuple) or any(
+        not isinstance(item, ReviewerViolation)
+        for item in evidence
+    ):
+        raise TypeError("confirmed rewrite evidence must be a typed tuple")
+    if len(evidence) > 16:
+        raise ValueError("confirmed rewrite evidence exceeds limit")
+    signatures: set[tuple[str, int, int]] = set()
+    for item in evidence:
+        signature = (item.code, item.start, item.end)
+        if (
+            item.severity != "hard"
+            or item not in review.violations
+            or item.code not in violation_codes
+            or isinstance(item.start, bool)
+            or not isinstance(item.start, int)
+            or isinstance(item.end, bool)
+            or not isinstance(item.end, int)
+            or item.start < 0
+            or item.end <= item.start
+            or item.end > len(candidate)
+            or signature in signatures
+        ):
+            raise ValueError("confirmed rewrite evidence is invalid")
+        signatures.add(signature)
+    return evidence

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -274,6 +274,9 @@ def test_reviewer_classifies_aggregation_failure_without_details(
     assert "private aggregation detail" not in repr(
         reviewer.last_failure_diagnostics
     )
+    assert reviewer.confirmed_rewrite_evidence(
+        "Synthetic candidate.", _intimacy_context(), result
+    ) == ()
 
 
 def test_unexpected_layer_parser_error_is_internal(
@@ -2419,7 +2422,7 @@ def test_rejected_and_confirmed_claims_in_one_layer_are_both_reported() -> None:
     }
 
 
-def test_first_letter_confirmed_memory_evidence_reaches_configured_rewriter(
+def test_only_adjudicated_first_letter_evidence_reaches_configured_rewriter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     candidate = (
@@ -2438,6 +2441,12 @@ def test_first_letter_confirmed_memory_evidence_reaches_configured_rewriter(
         claim_kind="location",
     )
     first = _passing_layer_payloads()
+    first[2] = _layer_score_payload(
+        "focus_response",
+        0,
+        hard_violations=["GENERIC_COUNSELOR"],
+        drift_detected=True,
+    )
     first[3] = _layer_score_payload(
         "continuity_memory",
         0,
@@ -2499,6 +2508,26 @@ def test_first_letter_confirmed_memory_evidence_reaches_configured_rewriter(
         "world_facts": "[]",
         "known_continuations": "[]",
     }
+
+
+def test_confirmed_rewrite_evidence_is_candidate_bound_and_single_use() -> None:
+    candidate = "Synthetic unsupported current location."
+    evidence = _hard_evidence_payload(candidate, "MEMORY_FABRICATION")
+    reviewer = GatewayPersonaReviewer(
+        SequencedQualityGateway(
+            candidate=candidate,
+            reviews=_reviews_requiring_adjudication(candidate),
+            adjudications=[_adjudication_payload(evidence, "CONFIRM")],
+        ),
+        ROOT / "linli_character" / "persona_release_v2.json",
+        1,
+    )
+    review = reviewer.review(candidate, _context())
+
+    with pytest.raises(ValueError, match="candidate mismatch"):
+        reviewer.confirmed_rewrite_evidence(candidate + "x", _context(), review)
+    with pytest.raises(ValueError, match="unavailable"):
+        reviewer.confirmed_rewrite_evidence(candidate, _context(), review)
 
 
 def test_rewrite_uses_fresh_candidate_evidence_and_adjudication(

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -1569,6 +1569,7 @@ def test_non_letter_hard_findings_keep_legacy_schema_without_adjudication(
         *("review",) * 5,
     ]
     assert gateway.adjudication_requests == []
+    assert gateway.rewrite_requests[0]["confirmed_violation_evidence"] == []
     assert pipeline.reviewer.last_failure_diagnostics == ()
     assert all(
         "hard_evidence" not in prompt
@@ -1662,13 +1663,16 @@ def test_hard_evidence_must_match_code_and_candidate_offsets(
         hard_evidence=[evidence],
     )
 
+    gateway = SequencedQualityGateway(candidate="unused", reviews=reviews)
     result = GatewayPersonaReviewer(
-        SequencedQualityGateway(candidate="unused", reviews=reviews),
+        gateway,
         ROOT / "linli_character" / "persona_release_v2.json",
         1,
     ).review(candidate, _context())
 
     assert result.verdict is ReviewVerdict.UNAVAILABLE
+    assert gateway.adjudication_requests == []
+    assert gateway.rewrite_requests == []
 
 
 @pytest.mark.parametrize(
@@ -1743,6 +1747,7 @@ def test_adjudicator_rejects_false_memory_fabrication_as_soft_warning() -> None:
         ("MEMORY_FABRICATION", "soft", 0, len(candidate))
     ]
     assert gateway.call_kinds == [*("review",) * 5, "adjudication"]
+    assert gateway.rewrite_requests == []
 
 
 @pytest.mark.parametrize(
@@ -2411,6 +2416,88 @@ def test_rejected_and_confirmed_claims_in_one_layer_are_both_reported() -> None:
     assert {(item.code, item.severity) for item in result.violations} == {
         ("STAGE_DRIFT", "hard"),
         ("RELATIONSHIP_RETRACTION", "soft"),
+    }
+
+
+def test_first_letter_confirmed_memory_evidence_reaches_configured_rewriter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = (
+        "The queue delay sounds like the part that hurt. "
+        "I am waiting beside the station window now."
+    )
+    unsupported = "I am waiting beside the station window now."
+    rewritten = "The queue delay sounds like the part that hurt."
+    start = candidate.index(unsupported)
+    evidence = _hard_evidence_payload(
+        candidate,
+        "MEMORY_FABRICATION",
+        evidence_id="evidence.first-letter.current-location",
+        start=start,
+        end=start + len(unsupported),
+        claim_kind="location",
+    )
+    first = _passing_layer_payloads()
+    first[3] = _layer_score_payload(
+        "continuity_memory",
+        0,
+        hard_violations=["MEMORY_FABRICATION"],
+        drift_detected=True,
+        hard_evidence=[evidence],
+    )
+    gateway = SequencedQualityGateway(
+        candidate=candidate,
+        reviews=[*first, *_passing_layer_payloads()],
+        rewritten=rewritten,
+        adjudications=[_adjudication_payload(evidence, "CONFIRM")],
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch, max_reasoning=True).run(
+            ReplyRequest(
+                content="The queue stalled, and that was the upsetting part.",
+                request_id="first-letter-memory-repair",
+                gateway_scope=GatewayRequestScope.TEXT_LETTER_MAX_REASONING,
+            ),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.quality_status == "accepted"
+    assert result.reviewer_calls == 2
+    assert result.rewrite_calls == 1
+    assert gateway.rewrite_requests[0]["confirmed_violation_evidence"] == [
+        {
+            "code": "MEMORY_FABRICATION",
+            "start": start,
+            "end": start + len(unsupported),
+        }
+    ]
+    serialized_rewrite = json.dumps(
+        gateway.rewrite_requests[0],
+        ensure_ascii=False,
+    )
+    assert evidence["evidence_id"] not in serialized_rewrite
+    assert evidence["reason_code"] not in serialized_rewrite
+    assert "CONFIRM" not in serialized_rewrite
+    assert (
+        "Do not replace one unsupported current or past fact, location, "
+        "action, or habit with another unsupported claim."
+        in gateway.rewrite_system_prompts[0]
+    )
+    assert gateway.call_kinds == [
+        "generation",
+        *("review",) * 5,
+        "adjudication",
+        "rewrite",
+        *("review",) * 5,
+    ]
+    continuity = gateway.review_requests[3]
+    assert continuity["memory_evidence"] == {
+        "assembled_memory": "",
+        "world_facts": "[]",
+        "known_continuations": "[]",
     }
 
 

--- a/tests/persona/test_reply_quality_gate.py
+++ b/tests/persona/test_reply_quality_gate.py
@@ -274,6 +274,7 @@ def test_invalid_confirmed_repair_evidence_fails_before_rewriter(
 
     assert result.status is QualityGateStatus.BLOCKED
     assert result.error_code == "REWRITE_FAILED"
+    assert result.rewrite_calls == 0
     assert rewriter.calls == 0
 
 

--- a/tests/persona/test_reply_quality_gate.py
+++ b/tests/persona/test_reply_quality_gate.py
@@ -38,6 +38,19 @@ class _Reviewer:
         return result
 
 
+class _ConfirmedEvidenceReviewer(_Reviewer):
+    def __init__(
+        self,
+        evidence: tuple[ReviewerViolation, ...],
+        *results: ReviewResult,
+    ) -> None:
+        super().__init__(*results)
+        self.evidence = evidence
+
+    def confirmed_rewrite_evidence(self, candidate, context, review):
+        return self.evidence
+
+
 class _Rewriter:
     def __init__(self, rewritten: str) -> None:
         self.rewritten = rewritten
@@ -47,6 +60,25 @@ class _Rewriter:
     def rewrite(self, candidate, context, violation_codes):
         self.calls += 1
         self.violation_codes.append(violation_codes)
+        return self.rewritten
+
+
+class _EvidenceAwareRewriter(_Rewriter):
+    def __init__(self, rewritten: str) -> None:
+        super().__init__(rewritten)
+        self.confirmed_violations: list[tuple[ReviewerViolation, ...]] = []
+
+    def rewrite_with_evidence(
+        self,
+        candidate,
+        context,
+        violation_codes,
+        generation_messages,
+        confirmed_violations,
+    ):
+        self.calls += 1
+        self.violation_codes.append(violation_codes)
+        self.confirmed_violations.append(confirmed_violations)
         return self.rewritten
 
 
@@ -134,6 +166,115 @@ def test_hard_candidate_is_rewritten_once_then_rechecked_before_acceptance() -> 
     assert result.rewrite_calls == 1
     assert reviewer.calls == 2
     assert rewriter.calls == 1
+    assert rewriter.violation_codes == [("INTERNAL_CONTROL_MARKUP",)]
+
+
+def test_unadjudicated_custom_reviewer_hard_finding_is_not_repair_evidence() -> None:
+    candidate = "Synthetic unsupported current fact."
+    reviewer = _Reviewer(
+        ReviewResult(
+            ReviewStatus.COMPLETED,
+            ReviewVerdict.REWRITE,
+            (
+                ReviewerViolation(
+                    "MEMORY_FABRICATION",
+                    "hard",
+                    10,
+                    len(candidate),
+                ),
+            ),
+            ReviewerScores(95, 30, 95, 95),
+            IntimacyRequest.NONE,
+            (),
+        ),
+        _pass_review(),
+    )
+    rewriter = _EvidenceAwareRewriter("Synthetic clean reply.")
+
+    result = run_reply_quality_gate(
+        candidate,
+        _context(),
+        reviewer=reviewer,
+        rewriter=rewriter,
+    )
+
+    assert result.status is QualityGateStatus.ACCEPTED
+    assert rewriter.confirmed_violations == [()]
+
+
+@pytest.mark.parametrize(
+    "invalid_kind",
+    ("range", "code", "non_hard", "limit"),
+)
+def test_invalid_confirmed_repair_evidence_fails_before_rewriter(
+    invalid_kind: str,
+) -> None:
+    candidate = "Synthetic unsupported current fact."
+    valid = ReviewerViolation(
+        "MEMORY_FABRICATION",
+        "hard",
+        10,
+        len(candidate),
+    )
+    invalid = {
+        "range": (
+            ReviewerViolation(
+                "MEMORY_FABRICATION",
+                "hard",
+                10,
+                len(candidate) + 1,
+            ),
+        ),
+        "code": (
+            ReviewerViolation(
+                "BOUNDARY_BREACH",
+                "hard",
+                10,
+                len(candidate),
+            ),
+        ),
+        "non_hard": (
+            ReviewerViolation(
+                "MEMORY_FABRICATION",
+                "soft",
+                10,
+                len(candidate),
+            ),
+        ),
+        "limit": tuple(
+            ReviewerViolation(
+                "MEMORY_FABRICATION",
+                "hard",
+                index,
+                index + 1,
+            )
+            for index in range(17)
+        ),
+    }[invalid_kind]
+    reviewer = _ConfirmedEvidenceReviewer(
+        invalid,
+        ReviewResult(
+            ReviewStatus.COMPLETED,
+            ReviewVerdict.REWRITE,
+            (valid,),
+            ReviewerScores(95, 30, 95, 95),
+            IntimacyRequest.NONE,
+            (),
+        ),
+        _pass_review(),
+    )
+    rewriter = _EvidenceAwareRewriter("Synthetic clean reply.")
+
+    result = run_reply_quality_gate(
+        candidate,
+        _context(),
+        reviewer=reviewer,
+        rewriter=rewriter,
+    )
+
+    assert result.status is QualityGateStatus.BLOCKED
+    assert result.error_code == "REWRITE_FAILED"
+    assert rewriter.calls == 0
 
 
 def test_candidate_bound_intimacy_claim_fails_closed_after_rewrite() -> None:


### PR DESCRIPTION
## Scope

- Carry only adjudicator-confirmed, candidate-bound Persona violation spans into the configured Letter rewriter.
- Bind transient evidence to the candidate digest, consume it once, and fail closed on stale, mismatched, malformed, or reused evidence.
- Validate evidence before invoking the rewriter; legacy and non-Letter paths keep their existing behavior.

## Why this is one atomic patch

The typed evidence contract, adjudicator producer, quality-gate consumer, configured payload, regression tests, and reviewer documentation must land together or the runtime either loses the evidence or accepts an unbound payload. The patch is still within the default review limit: 5 files, 499 changed lines.

## TDD and verification

- RED: the public ReplyPipeline configured-rewriter regression failed because `confirmed_violation_evidence` was absent.
- Round-1 RED: mixed hard layers exposed an unadjudicated `GENERIC_COUNSELOR`, and invalid evidence incremented `rewrite_calls`.
- GREEN: 9 focused evidence/boundary tests passed.
- GREEN: 281 Persona tests passed on the frozen head.
- Broader pre-freeze run before the final same-module tightening: 231 HTTP tests passed (1 deselected); 1563 full-suite tests passed, 1 skipped, 1 deselected, with 7 existing aiohttp warnings.
- `git diff --check`: clean. Secret/path/private-identifier scan: clean.
- Exact-head CI is the release gate; no real provider or private corpus is called by this PR.

## Frozen review evidence

- Base: `cc8cbaab911f3cae9979b597eac10c74b3f3f672`
- Head: `78cab24c464a9536e2febc104596af8194d32d2a`
- Round 1: Standards BLOCK and Spec BLOCK on one P0 (aggregate hard codes could be mistaken for adjudicated evidence) plus one P1 (invalid evidence reached the rewriter).
- Round 2: Standards PASS and Spec PASS; P0/P1/P2 all 0. Both reviews were static and provider-free.

## Privacy and non-goals

- Payload contains only `code`, `start`, and `end`; no candidate text, private letter text, decision rationale, evidence ID, or chain-of-thought is persisted.
- No Live, video routing, client status projection, provider configuration, private corpus, or relationship-state behavior changes.
