### PR TITLE
fix: type video length delivery repair

### DIFF
--- a/local_server.py
+++ b/local_server.py
@@ -3313,6 +3313,8 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
             exact_mode,
             idempotency_key=idempotency_key,
         )
+        from runtime.reply.reply_quality_gate import DeliveryRepairDisposition
+
         if (
             exact_mode
             in {
@@ -3321,11 +3323,8 @@ async def generate_reply(letter_id, content, *, idempotency_key=None):
             }
             and result.text
             and not ordinary_video_reply_length_ok(result.text)
-            and (
-                result.state is ReplyState.COMPLETED
-                or result.violation_codes
-                == ("VIDEO_REPLY_LENGTH_OUT_OF_RANGE",)
-            )
+            and result.delivery_repair_disposition
+            is DeliveryRepairDisposition.VIDEO_LENGTH
         ):
             result = await _run_reply_pipeline_for_letter(
                 letter,

--- a/runtime/reply/reply_pipeline.py
+++ b/runtime/reply/reply_pipeline.py
@@ -12,7 +12,12 @@ from persona_loader import load_persona
 from reply_model_quality import create_model_quality_ports
 from runtime.reply.reply_context import ReplyContext
 from reply_orchestrator import ReplyRequest, ReplyResult, ReplyState
-from runtime.reply.reply_quality_gate import ReviewerPort, RewriterPort, run_reply_quality_gate
+from runtime.reply.reply_quality_gate import (
+    DeliveryRepairDisposition,
+    ReviewerPort,
+    RewriterPort,
+    run_reply_quality_gate,
+)
 from runtime.reply.reply_reviewer import (
     NullReviewer,
     TrustedCharacterReply,
@@ -55,6 +60,9 @@ class PipelineResult:
     violation_codes: tuple[str, ...] = ()
     reviewer_calls: int = 0
     rewrite_calls: int = 0
+    delivery_repair_disposition: DeliveryRepairDisposition = (
+        DeliveryRepairDisposition.NONE
+    )
 
 
 @dataclass(frozen=True)
@@ -131,8 +139,8 @@ class ReplyPipeline:
         if not gate.accepted:
             repairable_text = (
                 gate.text
-                if gate.violation_codes
-                == ("VIDEO_REPLY_LENGTH_OUT_OF_RANGE",)
+                if gate.delivery_repair_disposition
+                is DeliveryRepairDisposition.VIDEO_LENGTH
                 else ""
             )
             return PipelineResult(
@@ -144,6 +152,9 @@ class ReplyPipeline:
                 violation_codes=gate.violation_codes,
                 reviewer_calls=gate.reviewer_calls,
                 rewrite_calls=gate.rewrite_calls,
+                delivery_repair_disposition=(
+                    gate.delivery_repair_disposition
+                ),
             )
         return PipelineResult(
             candidate.request_id,
@@ -153,6 +164,7 @@ class ReplyPipeline:
             violation_codes=gate.violation_codes,
             reviewer_calls=gate.reviewer_calls,
             rewrite_calls=gate.rewrite_calls,
+            delivery_repair_disposition=gate.delivery_repair_disposition,
         )
 
 

--- a/runtime/reply/reply_quality_gate.py
+++ b/runtime/reply/reply_quality_gate.py
@@ -24,6 +24,11 @@ class QualityGateStatus(StrEnum):
     BLOCKED = "blocked"
 
 
+class DeliveryRepairDisposition(StrEnum):
+    NONE = "none"
+    VIDEO_LENGTH = "video_length"
+
+
 @dataclass(frozen=True)
 class QualityGateResult:
     status: QualityGateStatus
@@ -33,6 +38,9 @@ class QualityGateResult:
     reviewer_calls: int
     rewrite_calls: int
     error_code: str | None = None
+    delivery_repair_disposition: DeliveryRepairDisposition = (
+        DeliveryRepairDisposition.NONE
+    )
 
     @property
     def accepted(self) -> bool:
@@ -61,6 +69,21 @@ def _stable_codes(*groups: Sequence[str]) -> tuple[str, ...]:
                 seen.add(code)
                 ordered.append(code)
     return tuple(ordered)
+
+
+def _delivery_repair_disposition(
+    deterministic_codes: tuple[str, ...],
+    review: ReviewResult,
+) -> DeliveryRepairDisposition:
+    if (
+        frozenset(deterministic_codes)
+        == frozenset({"VIDEO_REPLY_LENGTH_OUT_OF_RANGE"})
+        and not any(item.severity == "hard" for item in review.violations)
+        and review.verdict
+        not in {ReviewVerdict.BLOCK, ReviewVerdict.UNAVAILABLE}
+    ):
+        return DeliveryRepairDisposition.VIDEO_LENGTH
+    return DeliveryRepairDisposition.NONE
 
 
 def run_reply_quality_gate(
@@ -114,6 +137,10 @@ def run_reply_quality_gate(
     )
     review_codes = tuple(item.code for item in review.violations)
     initial_codes = _stable_codes(deterministic_codes, review_codes)
+    initial_delivery_repair = _delivery_repair_disposition(
+        deterministic_codes,
+        review,
+    )
     if (
         review.verdict is ReviewVerdict.UNAVAILABLE
         and review.status is not ReviewStatus.DISABLED
@@ -190,6 +217,7 @@ def run_reply_quality_gate(
             reviewer_calls=1,
             rewrite_calls=1,
             error_code="REWRITE_FAILED",
+            delivery_repair_disposition=initial_delivery_repair,
         )
     if not isinstance(rewritten, str) or not rewritten.strip():
         return QualityGateResult(
@@ -200,6 +228,7 @@ def run_reply_quality_gate(
             reviewer_calls=1,
             rewrite_calls=1,
             error_code="REWRITE_FAILED",
+            delivery_repair_disposition=initial_delivery_repair,
         )
     if (
         effective_intimacy_claims
@@ -296,6 +325,13 @@ def run_reply_quality_gate(
         reviewer_calls=2,
         rewrite_calls=1,
         error_code=final_review.error_code,
+        delivery_repair_disposition=_delivery_repair_disposition(
+            tuple(
+                item.code.value
+                for item in final_deterministic.violations
+            ),
+            final_review,
+        ),
     )
 
 

--- a/tests/http/test_reply_delay_and_media.py
+++ b/tests/http/test_reply_delay_and_media.py
@@ -14,6 +14,7 @@ from llm_gateway import GatewayConfig, GatewayRequestScope
 from runtime.reply.reply_context import ReplyMode
 from reply_orchestrator import ReplyState
 from runtime.reply.reply_pipeline import PipelineResult
+from runtime.reply.reply_quality_gate import DeliveryRepairDisposition
 from voice_direction import VoiceDirectionError, VoicePerformancePlan
 
 
@@ -932,9 +933,15 @@ def test_generate_reply_repairs_then_rechecks_video_copy_length(
             text="太短",
             error_code="REWRITE_FAILED",
             quality_status="blocked",
-            violation_codes=("VIDEO_REPLY_LENGTH_OUT_OF_RANGE",),
+            violation_codes=(
+                "VIDEO_REPLY_LENGTH_OUT_OF_RANGE",
+                "MEMORY_FABRICATION",
+            ),
             reviewer_calls=1,
             rewrite_calls=1,
+            delivery_repair_disposition=(
+                DeliveryRepairDisposition.VIDEO_LENGTH
+            ),
         )
 
     monkeypatch.setattr(local_server.emotion_triage, "classify", classify)
@@ -951,3 +958,65 @@ def test_generate_reply_repairs_then_rechecks_video_copy_length(
     ]
     assert "180到200个汉字" in requests[1].content
     assert letter["reply_text"] == "林" * 190
+
+
+def test_generate_reply_does_not_repair_hard_memory_video_failure(
+    monkeypatch,
+):
+    letter_id = "synthetic-hard-memory-video"
+    letter = {
+        "letter_id": letter_id,
+        "content": "synthetic current letter",
+        "reply_text": "",
+        "reply_mode": ReplyMode.TEXT_LETTER.value,
+        "letter_status": "PENDING",
+    }
+    local_server.store.letters[:] = [letter]
+    requests = []
+    scheduled = []
+
+    async def classify(_content):
+        return TriageResult(
+            "high",
+            ReplyMode.MUSICAL_VIDEO.value,
+            "melody_carries_this_reply",
+            "completed",
+            True,
+            music_contexts=("melody_idea",),
+            music_intent="compose",
+            music_materially_better=True,
+            character_willing=True,
+        )
+
+    async def run_pipeline(request, _context):
+        requests.append(request)
+        return PipelineResult(
+            letter_id,
+            ReplyState.FAILED,
+            text="太短",
+            error_code="REPLY_QUALITY_BLOCKED",
+            quality_status="blocked",
+            violation_codes=(
+                "VIDEO_REPLY_LENGTH_OUT_OF_RANGE",
+                "MEMORY_FABRICATION",
+            ),
+            delivery_repair_disposition=DeliveryRepairDisposition.NONE,
+        )
+
+    monkeypatch.setattr(local_server.emotion_triage, "classify", classify)
+    monkeypatch.setattr(local_server.reply_pipeline, "run", run_pipeline)
+    monkeypatch.setattr(local_server, "_persist_store_state", lambda: None)
+    monkeypatch.setattr(
+        local_server,
+        "_schedule_media_job",
+        lambda *_args: scheduled.append(True),
+    )
+
+    assert not asyncio.run(
+        local_server.generate_reply(letter_id, letter["content"])
+    )
+    assert [request.request_id for request in requests] == [
+        f"letter-reply:{letter_id}"
+    ]
+    assert scheduled == []
+    assert letter["media_status"] == "NOT_REQUESTED"

--- a/tests/persona/test_reply_pipeline.py
+++ b/tests/persona/test_reply_pipeline.py
@@ -29,11 +29,13 @@ from runtime.reply.reply_pipeline import (
     ReplyPipeline,
     UnavailableRewriter,
 )
+from runtime.reply.reply_quality_gate import DeliveryRepairDisposition
 from reply_model_quality import GatewayPersonaReviewer
 from runtime.reply.reply_reviewer import (
     NullReviewer,
     ReviewResult,
     ReviewerScores,
+    ReviewerViolation,
     ReviewStatus,
     ReviewVerdict,
 )
@@ -76,6 +78,14 @@ class PassingReviewer:
             IntimacyRequest.NONE,
             (),
         )
+
+
+class SequencedReviewer:
+    def __init__(self, *results: ReviewResult) -> None:
+        self.results = list(results)
+
+    def review(self, candidate: str, context: ReplyContext) -> ReviewResult:
+        return self.results.pop(0)
 
 
 class FixedRewriter:
@@ -153,6 +163,62 @@ def test_pipeline_preserves_only_length_blocked_video_copy_for_duration_repair()
     assert result.text == "太短。"
     assert result.error_code == "REWRITE_FAILED"
     assert result.violation_codes == ("VIDEO_REPLY_LENGTH_OUT_OF_RANGE",)
+    assert (
+        result.delivery_repair_disposition
+        is DeliveryRepairDisposition.VIDEO_LENGTH
+    )
+
+
+@pytest.mark.parametrize(
+    ("severity", "expected_text", "expected_disposition"),
+    (
+        (
+            "soft",
+            "Too short.",
+            DeliveryRepairDisposition.VIDEO_LENGTH,
+        ),
+        ("hard", "", DeliveryRepairDisposition.NONE),
+    ),
+)
+def test_pipeline_forwards_only_typed_video_length_repair_candidates(
+    severity: str,
+    expected_text: str,
+    expected_disposition: DeliveryRepairDisposition,
+) -> None:
+    candidate = "Too short."
+    passing = PassingReviewer().review(candidate, _context())
+    finding = ReviewResult(
+        ReviewStatus.COMPLETED,
+        ReviewVerdict.REWRITE,
+        (
+            ReviewerViolation(
+                "MEMORY_FABRICATION",
+                severity,
+                0,
+                len(candidate),
+            ),
+        ),
+        ReviewerScores(90, 30, 90, 90),
+        IntimacyRequest.NONE,
+        (),
+    )
+    pipeline = ReplyPipeline(
+        CompletedOrchestrator(candidate),
+        reviewer=SequencedReviewer(passing, finding),
+        rewriter=FixedRewriter(candidate),
+    )
+
+    result = asyncio.run(
+        pipeline.run(object(), _context(ReplyMode.MUSICAL_VIDEO))
+    )
+
+    assert result.state is ReplyState.FAILED
+    assert result.text == expected_text
+    assert result.violation_codes == (
+        "VIDEO_REPLY_LENGTH_OUT_OF_RANGE",
+        "MEMORY_FABRICATION",
+    )
+    assert result.delivery_repair_disposition is expected_disposition
 
 
 class RecordingProvider:

--- a/tests/persona/test_reply_quality_gate.py
+++ b/tests/persona/test_reply_quality_gate.py
@@ -11,7 +11,11 @@ from runtime.reply.reply_context import (
     TrustedTime,
 )
 from runtime.reply.reply_policy import IntimacyClaim
-from runtime.reply.reply_quality_gate import QualityGateStatus, run_reply_quality_gate
+from runtime.reply.reply_quality_gate import (
+    DeliveryRepairDisposition,
+    QualityGateStatus,
+    run_reply_quality_gate,
+)
 from runtime.reply.reply_reviewer import (
     NullReviewer,
     ReviewerScores,
@@ -481,6 +485,83 @@ def test_short_video_rewrite_is_blocked_without_a_second_rewrite() -> None:
     assert result.violation_codes == ("VIDEO_REPLY_LENGTH_OUT_OF_RANGE",)
     assert result.rewrite_calls == 1
     assert rewriter.calls == 1
+
+
+def test_video_length_with_soft_reviewer_finding_is_typed_for_delivery_repair() -> None:
+    candidate = "Too short."
+    final_review = ReviewResult(
+        ReviewStatus.COMPLETED,
+        ReviewVerdict.REWRITE,
+        (
+            ReviewerViolation(
+                "MEMORY_FABRICATION",
+                "soft",
+                0,
+                len(candidate),
+            ),
+        ),
+        ReviewerScores(90, 90, 90, 90),
+        IntimacyRequest.NONE,
+        (),
+    )
+
+    result = run_reply_quality_gate(
+        candidate,
+        _video_context(),
+        reviewer=_Reviewer(_pass_review(), final_review),
+        rewriter=_Rewriter(candidate),
+    )
+
+    assert result.status is QualityGateStatus.BLOCKED
+    assert result.violation_codes == (
+        "VIDEO_REPLY_LENGTH_OUT_OF_RANGE",
+        "MEMORY_FABRICATION",
+    )
+    assert (
+        result.delivery_repair_disposition
+        is DeliveryRepairDisposition.VIDEO_LENGTH
+    )
+
+
+def test_video_length_with_hard_reviewer_finding_is_not_delivery_repairable() -> None:
+    candidate = "Too short."
+    final_review = ReviewResult(
+        ReviewStatus.COMPLETED,
+        ReviewVerdict.REWRITE,
+        (
+            ReviewerViolation(
+                "MEMORY_FABRICATION",
+                "hard",
+                0,
+                len(candidate),
+            ),
+        ),
+        ReviewerScores(90, 30, 90, 90),
+        IntimacyRequest.NONE,
+        (),
+    )
+
+    result = run_reply_quality_gate(
+        candidate,
+        _video_context(),
+        reviewer=_Reviewer(_pass_review(), final_review),
+        rewriter=_Rewriter(candidate),
+    )
+
+    assert result.status is QualityGateStatus.BLOCKED
+    assert result.delivery_repair_disposition is DeliveryRepairDisposition.NONE
+
+
+def test_video_length_with_unavailable_reviewer_is_not_delivery_repairable() -> None:
+    result = run_reply_quality_gate(
+        "Too short.",
+        _video_context(),
+        reviewer=_Reviewer(_unavailable_review()),
+        rewriter=_NeverRewrite(),
+    )
+
+    assert result.status is QualityGateStatus.BLOCKED
+    assert result.delivery_repair_disposition is DeliveryRepairDisposition.NONE
 
 
 def test_final_soft_review_issue_is_accepted_with_warnings_after_one_rewrite() -> None:


### PR DESCRIPTION
## Scope

- Add a typed delivery-repair disposition for the one bounded video-copy length repair.
- Mark a result repairable only when the deterministic hard set is exactly `VIDEO_REPLY_LENGTH_OUT_OF_RANGE`, the reviewer has no hard finding, and its verdict is neither BLOCK nor UNAVAILABLE.
- Preserve blocked candidate text only for that typed disposition; run the existing second complete ReplyPipeline once before any persistence or media scheduling.

## Why this is atomic

The gate must classify repairability, the pipeline must carry the typed result, and the HTTP delivery boundary must consume it together; landing only one layer would either lose the repair or recreate tuple-based fail-open behavior. The patch is 6 files and 283 changed lines (`+273/-10`), below the default 10-file/500-line limit.

## TDD and verification

- Gate RED: typed disposition import missing; GREEN covers video length + soft MEMORY, video length + hard MEMORY, and reviewer unavailable.
- Pipeline RED: disposition missing; GREEN covers singleton forwarding, soft composite forwarding, and hard finding text clearing.
- HTTP RED: soft composite did not trigger the existing bounded duration repair; GREEN covers both video modes plus hard MEMORY no retry / media `NOT_REQUESTED`.
- Focused: 88 passed.
- Persona + HTTP: 518 passed, 1 deselected.
- Frozen-head full suite (the only full run for this patch): 1569 passed, 1 skipped, 1 deselected; 7 existing warnings.
- `git diff --check` and secret scan: clean.

## Frozen review evidence

- Base: `0f1e17643438a192fd976141d43985d16e01a188`
- Head: `e4fb16fb7f57f1fe2bd5f558fd106ac3472ae74c`
- Round 1 Standards: PASS, P0/P1/P2=0.
- Round 1 Spec: PASS, P0/P1/P2=0.
- Both were static, read-only, and provider-free.

## Non-goals

- No router, 180-200 character contract, music duration, provider, Persona prompt, Live, private corpus, terminal-status projection, or media renderer changes.
- `local_server.py` changes only the existing duration-repair decision region; failed/canceled letter projection remains owned by its separate patch.
