### PR TITLE
fix: expose failed and canceled letters before delivery deadline

### DIFF
--- a/local_server.py
+++ b/local_server.py
@@ -1186,6 +1186,7 @@ def fake_jwt():
 
 def letter_to_out(l):
     published = l.get("reply_not_before", 0.0) <= time.time()
+    failed = l.get("letter_status") in {"FAILED", "CANCELED", "CANCELLED"}
     metadata = l.get("metadata")
     imported_official = isinstance(metadata, dict) and (
         metadata.get("import_kind") == "official_text_reply"
@@ -1198,7 +1199,11 @@ def letter_to_out(l):
     return {
         "letter_id": l["letter_id"],
         "summary": summary[:50],
-        "letter_status": l.get("letter_status", 4) if published else "PENDING",
+        "letter_status": (
+            l.get("letter_status", 4)
+            if published or failed
+            else "PENDING"
+        ),
         "audit_status": l.get("audit_status", 2),
         "reply_type": 1 if published and l.get("reply_text") else 0,
         "reply_mode": _wire_reply_mode(l.get("reply_mode")) if published else "text",
@@ -2088,7 +2093,8 @@ def _reply_pipeline_timeout_seconds(exact_mode: str) -> float:
 
 
 def _send_result_for_letter(letter: dict) -> dict:
-    if letter.get("letter_status") in {"PENDING", "PROCESSING"}:
+    letter_status = letter.get("letter_status")
+    if letter_status in {"PENDING", "PROCESSING"}:
         return ok(
             {
                 "letter_id": letter["letter_id"],
@@ -2096,16 +2102,25 @@ def _send_result_for_letter(letter: dict) -> dict:
                 "status": "PENDING",
             }
         )
-    if letter.get("reply_not_before", 0.0) > time.time():
-        return ok({"letter_id": letter["letter_id"], "letterId": letter["letter_id"], "status": "PENDING", "reply_not_before": letter["reply_not_before"]})
-    if letter.get("letter_status") == "COMPLETED" and letter.get("reply_text"):
+    if letter_status in {"CANCELED", "CANCELLED"}:
         return ok(
             {
                 "letter_id": letter["letter_id"],
                 "letterId": letter["letter_id"],
-                "status": "COMPLETED",
+                "status": letter_status,
             }
         )
+    if letter_status == "COMPLETED":
+        if letter.get("reply_not_before", 0.0) > time.time():
+            return ok({"letter_id": letter["letter_id"], "letterId": letter["letter_id"], "status": "PENDING", "reply_not_before": letter["reply_not_before"]})
+        if letter.get("reply_text"):
+            return ok(
+                {
+                    "letter_id": letter["letter_id"],
+                    "letterId": letter["letter_id"],
+                    "status": "COMPLETED",
+                }
+            )
     error_code, retryable = _public_llm_error(letter.get("error_code"))
     return err(
         503,

--- a/original_client_letter_contract.py
+++ b/original_client_letter_contract.py
@@ -82,17 +82,26 @@ def _published(letter: Mapping[str, object], *, now: float | None) -> bool:
 
 
 def _letter_status(value: object, *, published: bool) -> int:
+    if isinstance(value, OriginalClientLetterStatus):
+        resolved = int(value)
+    elif type(value) is int:
+        try:
+            resolved = int(OriginalClientLetterStatus(value))
+        except ValueError:
+            resolved = int(OriginalClientLetterStatus.FAILED)
+    else:
+        normalized = str(value or "").strip().upper()
+        resolved = int(
+            _INTERNAL_LETTER_STATUS.get(
+                normalized,
+                OriginalClientLetterStatus.FAILED,
+            )
+        )
+    if resolved == int(OriginalClientLetterStatus.FAILED):
+        return resolved
     if not published:
         return int(OriginalClientLetterStatus.PENDING)
-    if isinstance(value, OriginalClientLetterStatus):
-        return int(value)
-    if type(value) is int:
-        try:
-            return int(OriginalClientLetterStatus(value))
-        except ValueError:
-            return int(OriginalClientLetterStatus.FAILED)
-    normalized = str(value or "").strip().upper()
-    return int(_INTERNAL_LETTER_STATUS.get(normalized, OriginalClientLetterStatus.FAILED))
+    return resolved
 
 
 def _audit_status(value: object) -> int:

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -799,6 +799,62 @@ def test_unexpected_background_failure_cannot_leave_processing_letter(
     assert detail["data"]["error_code"] == "LLM_UNAVAILABLE"
 
 
+def test_failed_letter_deadline_does_not_hide_terminal_send_list_or_detail() -> None:
+    import local_server
+
+    letter = {
+        "letter_id": "failed-before-delivery",
+        "content": "synthetic failed input",
+        "material": {},
+        "letter_status": "FAILED",
+        "audit_status": 2,
+        "is_read": 1,
+        "created_at": 1_700_000_000,
+        "reply_text": "",
+        "reply_mode": "text_letter",
+        "reply_not_before": 4_000_000_000.0,
+        "error_code": "REPLY_QUALITY_BLOCKED",
+        "media_status": "NOT_REQUESTED",
+    }
+    local_server.store.letters.append(letter)
+
+    sent = local_server._send_result_for_letter(letter)
+    listed = asyncio.run(local_server.route("GET", "/toy/letter/list", {}, {}))
+    detail = asyncio.run(
+        local_server.route(
+            "GET",
+            "/toy/letter/detail",
+            {},
+            {"letter_id": letter["letter_id"]},
+        )
+    )
+
+    assert sent["code"] == 503
+    assert sent["data"]["status"] == "FAILED"
+    assert listed["data"]["list"][0]["letter_status"] == "FAILED"
+    assert detail["data"]["letter_status"] == "FAILED"
+    assert detail["data"]["error_code"] == "REPLY_QUALITY_BLOCKED"
+
+
+@pytest.mark.parametrize("status", ["CANCELED", "CANCELLED"])
+def test_canceled_letter_deadline_preserves_terminal_send_status(
+    status: str,
+) -> None:
+    import local_server
+
+    letter = {
+        "letter_id": f"{status.casefold()}-before-delivery",
+        "letter_status": status,
+        "reply_not_before": 4_000_000_000.0,
+    }
+
+    sent = local_server._send_result_for_letter(letter)
+
+    assert sent["code"] == 0
+    assert sent["data"]["status"] == status
+    assert sent["data"]["letter_id"] == letter["letter_id"]
+
+
 def test_persona_not_ready_failure_persists_and_round_trips_through_http_detail(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/http/test_original_client_letter_contract.py
+++ b/tests/http/test_original_client_letter_contract.py
@@ -161,6 +161,22 @@ def test_failed_letter_preserves_original_failure_and_audit_enums() -> None:
     assert "repliedAt" not in summary
 
 
+def test_failed_letter_ignores_future_reply_publication_deadline() -> None:
+    letter = _letter(
+        letter_status="FAILED",
+        reply_text="",
+        replied_at=None,
+        reply_not_before=NOW + 60,
+    )
+
+    summary = serialize_letter_summary(letter, now=NOW)
+    detail = serialize_letter_detail(letter, now=NOW)
+
+    assert summary["letterStatus"] == OriginalClientLetterStatus.FAILED
+    assert detail["letterStatus"] == OriginalClientLetterStatus.FAILED
+    assert detail["replyText"] == ""
+
+
 def test_exact_aggregate_and_unread_names_are_emitted_with_optional_legacy_aliases() -> None:
     listing = serialize_letter_list(
         [_letter(), _letter(letter_id="letter-fixture-002", is_read=0)],


### PR DESCRIPTION
## Summary
- expose FAILED/CANCELED/CANCELLED terminal states even when reply_not_before is still in the future
- keep publication delay limited to COMPLETED reply content
- preserve original-client terminal enum mapping across send, list, and detail

## Focused validation
- 48 passed, 1 deselected: tests/http/test_contract.py + tests/http/test_original_client_letter_contract.py
- 5 passed: original mailbox integration checks
- py_compile passed
- git diff --check passed

## Review evidence
- Round 1: Standards PASS; Spec BLOCK (one P1: canceled send projection)
- Round 2 after TDD repair: Standards PASS; Spec PASS; P0/P1/P2 = 0
- frozen base: 98c68ae3e0740f254e8ab4f213bb23da527730a8
- frozen head: 588cb7b

## Boundary
- no Persona, reviewer, media routing, duration-repair, Live, installer, or private corpus changes
- local_server.py duration-repair region 3308-3336 is untouched