### PR TITLE
test: freeze candidate clock in control center runtime

### DIFF
--- a/control_center/runtime.py
+++ b/control_center/runtime.py
@@ -9,8 +9,9 @@ separate concern.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
-from typing import Mapping
+from typing import Callable, Mapping
 from urllib.parse import quote
 
 from aiohttp import web
@@ -108,6 +109,7 @@ def create_control_center_runtime(
     database_path: Path,
     *,
     session_manager: ControlSessionManager | None = None,
+    candidate_clock: Callable[[], datetime] | None = None,
 ) -> ControlCenterRuntime:
     """Build one complete in-process runtime over an explicit SQLite file."""
 
@@ -124,6 +126,7 @@ def create_control_center_runtime(
         candidate_backend = SQLiteCandidateReviewBackend(
             candidate_store,
             service,
+            clock=candidate_clock,
         )
         app = create_control_app(
             ledger,

--- a/tests/control_center/test_runtime.py
+++ b/tests/control_center/test_runtime.py
@@ -56,7 +56,8 @@ def test_runtime_assembles_shared_ledger_candidates_api_and_ui(
 ) -> None:
     async def scenario() -> None:
         runtime = create_control_center_runtime(
-            (tmp_path / "private_world.sqlite3").resolve()
+            (tmp_path / "private_world.sqlite3").resolve(),
+            candidate_clock=lambda: NOW,
         )
         candidate = _candidate()
         runtime.candidate_store.add(candidate)


### PR DESCRIPTION
Fixes the control-center candidate integration test time bomb by injecting its existing frozen NOW through the runtime assembly boundary. Product callers omit the argument and continue to use real UTC; candidate expiration semantics are unchanged. Scope: control_center/runtime.py and tests/control_center/test_runtime.py only. Validation: python -m pytest -q tests/control_center/test_runtime.py (4 passed); py_compile PASS; git diff --check PASS. Review: Standards PASS; Spec PASS; P0/P1/P2 0/0/0. No provider, GPU, original-client, or human acceptance was performed. Revert by reverting commit 3861dcd.