### PR TITLE
fix: retry invalid reviewer layer contract once

### DIFF
--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -69,8 +69,15 @@ questions remain allowed.
 ## Evidence-bound hard findings and adjudication
 
 This protocol is enabled only for `text_letter`. Spoken and musical-video
-reviews retain the pre-protocol response schema and call count: they neither
-require `hard_evidence` nor invoke adjudication.
+reviews retain the pre-protocol response schema and normal successful call
+count: they neither require `hard_evidence` nor invoke adjudication.
+
+Across Persona modes, the only failure-path exception that may add a call is
+one retry of the single layer whose result fails `LAYER_CONTRACT`. That retry
+uses a fresh request ID and does not rerun any other layer. A second
+`LAYER_CONTRACT` failure remains `REVIEWER_UNAVAILABLE`. `JSON`,
+`TOP_LEVEL_SCHEMA`, `EVIDENCE_CONTRACT`, `EMPTY_TEXT`, `TRANSPORT`, and
+`INTERNAL` failures are not retried.
 
 In `text_letter`, `identity_boundary`, `voice_style`, and `continuity_memory`
 cannot create a hard finding from a score or drift flag alone. Every hard code

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -1433,37 +1433,44 @@ def _complete_layer_reviews(
             layer: _LayerAuthority,
             messages: tuple[dict[str, str], dict[str, str]],
         ) -> _LayerResult:
-            try:
-                text = await _complete_layer_text(
-                    gateway,
-                    messages,
-                    timeout_seconds,
-                    f"quality-{uuid.uuid4().hex}:{layer.name}",
-                    gateway_scope,
-                )
-            except _GatewayInvocationFailure:
-                raise _diagnostic_error(
-                    ReviewFailureStage.LAYER,
-                    ReviewFailureReason.TRANSPORT,
-                    layer.name,
-                ) from None
-            if not isinstance(text, str) or not text.strip():
-                raise _diagnostic_error(
-                    ReviewFailureStage.LAYER,
-                    ReviewFailureReason.EMPTY_TEXT,
-                    layer.name,
-                )
-            try:
-                return _parse_layer_result(
-                    layer,
-                    text,
-                    candidate=candidate,
-                    evidence_bound=evidence_bound,
-                )
-            except _ReviewContractFailure as exc:
-                raise _diagnostic_error(
-                    ReviewFailureStage.LAYER, exc.reason, layer.name
-                ) from None
+            for attempt in range(2):
+                try:
+                    text = await _complete_layer_text(
+                        gateway,
+                        messages,
+                        timeout_seconds,
+                        f"quality-{uuid.uuid4().hex}:{layer.name}",
+                        gateway_scope,
+                    )
+                except _GatewayInvocationFailure:
+                    raise _diagnostic_error(
+                        ReviewFailureStage.LAYER,
+                        ReviewFailureReason.TRANSPORT,
+                        layer.name,
+                    ) from None
+                if not isinstance(text, str) or not text.strip():
+                    raise _diagnostic_error(
+                        ReviewFailureStage.LAYER,
+                        ReviewFailureReason.EMPTY_TEXT,
+                        layer.name,
+                    )
+                try:
+                    return _parse_layer_result(
+                        layer,
+                        text,
+                        candidate=candidate,
+                        evidence_bound=evidence_bound,
+                    )
+                except _ReviewContractFailure as exc:
+                    if (
+                        exc.reason is ReviewFailureReason.LAYER_CONTRACT
+                        and attempt == 0
+                    ):
+                        continue
+                    raise _diagnostic_error(
+                        ReviewFailureStage.LAYER, exc.reason, layer.name
+                    ) from None
+            raise AssertionError("unreachable")
 
         outcomes = await asyncio.gather(
             *(run_one(layer, messages) for layer, messages in requests),

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -119,6 +119,69 @@ def _run_diagnostic_review(
     return reviewer.review(candidate, context or _intimacy_context()), reviewer
 
 
+def test_layer_contract_failure_retries_only_the_failed_layer_once() -> None:
+    candidate = "Synthetic candidate."
+    layer_reviews = {
+        layer: [_layer_payload(layer)] for layer in _REVIEW_LAYERS
+    }
+    layer_reviews["continuity_memory"] = [
+        _layer_score_payload("continuity_memory", 1),
+        _layer_payload("continuity_memory"),
+    ]
+    gateway = SequencedQualityGateway(
+        candidate=candidate,
+        reviews=[],
+        layer_reviews=layer_reviews,
+    )
+
+    result, reviewer = _run_diagnostic_review(gateway, candidate)
+
+    assert result.verdict is ReviewVerdict.PASS
+    assert reviewer.last_failure_diagnostics == ()
+    layer_calls = [request["layer"] for request in gateway.review_requests]
+    assert layer_calls.count("continuity_memory") == 2
+    assert all(layer_calls.count(layer) == 1 for layer in _REVIEW_LAYERS[:3])
+    assert layer_calls.count("autonomy_life") == 1
+    assert gateway.call_kinds == ["review"] * 6
+    assert gateway.adjudication_requests == []
+    assert len(gateway.request_ids) == len(set(gateway.request_ids)) == 6
+
+
+def test_repeated_layer_contract_failure_stops_after_one_retry() -> None:
+    candidate = "Synthetic candidate."
+    invalid = _layer_score_payload("continuity_memory", 1)
+    layer_reviews = {
+        layer: [_layer_payload(layer)] for layer in _REVIEW_LAYERS
+    }
+    layer_reviews["continuity_memory"] = [invalid, invalid]
+    gateway = SequencedQualityGateway(
+        candidate=candidate,
+        reviews=[],
+        layer_reviews=layer_reviews,
+    )
+
+    result, reviewer = _run_diagnostic_review(gateway, candidate)
+
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert reviewer.last_failure_diagnostics == (
+        ReviewFailureDiagnostic(
+            ReviewFailureStage.LAYER,
+            ReviewFailureReason.LAYER_CONTRACT,
+            "continuity_memory",
+        ),
+    )
+    layer_calls = [request["layer"] for request in gateway.review_requests]
+    assert layer_calls.count("continuity_memory") == 2
+    assert all(
+        layer_calls.count(layer) == 1
+        for layer in _REVIEW_LAYERS
+        if layer != "continuity_memory"
+    )
+    assert gateway.call_kinds == ["review"] * 6
+    assert gateway.adjudication_requests == []
+    assert len(gateway.request_ids) == len(set(gateway.request_ids)) == 6
+
+
 @pytest.mark.parametrize(
     ("case", "reason", "layer"),
     (
@@ -169,17 +232,40 @@ def test_reviewer_classifies_layer_failure(
             drift_detected=True,
             hard_evidence=[evidence],
         )
-    gateway = (
-        FailingQualityGateway(failure="layer", failing_layer=layer)
-        if case == "transport"
-        else SequencedQualityGateway(candidate=candidate, reviews=reviews)
-    )
+    if case == "transport":
+        gateway = FailingQualityGateway(
+            failure="layer",
+            failing_layer=layer,
+        )
+    else:
+        layer_reviews = {
+            name: [reviews[layer_index]]
+            for layer_index, name in enumerate(_REVIEW_LAYERS)
+        }
+        if reason is ReviewFailureReason.LAYER_CONTRACT:
+            layer_reviews[layer].append(reviews[index])
+        gateway = SequencedQualityGateway(
+            candidate=candidate,
+            reviews=[],
+            layer_reviews=layer_reviews,
+        )
     result, reviewer = _run_diagnostic_review(gateway, candidate)
 
     assert result.error_code == "REVIEWER_UNAVAILABLE"
     assert reviewer.last_failure_diagnostics == (
         ReviewFailureDiagnostic(ReviewFailureStage.LAYER, reason, layer),
     )
+    layer_calls = [request["layer"] for request in gateway.review_requests]
+    expected_attempts = (
+        2 if reason is ReviewFailureReason.LAYER_CONTRACT else 1
+    )
+    assert layer_calls.count(layer) == expected_attempts
+    assert all(
+        layer_calls.count(name) == 1
+        for name in _REVIEW_LAYERS
+        if name != layer
+    )
+    assert len(gateway.request_ids) == len(set(gateway.request_ids))
 
 
 def test_reviewer_orders_multiple_layer_failures_by_authority() -> None:
@@ -290,12 +376,11 @@ def test_unexpected_layer_parser_error_is_internal(
         return original(layer, *args, **kwargs)
 
     monkeypatch.setattr(quality_module, "_parse_layer_result", fail_identity_parser)
-    result, reviewer = _run_diagnostic_review(
-        SequencedQualityGateway(
-            candidate="Synthetic candidate.",
-            reviews=_passing_layer_payloads(),
-        )
+    gateway = SequencedQualityGateway(
+        candidate="Synthetic candidate.",
+        reviews=_passing_layer_payloads(),
     )
+    result, reviewer = _run_diagnostic_review(gateway)
 
     assert result.error_code == "REVIEWER_UNAVAILABLE"
     assert reviewer.last_failure_diagnostics == (
@@ -306,6 +391,10 @@ def test_unexpected_layer_parser_error_is_internal(
         ),
     )
     assert "private parser detail" not in repr(reviewer.last_failure_diagnostics)
+    assert [
+        request["layer"] for request in gateway.review_requests
+    ].count("identity_boundary") == 1
+    assert len(gateway.request_ids) == len(set(gateway.request_ids)) == 5
 
 
 def test_layer_cancellation_is_not_converted_to_reviewer_unavailable(
@@ -599,12 +688,18 @@ class SequencedQualityGateway(Gateway):
         reviews: list[str],
         rewritten: str = "我听见了。先不用急着给自己一个结论。",
         adjudications: list[str] | None = None,
+        layer_reviews: Mapping[str, Sequence[str]] | None = None,
     ) -> None:
         self.candidate = candidate
         self.reviews = list(reviews)
+        self.layer_reviews = {
+            layer: list(responses)
+            for layer, responses in (layer_reviews or {}).items()
+        }
         self.rewritten = rewritten
         self.adjudications = list(adjudications or [])
         self.call_kinds: list[str] = []
+        self.request_ids: list[str | None] = []
         self.review_system_prompts: list[str] = []
         self.review_requests: list[dict[str, object]] = []
         self.rewrite_system_prompts: list[str] = []
@@ -632,6 +727,7 @@ class SequencedQualityGateway(Gateway):
         *,
         request_id: str | None = None,
     ) -> GatewayResponse:
+        self.request_ids.append(request_id)
         system = str(messages[0].get("content", ""))
         user = str(messages[-1].get("content", ""))
         if "P02_REPLY_EVIDENCE_ADJUDICATION_JSON" in system:
@@ -648,11 +744,17 @@ class SequencedQualityGateway(Gateway):
         elif "P02_REPLY_REVIEW_JSON" in system:
             self.call_kinds.append("review")
             self.review_system_prompts.append(system)
-            self.review_requests.append(json.loads(user))
+            request = json.loads(user)
+            self.review_requests.append(request)
             self.review_input_sizes.append(
                 sum(len(str(message.get("content", ""))) for message in messages)
             )
-            text = self.reviews.pop(0)
+            layer = str(request["layer"])
+            text = (
+                self.layer_reviews[layer].pop(0)
+                if self.layer_reviews
+                else self.reviews.pop(0)
+            )
         elif "P02_REPLY_REWRITE_TEXT" in system:
             self.call_kinds.append("rewrite")
             self.rewrite_system_prompts.append(system)
@@ -696,7 +798,11 @@ class FailingQualityGateway(SequencedQualityGateway):
         ):
             raise TimeoutError("private adjudication detail")
         if "P02_REPLY_REVIEW_JSON" in system:
-            layer = str(json.loads(str(messages[-1]["content"]))["layer"])
+            request = json.loads(str(messages[-1]["content"]))
+            layer = str(request["layer"])
+            self.request_ids.append(request_id)
+            self.call_kinds.append("review")
+            self.review_requests.append(request)
             if self.failure == "layer" and layer == self.failing_layer:
                 raise TimeoutError("private upstream detail")
             return GatewayResponse(


### PR DESCRIPTION
## Scope

- Retry only the single reviewer layer that returns a valid JSON envelope but fails the strict `LAYER_CONTRACT` semantic combination.
- Allow at most one retry with a fresh request ID; do not rerun the four successful layers.
- Keep the parser unchanged and fail closed with the original sanitized diagnostic when the second response is still invalid.

## TDD and verification

- RED: a first invalid `continuity_memory` layer made the whole review unavailable even when its next bounded response was valid.
- GREEN: failed layer called twice, every other layer once, all six request IDs unique, final review PASS.
- Repeated invalid response remains `REVIEWER_UNAVAILABLE` after exactly two calls.
- JSON, top-level schema, evidence contract, empty text, transport, and internal failures do not retry.
- Focused file: 111 passed after the first disjoint rebase; both later Persona commits are exact `range-diff =` matches.
- Persona suite: 288 passed before the disjoint main advances.
- The original full-suite run had one baseline-equal Control Center clock-expiry failure; PR #275 fixed that test, which then passed focused.
- `git diff --check` and secret/private-path scan: clean. Exact-head CI is the merge gate.

## Frozen review trace

- Final base: `e2b966881762c93f1c861d0e095cc40ab2b04aac`
- Final head: `f191c63ae18ae9771801c2d89a9c0522708905da`
- Round 1 Spec PASS. Standards BLOCK: P0=0, P1=1 for stale call-count documentation.
- Round 2 Spec PASS and Standards PASS; P0/P1/P2=0.
- Final rebase validations after disjoint PRs #275 and #274: Standards PASS and Spec PASS; P0/P1/P2=0. Both Persona commits remained exact `range-diff =` matches.
- Reviews were static and provider-free.

## Size and non-goals

- 3 files, `+166/-46`, within the default review limit.
- No parser relaxation, semantic fallback, prompt/persona changes, provider configuration, Live, client status, media, private corpus, or relationship-state changes.
- Normal successful reviewer call counts remain unchanged; only the bounded failure path may add one call.
