### PR TITLE
fix: harden Windows installer discovery and client launch

### DIFF
--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -57,7 +57,7 @@ webplayer.dat SHA-256：
 565b5e3e113c2a9dfb90d5fa4f2a0ccda9b0151c118ae3365e6ee0c8624a451d
 ```
 
-任一文件缺失或哈希不匹配时，安装在写入目标目录前停止。
+文件缺失时安装在写入目标目录前停止。自动发现多份 Steam 副本时，安装器优先选择上述双 SHA-256 精确匹配的第一份；仅发现一份非精确匹配副本时，由 Python 补丁器继续校验 ZIP 结构与补丁锚点。多份副本均不精确匹配时返回 `OFFICIAL_INSTALL_AMBIGUOUS`，用户必须返回上一步明确选择正版目录。
 
 安装器只在隔离副本中按顺序执行：
 
@@ -85,6 +85,12 @@ webplayer.dat.orig
 正版 Steam 目录不会产生备份、补丁或写入。任何补丁、验证或重打包步骤失败时，整个未完成安装目录会被删除，不留下部分可用的客户端。
 
 已有旧 marker 但缺少原版设置或 webplayer 本机媒体标记时，不会伪装成“已经安装”；安装器会停止并要求先按受控流程处理旧安装。
+
+## 安装源诊断契约
+
+单文件安装器失败时，会把 `olivia.setup-source-diagnostic.v1` JSON 写入本机安装日志。该诊断只包含 `selection_mode`、`candidate_count`、`client_version`、`manifest_feapp_sha256`、`manifest_webplayer_sha256`，以及 `observed_feapp_size`、`observed_feapp_sha256`、`observed_webplayer_size`、`observed_webplayer_sha256`。选中目录仅以 `selected_official_id`（规范化目录路径 SHA-256 的前 16 位）标识；日志不得包含原始正版目录路径。自动发现歧义时，`candidates` 按发现顺序记录 `candidate_index` 与上述观测 size/hash，无法读取的值为 `null`。
+
+稳定安装错误码 `OFFICIAL_INSTALL_AMBIGUOUS` 表示自动发现了多份候选，但没有任何候选同时匹配内嵌 manifest 的 `feapp.dat` 与 `webplayer.dat` SHA-256。该错误不可自动重试；应返回上一步显式选择 Steam 正版目录。
 
 ## 当前能力边界
 

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -16,6 +16,8 @@ $env:MEM0_TELEMETRY = 'False'
 $offlineRoot = if ($OfflineAssetsRoot) { $OfflineAssetsRoot } else { Join-Path $PayloadRoot 'offline' }
 $offlineManifestPath = if ($OfflineAssetsRoot) { Join-Path $OfflineAssetsRoot 'offline-core-assets.json' } else { Join-Path $PayloadRoot 'offline\offline-core-assets.json' }
 $requirements = Join-Path $PayloadRoot 'installer\runtime-requirements.txt'
+$setupDiagnosticPath = if ($SetupResultPath) { $SetupResultPath + '.diagnostic.json' } else { '' }
+$script:OfficialSourceDiagnostic = $null
 
 function Get-SafeSetupErrorCode {
     param([string]$Code)
@@ -44,8 +46,25 @@ function Write-SetupErrorResult {
     }
 }
 
+function Write-SetupDiagnosticResult {
+    param([AllowNull()][object]$Diagnostic)
+
+    if (-not $setupDiagnosticPath -or $null -eq $Diagnostic) { return }
+    try {
+        $utf8NoBom = [Text.UTF8Encoding]::new($false)
+        [IO.File]::WriteAllText(
+            $setupDiagnosticPath,
+            ($Diagnostic | ConvertTo-Json -Compress -Depth 4),
+            $utf8NoBom
+        )
+    } catch {
+        # Diagnostics must never replace the stable installer error code.
+    }
+}
+
 trap {
     $safeCode = Get-SafeSetupErrorCode -Code ([string]$_.Exception.Message)
+    Write-SetupDiagnosticResult -Diagnostic $script:OfficialSourceDiagnostic
     Write-SetupErrorResult -Code $safeCode
     if (-not $SetupResultPath) { Write-Output $safeCode }
     exit 2
@@ -73,6 +92,46 @@ function Get-Sha256 {
     } finally {
         $hasher.Dispose()
         $stream.Dispose()
+    }
+}
+
+function New-OfficialSourceDiagnostic {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Selection,
+        [Parameter(Mandatory)]
+        [string]$ManifestPath
+    )
+
+    $manifest = [IO.File]::ReadAllText($ManifestPath) | ConvertFrom-Json
+    $selected = [string]$Selection.Path
+    $normalizedSelected = [IO.Path]::GetFullPath($selected).TrimEnd('\').ToLowerInvariant()
+    $pathHasher = [Security.Cryptography.SHA256]::Create()
+    try {
+        $selectedId = ([BitConverter]::ToString(
+            $pathHasher.ComputeHash([Text.Encoding]::UTF8.GetBytes($normalizedSelected))
+        )).Replace('-', '').ToLowerInvariant().Substring(0, 16)
+    } finally {
+        $pathHasher.Dispose()
+    }
+    $version = [string]$manifest.client_version
+    $resources = Join-Path (Join-Path $selected $version) 'resources'
+    $feapp = Join-Path $resources 'feapp.dat'
+    $webplayer = Join-Path $resources 'webplayer.dat'
+    $feappInfo = if ([IO.File]::Exists($feapp)) { [IO.FileInfo]::new($feapp) } else { $null }
+    $webplayerInfo = if ([IO.File]::Exists($webplayer)) { [IO.FileInfo]::new($webplayer) } else { $null }
+    return [ordered]@{
+        schema_version = 'olivia.setup-source-diagnostic.v1'
+        selection_mode = [string]$Selection.SelectionMode
+        candidate_count = [int]$Selection.CandidateCount
+        selected_official_id = $selectedId
+        client_version = $version
+        observed_feapp_size = if ($feappInfo) { $feappInfo.Length } else { $null }
+        observed_feapp_sha256 = if ($feappInfo) { Get-Sha256 -LiteralPath $feapp } else { $null }
+        observed_webplayer_size = if ($webplayerInfo) { $webplayerInfo.Length } else { $null }
+        observed_webplayer_sha256 = if ($webplayerInfo) { Get-Sha256 -LiteralPath $webplayer } else { $null }
+        manifest_feapp_sha256 = [string]$manifest.feapp_sha256
+        manifest_webplayer_sha256 = [string]$manifest.webplayer_sha256
     }
 }
 
@@ -159,24 +218,38 @@ function Test-PathsOverlap {
 }
 
 function Resolve-OfficialInstall {
-    param([string]$RequestedRoot)
+    param(
+        [string]$RequestedRoot,
+        [Parameter(Mandatory)]
+        [string]$ManifestPath,
+        [string[]]$SteamRoots = @()
+    )
 
     if ($RequestedRoot) {
-        return [IO.Path]::GetFullPath($RequestedRoot)
+        return [pscustomobject]@{
+            Path = [IO.Path]::GetFullPath($RequestedRoot)
+            SelectionMode = 'explicit'
+            CandidateCount = 1
+        }
     }
-    $steamRoots = [Collections.Generic.List[string]]::new()
-    try {
-        $steamPath = (Get-ItemProperty -LiteralPath 'HKCU:\Software\Valve\Steam' -Name SteamPath).SteamPath
-        if ($steamPath) { $steamRoots.Add([string]$steamPath) }
-    } catch {
-        # Continue with conventional Steam roots.
-    }
-    foreach ($drive in 'CDEFGHIJKLMNOPQRSTUVWXYZ'.ToCharArray()) {
-        $candidate = $drive + ':\steam'
-        if ([IO.Directory]::Exists($candidate)) { $steamRoots.Add($candidate) }
+    if (-not $PSBoundParameters.ContainsKey('SteamRoots')) {
+        $discoveredSteamRoots = [Collections.Generic.List[string]]::new()
+        try {
+            $steamPath = (Get-ItemProperty -LiteralPath 'HKCU:\Software\Valve\Steam' -Name SteamPath).SteamPath
+            if ($steamPath) { $discoveredSteamRoots.Add([string]$steamPath) }
+        } catch {
+            # Continue with conventional Steam roots.
+        }
+        foreach ($drive in 'CDEFGHIJKLMNOPQRSTUVWXYZ'.ToCharArray()) {
+            $candidate = $drive + ':\steam'
+            if ([IO.Directory]::Exists($candidate)) {
+                $discoveredSteamRoots.Add($candidate)
+            }
+        }
+        $SteamRoots = $discoveredSteamRoots.ToArray()
     }
     $libraryRoots = [Collections.Generic.List[string]]::new()
-    foreach ($steamRoot in $steamRoots) {
+    foreach ($steamRoot in $SteamRoots) {
         try {
             $steamFull = [IO.Path]::GetFullPath($steamRoot)
             $libraryRoots.Add($steamFull)
@@ -191,6 +264,10 @@ function Resolve-OfficialInstall {
             # Ignore malformed or inaccessible Steam library entries.
         }
     }
+    $candidates = [Collections.Generic.List[string]]::new()
+    $seenCandidates = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::OrdinalIgnoreCase
+    )
     foreach ($libraryRoot in $libraryRoots) {
         try {
             $libraryFull = [IO.Path]::GetFullPath($libraryRoot)
@@ -204,13 +281,96 @@ function Resolve-OfficialInstall {
             if (-not $match.Success) { continue }
             $candidate = Join-Path $libraryFull ('steamapps\common\' + $match.Groups[1].Value)
             if ([IO.Directory]::Exists($candidate)) {
-                return [IO.Path]::GetFullPath($candidate)
+                $candidateFull = [IO.Path]::GetFullPath($candidate)
+                if ($seenCandidates.Add($candidateFull)) {
+                    $candidates.Add($candidateFull)
+                }
             }
         } catch {
             # Continue to the next Steam library.
         }
     }
-    throw 'OFFICIAL_INSTALL_NOT_FOUND'
+    if ($candidates.Count -eq 0) { throw 'OFFICIAL_INSTALL_NOT_FOUND' }
+    if ($candidates.Count -eq 1) {
+        return [pscustomobject]@{
+            Path = $candidates[0]
+            SelectionMode = 'auto_single'
+            CandidateCount = 1
+        }
+    }
+
+    try {
+        $manifest = [IO.File]::ReadAllText($ManifestPath) | ConvertFrom-Json
+        $version = [string]$manifest.client_version
+        $expectedFeapp = [string]$manifest.feapp_sha256
+        $expectedWebplayer = [string]$manifest.webplayer_sha256
+        if (
+            -not $version -or
+            $expectedFeapp -cnotmatch '^[0-9a-fA-F]{64}$' -or
+            $expectedWebplayer -cnotmatch '^[0-9a-fA-F]{64}$'
+        ) {
+            throw 'PATCH_MANIFEST_INVALID'
+        }
+    } catch {
+        if ([string]$_.Exception.Message -eq 'PATCH_MANIFEST_INVALID') { throw }
+        throw 'PATCH_MANIFEST_INVALID'
+    }
+    $candidateDiagnostics = [Collections.Generic.List[object]]::new()
+    $candidateIndex = 0
+    foreach ($candidate in $candidates) {
+        $resources = Join-Path (Join-Path $candidate $version) 'resources'
+        $feapp = Join-Path $resources 'feapp.dat'
+        $webplayer = Join-Path $resources 'webplayer.dat'
+        $observedFeappSize = $null
+        $observedWebplayerSize = $null
+        $actualFeapp = $null
+        $actualWebplayer = $null
+        if ([IO.File]::Exists($feapp)) {
+            try {
+                $observedFeappSize = [IO.FileInfo]::new($feapp).Length
+                $actualFeapp = Get-Sha256 -LiteralPath $feapp
+            } catch {
+                # This candidate remains observable but cannot be an exact match.
+            }
+        }
+        if ([IO.File]::Exists($webplayer)) {
+            try {
+                $observedWebplayerSize = [IO.FileInfo]::new($webplayer).Length
+                $actualWebplayer = Get-Sha256 -LiteralPath $webplayer
+            } catch {
+                # This candidate remains observable but cannot be an exact match.
+            }
+        }
+        $candidateDiagnostics.Add([ordered]@{
+            candidate_index = $candidateIndex
+            observed_feapp_size = $observedFeappSize
+            observed_feapp_sha256 = $actualFeapp
+            observed_webplayer_size = $observedWebplayerSize
+            observed_webplayer_sha256 = $actualWebplayer
+        })
+        $candidateIndex += 1
+        if (
+            $actualFeapp -ceq $expectedFeapp.ToLowerInvariant() -and
+            $actualWebplayer -ceq $expectedWebplayer.ToLowerInvariant()
+        ) {
+            return [pscustomobject]@{
+                Path = $candidate
+                SelectionMode = 'auto_manifest_match'
+                CandidateCount = $candidates.Count
+            }
+        }
+    }
+    $script:OfficialSourceDiagnostic = [ordered]@{
+        schema_version = 'olivia.setup-source-diagnostic.v1'
+        selection_mode = 'auto_ambiguous'
+        candidate_count = $candidates.Count
+        selected_official_id = $null
+        client_version = $version
+        manifest_feapp_sha256 = $expectedFeapp.ToLowerInvariant()
+        manifest_webplayer_sha256 = $expectedWebplayer.ToLowerInvariant()
+        candidates = $candidateDiagnostics.ToArray()
+    }
+    throw 'OFFICIAL_INSTALL_AMBIGUOUS'
 }
 
 function Assert-OfficialSource {
@@ -245,12 +405,6 @@ function Assert-OfficialSource {
     $webplayer = Join-Path $resources 'webplayer.dat'
     foreach ($required in @($launcher, $client, $feapp, $webplayer)) {
         if (-not [IO.File]::Exists($required)) { throw 'OFFICIAL_INSTALL_NOT_FOUND' }
-    }
-    if (
-        (Get-Sha256 -LiteralPath $feapp) -cne ([string]$manifest.feapp_sha256).ToLowerInvariant() -or
-        (Get-Sha256 -LiteralPath $webplayer) -cne ([string]$manifest.webplayer_sha256).ToLowerInvariant()
-    ) {
-        throw 'UNSUPPORTED_OFFICIAL_VERSION'
     }
 }
 
@@ -585,12 +739,16 @@ $selectedOfficial = $OfficialRoot
 if (-not $selectedOfficial -and -not $NonInteractive) {
     $selectedOfficial = Read-Host 'Steam 游戏目录（留空则按 AppID 自动发现）'
 }
-$selectedOfficial = Resolve-OfficialInstall -RequestedRoot $selectedOfficial
+$manifestPath = Join-Path $PayloadRoot 'installer\full-patch-manifest.json'
+$selectedOfficial = Resolve-OfficialInstall -RequestedRoot $selectedOfficial -ManifestPath $manifestPath
+$officialSelection = $selectedOfficial
+$selectedOfficial = [string]$officialSelection.Path
 Assert-NoReparsePointsInPath -LiteralPath $selectedOfficial -ErrorCode 'OFFICIAL_INSTALL_PATH_REPARSE_POINT'
 if (Test-PathsOverlap -Left $productRoot -Right $selectedOfficial) {
     throw 'INSTALL_ROOT_OVERLAPS_OFFICIAL'
 }
-$manifestPath = Join-Path $PayloadRoot 'installer\full-patch-manifest.json'
+$script:OfficialSourceDiagnostic = New-OfficialSourceDiagnostic -Selection $officialSelection -ManifestPath $manifestPath
+Write-SetupDiagnosticResult -Diagnostic $script:OfficialSourceDiagnostic
 Assert-OfficialSource -SourceRoot $selectedOfficial -ManifestPath $manifestPath
 $coreAssets = Get-OfflineCoreAssets -Root $offlineRoot -ManifestPath $offlineManifestPath -RequirementsPath $requirements
 $runtimeStaging = $runtimeRoot + '.staging.' + [guid]::NewGuid().ToString('N')
@@ -638,9 +796,6 @@ try {
         }
         throw 'OFFLINE_CORE_RUNTIME_PUBLISH_FAILED'
     }
-    if ($runtimeBackup -and (Test-Path -LiteralPath $runtimeBackup)) {
-        Remove-Item -LiteralPath $runtimeBackup -Recurse -Force -ErrorAction SilentlyContinue
-    }
 } catch {
     if (Test-Path -LiteralPath $runtimeStaging) {
         Remove-Item -LiteralPath $runtimeStaging -Recurse -Force
@@ -659,6 +814,12 @@ $bootstrap = Join-Path $PayloadRoot 'installer\bootstrap_install.py'
 $installOutput = @(& $runner.File @($runner.Args + @($bootstrap, $PayloadRoot) + $arguments))
 $installExitCode = $LASTEXITCODE
 if ($installExitCode -ne 0) {
+    if ($runtimeBackup -and (Test-Path -LiteralPath $runtimeBackup)) {
+        if (Test-Path -LiteralPath $runtimeRoot) {
+            Remove-Item -LiteralPath $runtimeRoot -Recurse -Force
+        }
+        [IO.Directory]::Move($runtimeBackup, $runtimeRoot)
+    }
     $installCode = 'SETUP_INSTALL_FAILED'
     foreach ($line in $installOutput) {
         try {
@@ -677,6 +838,9 @@ if ($installExitCode -ne 0) {
     Write-SetupErrorResult -Code $installCode
     if (-not $SetupResultPath) { $installOutput | Write-Output }
     exit $installExitCode
+}
+if ($runtimeBackup -and (Test-Path -LiteralPath $runtimeBackup)) {
+    Remove-Item -LiteralPath $runtimeBackup -Recurse -Force
 }
 if (-not $SetupResultPath) { $installOutput | Write-Output }
 

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -12,9 +12,12 @@ import uuid
 from pathlib import Path
 from typing import Any, Iterable
 
-from patch_companion_settings import patch_companion_settings
+from patch_companion_settings import (
+    CompanionSettingsPatchError,
+    patch_companion_settings,
+)
 from patch_feapp import patch_feapp
-from patch_webplayer import patch_webplayer
+from patch_webplayer import WebPlayerPatchError, patch_webplayer
 from installer.uninstall_safety import (
     MARKER_NAME,
     OWNED_PATHS,
@@ -275,13 +278,6 @@ def validate_official_source(
         raise PatchInstallError("OFFICIAL_INSTALL_NOT_FOUND")
     feapp = required[2]
     webplayer = required[3]
-    if (
-        _sha256(feapp).lower()
-        != str(manifest["feapp_sha256"]).lower()
-        or _sha256(webplayer).lower()
-        != str(manifest["webplayer_sha256"]).lower()
-    ):
-        raise PatchInstallError("UNSUPPORTED_OFFICIAL_VERSION")
     return version, feapp, webplayer
 
 
@@ -606,13 +602,14 @@ def _read_marker(path: Path) -> dict[str, Any]:
 
 def _marker_matches_current_install(
     marker: dict[str, Any],
-    manifest: dict[str, Any],
+    source_feapp_sha256: str,
+    source_webplayer_sha256: str,
 ) -> bool:
     return (
         marker.get("official_feapp_sha256")
-        == manifest["feapp_sha256"]
+        == source_feapp_sha256
         and marker.get("official_webplayer_sha256")
-        == manifest["webplayer_sha256"]
+        == source_webplayer_sha256
         and marker.get("original_client_only") is True
         and marker.get("companion_settings_embedded") is True
         and marker.get("webplayer_local_media") is True
@@ -631,17 +628,23 @@ def install_full_patch(
     source = Path(official_source).expanduser().resolve()
     target = Path(destination).expanduser().resolve()
     payload = Path(payload_root).expanduser().resolve()
-    version, _source_feapp, _source_webplayer = validate_official_source(
+    version, source_feapp, source_webplayer = validate_official_source(
         source,
         manifest,
     )
+    source_feapp_sha256 = _sha256(source_feapp)
+    source_webplayer_sha256 = _sha256(source_webplayer)
     if target == source or target in source.parents or source in target.parents:
         raise PatchInstallError("INSTALL_ROOT_OVERLAPS_OFFICIAL")
     marker_path = target / MARKER_NAME
     if target.exists():
         if marker_path.is_file():
             marker = _read_marker(marker_path)
-            if _marker_matches_current_install(marker, manifest):
+            if _marker_matches_current_install(
+                marker,
+                source_feapp_sha256,
+                source_webplayer_sha256,
+            ):
                 refreshed = _refresh_existing_install(target, payload, marker, port)
                 return {"status": "ALREADY_INSTALLED", **refreshed}
         raise PatchInstallError("INSTALL_ROOT_ALREADY_EXISTS")
@@ -659,29 +662,36 @@ def install_full_patch(
         webplayer = resources / "webplayer.dat"
         if (
             _sha256(feapp).lower()
-            != str(manifest["feapp_sha256"]).lower()
+            != source_feapp_sha256.lower()
             or _sha256(webplayer).lower()
-            != str(manifest["webplayer_sha256"]).lower()
+            != source_webplayer_sha256.lower()
         ):
             raise PatchInstallError("STAGED_COPY_VERIFICATION_FAILED")
         if not 1 <= port <= 65535:
             raise PatchInstallError("INVALID_PORT")
 
         base_http = f"http://127.0.0.1:{port}"
-        endpoint_patch = patch_feapp(
-            feapp,
-            f"ws://127.0.0.1:{port}/ws",
-            work_root=resources,
-        )
-        settings_patch = patch_companion_settings(
-            feapp,
-            base_http,
-            work_root=resources,
-        )
-        player_patch = patch_webplayer(
-            webplayer,
-            work_root=resources,
-        )
+        try:
+            endpoint_patch = patch_feapp(
+                feapp,
+                f"ws://127.0.0.1:{port}/ws",
+                work_root=resources,
+            )
+            settings_patch = patch_companion_settings(
+                feapp,
+                base_http,
+                work_root=resources,
+            )
+            player_patch = patch_webplayer(
+                webplayer,
+                work_root=resources,
+            )
+        except (
+            ValueError,
+            CompanionSettingsPatchError,
+            WebPlayerPatchError,
+        ) as exc:
+            raise PatchInstallError("UNSUPPORTED_OFFICIAL_VERSION") from exc
 
         _write_start_scripts(staging, port)
         (staging / "data").mkdir()
@@ -691,7 +701,7 @@ def install_full_patch(
             "client_version": version,
             "official_source": str(source),
             "owned_root": str(target),
-            "official_feapp_sha256": manifest["feapp_sha256"],
+            "official_feapp_sha256": source_feapp_sha256,
             "patched_feapp_sha256": _sha256(feapp),
             "backup_feapp_sha256": endpoint_patch["backup_sha256"],
             "companion_backup_feapp_sha256": settings_patch[
@@ -699,7 +709,7 @@ def install_full_patch(
             ],
             "companion_settings_status": settings_patch["status"],
             "companion_settings_ui_version": settings_patch["ui_version"],
-            "official_webplayer_sha256": manifest["webplayer_sha256"],
+            "official_webplayer_sha256": source_webplayer_sha256,
             "patched_webplayer_sha256": _sha256(webplayer),
             "backup_webplayer_sha256": player_patch["backup_sha256"],
             "webplayer_patch_status": player_patch["status"],

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -746,11 +746,14 @@ def main(argv: list[str] | None = None) -> int:
         local = profile / "Local"
         roaming.mkdir(parents=True, exist_ok=True)
         local.mkdir(parents=True, exist_ok=True)
-        return subprocess.call(
+        _append_launcher_event(data_root, "client_start")
+        exit_code = subprocess.call(
             _client_command(client, local),
-            cwd=root / "app",
+            cwd=client.parent,
             env=_client_environment(client_environment, roaming, local),
         )
+        _append_launcher_event(data_root, "client_exit", exit_code=exit_code)
+        return exit_code
     finally:
         # Stop only the backend process spawned and owned by this launcher.
         # A healthy backend reused from an earlier launcher has no local handle.

--- a/installer/windows_setup.iss
+++ b/installer/windows_setup.iss
@@ -154,11 +154,13 @@ var
   PowerShell: String;
   Params: String;
   ExitCode: Integer;
+  DiagnosticContent: AnsiString;
 begin
   Result := '';
   StableInstallCode := '';
   SetupResultPath := ExpandConstant('{tmp}\olivia-setup-result.txt');
   DeleteFile(SetupResultPath);
+  DeleteFile(SetupResultPath + '.diagnostic.json');
   ExitCode := -1;
   try
     ExtractTemporaryFiles('{tmp}\OliviaPayload\*');
@@ -195,7 +197,11 @@ begin
     if StableInstallCode = '' then
       StableInstallCode := 'SETUP_INSTALL_FAILED';
     Log('Olivia installer code: ' + StableInstallCode);
-    if StableInstallCode <> '' then
+    if LoadStringFromFile(SetupResultPath + '.diagnostic.json', DiagnosticContent) then
+      Log('Olivia installer diagnostic: ' + String(DiagnosticContent));
+    if StableInstallCode = 'OFFICIAL_INSTALL_AMBIGUOUS' then
+      Result := '检测到多个 Olivia 正版目录，且无法自动确认当前副本。请点击“上一步”，明确选择 Steam 中正在使用的正版游戏目录。'
+    else if StableInstallCode <> '' then
       Result := '安装失败：' + StableInstallCode + '。请保留安装日志后重试。'
     else
       Result := Format('安装失败（进程错误码 %d）。请保留安装日志后重试。', [ExitCode]);

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import hashlib
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
+import sys
+import zipfile
 
 from jsonschema import Draft202012Validator
 import pytest
@@ -153,6 +157,137 @@ def _run_install_preflight(
     )
 
 
+def _run_runtime_publish_fixture(
+    tmp_path: Path,
+    *,
+    bootstrap_exit_code: int,
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    payload = tmp_path / "payload"
+    payload_installer = payload / "installer"
+    payload_installer.mkdir(parents=True)
+    for name in (
+        "full-patch-manifest.json",
+        "runtime-requirements.txt",
+        "mem0-runtime-requirements.txt",
+        "verify_mem0_runtime.py",
+    ):
+        shutil.copy2(ROOT / "installer" / name, payload_installer / name)
+    (payload_installer / "bootstrap_install.py").write_text(
+        "import json\n"
+        f"print(json.dumps({{'status': 'ERROR', 'code': 'SYNTHETIC_PATCH_FAILED'}}))\n"
+        f"raise SystemExit({bootstrap_exit_code})\n",
+        encoding="utf-8",
+    )
+    official = tmp_path / "official"
+    resources = official / "0.0.9.627" / "resources"
+    resources.mkdir(parents=True)
+    (official / "launcher.exe").write_bytes(b"launcher")
+    (official / "0.0.9.627" / "Olivia.exe").write_bytes(b"client")
+    (resources / "feapp.dat").write_bytes(b"feapp")
+    (resources / "webplayer.dat").write_bytes(b"webplayer")
+
+    runtime_zip = tmp_path / "runtime.zip"
+    python_executable = Path(getattr(sys, "_base_executable", sys.executable))
+    python_home = python_executable.parent
+    python_tag = f"python{sys.version_info.major}{sys.version_info.minor}"
+    with zipfile.ZipFile(runtime_zip, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.write(python_executable, "python.exe")
+        for name in (f"{python_tag}.dll", "python3.dll", "vcruntime140.dll"):
+            candidate = python_home / name
+            if candidate.is_file():
+                archive.write(candidate, name)
+        archive.writestr(
+            f"{python_tag}._pth",
+            "\n".join(
+                [
+                    str(python_home / f"{python_tag}.zip"),
+                    str(python_home),
+                    str(python_home / "Lib"),
+                    str(python_home / "Lib" / "site-packages"),
+                    "import site",
+                ]
+            ),
+        )
+
+    script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
+    original = "$coreAssets = Get-OfflineCoreAssets -Root $offlineRoot -ManifestPath $offlineManifestPath -RequirementsPath $requirements"
+    replacement = "$coreAssets = @{ Runtime = $env:BSIDE_TEST_RUNTIME_ZIP; PipBootstrap = ''; Wheelhouse = '' }"
+    assert script.count(original) == 1
+    script = script.replace(original, replacement)
+    dependency_probe = "if (-not (Test-ManagedServerDependencies -PythonExe $candidateExe)) {"
+    assert script.count(dependency_probe) == 2
+    script = script.replace(dependency_probe, "if ($false) {", 1)
+    test_script = tmp_path / "Install.ps1"
+    test_script.write_text(script, encoding="utf-8-sig")
+    product = tmp_path / "product"
+    old_runtime = product / "runtime" / "python-3.12.10-embed-amd64"
+    old_runtime.mkdir(parents=True)
+    (old_runtime / "old-runtime.txt").write_text("preserve", encoding="utf-8")
+    environment = os.environ.copy()
+    environment["BSIDE_TEST_RUNTIME_ZIP"] = str(runtime_zip)
+    result = subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(test_script),
+            "-PayloadRoot",
+            str(payload),
+            "-Destination",
+            str(product),
+            "-OfficialRoot",
+            str(official),
+            "-NonInteractive",
+            "-SkipShortcut",
+        ],
+        env=environment,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+        check=False,
+    )
+    return result, product
+
+
+def test_patch_failure_restores_existing_runtime_and_cleans_transaction_paths(
+    tmp_path: Path,
+) -> None:
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=23,
+    )
+
+    runtime_parent = product / "runtime"
+    runtime = runtime_parent / "python-3.12.10-embed-amd64"
+    assert result.returncode == 23, result.stderr or result.stdout
+    assert (runtime / "old-runtime.txt").read_text(encoding="utf-8") == "preserve"
+    assert not (runtime / "python.exe").exists()
+    assert not list(runtime_parent.glob("python-3.12.10-embed-amd64.backup.*"))
+    assert not list(runtime_parent.glob("python-3.12.10-embed-amd64.staging.*"))
+
+
+def test_patch_success_discards_runtime_backup_after_install(
+    tmp_path: Path,
+) -> None:
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=0,
+    )
+
+    runtime_parent = product / "runtime"
+    runtime = runtime_parent / "python-3.12.10-embed-amd64"
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert (runtime / "python.exe").is_file()
+    assert not (runtime / "old-runtime.txt").exists()
+    assert not list(runtime_parent.glob("python-3.12.10-embed-amd64.backup.*"))
+    assert not list(runtime_parent.glob("python-3.12.10-embed-amd64.staging.*"))
+
+
 @pytest.mark.skipif(os.name != "nt", reason="Windows junction contract")
 @pytest.mark.parametrize("product_name", ["isolated-product", "install"])
 def test_first_install_rejects_a_reparse_point_at_the_selected_product_root(
@@ -264,7 +399,7 @@ def test_first_install_rejects_official_overlap_before_runtime_writes(
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows preflight contract")
-def test_first_install_validates_official_files_before_runtime_writes(
+def test_first_install_defers_official_archive_compatibility_to_python_installer(
     tmp_path: Path,
 ) -> None:
     product_root = tmp_path / "product"
@@ -284,8 +419,64 @@ def test_first_install_validates_official_files_before_runtime_writes(
     )
 
     assert result.returncode != 0
-    assert "UNSUPPORTED_OFFICIAL_VERSION" in result.stdout + result.stderr
+    output = result.stdout + result.stderr
+    assert "OFFLINE_CORE_ASSETS_MISSING" in output
+    assert "UNSUPPORTED_OFFICIAL_VERSION" not in output
     assert not (product_root / "runtime").exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows setup diagnostic contract")
+def test_failed_setup_records_selected_official_archives_and_manifest_hashes(
+    tmp_path: Path,
+) -> None:
+    product_root = tmp_path / "product"
+    official_root = tmp_path / "official"
+    resources = official_root / "0.0.9.627" / "resources"
+    resources.mkdir(parents=True)
+    (official_root / "launcher.exe").write_bytes(b"launcher")
+    (official_root / "0.0.9.627" / "Olivia.exe").write_bytes(b"client")
+    feapp = resources / "feapp.dat"
+    webplayer = resources / "webplayer.dat"
+    feapp.write_bytes(b"observed feapp")
+    webplayer.write_bytes(b"observed webplayer")
+    result_path = tmp_path / "setup-result.txt"
+
+    result = _run_install_preflight(
+        product_root,
+        tmp_path,
+        "-OfficialRoot",
+        str(official_root),
+        "-SetupResultPath",
+        str(result_path),
+    )
+
+    assert result.returncode != 0
+    diagnostic_path = Path(str(result_path) + ".diagnostic.json")
+    diagnostic_text = diagnostic_path.read_text(encoding="utf-8")
+    diagnostic = json.loads(diagnostic_text)
+    manifest = json.loads(
+        (ROOT / "installer" / "full-patch-manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert diagnostic == {
+        "schema_version": "olivia.setup-source-diagnostic.v1",
+        "selection_mode": "explicit",
+        "candidate_count": 1,
+        "selected_official_id": hashlib.sha256(
+            str(official_root.resolve()).rstrip("\\").lower().encode("utf-8")
+        ).hexdigest()[:16],
+        "client_version": "0.0.9.627",
+        "observed_feapp_size": feapp.stat().st_size,
+        "observed_feapp_sha256": hashlib.sha256(feapp.read_bytes()).hexdigest(),
+        "observed_webplayer_size": webplayer.stat().st_size,
+        "observed_webplayer_sha256": hashlib.sha256(
+            webplayer.read_bytes()
+        ).hexdigest(),
+        "manifest_feapp_sha256": manifest["feapp_sha256"],
+        "manifest_webplayer_sha256": manifest["webplayer_sha256"],
+    }
+    assert str(official_root) not in diagnostic_text
 
 
 def test_offline_asset_builder_uses_the_hash_locked_windows_wheel_closure() -> None:

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -319,6 +319,7 @@ def test_launcher_starts_combined_server_before_original_client(
     health = iter(("UNAVAILABLE", "READY", "READY", "READY"))
     commands: list[list[str]] = []
     client_commands: list[list[str]] = []
+    client_working_directories: list[Path] = []
     frontend_repairs: list[tuple[Path, int]] = []
 
     class Process:
@@ -330,8 +331,9 @@ def test_launcher_starts_combined_server_before_original_client(
         commands.append([str(value) for value in command])
         return Process()
 
-    def call(command, **_kwargs):
+    def call(command, **kwargs):
         client_commands.append([str(value) for value in command])
+        client_working_directories.append(Path(kwargs["cwd"]))
         return 0
 
     monkeypatch.setattr(start_local, "_health", lambda _port: next(health))
@@ -367,6 +369,9 @@ def test_launcher_starts_combined_server_before_original_client(
         str(root / "local_backend" / "original_client_server.py"),
     ]
     assert client_commands[0][0].endswith("Olivia.exe")
+    assert client_working_directories == [
+        root.resolve() / "app" / "0.0.9.615"
+    ]
     assert not backend_command[-1].endswith("local_server.py")
     assert frontend_repairs == [(root.resolve(), 8899)]
     launcher_log = (root / "data" / "logs" / "launcher.jsonl").read_text(
@@ -374,7 +379,11 @@ def test_launcher_starts_combined_server_before_original_client(
     )
     assert '"event": "backend_start"' in launcher_log
     assert '"event": "backend_ready"' in launcher_log
+    assert '"event": "client_start"' in launcher_log
+    assert '"event": "client_exit"' in launcher_log
+    assert '"exit_code": 0' in launcher_log
     assert "DEEPSEEK_API_KEY" not in launcher_log
+    assert str(root.resolve()) not in launcher_log
 
 
 def test_component_launcher_starts_the_backend_that_owns_start_local(

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -500,6 +500,227 @@ def test_install_entrypoint_uses_dotnet_sha256_not_optional_powershell_cmdlet() 
     assert "Get-FileHash" not in script
 
 
+def _run_official_install_resolution(
+    *,
+    manifest: Path,
+    steam_roots: list[Path],
+    requested_root: Path | None = None,
+    unreadable_root: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    repo_root = Path(__file__).parents[2]
+    command = (
+        "$tokens=$null;$errors=$null;"
+        "$ast=[System.Management.Automation.Language.Parser]::ParseFile("
+        "$env:BSIDE_INSTALL_SCRIPT,[ref]$tokens,[ref]$errors);"
+        "if($errors.Count){throw 'INSTALL_SCRIPT_PARSE_FAILED'};"
+        "$names=@('Get-Sha256','Resolve-OfficialInstall');"
+        "foreach($name in $names){"
+        "$function=$ast.Find({param($node)"
+        "$node -is [System.Management.Automation.Language.FunctionDefinitionAst]"
+        " -and $node.Name -eq $name},$true);"
+        "if(-not $function){throw ('FUNCTION_MISSING:'+$name)};"
+        ". ([scriptblock]::Create($function.Extent.Text))};"
+        "$script:RealGetSha256=${function:Get-Sha256};"
+        "function Get-Sha256{param([string]$LiteralPath)"
+        "if($env:BSIDE_UNREADABLE_ROOT -and "
+        "$LiteralPath.StartsWith($env:BSIDE_UNREADABLE_ROOT,[StringComparison]::OrdinalIgnoreCase))"
+        "{throw 'SYNTHETIC_ARCHIVE_UNREADABLE'};"
+        "& $script:RealGetSha256 -LiteralPath $LiteralPath};"
+        "$roots=@($env:BSIDE_STEAM_ROOTS -split \"`n\");"
+        "try{$selection=Resolve-OfficialInstall "
+        "-RequestedRoot $env:BSIDE_REQUESTED_ROOT "
+        "-ManifestPath $env:BSIDE_PATCH_MANIFEST -SteamRoots $roots;"
+        "$selection|ConvertTo-Json -Compress}catch{"
+        "[pscustomobject]@{code=$_.Exception.Message;"
+        "diagnostic=$script:OfficialSourceDiagnostic}|ConvertTo-Json -Compress -Depth 5;"
+        "exit 2}"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "BSIDE_INSTALL_SCRIPT": str(repo_root / "installer" / "Install.ps1"),
+            "BSIDE_PATCH_MANIFEST": str(manifest),
+            "BSIDE_REQUESTED_ROOT": str(requested_root or ""),
+            "BSIDE_UNREADABLE_ROOT": str(unreadable_root or ""),
+            "BSIDE_STEAM_ROOTS": "\n".join(str(root) for root in steam_roots),
+        }
+    )
+    return subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            command,
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+
+
+def _make_steam_library(
+    library: Path,
+    *,
+    archive_comment: bytes = b"",
+) -> tuple[Path, str, str]:
+    candidate, feapp_sha256, webplayer_sha256 = _make_official(
+        library / "steamapps" / "common" / "Olivia"
+    )
+    if archive_comment:
+        with zipfile.ZipFile(
+            candidate
+            / CURRENT_TEST_CLIENT_VERSION
+            / "resources"
+            / "webplayer.dat",
+            "a",
+        ) as archive:
+            archive.comment = archive_comment
+    (library / "steamapps" / "appmanifest_4532590.acf").write_text(
+        '"AppState" { "installdir" "Olivia" }', encoding="utf-8"
+    )
+    return candidate, feapp_sha256, webplayer_sha256
+
+
+def _selection(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    assert result.returncode == 0, result.stderr or result.stdout
+    return json.loads(result.stdout)
+
+
+def test_automatic_official_discovery_prefers_later_exact_archive_pair(
+    tmp_path: Path,
+) -> None:
+    stale_library = tmp_path / "stale-steam"
+    exact_library = tmp_path / "exact-steam"
+    _, feapp_sha256, webplayer_sha256 = _make_steam_library(
+        stale_library, archive_comment=b"stale official copy"
+    )
+    exact, _, _ = _make_steam_library(exact_library)
+    manifest = _write_manifest(
+        tmp_path / "manifest.json", feapp_sha256, webplayer_sha256
+    )
+
+    selection = _selection(
+        _run_official_install_resolution(
+            manifest=manifest, steam_roots=[stale_library, exact_library]
+        )
+    )
+
+    assert Path(selection["Path"]) == exact
+    assert selection["SelectionMode"] == "auto_manifest_match"
+    assert selection["CandidateCount"] == 2
+
+
+def test_automatic_official_discovery_skips_unreadable_candidate(
+    tmp_path: Path,
+) -> None:
+    unreadable_library = tmp_path / "unreadable-steam"
+    exact_library = tmp_path / "exact-steam"
+    unreadable, feapp_sha256, webplayer_sha256 = _make_steam_library(
+        unreadable_library
+    )
+    exact, _, _ = _make_steam_library(exact_library)
+    manifest = _write_manifest(
+        tmp_path / "manifest.json", feapp_sha256, webplayer_sha256
+    )
+    result = _run_official_install_resolution(
+        manifest=manifest,
+        steam_roots=[unreadable_library, exact_library],
+        unreadable_root=unreadable,
+    )
+
+    selection = _selection(result)
+    assert Path(selection["Path"]) == exact
+    assert selection["SelectionMode"] == "auto_manifest_match"
+    assert selection["CandidateCount"] == 2
+
+
+def test_automatic_official_discovery_rejects_multiple_nonmatching_candidates(
+    tmp_path: Path,
+) -> None:
+    libraries = [tmp_path / "steam-a", tmp_path / "steam-b"]
+    for index, library in enumerate(libraries):
+        _, feapp_sha256, webplayer_sha256 = _make_steam_library(
+            library, archive_comment=f"nonmatching candidate {index}".encode()
+        )
+    manifest = _write_manifest(
+        tmp_path / "manifest.json", feapp_sha256, webplayer_sha256
+    )
+
+    result = _run_official_install_resolution(
+        manifest=manifest, steam_roots=libraries
+    )
+
+    assert result.returncode != 0
+    report = json.loads(result.stdout)
+    assert report["code"] == "OFFICIAL_INSTALL_AMBIGUOUS"
+    diagnostic = report["diagnostic"]
+    assert diagnostic["schema_version"] == "olivia.setup-source-diagnostic.v1"
+    assert diagnostic["selection_mode"] == "auto_ambiguous"
+    assert diagnostic["candidate_count"] == 2
+    assert diagnostic["client_version"] == CURRENT_TEST_CLIENT_VERSION
+    assert diagnostic["manifest_feapp_sha256"] == feapp_sha256
+    assert diagnostic["manifest_webplayer_sha256"] == webplayer_sha256
+    assert len(diagnostic["candidates"]) == 2
+    for candidate in diagnostic["candidates"]:
+        assert set(candidate) == {
+            "candidate_index",
+            "observed_feapp_size",
+            "observed_feapp_sha256",
+            "observed_webplayer_size",
+            "observed_webplayer_sha256",
+        }
+        assert candidate["observed_feapp_size"] > 0
+        assert candidate["observed_webplayer_size"] > 0
+    assert str(libraries[0]) not in result.stdout
+    assert str(libraries[1]) not in result.stdout
+
+
+def test_automatic_official_discovery_defers_single_nonmatching_candidate(
+    tmp_path: Path,
+) -> None:
+    library = tmp_path / "steam"
+    candidate, feapp_sha256, webplayer_sha256 = _make_steam_library(
+        library, archive_comment=b"compatible nonmatching candidate"
+    )
+    manifest = _write_manifest(
+        tmp_path / "manifest.json", feapp_sha256, webplayer_sha256
+    )
+
+    selection = _selection(
+        _run_official_install_resolution(
+            manifest=manifest, steam_roots=[library]
+        )
+    )
+
+    assert Path(selection["Path"]) == candidate
+    assert selection["SelectionMode"] == "auto_single"
+    assert selection["CandidateCount"] == 1
+
+
+def test_explicit_official_root_bypasses_automatic_candidate_selection(
+    tmp_path: Path,
+) -> None:
+    explicit, feapp_sha256, webplayer_sha256 = _make_official(tmp_path / "explicit")
+    library = tmp_path / "auto-steam"
+    _make_steam_library(library)
+    manifest = _write_manifest(
+        tmp_path / "manifest.json", feapp_sha256, webplayer_sha256
+    )
+
+    selection = _selection(
+        _run_official_install_resolution(
+            manifest=manifest, steam_roots=[library], requested_root=explicit
+        )
+    )
+
+    assert Path(selection["Path"]) == explicit
+    assert selection["SelectionMode"] == "explicit"
+    assert selection["CandidateCount"] == 1
+
+
 def test_managed_runtime_installs_all_server_dependencies() -> None:
     repo_root = Path(__file__).parents[2]
     project = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
@@ -1646,20 +1867,63 @@ def test_incomplete_old_marker_is_not_treated_as_current_install(
         install_full_patch(official, target, payload, manifest)
 
 
-@pytest.mark.parametrize("field", ["feapp_sha256", "webplayer_sha256"])
-def test_install_rejects_bad_source_hash_before_target_write(
+def test_install_rejects_unpatchable_same_version_without_leaving_target(
     fixture_inputs,
     tmp_path: Path,
-    field: str,
 ) -> None:
     official, payload, manifest, _feapp, _webplayer = fixture_inputs
-    bad = json.loads(manifest.read_text(encoding="utf-8"))
-    bad[field] = "0" * 64
-    manifest.write_text(json.dumps(bad), encoding="utf-8")
+    feapp = (
+        official
+        / CURRENT_TEST_CLIENT_VERSION
+        / "resources"
+        / "feapp.dat"
+    )
+    with zipfile.ZipFile(feapp) as archive:
+        members = {
+            info.filename: archive.read(info.filename)
+            for info in archive.infolist()
+        }
+    main_member = "assets/main-917d29fc.js"
+    members[main_member] = members[main_member].replace(
+        b"He=e=>new Promise",
+        b"unsupported=>new Promise",
+    )
+    with zipfile.ZipFile(feapp, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, content in members.items():
+            archive.writestr(name, content)
+
     target = tmp_path / "installed"
     with pytest.raises(PatchInstallError, match="UNSUPPORTED_OFFICIAL_VERSION"):
         install_full_patch(official, target, payload, manifest)
     assert not target.exists()
+
+
+def test_install_accepts_patch_compatible_same_version_with_different_archive_hash(
+    fixture_inputs,
+    tmp_path: Path,
+) -> None:
+    official, payload, manifest, _feapp, expected_webplayer = fixture_inputs
+    webplayer = (
+        official
+        / CURRENT_TEST_CLIENT_VERSION
+        / "resources"
+        / "webplayer.dat"
+    )
+    with zipfile.ZipFile(webplayer, "a") as archive:
+        archive.comment = b"same client files, different official package"
+    actual_webplayer = _sha256(webplayer)
+    assert actual_webplayer != expected_webplayer
+
+    target = tmp_path / "installed"
+    report = install_full_patch(official, target, payload, manifest)
+
+    assert report["status"] == "INSTALLED"
+    assert report["official_webplayer_sha256"] == actual_webplayer
+
+    repeated = install_full_patch(official, target, payload, manifest)
+
+    assert repeated["status"] == "ALREADY_INSTALLED"
+    assert repeated["official_webplayer_sha256"] == actual_webplayer
 
 
 def test_install_rejects_official_source_overlap(

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -288,6 +288,10 @@ def test_inno_wrapper_is_current_user_offline_and_delegates_to_install_ps1() -> 
     assert "StableInstallCode" in script
     assert "SetupResultPath" in script
     assert "OLIVIA_SETUP_ERROR=" in script
+    assert "OFFICIAL_INSTALL_AMBIGUOUS" in script
+    assert "上一步" in script
+    assert ".diagnostic.json" in script
+    assert "Olivia installer diagnostic:" in script
     assert "function PrepareToInstall" in script
     assert "dontcopy noencryption" in script
     assert "OfficialDirPage: TInputQueryWizardPage" in script
@@ -326,6 +330,18 @@ def test_install_ps1_supports_noninteractive_setup_without_optional_downloads() 
     assert "if (-not $selectedOfficial -and -not $NonInteractive)" in script
     assert "Invoke-WebRequest" not in script
     assert "provision_mem0_embedding.py" not in script
+
+
+def test_windows_installer_documents_ambiguous_source_diagnostic_contract() -> None:
+    documentation = (ROOT / "docs" / "WINDOWS_FULL_PATCH.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "OFFICIAL_INSTALL_AMBIGUOUS" in documentation
+    assert "olivia.setup-source-diagnostic.v1" in documentation
+    assert "selected_official_id" in documentation
+    assert "observed_feapp_sha256" in documentation
+    assert "observed_webplayer_sha256" in documentation
 
 
 def test_github_build_publishes_setup_and_checksum_for_merged_main() -> None:


### PR DESCRIPTION
Fixes two cross-machine release failures: Steam auto-discovery selecting a stale installation and Olivia.exe launching with the wrong working directory. Explicit OfficialRoot remains authoritative. Automatic discovery now enumerates/deduplicates candidates, prefers the manifest hash pair, isolates unreadable candidates, uses structural compatibility for a sole non-exact candidate, and returns OFFICIAL_INSTALL_AMBIGUOUS when multiple unmatched roots exist. Diagnostics record counts/version/sizes/hashes and a path digest, never the raw official path. The launcher now starts Olivia.exe with cwd=client.parent and records path-free start/exit events. No first-profile blind retry and no Live changes. Scope is one Windows installer selection-validation-diagnostics-launch lifecycle; 9 files and 811 changed lines are kept together because splitting would leave the public PowerShell transaction or launcher regression unclosed. Validation: four focused installer files 130 passed, 1 skipped; py_compile PASS; git diff --check PASS. Final mechanical rebase onto Persona release main 08cabee: range-diff bfce992 = 3693481, installer diff unchanged. No full local suite, ISCC build, failing-machine reinstall, GPU, provider, or human acceptance. Review history: round1 BLOCK repaired; round2 Spec PASS/Standards BLOCK repaired; round3 reported two remaining P1 rollback edges under the user two-round cap: a first-install bootstrap failure may leave the newly published runtime, and a Python process-start exception may bypass old-runtime restoration. These are disclosed and not claimed fixed. Revert commit 3693481 to roll back the whole change.