### PR TITLE
fix: retry invalid reviewer evidence once

### DIFF
--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -106,11 +106,13 @@ requires score 1 and no drift, while `false` requires score 2 and no drift. A
 hard claim cannot be used to infer this field. Missing, non-boolean, or
 score/drift-inconsistent values make the review unavailable.
 
-Missing, duplicate, mismatched, out-of-range, or schema-invalid evidence makes
-the whole enabled Letter review unavailable and therefore fails closed. A
-semantic duplicate is keyed by at least `(code, start, end)` across layers;
-changing ids, kinds, sources, or reasons cannot make it distinct. Other review
-layers keep their existing response schema.
+Missing, duplicate, mismatched, out-of-range, or schema-invalid evidence is
+rejected by the strict parser as `EVIDENCE_CONTRACT`. The first such failure
+may trigger the documented one same-layer retry; only if that retry is also
+invalid does the whole enabled Letter review become unavailable and therefore
+fail closed. A semantic duplicate is keyed by at least `(code, start, end)`
+across layers; changing ids, kinds, sources, or reasons cannot make it distinct.
+Other review layers keep their existing response schema.
 
 Well-formed hard evidence conditionally spends at most one additional model
 call per candidate. The call uses the same configured quality Gateway and

--- a/docs/P02_REPLY_REVIEWER.md
+++ b/docs/P02_REPLY_REVIEWER.md
@@ -73,11 +73,11 @@ reviews retain the pre-protocol response schema and normal successful call
 count: they neither require `hard_evidence` nor invoke adjudication.
 
 Across Persona modes, the only failure-path exception that may add a call is
-one retry of the single layer whose result fails `LAYER_CONTRACT`. That retry
-uses a fresh request ID and does not rerun any other layer. A second
-`LAYER_CONTRACT` failure remains `REVIEWER_UNAVAILABLE`. `JSON`,
-`TOP_LEVEL_SCHEMA`, `EVIDENCE_CONTRACT`, `EMPTY_TEXT`, `TRANSPORT`, and
-`INTERNAL` failures are not retried.
+one retry of the single layer whose result fails `LAYER_CONTRACT` or
+`EVIDENCE_CONTRACT`. That retry uses the same messages with a fresh request ID
+and does not rerun any other layer. A second failure for either allowed reason
+remains `REVIEWER_UNAVAILABLE`. `JSON`, `TOP_LEVEL_SCHEMA`, `EMPTY_TEXT`,
+`TRANSPORT`, and `INTERNAL` failures are not retried.
 
 In `text_letter`, `identity_boundary`, `voice_style`, and `continuity_memory`
 cannot create a hard finding from a score or drift flag alone. Every hard code

--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -1463,7 +1463,11 @@ def _complete_layer_reviews(
                     )
                 except _ReviewContractFailure as exc:
                     if (
-                        exc.reason is ReviewFailureReason.LAYER_CONTRACT
+                        exc.reason
+                        in {
+                            ReviewFailureReason.LAYER_CONTRACT,
+                            ReviewFailureReason.EVIDENCE_CONTRACT,
+                        }
                         and attempt == 0
                     ):
                         continue

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -147,6 +147,70 @@ def test_layer_contract_failure_retries_only_the_failed_layer_once() -> None:
     assert len(gateway.request_ids) == len(set(gateway.request_ids)) == 6
 
 
+def test_evidence_contract_failure_retries_only_the_failed_layer_once() -> None:
+    candidate = "Synthetic candidate."
+    invalid_identity = json.loads(_layer_payload("identity_boundary"))
+    invalid_identity["hard_evidence"] = {}
+    layer_reviews = {
+        layer: [_layer_payload(layer)] for layer in _REVIEW_LAYERS
+    }
+    layer_reviews["identity_boundary"] = [
+        json.dumps(invalid_identity),
+        _layer_payload("identity_boundary"),
+    ]
+    gateway = SequencedQualityGateway(
+        candidate=candidate,
+        reviews=[],
+        layer_reviews=layer_reviews,
+    )
+
+    result, reviewer = _run_diagnostic_review(gateway, candidate)
+
+    assert result.verdict is ReviewVerdict.PASS
+    assert reviewer.last_failure_diagnostics == ()
+    layer_calls = [request["layer"] for request in gateway.review_requests]
+    assert layer_calls.count("identity_boundary") == 2
+    assert all(layer_calls.count(layer) == 1 for layer in _REVIEW_LAYERS[1:])
+    assert gateway.call_kinds == ["review"] * 6
+    assert gateway.adjudication_requests == []
+    assert gateway.rewrite_requests == []
+    assert len(gateway.request_ids) == len(set(gateway.request_ids)) == 6
+
+
+def test_repeated_evidence_contract_failure_stops_after_one_retry() -> None:
+    candidate = "Synthetic candidate."
+    invalid_identity = json.loads(_layer_payload("identity_boundary"))
+    invalid_identity["hard_evidence"] = {}
+    invalid = json.dumps(invalid_identity)
+    layer_reviews = {
+        layer: [_layer_payload(layer)] for layer in _REVIEW_LAYERS
+    }
+    layer_reviews["identity_boundary"] = [invalid, invalid]
+    gateway = SequencedQualityGateway(
+        candidate=candidate,
+        reviews=[],
+        layer_reviews=layer_reviews,
+    )
+
+    result, reviewer = _run_diagnostic_review(gateway, candidate)
+
+    assert result.error_code == "REVIEWER_UNAVAILABLE"
+    assert reviewer.last_failure_diagnostics == (
+        ReviewFailureDiagnostic(
+            ReviewFailureStage.LAYER,
+            ReviewFailureReason.EVIDENCE_CONTRACT,
+            "identity_boundary",
+        ),
+    )
+    layer_calls = [request["layer"] for request in gateway.review_requests]
+    assert layer_calls.count("identity_boundary") == 2
+    assert all(layer_calls.count(layer) == 1 for layer in _REVIEW_LAYERS[1:])
+    assert gateway.call_kinds == ["review"] * 6
+    assert gateway.adjudication_requests == []
+    assert gateway.rewrite_requests == []
+    assert len(gateway.request_ids) == len(set(gateway.request_ids)) == 6
+
+
 def test_repeated_layer_contract_failure_stops_after_one_retry() -> None:
     candidate = "Synthetic candidate."
     invalid = _layer_score_payload("continuity_memory", 1)
@@ -192,7 +256,6 @@ def test_repeated_layer_contract_failure_stops_after_one_retry() -> None:
         ("layer_mismatch", ReviewFailureReason.TOP_LEVEL_SCHEMA, "continuity_memory"),
         ("score", ReviewFailureReason.LAYER_CONTRACT, "autonomy_life"),
         ("identity", ReviewFailureReason.LAYER_CONTRACT, "identity_boundary"),
-        ("evidence", ReviewFailureReason.EVIDENCE_CONTRACT, "identity_boundary"),
     ),
 )
 def test_reviewer_classifies_layer_failure(
@@ -220,18 +283,6 @@ def test_reviewer_classifies_layer_failure(
         else:
             payload["intimacy_request"] = "invented"
         reviews[index] = json.dumps(payload)
-    else:
-        evidence = _hard_evidence_payload(
-            candidate, "IDENTITY_DRIFT", claim_kind="identity_claim"
-        )
-        evidence["start"] = True
-        reviews[index] = _layer_score_payload(
-            layer,
-            0,
-            hard_violations=["IDENTITY_DRIFT"],
-            drift_detected=True,
-            hard_evidence=[evidence],
-        )
     if case == "transport":
         gateway = FailingQualityGateway(
             failure="layer",


### PR DESCRIPTION
## Scope

- Extend the existing bounded failed-layer retry to strict `EVIDENCE_CONTRACT` failures.
- Keep evidence parsing fully strict; retry only the failed layer once with the same messages and a fresh request ID.
- A second invalid evidence response remains `REVIEWER_UNAVAILABLE`; no adjudication or rewrite runs.

## Real release evidence

On final main after PR #276, strict private acceptance executed 13/13 cases. All 12 effective cases passed independent judge 9/9 with zero persona drift or forced question. One case was not semantically evaluable because `identity_boundary` returned `EVIDENCE_CONTRACT`; no timeout, transport retry, or semantic violation occurred. The existing `LAYER_CONTRACT` retry was exercised twice by the real provider and recovered both times, supporting this same bounded mechanism.

## TDD and verification

- RED/GREEN: first invalid identity evidence then valid — final PASS; identity layer twice, other four once, unique request IDs.
- Repeated invalid evidence — exact sanitized unavailable diagnostic, two calls, no adjudication/rewrite.
- JSON, top-level schema, empty text, transport, and internal failures still do not retry.
- Focused: 112 passed.
- Persona: 289 passed.
- Frozen-head full suite: 1576 passed, 1 skipped, 1 deselected; 7 existing warnings.
- `git diff --check` and secret scan: clean.

## Frozen review trace

- Base: `ac8dd2092bb0ca9e718aeca8b5cc254c918ffb29`
- Head: `61a8f2e356c9d82553f4d945074f784a514fefe1`
- Round 1 Standards PASS; Spec BLOCK with P0=0/P1=1 for one contradictory documentation sentence.
- Round 2 Standards PASS and Spec PASS; P0/P1/P2=0. Code/tests were unchanged in round 2.
- Reviews were static and provider-free.

## Size and non-goals

- 3 files, `+81/-24`, within the default limit.
- No parser relaxation, semantic fallback, provider configuration, Persona prompt, Live, client, media, private corpus, or relationship-state changes.
