### PR TITLE
fix: retry known fresh-profile client exit

### DIFF
--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -44,6 +44,8 @@ GitHub Actions 会在 PR 和 `main` 更新时生成同样的可下载 artifact�
 
 `installer/start_local.py --health-only` 输出一行符合 [`contracts/launcher_health.schema.json`](../contracts/launcher_health.schema.json) 的 JSON。`READY` 的退出码为 0；`UNAVAILABLE` 与 `PORT_CONFLICT` 的退出码为 2。`PORT_CONFLICT` 表示端口已有非本契约监听器或返回了无效健康契约，启动器不会尝试启动第二个后端。正常启动还会核对 health 中不含路径的 `backend_id`，它同时绑定活动组件与当前安装实例；版本或安装实例不匹配时不会复用该服务。首个组件补丁遇到旧版遗留服务时，只有在 Windows 确认监听进程是当前产品目录自带 runtime 的 Python 后才会终止并启动新版本；无法证明归属时以 `STALE_BACKEND_RUNNING` 停止，不会结束其他程序。启动器自己创建的后端随 Olivia 客户端退出而结束。
 
+客户端启动协议以整个隔离 profile 目录为边界：启动器在创建 `profile/` 前记录该目录是否已存在，只有此前不存在才视为全新 profile。客户端始终以安装目录下的 `app/` 为工作目录。若且仅若全新 profile 的第一次退出码为 `0x0E000003`，启动器会在同一后端生命周期内重启客户端一次，因此客户端最多启动两次；已有 profile 或任何其他退出码均不重试，第二次退出码原样透传。每次启动和退出分别记录不含路径的 `client_start` 与 `client_exit`，并以 `attempt` 标记第 1 或第 2 次，退出记录只附整数退出码；触发重试时另记 `client_retry`，其固定原因为 `known_fresh_profile_exit`。这些诊断不记录安装路径、profile 路径、环境变量或凭据。
+
 ## 原版客户端补丁
 
 安装前同时校验：

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -179,6 +179,7 @@ _CORE_HEALTH_REQUIRED_CHECKS = (
 _CORE_HEALTH_CHECK_STATES = frozenset({"available", "degraded", "unavailable"})
 _BACKEND_START_TIMEOUT_SECONDS = 120
 _BACKEND_ID_RE = re.compile(r"[0-9A-Za-z.+-]{1,160}")
+_KNOWN_FRESH_PROFILE_EXIT_CODE = 0x0E000003
 
 
 def _port_is_bindable(port: int) -> bool:
@@ -742,17 +743,42 @@ def main(argv: list[str] | None = None) -> int:
                 print("LOCAL_SERVER_UNAVAILABLE")
                 return 2
         profile = root / "profile"
+        fresh_profile = not profile.exists()
         roaming = profile / "Roaming"
         local = profile / "Local"
         roaming.mkdir(parents=True, exist_ok=True)
         local.mkdir(parents=True, exist_ok=True)
-        _append_launcher_event(data_root, "client_start")
+        _append_launcher_event(data_root, "client_start", attempt=1)
         exit_code = subprocess.call(
             _client_command(client, local),
-            cwd=client.parent,
+            cwd=root / "app",
             env=_client_environment(client_environment, roaming, local),
         )
-        _append_launcher_event(data_root, "client_exit", exit_code=exit_code)
+        _append_launcher_event(
+            data_root,
+            "client_exit",
+            attempt=1,
+            exit_code=exit_code,
+        )
+        if fresh_profile and exit_code == _KNOWN_FRESH_PROFILE_EXIT_CODE:
+            _append_launcher_event(
+                data_root,
+                "client_retry",
+                attempt=2,
+                reason="known_fresh_profile_exit",
+            )
+            _append_launcher_event(data_root, "client_start", attempt=2)
+            exit_code = subprocess.call(
+                _client_command(client, local),
+                cwd=root / "app",
+                env=_client_environment(client_environment, roaming, local),
+            )
+            _append_launcher_event(
+                data_root,
+                "client_exit",
+                attempt=2,
+                exit_code=exit_code,
+            )
         return exit_code
     finally:
         # Stop only the backend process spawned and owned by this launcher.

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -370,7 +370,7 @@ def test_launcher_starts_combined_server_before_original_client(
     ]
     assert client_commands[0][0].endswith("Olivia.exe")
     assert client_working_directories == [
-        root.resolve() / "app" / "0.0.9.615"
+        root.resolve() / "app"
     ]
     assert not backend_command[-1].endswith("local_server.py")
     assert frontend_repairs == [(root.resolve(), 8899)]
@@ -384,6 +384,178 @@ def test_launcher_starts_combined_server_before_original_client(
     assert '"exit_code": 0' in launcher_log
     assert "DEEPSEEK_API_KEY" not in launcher_log
     assert str(root.resolve()) not in launcher_log
+
+
+def _run_launcher_with_client_results(
+    tmp_path: Path,
+    monkeypatch,
+    client_results: tuple[int, ...],
+    *,
+    existing_profile: bool = False,
+) -> tuple[Path, int, list[tuple[list[str], Path]], list[dict[str, object]], str]:
+    root = _installation(tmp_path)
+    if existing_profile:
+        (root / "profile").mkdir()
+    health = iter(("UNAVAILABLE", "READY", "READY", "READY"))
+    results = iter(client_results)
+    client_runs: list[tuple[list[str], Path]] = []
+
+    class Process:
+        @staticmethod
+        def poll():
+            return None
+
+    def call(command, **kwargs):
+        client_runs.append(
+            ([str(value) for value in command], Path(kwargs["cwd"]))
+        )
+        return next(results)
+
+    monkeypatch.setattr(start_local, "_health", lambda _port: next(health))
+    monkeypatch.setattr(start_local, "_active_backend", lambda: root / "local_backend")
+    monkeypatch.setattr(
+        start_local,
+        "_server_backend_id",
+        lambda _port: start_local._backend_id(root / "local_backend", root.resolve()),
+    )
+    monkeypatch.setattr(
+        start_local,
+        "_backend_executable",
+        lambda: Path("pythonw-fixture.exe"),
+    )
+    monkeypatch.setattr(
+        start_local.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: Process(),
+    )
+    monkeypatch.setattr(start_local.subprocess, "call", call)
+    monkeypatch.setattr(
+        start_local,
+        "_repair_client_frontend",
+        lambda *_args: "PATCHED",
+    )
+
+    result = start_local.main(["--install-root", str(root), "--port", "8899"])
+    launcher_log = (root / "data" / "logs" / "launcher.jsonl").read_text(
+        encoding="utf-8"
+    )
+    client_events = [
+        record
+        for line in launcher_log.splitlines()
+        if (record := json.loads(line))["event"].startswith("client_")
+    ]
+    return root, result, client_runs, client_events, launcher_log
+
+
+def test_fresh_profile_retries_known_first_exit_once(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    root, result, client_runs, client_events, launcher_log = (
+        _run_launcher_with_client_results(
+            tmp_path,
+            monkeypatch,
+            (0x0E000003, 0),
+        )
+    )
+
+    assert result == 0
+    assert len(client_runs) == 2
+    assert {run[1] for run in client_runs} == {root.resolve() / "app"}
+    assert client_events == [
+        {"attempt": 1, "event": "client_start"},
+        {"attempt": 1, "event": "client_exit", "exit_code": 0x0E000003},
+        {
+            "attempt": 2,
+            "event": "client_retry",
+            "reason": "known_fresh_profile_exit",
+        },
+        {"attempt": 2, "event": "client_start"},
+        {"attempt": 2, "event": "client_exit", "exit_code": 0},
+    ]
+    assert str(root.resolve()) not in launcher_log
+
+
+def test_fresh_profile_returns_second_failure_without_third_attempt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _root, result, client_runs, client_events, _launcher_log = (
+        _run_launcher_with_client_results(
+            tmp_path,
+            monkeypatch,
+            (0x0E000003, 23),
+        )
+    )
+
+    assert result == 23
+    assert len(client_runs) == 2
+    assert client_events[-1] == {
+        "attempt": 2,
+        "event": "client_exit",
+        "exit_code": 23,
+    }
+
+
+def test_existing_profile_never_retries_known_exit(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _root, result, client_runs, client_events, _launcher_log = (
+        _run_launcher_with_client_results(
+            tmp_path,
+            monkeypatch,
+            (0x0E000003,),
+            existing_profile=True,
+        )
+    )
+
+    assert result == 0x0E000003
+    assert len(client_runs) == 1
+    assert [event["event"] for event in client_events] == [
+        "client_start",
+        "client_exit",
+    ]
+
+
+def test_fresh_profile_does_not_retry_other_exit(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _root, result, client_runs, client_events, _launcher_log = (
+        _run_launcher_with_client_results(
+            tmp_path,
+            monkeypatch,
+            (19,),
+        )
+    )
+
+    assert result == 19
+    assert len(client_runs) == 1
+    assert [event["event"] for event in client_events] == [
+        "client_start",
+        "client_exit",
+    ]
+
+
+def test_fresh_profile_retry_protocol_is_documented() -> None:
+    documentation = (
+        Path(__file__).resolve().parents[2] / "docs" / "WINDOWS_FULL_PATCH.md"
+    ).read_text(encoding="utf-8")
+
+    for expected in (
+        "创建 `profile/` 前",
+        "`0x0E000003`",
+        "最多启动两次",
+        "第二次退出码原样透传",
+        "`client_start`",
+        "`client_exit`",
+        "`attempt`",
+        "`client_retry`",
+        "`known_fresh_profile_exit`",
+        "不记录安装路径",
+    ):
+        assert expected in documentation
 
 
 def test_component_launcher_starts_the_backend_that_owns_start_local(


### PR DESCRIPTION
## Result
- restore Olivia.exe working directory to the packaged app directory
- on a genuinely new profile only, retry once for the observed Olivia-specific first-launch exit 0x0E000003
- preserve the second exit code and never retry existing profiles or other exits
- keep launcher diagnostics path-free and document the contract

## Verification
- focused launcher tests: 51 passed
- py_compile: PASS
- git diff --check: PASS
- Standards review: PASS, P0/P1/P2=0
- Spec review: PASS, P0/P1/P2=0

## Boundary
This does not change backend lifecycle, downloads, Persona, media routing, or profile contents.