### PR TITLE
fix: preflight LLM before history import

### DIFF
--- a/contracts/official_history_import_preflight.schema.json
+++ b/contracts/official_history_import_preflight.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Ornn8/bside-olivia-community/blob/main/contracts/official_history_import_preflight.schema.json",
+  "title": "Official history import preflight response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["code", "message", "data"],
+  "properties": {
+    "code": {"const": 0},
+    "message": {"const": "ok"},
+    "data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "llm_required"],
+      "properties": {
+        "status": {"const": "READY"},
+        "llm_required": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -26,6 +26,7 @@
 | 503 | `MEMORY_UNAVAILABLE` | UNAVAILABLE | 是 | legacy import 的 SQLite 存储不可用；不回显正文、路径或密钥 |
 | 503 | `OFFICIAL_LETTER_IMPORT_UNAVAILABLE` | UNAVAILABLE | 是 | 官方登录日志或文字信件接口暂不可用；不回显凭证、正文或本机路径 |
 | 503 | `OFFICIAL_HISTORY_MEMORY_UNAVAILABLE` | UNAVAILABLE | 是 | Mem0 未安装、未启用或状态不可用；在采集官方历史前拒绝导入 |
+| 503 | `OFFICIAL_HISTORY_LLM_UNAVAILABLE` | UNAVAILABLE | 是 | 首次恢复关系状态需要已配置的大模型；在采集和写入官方历史前拒绝导入 |
 | 503 | `OFFICIAL_HISTORY_MEMORY_WRITE_FAILED` | UNAVAILABLE | 是 | 官方历史无法严格写入 Mem0；本批历史信件不会发布到信箱，重试使用稳定 source id 判重 |
 | 409 | `OFFICIAL_ACCOUNT_CONFLICT` | FAILED | 否 | 当前本地档案已绑定另一个官方账户；拒绝把两个账户写入同一记忆空间 |
 | 503 | `PRIVATE_WORLD_HISTORY_UNAVAILABLE` | UNAVAILABLE | 是 | PrivateWorld 在采集前不可用，或历史基线初始化失败；本批历史信件不会发布到信箱 |

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -39,7 +39,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 | 音乐写操作 | `/toy/addPerformance` 等 | unavailable | 501 `MUSIC_WRITE_NOT_IMPLEMENTED` |
 | MIDI | `/toy/midi/*` | terminal/partial | 任务状态兼容现有原型；生成/上传/分享码导入明确 501 |
 | legacy import | `/toy/letter/legacy/import` | available | SQLite 本地扩展；仅接受 `mode=read_only`，以单事务原子导入旧信并按内容哈希去重；导入后旧信域只读且不与新聊天合并 |
-| 官方文字信件导入 | `/toy/letter/legacy/official-import` | available/degraded | 用户在设置页明确确认后，先要求 Mem0 与 PrivateWorld 可用，再临时读取官方客户端登录日志并从官方接口导入原信与文字回信；严格按时间写入 Mem0、初始化 PrivateWorld，最后才原子发布到信箱；忽略视频，不保存或回显凭证 |
+| 官方文字信件导入 | `/toy/letter/legacy/official-import` | available/degraded | 用户在设置页明确确认后，先要求 Mem0 与 PrivateWorld 可用；首次初始化关系状态时还要求大模型已配置。随后临时读取官方客户端登录日志并从官方接口导入原信与文字回信；严格按时间写入 Mem0、初始化 PrivateWorld，最后才原子发布到信箱；忽略视频，不保存或回显凭证 |
 
 原生 WebSocket、ASR、TTS、Live 没有假 route；`/health` 的 capability registry 明确为 `unavailable`，错误码分别为 `WEBSOCKET_UNAVAILABLE`、`ASR_UNAVAILABLE`、`TTS_UNAVAILABLE`、`LIVE_UNAVAILABLE`。
 
@@ -49,9 +49,9 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 - `content` 为空、`material` 非 object、JSON 非法或请求体非 object：400 稳定错误。
 - legacy import 的 body、`mode` 或 `letters` 不合法：400 `INVALID_BODY`；SQLite 存储不可用：503 `MEMORY_UNAVAILABLE`。两类错误都不回显旧信正文、路径或密钥。
 - 官方文字信件导入无法读取登录日志、官方接口或有效账户时：503 `OFFICIAL_LETTER_IMPORT_UNAVAILABLE`；用户可先启动官方客户端并登录后重试。
-- Mem0 或 PrivateWorld 在采集前不可用时，分别返回 503 `OFFICIAL_HISTORY_MEMORY_UNAVAILABLE` 或 `PRIVATE_WORLD_HISTORY_UNAVAILABLE`，不会读取官方历史。迁移中断时返回 503 `OFFICIAL_HISTORY_MEMORY_WRITE_FAILED` 或 `PRIVATE_WORLD_HISTORY_UNAVAILABLE`，不会把本批历史信件发布到信箱；已写入 Mem0 的记录由稳定 source id 判重，重试不会重复生成。SQLite 只读归档是最后一步可见性提交，成功后官方历史信件按原时间出现在默认信箱中，但保持 `scope=legacy`、`read_only=true`、`is_read=true`，不增加未读数，也不生成新回信或视频。
+- Mem0 或 PrivateWorld 在采集前不可用时，分别返回 503 `OFFICIAL_HISTORY_MEMORY_UNAVAILABLE` 或 `PRIVATE_WORLD_HISTORY_UNAVAILABLE`，不会读取官方历史。首次初始化关系状态且大模型未配置时返回 503 `OFFICIAL_HISTORY_LLM_UNAVAILABLE`，同样不会读取官方历史或写入 Mem0；已有关系状态的幂等导入不需要这项检查。迁移中断时返回 503 `OFFICIAL_HISTORY_MEMORY_WRITE_FAILED` 或 `PRIVATE_WORLD_HISTORY_UNAVAILABLE`，不会把本批历史信件发布到信箱；已写入 Mem0 的记录由稳定 source id 判重，重试不会重复生成。SQLite 只读归档是最后一步可见性提交，成功后官方历史信件按原时间出现在默认信箱中，但保持 `scope=legacy`、`read_only=true`、`is_read=true`，不增加未读数，也不生成新回信或视频。
 
-`GET /toy/letter/legacy/official-import` 返回当前导入进度，响应遵循 `contracts/official_history_import_progress.schema.json`。客户端使用 `stage`、`processed` 和 `total` 显示读取、记忆整理、关系恢复与信箱写入进度；该查询只读，不会启动或重试导入。
+`GET /toy/letter/legacy/official-import` 返回当前导入进度，响应遵循 `contracts/official_history_import_progress.schema.json`。带 `preflight=1` 时响应遵循 `contracts/official_history_import_preflight.schema.json`，只检查本地 Mem0、PrivateWorld 和必要的大模型配置，不读取信件、不调用 provider，也不启动或重试导入。成功返回 `READY` 和布尔值 `llm_required`；不可用时返回稳定错误 envelope。客户端使用 `stage`、`processed` 和 `total` 显示读取、记忆整理、关系恢复与信箱写入进度。
 - 找不到信件或 MIDI job：404，不返回空的成功对象。
 - 空信箱、无匹配歌曲、空 playlist：200，但 `source=local-memory|empty`、列表和计数明确为空。
 - LLM timeout/error：发信确认保持 200/PENDING，detail 随后标记 `FAILED` 并带错误码；不得写入 `reply_text` 占位符。

--- a/http_contract.py
+++ b/http_contract.py
@@ -66,6 +66,7 @@ ERROR_CODES: dict[str, dict[str, Any]] = {
     "MEMORY_UNAVAILABLE": {"http_status": 503, "retryable": True},
     "OFFICIAL_LETTER_IMPORT_UNAVAILABLE": {"http_status": 503, "retryable": True},
     "OFFICIAL_HISTORY_MEMORY_UNAVAILABLE": {"http_status": 503, "retryable": True},
+    "OFFICIAL_HISTORY_LLM_UNAVAILABLE": {"http_status": 503, "retryable": True},
     "OFFICIAL_HISTORY_MEMORY_WRITE_FAILED": {"http_status": 503, "retryable": True},
     "OFFICIAL_ACCOUNT_CONFLICT": {"http_status": 409, "retryable": False},
     "PRIVATE_WORLD_HISTORY_UNAVAILABLE": {"http_status": 503, "retryable": True},

--- a/local_server.py
+++ b/local_server.py
@@ -952,6 +952,40 @@ def _official_history_private_world_available() -> bool:
         return False
 
 
+def _llm_runtime_ready(config: GatewayConfig | None = None) -> bool:
+    runtime_config = config or LLM_CONFIG
+    key_present = api_key_configured(runtime_config)
+    return bool(
+        runtime_config.feature_enabled
+        and (
+            runtime_config.provider == "mock"
+            or (
+                runtime_config.provider == "openai_compatible"
+                and runtime_config.base_url
+                and runtime_config.model
+                and (not runtime_config.requires_api_key or key_present)
+            )
+        )
+    )
+
+
+def _official_history_llm_required() -> bool:
+    try:
+        return private_world_port.snapshot() == PrivateWorldSnapshot()
+    except Exception:
+        return True
+
+
+def _official_history_preflight_error() -> str | None:
+    if not _official_history_memory_available():
+        return "OFFICIAL_HISTORY_MEMORY_UNAVAILABLE"
+    if not _official_history_private_world_available():
+        return "PRIVATE_WORLD_HISTORY_UNAVAILABLE"
+    if _official_history_llm_required() and not _llm_runtime_ready():
+        return "OFFICIAL_HISTORY_LLM_UNAVAILABLE"
+    return None
+
+
 async def _migrate_official_history(
     payload: Mapping[str, object],
     *,
@@ -1593,16 +1627,7 @@ def _health_result(profile: str = contract.HEALTH_PROFILE_CORE) -> dict:
                 "probe": "in-process" if status in {"available", "degraded"} else "not-run",
             }
         )
-    llm_ready = (
-        LLM_CONFIG.feature_enabled
-        and LLM_CONFIG.provider == "mock"
-    ) or (
-        LLM_CONFIG.feature_enabled
-        and LLM_CONFIG.provider == "openai_compatible"
-        and bool(LLM_CONFIG.base_url)
-        and bool(LLM_CONFIG.model)
-        and (not LLM_CONFIG.requires_api_key or llm_key_present)
-    )
+    llm_ready = _llm_runtime_ready()
     if LLM_CONFIG.provider == "mock" and LLM_CONFIG.feature_enabled:
         llm_status = "available"
         llm_profile_status = "HEALTHY"
@@ -2218,6 +2243,18 @@ async def route(
 
     if p == "/toy/letter/legacy/official-import":
         if method == "GET":
+            if query.get("preflight") == "1":
+                preflight_error = _official_history_preflight_error()
+                if preflight_error is not None:
+                    return err(503, preflight_error, {
+                        "status": "UNAVAILABLE",
+                        "error_code": preflight_error,
+                        "retryable": True,
+                    })
+                return ok({
+                    "status": "READY",
+                    "llm_required": _official_history_llm_required(),
+                })
             return ok(_official_import_progress_snapshot())
         if companion_confirmed is not True:
             return err(403, "COMPANION_CONFIRMATION_REQUIRED", {
@@ -2234,22 +2271,14 @@ async def route(
             skipped=0,
             retryable=False,
         )
-        if not _official_history_memory_available():
+        preflight_error = _official_history_preflight_error()
+        if preflight_error is not None:
             _update_official_import_progress(
                 status="FAILED", stage="failed", retryable=True
             )
-            return err(503, "OFFICIAL_HISTORY_MEMORY_UNAVAILABLE", {
+            return err(503, preflight_error, {
                 "status": "UNAVAILABLE",
-                "error_code": "OFFICIAL_HISTORY_MEMORY_UNAVAILABLE",
-                "retryable": True,
-            })
-        if not _official_history_private_world_available():
-            _update_official_import_progress(
-                status="FAILED", stage="failed", retryable=True
-            )
-            return err(503, "PRIVATE_WORLD_HISTORY_UNAVAILABLE", {
-                "status": "UNAVAILABLE",
-                "error_code": "PRIVATE_WORLD_HISTORY_UNAVAILABLE",
+                "error_code": preflight_error,
                 "retryable": True,
             })
         official_import = True

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-SETTINGS_UI_VERSION = "p03.original-settings-manage.v9"
+SETTINGS_UI_VERSION = "p03.original-settings-manage.v10"
 
 BOOTSTRAP_JAVASCRIPT = r'''(() => {
   "use strict";
@@ -283,11 +283,16 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         signal: controller.signal,
       });
       const responseBody = await response.json();
+      const officialPreflight = path === OFFICIAL_LETTER_IMPORT_PATH
+        && params.preflight === "1";
       const payload = (path === VIDEO_REPLY_SETTINGS_PATH || path === OFFICIAL_LETTER_IMPORT_PATH)
         && responseBody && responseBody.data
         ? responseBody.data
         : responseBody;
-      const valid = path === OFFICIAL_LETTER_IMPORT_PATH
+      const valid = officialPreflight
+        ? payload && payload.status === "READY"
+          && typeof payload.llm_required === "boolean"
+        : path === OFFICIAL_LETTER_IMPORT_PATH
         ? payload && ["IDLE", "RUNNING", "COMPLETED", "FAILED"].includes(payload.status)
           && typeof payload.stage === "string"
           && Number.isInteger(payload.total)
@@ -300,7 +305,11 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
           || payload.state === "unavailable" && typeof payload.reason_code === "string")
         : payload && ["READY", "PAUSED", "UNAVAILABLE"].includes(payload.status);
       if (!response.ok || !valid) {
-        throw new Error("unavailable");
+        const error = new Error("unavailable");
+        error.code = payload && typeof payload.error_code === "string"
+          ? payload.error_code
+          : "COMPANION_READ_UNAVAILABLE";
+        throw error;
       }
       return payload;
     } finally {
@@ -2022,16 +2031,16 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         return;
       }
       try {
-        const companion = await requestJson(STATUS_PATH);
-        const capabilities = companion && companion.capabilities;
-        const memory = capabilities && capabilities.memory;
-        const privateWorld = capabilities && capabilities.private_world;
-        if (!memory || memory.state !== "available" || !privateWorld || privateWorld.state !== "available") {
-          importState.textContent = "请先安装并启用长期记忆组件，确认私人世界可用并重启客户端后再导入。";
-          return;
-        }
-      } catch (_error) {
-        importState.textContent = "无法确认长期记忆组件状态，请重启客户端后再试。";
+        await requestJson(OFFICIAL_LETTER_IMPORT_PATH, { preflight: "1" });
+      } catch (error) {
+        importState.textContent = error && error.code === "OFFICIAL_HISTORY_LLM_UNAVAILABLE"
+          ? "请先在“大模型”中完成连接测试并保存，再导入。"
+          : error && [
+            "OFFICIAL_HISTORY_MEMORY_UNAVAILABLE",
+            "PRIVATE_WORLD_HISTORY_UNAVAILABLE",
+          ].includes(error.code)
+            ? "请先安装并启用长期记忆组件，确认私人世界可用并重启客户端后再导入。"
+            : "无法确认导入条件，请重启客户端后再试。";
         return;
       }
       if (!await confirmAction("确认从这台电脑上的官方 Olivia 账户导入文字信件？")) {
@@ -2060,13 +2069,15 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         importState.textContent = `已导入 ${inserted} 封，跳过 ${duplicates} 封重复信件。${memoryText}${relationText}`;
         importButton.textContent = "再次导入";
       } catch (error) {
-        importState.textContent = error && [
-          "OFFICIAL_HISTORY_MEMORY_UNAVAILABLE",
-          "OFFICIAL_HISTORY_MEMORY_WRITE_FAILED",
-          "PRIVATE_WORLD_HISTORY_UNAVAILABLE",
-        ].includes(error.code)
-          ? "长期记忆未就绪或写入失败，未发布任何历史信件。请检查记忆组件后重试。"
-          : "导入失败。请先启动官方客户端并登录，再重试。";
+        importState.textContent = error && error.code === "OFFICIAL_HISTORY_LLM_UNAVAILABLE"
+          ? "请先在“大模型”中完成连接测试并保存，再导入。"
+          : error && [
+            "OFFICIAL_HISTORY_MEMORY_UNAVAILABLE",
+            "OFFICIAL_HISTORY_MEMORY_WRITE_FAILED",
+            "PRIVATE_WORLD_HISTORY_UNAVAILABLE",
+          ].includes(error.code)
+            ? "长期记忆未就绪或写入失败，未发布任何历史信件。请检查记忆组件后重试。"
+            : "导入失败。请先启动官方客户端并登录，再重试。";
         importButton.textContent = "重试导入";
       } finally {
         importPending = false;

--- a/tests/imports/test_official_letters.py
+++ b/tests/imports/test_official_letters.py
@@ -6,6 +6,8 @@ import sqlite3
 from pathlib import Path
 
 import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
 from jsonschema import Draft202012Validator, FormatChecker
 
 from conversation_memory_port import (
@@ -28,6 +30,11 @@ def _allow_official_history_preflight(monkeypatch, local_server) -> None:
     )
     monkeypatch.setattr(
         local_server, "_official_history_private_world_available", lambda: True
+    )
+    monkeypatch.setattr(
+        local_server,
+        "LLM_CONFIG",
+        local_server.GatewayConfig(provider="mock", feature_enabled=True),
     )
 
 
@@ -58,6 +65,57 @@ def test_official_import_progress_response_matches_public_schema(monkeypatch) ->
     )
 
     Draft202012Validator(schema, format_checker=FormatChecker()).validate(response)
+
+
+def test_official_import_preflight_is_a_versioned_public_http_contract(
+    monkeypatch,
+) -> None:
+    import local_server
+
+    class EmptyPrivateWorld:
+        @staticmethod
+        def snapshot() -> PrivateWorldSnapshot:
+            return PrivateWorldSnapshot()
+
+    _allow_official_history_preflight(monkeypatch, local_server)
+    monkeypatch.setattr(local_server, "private_world_port", EmptyPrivateWorld())
+    schema = json.loads(
+        (Path("contracts") / "official_history_import_preflight.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    async def scenario() -> None:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            ready_response = await client.get(
+                "/toy/letter/legacy/official-import?preflight=1"
+            )
+            ready_payload = await ready_response.json()
+            assert ready_response.status == 200
+            Draft202012Validator(schema).validate(ready_payload)
+
+            monkeypatch.setattr(
+                local_server,
+                "LLM_CONFIG",
+                local_server.GatewayConfig(provider="none", feature_enabled=False),
+            )
+            unavailable_response = await client.get(
+                "/toy/letter/legacy/official-import?preflight=1"
+            )
+            assert unavailable_response.status == 503
+            assert await unavailable_response.json() == {
+                "code": 503,
+                "message": "OFFICIAL_HISTORY_LLM_UNAVAILABLE",
+                "data": {
+                    "status": "UNAVAILABLE",
+                    "error_code": "OFFICIAL_HISTORY_LLM_UNAVAILABLE",
+                    "retryable": True,
+                },
+            }
+
+    asyncio.run(scenario())
 
 
 def test_history_skip_requires_current_first_person_semantics(monkeypatch) -> None:
@@ -693,6 +751,130 @@ def test_official_import_requires_private_world_before_collecting_history(
         "retryable": True,
     }
     assert calls == []
+
+
+def test_official_import_requires_llm_before_collecting_or_writing_history(
+    monkeypatch,
+) -> None:
+    import local_server
+
+    calls: list[str] = []
+    _allow_official_history_preflight(monkeypatch, local_server)
+    monkeypatch.setattr(
+        local_server,
+        "LLM_CONFIG",
+        local_server.GatewayConfig(provider="none", feature_enabled=False),
+    )
+    monkeypatch.setattr(
+        local_server,
+        "collect_default_official_text_replies",
+        lambda: calls.append("collect") or {},
+    )
+    monkeypatch.setattr(
+        local_server,
+        "_legacy_import_adapter",
+        lambda: (_ for _ in ()).throw(AssertionError("archive must not open")),
+    )
+
+    response = asyncio.run(
+        local_server.route(
+            "POST",
+            "/toy/letter/legacy/official-import",
+            {},
+            {},
+            companion_confirmed=True,
+        )
+    )
+    progress = asyncio.run(
+        local_server.route(
+            "GET",
+            "/toy/letter/legacy/official-import",
+            {},
+            {},
+        )
+    )
+
+    assert local_server.contract.error_metadata(
+        "OFFICIAL_HISTORY_LLM_UNAVAILABLE"
+    ) == {"http_status": 503, "retryable": True}
+    assert response == {
+        "code": 503,
+        "message": "OFFICIAL_HISTORY_LLM_UNAVAILABLE",
+        "data": {
+            "status": "UNAVAILABLE",
+            "error_code": "OFFICIAL_HISTORY_LLM_UNAVAILABLE",
+            "retryable": True,
+        },
+    }
+    assert progress["data"]["processed"] == 0
+    assert progress["data"]["imported"] == 0
+    assert calls == []
+
+
+def test_official_import_preflight_reports_llm_before_user_confirmation(
+    monkeypatch,
+) -> None:
+    import local_server
+
+    _allow_official_history_preflight(monkeypatch, local_server)
+    monkeypatch.setattr(
+        local_server,
+        "LLM_CONFIG",
+        local_server.GatewayConfig(provider="none", feature_enabled=False),
+    )
+
+    response = asyncio.run(
+        local_server.route(
+            "GET",
+            "/toy/letter/legacy/official-import",
+            {},
+            {"preflight": "1"},
+        )
+    )
+
+    assert response == {
+        "code": 503,
+        "message": "OFFICIAL_HISTORY_LLM_UNAVAILABLE",
+        "data": {
+            "status": "UNAVAILABLE",
+            "error_code": "OFFICIAL_HISTORY_LLM_UNAVAILABLE",
+            "retryable": True,
+        },
+    }
+
+
+def test_official_import_ready_preflight_does_not_call_the_provider(
+    monkeypatch,
+) -> None:
+    import local_server
+
+    class EmptyPrivateWorld:
+        @staticmethod
+        def snapshot() -> PrivateWorldSnapshot:
+            return PrivateWorldSnapshot()
+
+    _allow_official_history_preflight(monkeypatch, local_server)
+    monkeypatch.setattr(local_server, "private_world_port", EmptyPrivateWorld())
+    network_calls_before = local_server.letters_adapter.gateway.network_call_count
+
+    response = asyncio.run(
+        local_server.route(
+            "GET",
+            "/toy/letter/legacy/official-import",
+            {},
+            {"preflight": "1"},
+        )
+    )
+
+    assert response == {
+        "code": 0,
+        "message": "ok",
+        "data": {"status": "READY", "llm_required": True},
+    }
+    assert (
+        local_server.letters_adapter.gateway.network_call_count
+        == network_calls_before
+    )
 
 
 def test_official_history_is_visible_in_current_mailbox_without_unread_pollution(

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -123,7 +123,7 @@ def test_ready_mem0_preserves_restart_fallback_when_companion_is_offline() -> No
 
 # The shipped CEF surface needs explicit no-drag/pointer and display-state guards.
 def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
-    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v9"
+    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v10"
     for declaration in (
             'const STATUS_PATH = "/toy/companion/status";',
             'const MEMORY_PATH = "/toy/companion/memory";',
@@ -213,6 +213,11 @@ def test_original_settings_can_import_official_text_reply_history() -> None:
     assert "payload.memory_migration" in BOOTSTRAP_JAVASCRIPT
     assert "记忆已按时间顺序处理" in BOOTSTRAP_JAVASCRIPT
     assert "requestJson(OFFICIAL_LETTER_IMPORT_PATH)" in BOOTSTRAP_JAVASCRIPT
+    assert (
+        'requestJson(OFFICIAL_LETTER_IMPORT_PATH, { preflight: "1" })'
+        in BOOTSTRAP_JAVASCRIPT
+    )
+    assert "请先在“大模型”中完成连接测试并保存，再导入。" in BOOTSTRAP_JAVASCRIPT
     assert "正在获取信件列表" in BOOTSTRAP_JAVASCRIPT
     assert "正在读取信件内容" in BOOTSTRAP_JAVASCRIPT
     assert "正在整理长期记忆" in BOOTSTRAP_JAVASCRIPT
@@ -332,15 +337,27 @@ const fetch = async (endpoint, options) => {
   }
   if (endpoint.pathname === "/toy/letter/legacy/official-import") {
     if (options.method === "GET") {
+      if (endpoint.searchParams.get("preflight") === "1") {
+        return memoryAvailable
+          ? { ok: true, json: async () => ({ code: 0, data: {
+              status: "READY", llm_required: true,
+            } }) }
+          : { ok: false, json: async () => ({ code: 503, data: {
+              status: "UNAVAILABLE",
+              error_code: "OFFICIAL_HISTORY_LLM_UNAVAILABLE",
+              retryable: true,
+            } }) };
+      }
       return { ok: true, json: async () => ({ code: 0, data: {
         status: "RUNNING", stage: "reading", total: 2, processed: 1,
         imported: 0, skipped: 0, last_updated_at: "2026-08-29T00:00:00+00:00",
         retryable: false,
       } }) };
     }
-    return { ok: true, json: async () => ({ code: 0, data: {
-      status: "APPLIED", inserted: 1, duplicates: 0,
-      memory_migration: { status: "completed", processed: 1 },
+    return { ok: false, json: async () => ({ code: 503, data: {
+      status: "UNAVAILABLE",
+      error_code: "OFFICIAL_HISTORY_LLM_UNAVAILABLE",
+      retryable: true,
     } }) };
   }
   throw new Error(`unexpected request: ${endpoint.pathname}`);
@@ -372,8 +389,8 @@ const flush = async () => { for (let index = 0; index < 8; index += 1) await Pro
   if (body.querySelector("[data-olivia-companion-official-import-confirm]")) {
     throw new Error("confirmation opened while memory was unavailable");
   }
-  if (calls.some((item) => item.path === "/toy/letter/legacy/official-import")) {
-    throw new Error("official import ran while memory was unavailable");
+  if (calls.some((item) => item.path === "/toy/letter/legacy/official-import" && item.method === "POST")) {
+    throw new Error("official import wrote while LLM was unavailable");
   }
   memoryAvailable = true;
   const importPending = importButton.click();
@@ -386,16 +403,20 @@ const flush = async () => { for (let index = 0; index < 8; index += 1) await Pro
   await importPending;
   await flush();
   const importCall = calls.find((item) => item.path === "/toy/letter/legacy/official-import" && item.method === "POST");
-  const statusIndex = calls.findIndex((item) => item.path === "/toy/companion/status");
+  const preflightIndex = calls.findIndex((item) => item.path === "/toy/letter/legacy/official-import" && item.method === "GET");
   const importIndex = calls.findIndex((item) => item.path === "/toy/letter/legacy/official-import" && item.method === "POST");
   if (!importCall || importCall.headers["X-Olivia-Companion-Action"] !== "confirmed") throw new Error("official import confirmation header missing");
   if (!calls.some((item) => item.path === "/toy/letter/legacy/official-import" && item.method === "GET")) throw new Error("official import progress was not polled");
-  if (statusIndex < 0 || statusIndex >= importIndex) throw new Error("memory preflight did not run before official import");
+  if (preflightIndex < 0 || preflightIndex >= importIndex) throw new Error("import preflight did not run before official import");
+  if (!body.querySelectorAll("div").some((item) => item.textContent === "请先在“大模型”中完成连接测试并保存，再导入。")) {
+    throw new Error("LLM mutation failure did not show the actionable model setup message");
+  }
   if (nativeConfirmCalls !== 0) throw new Error("native confirmation was used");
   process.stdout.write(JSON.stringify({
     legacyListRequests: calls.filter((item) => item.path === "/toy/letter/list").length,
-    memoryBlocked: true,
-    memoryPreflight: true,
+    llmBlocked: true,
+    importPreflight: true,
+    llmMutationMapped: true,
   }));
 })().catch((error) => { console.error(error.stack); process.exitCode = 1; });
 '''
@@ -410,8 +431,9 @@ const flush = async () => { for (let index = 0; index < 8; index += 1) await Pro
     assert result.returncode == 0, output
     assert json.loads(result.stdout.decode("utf-8")) == {
         "legacyListRequests": 0,
-        "memoryBlocked": True,
-        "memoryPreflight": True,
+        "llmBlocked": True,
+        "importPreflight": True,
+        "llmMutationMapped": True,
     }
 
 

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1687,7 +1687,7 @@ def test_install_isolated_copy_activates_original_client_surfaces(
         main = archive.read("assets/main-917d29fc.js").decode("utf-8")
     assert "assets/olivia-companion-settings.js" in names
     assert "data-olivia-companion-settings" in index
-    assert "data-ui-version=\"p03.original-settings-manage.v9\"" in index
+    assert "data-ui-version=\"p03.original-settings-manage.v10\"" in index
     assert (installed / "local_backend" / "original_client_setup_api.py").is_file()
     assert (installed / "local_backend" / "original_client_capability_api.py").is_file()
     assert (installed / "local_backend" / "original_client_update_api.py").is_file()


### PR DESCRIPTION
## Result
- block first-time official history import before reading letters when the configured LLM is not statically ready
- keep idempotent re-import for an existing PrivateWorld independent of that gate
- expose a dedicated preflight response schema and map the POST race to an actionable LLM setup message

## Verification
- focused import and Settings UI tests: 47 passed
- git diff --check: PASS
- Standards: PASS, P0/P1/P2=0
- Spec: PASS, P0/P1/P2=0
- exact rebase range-diff: =

## Boundary
No provider probe, letter body read, memory write, relationship mutation, Persona change, launcher change, or media change is introduced by preflight.