### PR TITLE
fix: recover stalled capability downloads

### DIFF
--- a/mem0_capability_install.py
+++ b/mem0_capability_install.py
@@ -741,6 +741,10 @@ class ManagedMem0Runtime:
             "install",
             "--disable-pip-version-check",
             "--require-hashes",
+            "--timeout",
+            "15",
+            "--retries",
+            "1",
             "--only-binary=:all:",
             "--no-compile",
             "--ignore-installed",
@@ -1289,12 +1293,34 @@ class Mem0CapabilityInstaller:
         except Exception:
             ready = False
         with self._lock:
-            if ready and self._status.state in {
-                CapabilityState.MISSING,
-                CapabilityState.READY,
-            }:
+            active = self._status.state in {
+                CapabilityState.QUEUED,
+                CapabilityState.DOWNLOADING,
+                CapabilityState.VERIFYING,
+            }
+            worker_finished = (
+                self._thread is not None
+                and getattr(self._thread, "ident", None) is not None
+                and not self._thread.is_alive()
+            )
+            if ready and (
+                self._status.state in {
+                    CapabilityState.MISSING,
+                    CapabilityState.READY,
+                }
+                or active and worker_finished
+            ):
                 self._set_ready(None)
                 return self._status
+            if not ready and active and worker_finished:
+                self._status = self._new_status(
+                    CapabilityState.REPAIR,
+                    self._status.phase,
+                    self._status.downloaded_bytes,
+                    current=self._status.current_file,
+                    source=self._status.source,
+                    reason="MEM0_CAPABILITY_INSTALL_FAILED",
+                )
             if not ready and self._status.state is CapabilityState.READY:
                 self._status = self._new_status(
                     CapabilityState.REPAIR,
@@ -1488,7 +1514,18 @@ class Mem0CapabilityInstaller:
         source_mode: str,
         offline_root: Path | None,
     ) -> None:
-        self.install(source_mode=source_mode, offline_root=offline_root)
+        try:
+            self.install(source_mode=source_mode, offline_root=offline_root)
+        except Exception:
+            with self._lock:
+                self._status = self._new_status(
+                    CapabilityState.REPAIR,
+                    self._status.phase,
+                    self._status.downloaded_bytes,
+                    current=self._status.current_file,
+                    source=self._status.source or source_mode,
+                    reason="MEM0_CAPABILITY_INSTALL_FAILED",
+                )
 
     def pause(self) -> str:
         with self._lock:

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-SETTINGS_UI_VERSION = "p03.original-settings-manage.v10"
+SETTINGS_UI_VERSION = "p03.original-settings-manage.v11"
 
 BOOTSTRAP_JAVASCRIPT = r'''(() => {
   "use strict";
@@ -1125,7 +1125,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     result.setAttribute("aria-live", "polite");
     if (["queued", "downloading", "verifying"].includes(stateValue)) {
       const currentFile = payload.current_file === "python-dependencies"
-        ? "Python 依赖下载与安装"
+        ? "正在连接或解析 Python 依赖，下载进度可能暂时不变"
         : payload.current_file;
       const current = typeof currentFile === "string" ? `，当前：${currentFile}` : "";
       result.textContent = `${labels[stateValue]}：${formatBytes(payload.downloaded_bytes)} / ${formatBytes(payload.total_bytes)}，剩余 ${formatBytes(payload.remaining_bytes)}${current}`;

--- a/tests/installer/test_mem0_capability_install.py
+++ b/tests/installer/test_mem0_capability_install.py
@@ -527,6 +527,96 @@ def test_capability_start_returns_before_background_install_finishes() -> None:
     assert installer.status().state is CapabilityState.READY
 
 
+def test_background_preflight_failure_becomes_repair() -> None:
+    class FailingSecondReadLayer(_Layer):
+        def __init__(self) -> None:
+            super().__init__()
+            self.ready_calls = 0
+
+        def ready(self) -> bool:
+            self.ready_calls += 1
+            if self.ready_calls == 2:
+                raise RuntimeError("synthetic preflight failure")
+            return False
+
+    installer = Mem0CapabilityInstaller(
+        runtime=FailingSecondReadLayer(),
+        model=_Layer(),
+        version="fixture-v1",
+        estimated_download_bytes=20,
+        license_summary="fixture licenses",
+        requires_gpu=False,
+    )
+
+    assert installer.start(source_mode="auto") == "APPLIED"
+    assert installer._thread is not None
+    installer._thread.join(timeout=2)
+
+    status = installer.status()
+    assert status.state is CapabilityState.REPAIR
+    assert status.phase == "queued"
+    assert status.reason_code == "MEM0_CAPABILITY_INSTALL_FAILED"
+
+
+def test_status_reconciles_dead_active_worker_as_repair() -> None:
+    installer = Mem0CapabilityInstaller(
+        runtime=_Layer(),
+        model=_Layer(),
+        version="fixture-v1",
+        estimated_download_bytes=20,
+        license_summary="fixture licenses",
+        requires_gpu=False,
+    )
+    worker = threading.Thread(target=lambda: None)
+    worker.start()
+    worker.join(timeout=1)
+    installer._thread = worker
+    installer._status = installer._new_status(
+        CapabilityState.DOWNLOADING,
+        "runtime",
+        5,
+        current="python-dependencies",
+        source="auto",
+    )
+
+    status = installer.status()
+
+    assert status.state is CapabilityState.REPAIR
+    assert status.phase == "runtime"
+    assert status.downloaded_bytes == 5
+    assert status.current_file == "python-dependencies"
+    assert status.source == "auto"
+    assert status.reason_code == "MEM0_CAPABILITY_INSTALL_FAILED"
+
+
+def test_status_reconciles_dead_active_worker_as_ready_when_layers_are_ready() -> None:
+    installer = Mem0CapabilityInstaller(
+        runtime=_Layer(ready=True),
+        model=_Layer(ready=True),
+        version="fixture-v1",
+        estimated_download_bytes=20,
+        license_summary="fixture licenses",
+        requires_gpu=False,
+    )
+    worker = threading.Thread(target=lambda: None)
+    worker.start()
+    worker.join(timeout=1)
+    installer._thread = worker
+    installer._status = installer._new_status(
+        CapabilityState.DOWNLOADING,
+        "verification",
+        20,
+        source="auto",
+    )
+
+    status = installer.status()
+
+    assert status.state is CapabilityState.READY
+    assert status.phase == "complete"
+    assert status.downloaded_bytes == 20
+    assert status.reason_code is None
+
+
 def test_queued_pause_survives_worker_start_and_resume(monkeypatch) -> None:
     class DeferredThread:
         def __init__(self, *, target, kwargs, **_options) -> None:
@@ -698,6 +788,8 @@ def test_managed_runtime_uses_mirror_then_official_and_registers_atomic_target(
         assert environment["PIP_DISABLE_PIP_VERSION_CHECK"] == "1"
         assert not pause_requested.is_set()
         assert "--ignore-installed" in command
+        assert command[command.index("--timeout") + 1] == "15"
+        assert command[command.index("--retries") + 1] == "1"
         assert progress_roots
         calls.append(list(command))
         target = Path(command[command.index("--target") + 1])

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -121,9 +121,16 @@ def test_ready_mem0_preserves_restart_fallback_when_companion_is_offline() -> No
     )
 
 
+def test_mem0_runtime_download_explains_temporarily_flat_progress() -> None:
+    assert (
+        'payload.current_file === "python-dependencies"\n'
+        '        ? "正在连接或解析 Python 依赖，下载进度可能暂时不变"'
+    ) in BOOTSTRAP_JAVASCRIPT
+
+
 # The shipped CEF surface needs explicit no-drag/pointer and display-state guards.
 def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
-    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v10"
+    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v11"
     for declaration in (
             'const STATUS_PATH = "/toy/companion/status";',
             'const MEMORY_PATH = "/toy/companion/memory";',

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1687,7 +1687,7 @@ def test_install_isolated_copy_activates_original_client_surfaces(
         main = archive.read("assets/main-917d29fc.js").decode("utf-8")
     assert "assets/olivia-companion-settings.js" in names
     assert "data-olivia-companion-settings" in index
-    assert "data-ui-version=\"p03.original-settings-manage.v10\"" in index
+    assert "data-ui-version=\"p03.original-settings-manage.v11\"" in index
     assert (installed / "local_backend" / "original_client_setup_api.py").is_file()
     assert (installed / "local_backend" / "original_client_capability_api.py").is_file()
     assert (installed / "local_backend" / "original_client_update_api.py").is_file()


### PR DESCRIPTION
## Result
- reconcile a finished Mem0 worker to READY when both layers completed, otherwise to repair instead of leaving a false active state
- catch background failures that occur before the installer body enters its existing error boundary
- bound pip mirror attempts with a 15-second timeout and one retry before the existing official-source fallback
- explain that Python dependency resolution can keep byte progress unchanged, and bump the injected Settings UI to v11

## Verification
- strict RED reproduced dead+ready, dead+not-ready, preflight exception, missing pip bounds, and missing UI explanation
- focused regression: 69 passed, 53 deselected
- git diff --check: PASS
- Standards: PASS, P0/P1/P2=0
- Spec round 2: PASS, P0/P1/P2=0

## Boundary
Top-level READY/UNAVAILABLE meaning, capability schemas, video downloader, model hashes, atomic staging, Persona, PrivateWorld, imports, launcher, and media routing are unchanged.