### PR TITLE
fix(installer): stabilize repeated desktop launches

### DIFF
--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -44,7 +44,7 @@ GitHub Actions 会在 PR 和 `main` 更新时生成同样的可下载 artifact�
 
 `installer/start_local.py --health-only` 输出一行符合 [`contracts/launcher_health.schema.json`](../contracts/launcher_health.schema.json) 的 JSON。`READY` 的退出码为 0；`UNAVAILABLE` 与 `PORT_CONFLICT` 的退出码为 2。`PORT_CONFLICT` 表示端口已有非本契约监听器或返回了无效健康契约，启动器不会尝试启动第二个后端。正常启动还会核对 health 中不含路径的 `backend_id`，它同时绑定活动组件与当前安装实例；版本或安装实例不匹配时不会复用该服务。首个组件补丁遇到旧版遗留服务时，只有在 Windows 确认监听进程是当前产品目录自带 runtime 的 Python 后才会终止并启动新版本；无法证明归属时以 `STALE_BACKEND_RUNNING` 停止，不会结束其他程序。启动器自己创建的后端随 Olivia 客户端退出而结束。
 
-客户端启动协议以整个隔离 profile 目录为边界：启动器在创建 `profile/` 前记录该目录是否已存在，只有此前不存在才视为全新 profile。客户端始终以安装目录下的 `app/` 为工作目录。若且仅若全新 profile 的第一次退出码为 `0x0E000003`，启动器会在同一后端生命周期内重启客户端一次，因此客户端最多启动两次；已有 profile 或任何其他退出码均不重试，第二次退出码原样透传。每次启动和退出分别记录不含路径的 `client_start` 与 `client_exit`，并以 `attempt` 标记第 1 或第 2 次，退出记录只附整数退出码；触发重试时另记 `client_retry`，其固定原因为 `known_fresh_profile_exit`。这些诊断不记录安装路径、profile 路径、环境变量或凭据。
+客户端启动协议以整个隔离 profile 目录为边界：启动器在创建 `profile/` 前记录该目录是否已存在，只有此前不存在才视为全新 profile。客户端始终以安装目录下的 `app/` 为工作目录。若且仅若全新 profile 的第一次退出码为 `0x0E000003`，启动器会在同一后端生命周期内重启客户端一次，因此客户端最多启动两次；已有 profile 或任何其他退出码均不重试，第二次退出码原样透传。每次启动和退出分别记录不含路径的 `client_start` 与 `client_exit`，并以 `attempt` 标记第 1 或第 2 次，退出记录只附整数退出码；触发重试时另记 `client_retry`，其固定原因为 `known_fresh_profile_exit`。这些诊断不记录安装路径、profile 路径、环境变量或凭据。同一安装目录的稳定启动器只允许一个启动生命周期；首个 Olivia 尚在运行时重复点击会记录 `launch_already_running` 并立即结束第二个启动器，不会重复启动后端或客户端。不同安装目录互不阻塞，进程异常退出后自动释放该启动占用。若启动器无法创建该占用，则记录 `launch_lock_unavailable`，输出稳定错误码 `START_LOCK_UNAVAILABLE` 并以退出码 `2` 结束，不会继续启动后端或客户端。Windows 稳定启动器还使用 Job Object 归属本次启动的后端、客户端及其子进程；启动器正常或异常退出时由系统结束整棵子进程树，不进行宽泛进程清理。若无法建立该归属，则记录 `launch_job_unavailable`，输出稳定错误码 `START_JOB_UNAVAILABLE` 并以退出码 `2` 结束。
 
 ## 原版客户端补丁
 

--- a/installer/version_launcher.py
+++ b/installer/version_launcher.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import errno
+import hashlib
 import json
 import os
 import re
@@ -23,6 +25,157 @@ _LEGACY_PAYLOAD_PATH = "local_backend"
 
 class VersionLauncherError(RuntimeError):
     """Stable, user-safe launcher failure code."""
+
+
+class _StartInstance:
+    """One process-held installation launch lease."""
+
+    def __init__(self, close) -> None:
+        self._close = close
+
+    def close(self) -> None:
+        close, self._close = self._close, None
+        if close is not None:
+            close()
+
+
+def _try_acquire_start_instance(installation: Path) -> _StartInstance | None:
+    """Acquire a non-blocking launch lease scoped to one installation root."""
+
+    root = installation.expanduser().absolute()
+    identity = hashlib.sha256(
+        os.path.normcase(os.fspath(root)).encode("utf-8")
+    ).hexdigest()
+    if os.name == "nt":
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.CreateMutexW.argtypes = [
+            wintypes.LPVOID,
+            wintypes.BOOL,
+            wintypes.LPCWSTR,
+        ]
+        kernel32.CreateMutexW.restype = wintypes.HANDLE
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        ctypes.set_last_error(0)
+        handle = kernel32.CreateMutexW(
+            None,
+            False,
+            f"Local\\Olivia.Local.Start.{identity}",
+        )
+        if not handle:
+            raise OSError(ctypes.get_last_error(), "CreateMutexW failed")
+        if ctypes.get_last_error() == 183:
+            kernel32.CloseHandle(handle)
+            return None
+        return _StartInstance(lambda: kernel32.CloseHandle(handle))
+
+    import fcntl
+
+    lock_path = root / "data" / "launcher.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("a+b")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        handle.close()
+        if exc.errno in {errno.EACCES, errno.EAGAIN}:
+            return None
+        raise
+
+    def close_file_lock() -> None:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            handle.close()
+
+    return _StartInstance(close_file_lock)
+
+
+def _append_launcher_event(installation: Path, event: str) -> None:
+    """Persist a path-free stable-launcher event."""
+
+    try:
+        log_root = installation / "data" / "logs"
+        log_root.mkdir(parents=True, exist_ok=True)
+        with (log_root / "launcher.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps({"event": event}, sort_keys=True) + "\n")
+    except OSError:
+        pass
+
+
+def _own_windows_start_process_tree() -> object | None:
+    """Make descendants exit when this stable launcher process exits."""
+
+    if os.name != "nt":
+        return None
+    import ctypes
+    from ctypes import wintypes
+
+    class IoCounters(ctypes.Structure):
+        _fields_ = [
+            ("read_operation_count", ctypes.c_ulonglong),
+            ("write_operation_count", ctypes.c_ulonglong),
+            ("other_operation_count", ctypes.c_ulonglong),
+            ("read_transfer_count", ctypes.c_ulonglong),
+            ("write_transfer_count", ctypes.c_ulonglong),
+            ("other_transfer_count", ctypes.c_ulonglong),
+        ]
+
+    class BasicLimitInformation(ctypes.Structure):
+        _fields_ = [
+            ("per_process_user_time_limit", ctypes.c_longlong),
+            ("per_job_user_time_limit", ctypes.c_longlong),
+            ("limit_flags", wintypes.DWORD),
+            ("minimum_working_set_size", ctypes.c_size_t),
+            ("maximum_working_set_size", ctypes.c_size_t),
+            ("active_process_limit", wintypes.DWORD),
+            ("affinity", ctypes.c_size_t),
+            ("priority_class", wintypes.DWORD),
+            ("scheduling_class", wintypes.DWORD),
+        ]
+
+    class ExtendedLimitInformation(ctypes.Structure):
+        _fields_ = [
+            ("basic_limit_information", BasicLimitInformation),
+            ("io_info", IoCounters),
+            ("process_memory_limit", ctypes.c_size_t),
+            ("job_memory_limit", ctypes.c_size_t),
+            ("peak_process_memory_used", ctypes.c_size_t),
+            ("peak_job_memory_used", ctypes.c_size_t),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateJobObjectW.argtypes = [wintypes.LPVOID, wintypes.LPCWSTR]
+    kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    kernel32.SetInformationJobObject.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    kernel32.SetInformationJobObject.restype = wintypes.BOOL
+    kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+    kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+    kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    job = kernel32.CreateJobObjectW(None, None)
+    if not job:
+        raise OSError(ctypes.get_last_error(), "CreateJobObjectW failed")
+    limits = ExtendedLimitInformation()
+    limits.basic_limit_information.limit_flags = 0x00002000
+    if not kernel32.SetInformationJobObject(
+        job,
+        9,
+        ctypes.byref(limits),
+        ctypes.sizeof(limits),
+    ) or not kernel32.AssignProcessToJobObject(job, kernel32.GetCurrentProcess()):
+        error = ctypes.get_last_error()
+        kernel32.CloseHandle(job)
+        raise OSError(error, "Windows Job Object setup failed")
+    return job
 
 
 def _is_reparse_point(path: Path) -> bool:
@@ -172,12 +325,7 @@ def _entrypoint_arguments(
     return entrypoint, [root_option, os.fspath(root)]
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(prog="olivia-version-launcher")
-    parser.add_argument("--install-root", type=Path, required=True)
-    parser.add_argument("action", choices=("start", "configure", "uninstall"))
-    parser.add_argument("arguments", nargs=argparse.REMAINDER)
-    args = parser.parse_args(argv)
+def _run_action(args: argparse.Namespace) -> int:
     try:
         entrypoint, root_arguments = _entrypoint_arguments(
             args.action,
@@ -200,8 +348,55 @@ def main(argv: list[str] | None = None) -> int:
         return int(exc.code or 0)
 
 
+def _parse_arguments(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="olivia-version-launcher")
+    parser.add_argument("--install-root", type=Path, required=True)
+    parser.add_argument("action", choices=("start", "configure", "uninstall"))
+    parser.add_argument("arguments", nargs=argparse.REMAINDER)
+    return parser.parse_args(argv)
+
+
+def _run_main(
+    args: argparse.Namespace,
+    *,
+    own_windows_tree: bool = False,
+) -> int:
+    instance = None
+    if args.action == "start":
+        try:
+            instance = _try_acquire_start_instance(args.install_root)
+        except OSError:
+            _append_launcher_event(args.install_root, "launch_lock_unavailable")
+            print(json.dumps({"status": "ERROR", "code": "START_LOCK_UNAVAILABLE"}))
+            return 2
+        if instance is None:
+            _append_launcher_event(args.install_root, "launch_already_running")
+            return 0
+    try:
+        if own_windows_tree and args.action == "start":
+            try:
+                # The raw handle intentionally remains open until process teardown.
+                _job = _own_windows_start_process_tree()
+            except OSError:
+                _append_launcher_event(args.install_root, "launch_job_unavailable")
+                print(json.dumps({"status": "ERROR", "code": "START_JOB_UNAVAILABLE"}))
+                return 2
+        return _run_action(args)
+    finally:
+        if instance is not None:
+            instance.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    return _run_main(_parse_arguments(argv))
+
+
+def _cli(argv: list[str] | None = None) -> int:
+    return _run_main(_parse_arguments(argv), own_windows_tree=True)
+
+
 __all__ = ["VersionLauncherError", "main", "resolve_active_backend"]
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(_cli())

--- a/tests/installer/test_component_update.py
+++ b/tests/installer/test_component_update.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import signal
 import shutil
 import stat
 import subprocess
+import sys
+import time
 import zipfile
 from pathlib import Path
 
@@ -368,6 +371,283 @@ def test_stable_launcher_runs_without_importing_the_legacy_backend_first(
     assert arguments[0] == os.fspath(entrypoint)
     assert arguments[1:3] == ["--install-root", os.fspath(installation.resolve())]
     assert arguments[3:] == ["--record", os.fspath(record)]
+
+
+def _windows_process_exits_within(process_id: int, timeout_ms: int = 5000) -> bool:
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    handle = kernel32.OpenProcess(0x00100000, False, process_id)
+    if not handle:
+        return True
+    try:
+        return kernel32.WaitForSingleObject(handle, timeout_ms) == 0
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows Job Objects are required")
+@pytest.mark.parametrize(
+    ("abrupt", "expected_exit_code"),
+    ((False, 0), (True, 23)),
+    ids=("normal-exit", "abrupt-exit"),
+)
+def test_stable_start_cli_ends_descendant_with_launcher(
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+    abrupt: bool,
+    expected_exit_code: int,
+) -> None:
+    sentinel = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(600)"])
+    request.addfinalizer(lambda: (sentinel.terminate(), sentinel.wait(timeout=5)))
+    installation, legacy = _managed_installation(tmp_path)
+    launcher = installation / "launcher" / "version_launcher.py"
+    launcher.parent.mkdir()
+    shutil.copy2(Path(version_launcher.__file__), launcher)
+    entrypoint = legacy / "installer" / "start_local.py"
+    entrypoint.parent.mkdir()
+    child_pid = tmp_path / "child.pid"
+    entrypoint.write_text(
+        "from pathlib import Path\n"
+        "import os, subprocess, sys\n"
+        "child = subprocess.Popen([sys.executable, '-c', "
+        "'import time; time.sleep(60)'], stdin=subprocess.DEVNULL, "
+        "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)\n"
+        f"Path({str(child_pid)!r}).write_text(str(child.pid), encoding='utf-8')\n"
+        + ("os._exit(23)\n" if abrupt else ""),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            os.fspath(Path(sys.executable)),
+            os.fspath(launcher),
+            "--install-root",
+            os.fspath(installation),
+            "start",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert completed.returncode == expected_exit_code, completed.stderr
+    process_id = int(child_pid.read_text())
+    exited = _windows_process_exits_within(process_id, 5000)
+    if not exited:
+        os.kill(process_id, signal.SIGTERM)
+    assert exited
+    assert sentinel.poll() is None
+    recovered = version_launcher._try_acquire_start_instance(installation)
+    assert recovered is not None
+    recovered.close()
+
+
+def test_duplicate_stable_start_cli_does_not_create_job_or_run_backend(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    installation, legacy = _managed_installation(tmp_path)
+    entrypoint = legacy / "installer" / "start_local.py"
+    entrypoint.parent.mkdir()
+    record = tmp_path / "backend-entrypoint-ran.txt"
+    entrypoint.write_text(
+        "from pathlib import Path\n"
+        f"Path({str(record)!r}).write_text('ran', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    first = version_launcher._try_acquire_start_instance(installation)
+    assert first is not None
+    monkeypatch.setattr(
+        version_launcher,
+        "_own_windows_start_process_tree",
+        lambda: pytest.fail("duplicate start must not create a Job Object"),
+    )
+    try:
+        assert version_launcher._cli(
+            ["--install-root", str(installation), "start"]
+        ) == 0
+    finally:
+        first.close()
+
+    assert not record.exists()
+    events = [
+        json.loads(line)
+        for line in (
+            installation / "data" / "logs" / "launcher.jsonl"
+        ).read_text(encoding="utf-8").splitlines()
+    ]
+    assert events == [{"event": "launch_already_running"}]
+
+
+def test_stable_start_public_cli_serializes_same_installation(tmp_path: Path) -> None:
+    installation, legacy = _managed_installation(tmp_path)
+    launcher = installation / "launcher" / "version_launcher.py"
+    launcher.parent.mkdir()
+    shutil.copy2(Path(version_launcher.__file__), launcher)
+    record, release = tmp_path / "runs.txt", tmp_path / "release"
+    entrypoint = legacy / "installer" / "start_local.py"
+    entrypoint.parent.mkdir()
+    entrypoint.write_text(
+        "from pathlib import Path\nimport time\n"
+        f"record, release = Path({str(record)!r}), Path({str(release)!r})\n"
+        "record.open('a', encoding='utf-8').write('run\\n')\n"
+        "while not release.exists(): time.sleep(0.05)\n",
+        encoding="utf-8",
+    )
+    command = [
+        sys.executable, str(launcher), "--install-root", str(installation), "start"
+    ]
+    first = subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        for _ in range(100):
+            if record.exists():
+                break
+            time.sleep(0.05)
+        assert record.exists()
+        second = subprocess.run(command, timeout=5, check=False)
+        assert second.returncode == 0
+        assert record.read_text(encoding="utf-8").splitlines() == ["run"]
+    finally:
+        release.touch()
+        try:
+            first.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            first.kill()
+            first.wait(timeout=5)
+
+
+def test_start_instance_is_scoped_to_one_installation_root(tmp_path: Path) -> None:
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first = version_launcher._try_acquire_start_instance(first_root)
+    assert first is not None
+    second = None
+    try:
+        assert version_launcher._try_acquire_start_instance(first_root) is None
+        second = version_launcher._try_acquire_start_instance(second_root)
+        assert second is not None
+    finally:
+        if second is not None:
+            second.close()
+        first.close()
+
+
+def test_stable_start_reports_lock_creation_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    installation = tmp_path / "installation"
+    monkeypatch.setattr(
+        version_launcher,
+        "_try_acquire_start_instance",
+        lambda _installation: (_ for _ in ()).throw(OSError("lock failed")),
+    )
+
+    assert version_launcher.main(
+        ["--install-root", str(installation), "start"]
+    ) == 2
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "ERROR",
+        "code": "START_LOCK_UNAVAILABLE",
+    }
+    events = [
+        json.loads(line)
+        for line in (
+            installation / "data" / "logs" / "launcher.jsonl"
+        ).read_text(encoding="utf-8").splitlines()
+    ]
+    assert events == [{"event": "launch_lock_unavailable"}]
+
+
+def test_stable_start_cli_reports_windows_job_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    installation = tmp_path / "installation"
+    released: list[bool] = []
+    monkeypatch.setattr(
+        version_launcher,
+        "_try_acquire_start_instance",
+        lambda _installation: version_launcher._StartInstance(
+            lambda: released.append(True)
+        ),
+    )
+    monkeypatch.setattr(
+        version_launcher,
+        "_own_windows_start_process_tree",
+        lambda: (_ for _ in ()).throw(OSError("job failed")),
+    )
+
+    assert version_launcher._cli(
+        ["--install-root", str(installation), "start"]
+    ) == 2
+    assert released == [True]
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "ERROR",
+        "code": "START_JOB_UNAVAILABLE",
+    }
+    events = [
+        json.loads(line)
+        for line in (
+            installation / "data" / "logs" / "launcher.jsonl"
+        ).read_text(encoding="utf-8").splitlines()
+    ]
+    assert events == [{"event": "launch_job_unavailable"}]
+
+
+def test_stable_configure_cli_does_not_create_start_job(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    installation, legacy = _managed_installation(tmp_path)
+    entrypoint = legacy / "installer" / "configure.py"
+    entrypoint.parent.mkdir()
+    record = tmp_path / "configured.txt"
+    entrypoint.write_text(
+        "from pathlib import Path\n"
+        f"Path({str(record)!r}).write_text('configured', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        version_launcher,
+        "_own_windows_start_process_tree",
+        lambda: (_ for _ in ()).throw(AssertionError("start job called")),
+    )
+
+    assert version_launcher._cli(
+        ["--install-root", str(installation), "configure"]
+    ) == 0
+    assert record.read_text(encoding="utf-8") == "configured"
+
+
+def test_stable_start_single_instance_is_documented() -> None:
+    documentation = (
+        Path(__file__).parents[2] / "docs" / "WINDOWS_FULL_PATCH.md"
+    ).read_text(encoding="utf-8")
+
+    for expected in (
+        "同一安装目录",
+        "重复点击",
+        "`launch_already_running`",
+        "不会重复启动后端或客户端",
+        "异常退出后自动释放",
+        "`START_LOCK_UNAVAILABLE`",
+        "`launch_lock_unavailable`",
+        "`START_JOB_UNAVAILABLE`",
+        "`launch_job_unavailable`",
+    ):
+        assert expected in documentation
 
 
 def test_stable_launcher_cli_rejects_a_reparse_installation_root(


### PR DESCRIPTION
## 结果
- 同一安装目录重复点击只保留首个启动生命周期，第二个启动器直接成功退出，不重复启动后端或客户端。
- Windows Job Object 只归属本次启动器及其后代；启动器正常或异常退出时清理该进程树，不枚举或误杀无关进程。
- 锁与 Job 建立失败返回稳定错误码，并释放已获得的资源。

## 冻结证据
- Base: c01d06c31bd671b5048d81839fa30e294c37afd8
- Head: 3ddc9062314530a49663db1e5db312707b738ad5
- Exact pre-commit diff hash: 98c6f9925ad1744c335f52fc3ddae42be3053118
- Scope: 3 files, +483/-8

## 验证
- tests/installer/test_component_update.py: 43 passed
- installer/version_launcher.py py_compile: PASS
- git diff --check: PASS
- Standards: PASS, P0/P1/P2=0
- Spec: PASS, P0/P1=0; one non-blocking physical-path-alias P2 recorded

## 边界
只改稳定启动器、Windows 启动文档及相关测试；不修改客户端、下载、Persona、PrivateWorld、Live 或媒体路由。真实安装包快捷方式验收在合并后最终构建执行。