### PR TITLE
fix(memory): defer startup and resume pending replies

### DIFF
--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -17,7 +17,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 - 错误响应：`{"code":<HTTP 状态>,"message":"<error_code>","data":{"status":"FAILED","error_code":"<error_code>"}}`
 - 真正未实现能力：HTTP `501`，`data.status=NOT_IMPLEMENTED`。
 - 已知但不可用的可选能力：HTTP `501`，`data.status=UNAVAILABLE`，并带 `capability`；不会返回 200 假成功。
-- HTTP 发信先返回 `200`/`PENDING`；LLM 超时或不可用随后写入信件 `FAILED` 终态，detail 返回稳定 `error_code` 与 `retryable`。重启只恢复尚未派发的 `PENDING`；不确定是否已到达 provider 的 `PROCESSING` 会 fail closed 为 `LLM_INTERRUPTED`，不自动重复生成。
+- HTTP 发信先返回 `200`/`PENDING`；启用的 Mem0 或 durable outbox 尚未就绪时信件保持 `PENDING`，运行时恢复后只派发一次，不会降级为无记忆生成。LLM 超时或不可用随后写入信件 `FAILED` 终态，detail 返回稳定 `error_code` 与 `retryable`。重启只恢复尚未派发的 `PENDING`；不确定是否已到达 provider 的 `PROCESSING` 会 fail closed 为 `LLM_INTERRUPTED`，不自动重复生成。
 - 视频回信的 detail 额外公开 `media_status`、`media_error_code` 与布尔值 `media_retryable`。路由选中视频后、正文仍在生成时为 `PENDING`；若正文生成、质量检查或重启恢复在媒体启动前失败，则为 `NOT_REQUESTED` 且没有媒体错误；只有正文成功后才进入实际媒体任务。`TTS_CONTENT_GATE_UNAVAILABLE` 为可重试的 `UNAVAILABLE`；三条有效候选均被内容门拒绝时，`TTS_CONTENT_GATE_REJECTED` 为不可重试的 `FAILED`。
 
 机器可读定义：
@@ -40,6 +40,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 | MIDI | `/toy/midi/*` | terminal/partial | 任务状态兼容现有原型；生成/上传/分享码导入明确 501 |
 | legacy import | `/toy/letter/legacy/import` | available | SQLite 本地扩展；仅接受 `mode=read_only`，以单事务原子导入旧信并按内容哈希去重；导入后旧信域只读且不与新聊天合并 |
 | 官方文字信件导入 | `/toy/letter/legacy/official-import` | available/degraded | 用户在设置页明确确认后，先要求 Mem0 与 PrivateWorld 可用；首次初始化关系状态时还要求大模型已配置。随后临时读取官方客户端登录日志并从官方接口导入原信与文字回信；严格按时间写入 Mem0、初始化 PrivateWorld，最后才原子发布到信箱；忽略视频，不保存或回显凭证 |
+| 长期记忆重试 | `/toy/companion/memory/retry` | available/degraded | 仅接受带确认头的 `POST`；返回 `INITIALIZING`、`AVAILABLE`、`DEGRADED`、`UNAVAILABLE` 或 `DISABLED`，其中显式禁用的 `DISABLED` 不可重试；重试真实 Mem0 factory，并在 delegate 已就绪时重新启动 durable outbox，不要求退出重进 |
 
 原生 WebSocket、ASR、TTS、Live 没有假 route；`/health` 的 capability registry 明确为 `unavailable`，错误码分别为 `WEBSOCKET_UNAVAILABLE`、`ASR_UNAVAILABLE`、`TTS_UNAVAILABLE`、`LIVE_UNAVAILABLE`。
 

--- a/docs/B04_LOCAL_MEMORY.md
+++ b/docs/B04_LOCAL_MEMORY.md
@@ -4,7 +4,7 @@
 
 ## 数据边界
 
-- 仓库默认仍是 session-only：未显式启用 `memory_config.json` 或 `OLIVIA_MEMORY_ENABLED=true` 时，不创建数据库，也不保存个人聊天。隔离 Windows 安装默认选择本地 Mem0，并提供可选运行依赖安装；用户可用 `OLIVIA_MEMORY_ENABLED=0` 明确关闭。Embedding 只会在安装器或原版 Settings 中得到用户确认后下载；依赖、模型或初始化失败时，写信继续走现有无记忆降级路径。
+- 仓库默认仍是 session-only：未显式启用 `memory_config.json` 或 `OLIVIA_MEMORY_ENABLED=true` 时，不创建数据库，也不保存个人聊天。隔离 Windows 安装默认选择本地 Mem0，并提供可选运行依赖安装；用户可用 `OLIVIA_MEMORY_ENABLED=0` 明确关闭。Embedding 只会在安装器或原版 Settings 中得到用户确认后下载。Mem0 已启用但依赖、模型或 durable outbox 尚未就绪时，core 和其他功能继续可用，新信保留为 `PENDING`，待记忆运行时恢复后再生成回信，不会静默走无记忆路径。
 - `legacy_letters` 是独立的只读角色经历资料库。导入内容保留原文、来源标签、来源记录 ID、时间、内容哈希和完整 metadata；它不会写入新聊天集合，也不会改写原始文本。
 - `conversation_memory` 只在 opt-in profile 启用后保存新聊天摘要/事实，支持 TTL 和单独清空。
 - `persona_evidence` 仅保存配置引用、版本和哈希，不会被当作记忆事实写入 prompt。

--- a/http_contract.py
+++ b/http_contract.py
@@ -198,6 +198,7 @@ ROUTES: dict[str, dict[str, Any]] = {
         "letters.official_import",
         evidence="local-extension",
     ),
+    "/toy/companion/memory/retry": _route(["POST"], "memory.local", evidence="local-extension"),
     "/toy/getMusicTypeInfo": _route(["GET"], "music.catalog", read_only=True),
     "/toy/searchSongs": _route(["GET"], "music.catalog", read_only=True),
     "/toy/searchPlaylist": _route(["GET"], "music.catalog", read_only=True),

--- a/local_server.py
+++ b/local_server.py
@@ -84,7 +84,11 @@ from runtime.video_reply_settings import (
     receive_eligibility_from_letter,
 )
 from conversation_memory_port import ConversationMemoryPort
-from conversation_memory_runtime import conversation_memory_runtime_status
+from conversation_memory_runtime import (
+    conversation_memory_runtime_status,
+    ensure_conversation_memory_runtime,
+    stop_conversation_memory_runtime,
+)
 from local_memory import (
     create_conversation_memory_adapter,
     create_memory_adapter,
@@ -276,6 +280,27 @@ def apply_runtime_llm_config(base_url: str, model: str, api_key: str | None) -> 
         _os.environ.pop(key_env, None)
     else:
         _os.environ[key_env] = "1"
+    memory_environment = dict(_os.environ)
+    if api_key is not None:
+        memory_environment[key_env] = api_key
+    replacement = create_conversation_memory_adapter(
+        _memory_config,
+        environ=memory_environment,
+        llm_fallback={
+            "base_url": candidate.base_url,
+            "model": candidate.model,
+            "api_key_env": key_env,
+        },
+        defer_initialization=True,
+    )
+    reconfigure = getattr(conversation_memory_adapter, "reconfigure_from", None)
+    if callable(reconfigure) and reconfigure(replacement):
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            _start_conversation_memory_initialization(loop)
 
 
 def _persona() -> str:
@@ -845,6 +870,7 @@ conversation_memory_adapter: ConversationMemoryPort = (
             "model": LLM_CONFIG.model,
             "api_key_env": LLM_CONFIG.api_key_env,
         },
+        defer_initialization=True,
     )
 )
 
@@ -942,6 +968,17 @@ def _official_history_memory_available() -> bool:
         and status.enabled is True
         and status.provider == "mem0"
     )
+
+
+def _conversation_memory_ready_for_reply() -> bool:
+    try:
+        status = conversation_memory_adapter.status().status
+        runtime = conversation_memory_runtime_status()
+        return status == "disabled" or (
+            status == "available" and runtime.status == "available"
+        )
+    except Exception:
+        return False
 
 
 def _official_history_private_world_available() -> bool:
@@ -2239,6 +2276,29 @@ async def route(
         query = {}
     if p == "/health":
         return _health_result(query.get("profile", contract.HEALTH_PROFILE_CORE))
+    if p == "/toy/companion/memory/retry":
+        if companion_confirmed is not True:
+            return err(403, "COMPANION_CONFIRMATION_REQUIRED", {
+                "status": "FAILED",
+                "error_code": "COMPANION_CONFIRMATION_REQUIRED",
+                "retryable": False,
+            })
+        started = _start_conversation_memory_initialization(
+            asyncio.get_running_loop()
+        )
+        status = conversation_memory_adapter.status()
+        runtime_status = (
+            _start_ready_conversation_memory_runtime()
+            if not started and status.status == "available"
+            else None
+        )
+        public_status = "INITIALIZING" if started or status.reason_code == "MEM0_INITIALIZING" else (
+            runtime_status.status.upper() if runtime_status is not None else status.status.upper()
+        )
+        return ok({
+            "status": public_status,
+            "retryable": public_status in {"INITIALIZING", "DEGRADED", "UNAVAILABLE"},
+        })
     if spec["state"] == "not_implemented" and p != "/toy/midi/generate":
         return not_implemented(spec["error_code"] or "ROUTE_NOT_IMPLEMENTED")
 
@@ -2761,7 +2821,7 @@ async def route(
         if idempotency_key is not None:
             store.request_keys[idempotency_key] = lid
         _persist_store_state()
-        if defer_reply:
+        if defer_reply or not _conversation_memory_ready_for_reply():
             _schedule_reply_job(lid, content, idempotency_key=idempotency_key)
             return _send_result_for_letter(letter)
         completed = await generate_reply(lid, content, idempotency_key=idempotency_key)
@@ -3044,6 +3104,12 @@ async def _run_reply_job(
         return False
 
 
+async def _run_reply_when_memory_ready(letter_id: str, content: str, *, idempotency_key: str | None) -> bool:
+    while not _conversation_memory_ready_for_reply():
+        await asyncio.sleep(0.25)
+    return await _run_reply_job(letter_id, content, idempotency_key=idempotency_key)
+
+
 def _schedule_reply_job(
     letter_id: str,
     content: str,
@@ -3054,7 +3120,7 @@ def _schedule_reply_job(
     if active is not None and not active.done():
         return
     task = asyncio.create_task(
-        _run_reply_job(
+        _run_reply_when_memory_ready(
             letter_id,
             content,
             idempotency_key=idempotency_key,
@@ -3139,6 +3205,38 @@ async def _start_reply_tasks(_app: web.Application) -> None:
     _schedule_pending_media_jobs()
 
 
+def _start_ready_conversation_memory_runtime():
+    if getattr(conversation_memory_adapter, "closed", False):
+        return None
+    builder = letters_adapter.memory_prompt_builder
+    status = ensure_conversation_memory_runtime(
+        memory_adapter,
+        conversation_memory_adapter,
+        memory_lifecycle=builder.memory_lifecycle,
+    )
+    builder.conversation_runtime_status = status.to_dict()
+    if status.status == "available":
+        _schedule_pending_reply_jobs()
+    return status
+
+
+async def _start_conversation_memory(_app: web.Application) -> None:
+    started = _start_conversation_memory_initialization(asyncio.get_running_loop())
+    if not started and conversation_memory_adapter.status().status == "available":
+        _start_ready_conversation_memory_runtime()
+
+
+def _start_conversation_memory_initialization(loop: asyncio.AbstractEventLoop) -> bool:
+    start = getattr(conversation_memory_adapter, "start_initialization", None)
+    if callable(start):
+        return bool(start(
+            on_ready=lambda: loop.call_soon_threadsafe(
+                _start_ready_conversation_memory_runtime
+            )
+        ))
+    return False
+
+
 async def _stop_reply_tasks(_app: web.Application) -> None:
     tasks = tuple(reply_tasks | media_tasks | private_world_candidate_tasks)
     for task in tasks:
@@ -3152,10 +3250,19 @@ async def _stop_reply_tasks(_app: web.Application) -> None:
     media_jobs.clear()
 
 
+async def _stop_conversation_memory(_app: web.Application) -> None:
+    close = getattr(conversation_memory_adapter, "close", None)
+    if callable(close):
+        close()
+    stop_conversation_memory_runtime()
+
+
 def install_reply_task_lifecycle(app: web.Application) -> None:
     """Resume durable pending replies and stop owned tasks with the HTTP app."""
 
+    app.on_startup.append(_start_conversation_memory)
     app.on_startup.append(_start_reply_tasks)
+    app.on_cleanup.append(_stop_conversation_memory)
     app.on_cleanup.append(_stop_reply_tasks)
 
 

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-SETTINGS_UI_VERSION = "p03.original-settings-manage.v12"
+SETTINGS_UI_VERSION = "p03.original-settings-manage.v13"
 
 BOOTSTRAP_JAVASCRIPT = r'''(() => {
   "use strict";
@@ -25,6 +25,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const MEMORY_CLEAR_PATH = "/toy/companion/memory/clear";
   const MEMORY_PAUSE_PATH = "/toy/companion/memory/pause";
   const MEMORY_RESUME_PATH = "/toy/companion/memory/resume";
+  const MEMORY_RETRY_PATH = "/toy/companion/memory/retry";
   const SETUP_STATUS_PATH = "/toy/setup/status";
   const LLM_TEST_PATH = "/toy/setup/llm/test";
   const LLM_SAVE_PATH = "/toy/setup/llm/save";
@@ -346,7 +347,8 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         responseBody = null;
       }
       const payload = (path === VIDEO_REPLY_SETTINGS_PATH
-          || path === OFFICIAL_LETTER_IMPORT_PATH)
+          || path === OFFICIAL_LETTER_IMPORT_PATH
+          || path === MEMORY_RETRY_PATH)
         && responseBody && responseBody.data && typeof responseBody.data === "object"
         ? responseBody.data
         : responseBody;
@@ -636,11 +638,33 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     }
   };
 
+  const scheduleMemoryStatusRefresh = (panel, delay = 1000) => {
+    window.clearTimeout(panel.__oliviaMemoryStatusTimer);
+    panel.__oliviaMemoryStatusTimer = window.setTimeout(async () => {
+      if (!panel.isConnected) return;
+      try {
+        const status = await requestJson(STATUS_PATH);
+        await renderMemoryPanel(panel, status.capabilities.memory);
+      } catch (_error) {
+        scheduleMemoryStatusRefresh(panel, Math.min(delay * 2, 5000));
+      }
+    }, delay);
+  };
+
   const renderMemoryPanel = async (panel, capability) => {
+    window.clearTimeout(panel.__oliviaMemoryStatusTimer);
     const state = capabilityState(capability);
     const confirmClear = async () => await confirmAction("确认清空当前用户的 Mem0 长期记忆？")
       && await confirmAction("清空后无法恢复。原始信件和私人世界不会受影响，仍要继续吗？");
     if (state === "disabled" || state === "unavailable") {
+      if (state === "unavailable" && capability && capability.reason_code === "MEM0_INITIALIZING") {
+        panel.replaceChildren(
+          text("h3", "长期记忆", "text-text-title text-title-m"),
+          text("p", "长期记忆正在准备，其他功能可正常使用。需要长期记忆的回信会在准备完成后继续。", "text-text-secondary text-body-m font-regular")
+        );
+        scheduleMemoryStatusRefresh(panel);
+        return;
+      }
       if (state === "unavailable" && capability && capability.reason_code === "MEMORY_ADMIN_CLEAR_PENDING") {
         const heading = text("h3", "长期记忆", "text-text-title text-title-m");
         const summary = text("p", "上次清空尚未完成。", "text-text-secondary text-body-m font-regular");
@@ -735,6 +759,32 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
           }
         });
         panel.replaceChildren(heading, summary, install, resultState);
+        return;
+      }
+      if (state === "unavailable") {
+        const resultState = text("p", "", "text-text-secondary text-body-m font-regular");
+        const retry = button("重新准备长期记忆", async () => {
+          setButtonsBusy([retry], true);
+          try {
+            const payload = await requestMutation(MEMORY_RETRY_PATH, {});
+            if (["INITIALIZING", "AVAILABLE"].includes(payload.status)) {
+              const status = await requestJson(STATUS_PATH);
+              await renderMemoryPanel(panel, status.capabilities.memory);
+              return;
+            }
+            resultState.textContent = "当前配置仍未就绪，请检查长期记忆下载状态。";
+          } catch (_error) {
+            resultState.textContent = "长期记忆仍未准备好，请稍后重试。";
+          } finally {
+            setButtonsBusy([retry], false);
+          }
+        });
+        panel.replaceChildren(
+          text("h3", "长期记忆", "text-text-title text-title-m"),
+          text("p", "长期记忆没有准备成功，其他功能仍可使用；等待中的回信会保留。", "text-text-secondary text-body-m font-regular"),
+          retry,
+          resultState
+        );
         return;
       }
       renderUnavailable(panel, state, "长期记忆");

--- a/runtime/memory/local_memory.py
+++ b/runtime/memory/local_memory.py
@@ -27,7 +27,11 @@ from .conversation_memory_port import (
     NullConversationMemoryPort,
     UnavailableConversationMemoryPort,
 )
-from .mem0_memory import create_mem0_adapter
+from .mem0_memory import (
+    DeferredConversationMemoryAdapter,
+    create_mem0_adapter,
+    load_mem0_config,
+)
 from .memory_port import (
     CONVERSATION_MEMORY,
     LEGACY_LETTERS,
@@ -1199,6 +1203,7 @@ def create_conversation_memory_adapter(
     *,
     environ: Mapping[str, str] | None = None,
     llm_fallback: Mapping[str, str] | None = None,
+    defer_initialization: bool = False,
 ) -> ConversationMemoryPort:
     """Select the optional conversation-memory provider without crossing Archive.
 
@@ -1288,6 +1293,15 @@ def create_conversation_memory_adapter(
         if isinstance(value, str) and value.strip():
             mem0_environment[memory_name] = value.strip()
     try:
+        if defer_initialization:
+            mem0_config = load_mem0_config(environ=mem0_environment)
+            return DeferredConversationMemoryAdapter(
+                mem0_config,
+                lambda: create_mem0_adapter(
+                    config=mem0_config,
+                    environ=mem0_environment,
+                ),
+            )
         return create_mem0_adapter(environ=mem0_environment)
     except Exception:
         return UnavailableConversationMemoryPort(

--- a/runtime/memory/mem0_memory.py
+++ b/runtime/memory/mem0_memory.py
@@ -273,6 +273,140 @@ class Mem0Config:
         }
 
 
+class DeferredConversationMemoryAdapter:
+    """Expose Mem0 immediately while constructing its backend off-thread."""
+
+    enabled = True
+
+    def __init__(
+        self,
+        config: Mem0Config,
+        factory: Callable[[], ConversationMemoryPort],
+    ) -> None:
+        self.config = config
+        self._factory = factory
+        self._delegate: ConversationMemoryPort | None = None
+        self._reason_code = "MEM0_INITIALIZING"
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._ready_callbacks: list[Callable[[], None]] = []
+        self._closed = False
+        self._generation = 0
+
+    @property
+    def closed(self) -> bool:
+        with self._lock:
+            return self._closed
+
+    def reconfigure_from(self, other: object) -> bool:
+        if not isinstance(other, DeferredConversationMemoryAdapter):
+            return False
+        with other._lock:
+            config, factory = other.config, other._factory
+        with self._lock:
+            self._generation += 1
+            self.config, self._factory = config, factory
+            self._delegate = None
+            self._reason_code, self._closed = "MEM0_INITIALIZING", False
+        return True
+
+    def start_initialization(
+        self,
+        *,
+        on_ready: Callable[[], None] | None = None,
+    ) -> bool:
+        with self._lock:
+            if self._closed:
+                self._closed = False
+            if self._delegate is not None:
+                return False
+            if on_ready is not None and not self._ready_callbacks:
+                self._ready_callbacks.append(on_ready)
+            if self._thread is not None and self._thread.is_alive():
+                return False
+            self._reason_code = "MEM0_INITIALIZING"
+            self._generation += 1
+            self._thread = threading.Thread(target=self._initialize, name="olivia-mem0-initializer", daemon=True)
+            self._thread.start()
+            return True
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+            self._ready_callbacks.clear()
+
+    def status(self) -> ConversationMemoryStatus:
+        with self._lock:
+            delegate = self._delegate
+            reason_code = self._reason_code
+        if delegate is not None:
+            return delegate.status()
+        return ConversationMemoryStatus(
+            "unavailable",
+            True,
+            "mem0",
+            "qdrant-local",
+            reason_code=reason_code,
+        )
+
+    def search_context(self, query: str, *, user_id: str, limit: int):
+        return self._current().search_context(query, user_id=user_id, limit=limit)
+
+    def remember_exchange(self, **kwargs):
+        return self._current().remember_exchange(**kwargs)
+
+    def list_memories(self, *, user_id: str, limit: int = 100):
+        return self._current().list_memories(user_id=user_id, limit=limit)
+
+    def add_manual_memory(self, text: str, *, user_id: str, source_id: str):
+        return self._current().add_manual_memory(text, user_id=user_id, source_id=source_id)
+
+    def delete_memory(self, memory_id: str, *, user_id: str) -> bool:
+        return self._current().delete_memory(memory_id, user_id=user_id)
+
+    def clear_user(self, *, user_id: str) -> int:
+        return self._current().clear_user(user_id=user_id)
+
+    def export_user(self, *, user_id: str) -> dict[str, object]:
+        return self._current().export_user(user_id=user_id)
+
+    def _current(self) -> ConversationMemoryPort:
+        with self._lock:
+            if self._delegate is not None:
+                return self._delegate
+            reason_code = self._reason_code
+        return UnavailableConversationMemoryPort(reason_code, config=self.config)
+
+    def _initialize(self) -> None:
+        while True:
+            with self._lock:
+                generation, factory = self._generation, self._factory
+            try:
+                candidate = factory()
+                status = candidate.status()
+                reason_code = None if status.status == "available" and status.enabled is True else status.reason_code or "MEM0_INITIALIZATION_FAILED"
+            except Exception:
+                candidate, reason_code = None, "MEM0_INITIALIZATION_FAILED"
+            with self._lock:
+                if self._closed:
+                    self._thread = None
+                    return
+                if generation != self._generation:
+                    candidate = None
+                    continue
+                if reason_code is not None:
+                    self._reason_code, self._thread = reason_code, None
+                    return
+                self._delegate, self._thread = candidate, None
+                callbacks = tuple(self._ready_callbacks)
+                self._ready_callbacks.clear()
+                break
+        for callback in callbacks:
+            try:
+                callback()
+            except Exception:
+                pass
+
+
 def _bool(value: object, default: bool = False) -> bool:
     if isinstance(value, bool):
         return value
@@ -1402,6 +1536,7 @@ def create_mem0_adapter(
 
 
 __all__ = [
+    "DeferredConversationMemoryAdapter",
     "MEM0_EMBEDDING_MODEL",
     "MEM0_EMBEDDING_MODEL_REVISION",
     "MEM0_OSS_VERSION",

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -55,6 +55,151 @@ def test_core_health_is_versioned_and_reports_unavailable_optional_capabilities(
         assert data["capabilities"][capability]["status"] == "unavailable"
 
 
+def test_http_startup_exposes_core_health_while_mem0_initializes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+    from conversation_memory_port import (
+        ConversationMemoryStatus,
+        NullConversationMemoryPort,
+        UnavailableConversationMemoryPort,
+    )
+    from conversation_memory_runtime import ConversationMemoryRuntimeStatus
+    from mem0_memory import DeferredConversationMemoryAdapter, Mem0Config
+
+    import local_server
+    entered = threading.Event()
+    release = threading.Event()
+    generated: list[str] = []
+    runtime_starts: list[int] = []
+    runtime_state = ["unavailable"]
+    factory_calls: list[str] = []
+    class ReadyMemory(NullConversationMemoryPort):
+        enabled = True
+
+        def status(self) -> ConversationMemoryStatus:
+            return ConversationMemoryStatus("available", True, "mem0", "qdrant-local")
+
+    def blocked_factory():
+        factory_calls.append("old")
+        entered.set()
+        assert release.wait(2)
+        return ReadyMemory()
+
+    memory = DeferredConversationMemoryAdapter(Mem0Config(enabled=True, data_root=tmp_path), blocked_factory)
+    monkeypatch.setattr(local_server, "conversation_memory_adapter", memory)
+    monkeypatch.setattr(local_server.letters_adapter.memory_prompt_builder, "conversation_runtime_status", None)
+    async def record_generation(_letter_id: str, content: str, **_kwargs) -> bool:
+        generated.append(content)
+        letter = next(item for item in local_server.store.letters if item["letter_id"] == _letter_id)
+        letter["letter_status"] = "COMPLETED"
+        return True
+
+    monkeypatch.setattr(local_server, "generate_reply", record_generation)
+    def runtime_status(*_args, **_kwargs):
+        runtime_starts.append(1)
+        state = "unavailable" if len(runtime_starts) == 1 else "available"
+        runtime_state[0] = state
+        return ConversationMemoryRuntimeStatus(state, True, "mem0-outbox", state == "available")
+    monkeypatch.setattr(
+        local_server,
+        "ensure_conversation_memory_runtime",
+        runtime_status,
+    )
+    monkeypatch.setattr(local_server, "conversation_memory_runtime_status", lambda: ConversationMemoryRuntimeStatus(runtime_state[0], True, "mem0-outbox", runtime_state[0] == "available"))
+    history_calls: list[str] = []
+    monkeypatch.setattr(local_server, "collect_default_official_text_replies", lambda: history_calls.append("collector"))
+    monkeypatch.setattr(local_server, "_legacy_import_adapter", lambda: history_calls.append("archive"))
+
+    async def exercise() -> tuple:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        local_server.install_reply_task_lifecycle(app)
+        started_at = asyncio.get_running_loop().time()
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            response = await client.get("/health", params={"profile": "core"})
+            health = await response.json()
+            health_elapsed = asyncio.get_running_loop().time() - started_at
+            imported = await client.post("/toy/letter/legacy/official-import", json={}, headers={"X-Olivia-Companion-Action": "confirmed"})
+            await client.post("/toy/letter/send", json={"content": "synthetic letter"})
+            assert entered.wait(0.2)
+            generated_before_ready = len(generated)
+            await client.post("/toy/companion/memory/retry", json={}, headers={"X-Olivia-Companion-Action": "confirmed"})
+            latest = DeferredConversationMemoryAdapter(Mem0Config(enabled=True, data_root=tmp_path), lambda: (factory_calls.append("latest"), ReadyMemory())[1])
+            assert memory.reconfigure_from(latest) and not memory.start_initialization()
+            assert factory_calls == ["old"]
+            release.set()
+            await asyncio.sleep(0.05)
+            generated_before_runtime_retry = len(generated)
+            retry = await client.post("/toy/companion/memory/retry", json={}, headers={
+                "X-Olivia-Companion-Action": "confirmed"
+            })
+            deadline = asyncio.get_running_loop().time() + 1
+            while not generated and asyncio.get_running_loop().time() < deadline:
+                await asyncio.sleep(0.01)
+            runtime_state[0] = "unavailable"
+            await client.post("/toy/letter/send", json={"content": "letter during runtime failure"})
+            await asyncio.sleep(0.05)
+            generated_during_runtime_failure = len(generated)
+            runtime_state[0] = "available"
+            deadline = asyncio.get_running_loop().time() + 2
+            while len(generated) < 2 and asyncio.get_running_loop().time() < deadline:
+                await asyncio.sleep(0.05)
+            imported_payload, retry_payload = await imported.json(), await retry.json()
+        closed_after_first = memory.closed
+        restarted = web.Application()
+        restarted.router.add_route("*", "/{tail:.*}", local_server.handler)
+        local_server.install_reply_task_lifecycle(restarted)
+        async with TestClient(TestServer(restarted, access_log=None)):
+            pass
+        failure = DeferredConversationMemoryAdapter(Mem0Config(enabled=True, data_root=tmp_path), lambda: UnavailableConversationMemoryPort("MEM0_IMPORT_FAILED"))
+        assert memory.reconfigure_from(failure) and memory.start_initialization()
+        await asyncio.sleep(0.05)
+        failure_reason = memory.status().reason_code
+        assert memory.reconfigure_from(DeferredConversationMemoryAdapter(Mem0Config(enabled=True, data_root=tmp_path), ReadyMemory)) and memory.start_initialization()
+        await asyncio.sleep(0.05)
+        recovered = memory.status().status
+        memory.close()
+        return health, health_elapsed, generated_before_ready, generated_before_runtime_retry, generated_during_runtime_failure, imported_payload, retry_payload, closed_after_first, failure_reason, recovered
+
+    try:
+        result, elapsed, generated_before_ready, generated_before_retry, generated_during_runtime_failure, imported, retry, closed_after_first, failure_reason, recovered = asyncio.run(exercise())
+        assert elapsed < 1
+        assert result["data"]["status"] == "HEALTHY"
+        assert result["data"]["providers"]["memory"]["conversation"]["reason_code"] == "MEM0_INITIALIZING"
+        assert generated_before_ready == 0
+        assert generated_before_retry == 0
+        assert generated_during_runtime_failure == 1
+        assert generated == ["synthetic letter", "letter during runtime failure"]
+        assert history_calls == [] and imported["message"] == "OFFICIAL_HISTORY_MEMORY_UNAVAILABLE"
+        assert runtime_starts == [1, 1, 1]
+        assert retry["data"]["status"] == "AVAILABLE"
+        assert closed_after_first and memory.closed and local_server._start_ready_conversation_memory_runtime() is None
+        assert failure_reason == "MEM0_IMPORT_FAILED" and recovered == "available"
+        assert factory_calls == ["old", "latest"]
+    finally:
+        release.set()
+
+
+@pytest.mark.parametrize(
+    ("adapter_state", "runtime_state", "expected"),
+    [("available", "degraded", ("DEGRADED", True)), ("disabled", None, ("DISABLED", False))],
+)
+def test_memory_retry_reports_runtime_degradation_and_disabled_state(monkeypatch: pytest.MonkeyPatch, adapter_state: str, runtime_state: str | None, expected: tuple[str, bool]) -> None:
+    import local_server
+    from conversation_memory_port import ConversationMemoryStatus
+    from conversation_memory_runtime import ConversationMemoryRuntimeStatus
+    class Adapter:
+        def status(self):
+            return ConversationMemoryStatus(adapter_state, adapter_state != "disabled", "mem0" if adapter_state != "disabled" else "none", "qdrant-local" if adapter_state != "disabled" else "none")
+    monkeypatch.setattr(local_server, "conversation_memory_adapter", Adapter())
+    monkeypatch.setattr(local_server, "_start_conversation_memory_initialization", lambda _loop: False)
+    monkeypatch.setattr(local_server, "_start_ready_conversation_memory_runtime", lambda: None if runtime_state is None else ConversationMemoryRuntimeStatus(runtime_state, True, "mem0-outbox", False))
+    result = asyncio.run(local_server.route("POST", "/toy/companion/memory/retry", {}, {}, companion_confirmed=True))
+    assert (result["data"]["status"], result["data"]["retryable"]) == expected
+
+
 def test_invalid_health_profile_is_a_stable_client_error() -> None:
     import local_server
 

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -128,9 +128,31 @@ def test_mem0_runtime_download_explains_temporarily_flat_progress() -> None:
     ) in BOOTSTRAP_JAVASCRIPT
 
 
+def test_memory_initialization_poll_recovers_and_stops_when_detached() -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is not installed")
+    harness = r'''
+const fs = require("fs");
+const source = fs.readFileSync(0, "utf8");
+const body = source.split("  const scheduleMemoryStatusRefresh =")[1].split("\n\n  const renderMemoryPanel =")[0];
+let timers = new Map(), nextId = 0, attempts = 0;
+const window = { clearTimeout: (id) => timers.delete(id), setTimeout: (fn) => (timers.set(++nextId, fn), nextId) };
+const requestJson = async () => { if (++attempts === 1) throw new Error("transient"); return { capabilities: { memory: {} } }; };
+const renderMemoryPanel = async () => {}; const STATUS_PATH = "/status";
+eval("var scheduleMemoryStatusRefresh =" + body);
+const panel = { isConnected: true };
+const run = async () => { const [id, fn] = timers.entries().next().value; timers.delete(id); await fn(); };
+(async () => { scheduleMemoryStatusRefresh(panel); await run(); const failed = timers.size; await run(); const recovered = timers.size; scheduleMemoryStatusRefresh(panel); panel.isConnected = false; await run(); process.stdout.write(JSON.stringify({ failed, recovered, detached: timers.size })); })().catch((error) => { console.error(error.stack); process.exitCode = 1; });
+'''
+    result = subprocess.run([node, "-e", harness], input=BOOTSTRAP_JAVASCRIPT.encode(), capture_output=True, timeout=20)
+    assert result.returncode == 0, result.stderr.decode(errors="replace")
+    assert json.loads(result.stdout) == {"failed": 1, "recovered": 0, "detached": 0}
+
+
 # The shipped CEF surface needs explicit no-drag/pointer and display-state guards.
 def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
-    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v12"
+    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v13"
     for declaration in (
             'const STATUS_PATH = "/toy/companion/status";',
             'const MEMORY_PATH = "/toy/companion/memory";',
@@ -139,6 +161,7 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
         'const MEMORY_CLEAR_PATH = "/toy/companion/memory/clear";',
         'const MEMORY_PAUSE_PATH = "/toy/companion/memory/pause";',
         'const MEMORY_RESUME_PATH = "/toy/companion/memory/resume";',
+        'const MEMORY_RETRY_PATH = "/toy/companion/memory/retry";',
         'const CONFIRM_HEADER = "X-Olivia-Companion-Action";',
         'const CONFIRM_VALUE = "confirmed";',
     ):
@@ -154,6 +177,9 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
     assert 'const LETTER_COMPOSER_TITLE = "写下你的感受";' in BOOTSTRAP_JAVASCRIPT
     assert 'const LETTER_SUBMIT_LABEL = "寄出信件";' in BOOTSTRAP_JAVASCRIPT
     assert "Promise.allSettled" in BOOTSTRAP_JAVASCRIPT
+    assert "长期记忆正在准备，其他功能可正常使用" in BOOTSTRAP_JAVASCRIPT
+    assert "重新准备长期记忆" in BOOTSTRAP_JAVASCRIPT
+    assert '["INITIALIZING", "AVAILABLE"].includes(payload.status)' in BOOTSTRAP_JAVASCRIPT
     assert "window.confirm" not in BOOTSTRAP_JAVASCRIPT
     assert "const confirmAction = (message) => new Promise" in BOOTSTRAP_JAVASCRIPT
     assert 'confirmation.style.backgroundColor = "#18191c";' in BOOTSTRAP_JAVASCRIPT

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1857,7 +1857,7 @@ def test_install_isolated_copy_activates_original_client_surfaces(
         main = archive.read("assets/main-917d29fc.js").decode("utf-8")
     assert "assets/olivia-companion-settings.js" in names
     assert "data-olivia-companion-settings" in index
-    assert "data-ui-version=\"p03.original-settings-manage.v12\"" in index
+    assert "data-ui-version=\"p03.original-settings-manage.v13\"" in index
     assert (installed / "local_backend" / "original_client_setup_api.py").is_file()
     assert (installed / "local_backend" / "original_client_capability_api.py").is_file()
     assert (installed / "local_backend" / "original_client_update_api.py").is_file()


### PR DESCRIPTION
## 结果
- Mem0/BGE 初始化移出应用启动关键路径；核心服务先就绪，长期记忆在后台准备。
- 记忆未就绪时信件保持 PENDING；可用后每封信只派发一次，不要求退出重进。
- 设置页持续显示准备状态；瞬时轮询失败会有界重试，手动重试成功后立即刷新。
- 运行时重新配置只保留一个初始化线程，旧轮结束后串行应用最新配置，避免并发加载两套模型。
- 官方信件导入在记忆未就绪时继续严格阻止 collector/archive 副作用。

## 冻结证据
- Base: 0709a1d53543c7a582008480531f2f4c59c60d1e
- Head: ae2ec66abc8ae54de7f3f6bee29f34ed70d48e40
- Exact binary diff hash: 0f9d8a5f629bbc4769da2d09eb3de263b1d7e3da
- Scope: 10 files, +489/-10

## 验证
- Focused tests: 78 passed, 1 deselected
- Changed Python compileall: PASS
- git diff --check: PASS
- Standards: PASS, P0/P1/P2=0
- Spec: PASS, P0/P1/P2=0

## 边界
只改长期记忆启动时序、实时状态门控、自动恢复、设置页状态与对应契约/测试；不修改 Persona、PrivateWorld 亲密度算法、Live 或媒体路由。第三方机器冷启动与真实 Mem0 初始化由最终安装包验收。