### PR TITLE
fix(import): allow large official histories to finish

### DIFF
--- a/docs/B04_LOCAL_MEMORY.md
+++ b/docs/B04_LOCAL_MEMORY.md
@@ -35,6 +35,8 @@ Mem0 完成后，PrivateWorld 以完整、规范排序的 `source_record_id` 集
 
 官方历史导入期间可通过同一路径的 `GET` 请求读取进度；字段与状态见 `contracts/official_history_import_progress.schema.json`。进程启动后若同时存在内存引导记录和 SQLite 只读归档，信箱会按 `source_record_id`（缺失时按 `letter_id`）合并去重，不会让一侧遮蔽另一侧。若 PrivateWorld 已提交而后续只读归档失败，重试会命中同一命令审计并跳过 provider，再继续归档；已有关系只吸收两个亲密轴的更高历史下限，不会被历史导入降级或改写其他状态。
 
+设置页不会给官方历史导入 POST 设置固定总时限；大量信件仍按上述逐封边界处理，并以同路径 GET 进度和各 provider 自身的单次超时判断是否卡住，避免总耗时随信件数增长时被客户端提前中止。
+
 ## 健康检查与验证
 
 `/health?profile=memory` 只返回状态、域计数、FTS5/vector 配置边界和 `network_called=false`，不返回数据根、正文或密钥；memory 不可用不会让 core health 变成假成功或假失败。

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -322,11 +322,11 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     const endpoint = new URL(path, apiBase);
     const controller = new AbortController();
     const timeoutMs = path === OFFICIAL_LETTER_IMPORT_PATH
-      ? 600000
+      ? null
       : path === VIDEO_REPLY_SETTINGS_PATH
       ? 300000
       : 8000;
-    const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
+    const timeout = timeoutMs === null ? null : window.setTimeout(() => controller.abort(), timeoutMs);
     try {
       const response = await fetch(endpoint, {
         method: "POST",
@@ -364,7 +364,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       }
       return payload;
     } finally {
-      window.clearTimeout(timeout);
+      if (timeout !== null) window.clearTimeout(timeout);
     }
   };
 

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -240,7 +240,8 @@ def test_original_settings_can_import_official_text_reply_history() -> None:
     assert "双方内容会形成长期语义记忆" in BOOTSTRAP_JAVASCRIPT
     assert "历史往来会初始化关系状态" in BOOTSTRAP_JAVASCRIPT
     assert "requestMutation(OFFICIAL_LETTER_IMPORT_PATH, {})" in BOOTSTRAP_JAVASCRIPT
-    assert "path === OFFICIAL_LETTER_IMPORT_PATH\n      ? 600000" in BOOTSTRAP_JAVASCRIPT
+    assert "path === OFFICIAL_LETTER_IMPORT_PATH\n      ? null" in BOOTSTRAP_JAVASCRIPT
+    assert "timeoutMs === null ? null" in BOOTSTRAP_JAVASCRIPT
     assert ": 8000;" in BOOTSTRAP_JAVASCRIPT
     assert "payload.inserted" in BOOTSTRAP_JAVASCRIPT
     assert "payload.memory_migration" in BOOTSTRAP_JAVASCRIPT


### PR DESCRIPTION
## Problem\n\nLarge official-history imports scale with the number of detail fetches and Mem0 writes, but the injected Settings client aborted the whole POST after a fixed 600 seconds. At 500 letters that budget permits only 1.2 seconds per detail-plus-memory pair before the client reports failure.\n\n## Change\n\n- remove only the fixed total deadline for the official-history import POST\n- keep per-provider timeouts, GET progress polling, and the 20-second stalled-progress notice\n- retain the existing 8-second and 300-second deadlines for other mutations\n\n## Focused verification\n\n- RED: focused official-import Settings test failed while the 600000ms deadline remained\n- GREEN: python -m pytest -q --tb=short tests/installer/test_original_client_settings_ui.py tests/installer/test_original_settings_javascript.py tests/installer/test_patch_companion_settings.py -> 55 passed\n- python -m py_compile original_client_settings_ui.py\n- git diff --check\n- frozen Standards review: PASS, P0=0/P1=0\n- frozen Spec review: PASS, P0=0/P1=0\n\n## Boundaries\n\nAll fixtures and measurements are synthetic. No private letter content, credentials, paths, or provider bodies were logged or committed. This does not claim real-account, real-provider, or large-history acceptance. It does not change Live, media, installer lifecycle, voice branches, Persona semantics, server transactions, or provider per-call timeouts.\n\nRollback: revert commit d54ebc294149be31f547ee0108e19dd4f588c556.