### PR TITLE
fix(media): terminate complete renderer process trees

### DIFF
--- a/runtime/media/managed_subprocess.py
+++ b/runtime/media/managed_subprocess.py
@@ -107,15 +107,19 @@ def _create_windows_job():
     return WindowsJob()
 
 
-def _bounded_communicate(
-    process: subprocess.Popen[bytes], original: subprocess.TimeoutExpired
-) -> tuple[bytes, bytes]:
-    try:
-        return process.communicate(timeout=_TREE_SHUTDOWN_TIMEOUT_SECONDS)
-    except subprocess.TimeoutExpired as exc:
-        exc.output = exc.output or original.output or b""
-        exc.stderr = exc.stderr or original.stderr or b""
-        raise OSError("PROCESS_TREE_TERMINATION_FAILED") from exc
+def _report_cleanup_failures(
+    active_error: BaseException | None,
+    failures: list[tuple[str, BaseException]],
+) -> None:
+    if not failures:
+        return
+    message = "PROCESS_TREE_CLEANUP_FAILED: " + ", ".join(
+        stage for stage, _error in failures
+    )
+    if active_error is not None:
+        active_error.add_note(message)
+        return
+    raise OSError(message) from failures[0][1]
 
 
 def run_managed_process(
@@ -138,42 +142,68 @@ def run_managed_process(
         )
     else:
         kwargs["start_new_session"] = True
+    process: subprocess.Popen[bytes] | None = None
+    assigned = False
     try:
         process = subprocess.Popen(arguments, **kwargs)
         if job is not None:
-            assigned = False
             try:
                 job.assign(process)
                 assigned = True
                 job.resume(process)
             except OSError:
-                job.terminate() if assigned else process.kill()
-                process.communicate(timeout=_TREE_SHUTDOWN_TIMEOUT_SECONDS)
+                if not assigned:
+                    process.kill()
+                    process.communicate(timeout=_TREE_SHUTDOWN_TIMEOUT_SECONDS)
                 raise
         try:
             stdout, stderr = process.communicate(timeout=timeout_seconds)
-        except subprocess.TimeoutExpired as exc:
-            if job is not None:
-                job.terminate()
-            else:
-                try:
-                    os.killpg(process.pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass
-            stdout, stderr = _bounded_communicate(process, exc)
-            exc.output, exc.stderr = stdout, stderr
+        except subprocess.TimeoutExpired:
             raise
         return subprocess.CompletedProcess(
             arguments, int(process.returncode or 0), stdout, stderr
         )
     finally:
-        active_error = sys.exc_info()[0]
+        active_error = sys.exc_info()[1]
         if job is not None:
+            failures: list[tuple[str, BaseException]] = []
+            if assigned and process is not None:
+                try:
+                    job.terminate()
+                except OSError as exc:
+                    failures.append(("terminate", exc))
+                try:
+                    reaped_stdout, reaped_stderr = process.communicate(
+                        timeout=_TREE_SHUTDOWN_TIMEOUT_SECONDS
+                    )
+                    if isinstance(active_error, subprocess.TimeoutExpired):
+                        active_error.output = reaped_stdout or active_error.output
+                        active_error.stderr = reaped_stderr or active_error.stderr
+                except (OSError, subprocess.TimeoutExpired) as exc:
+                    failures.append(("reap", exc))
             try:
                 job.close()
-            except OSError:
-                if active_error is None:
-                    raise
+            except OSError as exc:
+                failures.append(("close", exc))
+            _report_cleanup_failures(active_error, failures)
+        elif process is not None:
+            failures = []
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            except OSError as exc:
+                failures.append(("killpg", exc))
+            try:
+                reaped_stdout, reaped_stderr = process.communicate(
+                    timeout=_TREE_SHUTDOWN_TIMEOUT_SECONDS
+                )
+                if isinstance(active_error, subprocess.TimeoutExpired):
+                    active_error.output = reaped_stdout or active_error.output
+                    active_error.stderr = reaped_stderr or active_error.stderr
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                failures.append(("reap", exc))
+            _report_cleanup_failures(active_error, failures)
 
 
 __all__ = ["run_managed_process"]

--- a/runtime/media/managed_subprocess.py
+++ b/runtime/media/managed_subprocess.py
@@ -1,0 +1,179 @@
+"""Bounded external media processes with whole-tree cleanup."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+_TREE_SHUTDOWN_TIMEOUT_SECONDS = 15.0
+
+
+def _create_windows_job():
+    """Create a kill-on-close Job Object before the worker is launched."""
+
+    import ctypes
+    from ctypes import wintypes
+
+    class BasicLimits(ctypes.Structure):
+        _fields_ = [
+            ("per_process_time", ctypes.c_longlong),
+            ("per_job_time", ctypes.c_longlong),
+            ("flags", wintypes.DWORD),
+            ("min_working_set", ctypes.c_size_t),
+            ("max_working_set", ctypes.c_size_t),
+            ("active_process_limit", wintypes.DWORD),
+            ("affinity", ctypes.c_size_t),
+            ("priority_class", wintypes.DWORD),
+            ("scheduling_class", wintypes.DWORD),
+        ]
+
+    class IoCounters(ctypes.Structure):
+        _fields_ = [
+            (name, ctypes.c_ulonglong)
+            for name in (
+                "read_operations", "write_operations", "other_operations",
+                "read_bytes", "write_bytes", "other_bytes",
+            )
+        ]
+
+    class ExtendedLimits(ctypes.Structure):
+        _fields_ = [
+            ("basic", BasicLimits), ("io", IoCounters),
+            ("process_memory", ctypes.c_size_t), ("job_memory", ctypes.c_size_t),
+            ("peak_process_memory", ctypes.c_size_t),
+            ("peak_job_memory", ctypes.c_size_t),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    kernel32.SetInformationJobObject.argtypes = (
+        wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD,
+    )
+    kernel32.AssignProcessToJobObject.argtypes = (wintypes.HANDLE, wintypes.HANDLE)
+    kernel32.TerminateJobObject.argtypes = (wintypes.HANDLE, wintypes.UINT)
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    for function in (
+        kernel32.SetInformationJobObject,
+        kernel32.AssignProcessToJobObject,
+        kernel32.TerminateJobObject,
+        kernel32.CloseHandle,
+    ):
+        function.restype = wintypes.BOOL
+    ntdll = ctypes.WinDLL("ntdll")
+    ntdll.NtResumeProcess.argtypes = (wintypes.HANDLE,)
+    ntdll.NtResumeProcess.restype = wintypes.LONG
+
+    handle = kernel32.CreateJobObjectW(None, None)
+    if not handle:
+        raise ctypes.WinError(ctypes.get_last_error())
+    limits = ExtendedLimits()
+    limits.basic.flags = 0x00002000  # JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    if not kernel32.SetInformationJobObject(
+        handle, 9, ctypes.byref(limits), ctypes.sizeof(limits)
+    ):
+        error = ctypes.WinError(ctypes.get_last_error())
+        kernel32.CloseHandle(handle)
+        raise error
+
+    class WindowsJob:
+        def __init__(self) -> None:
+            self.handle = handle
+
+        def assign(self, process: subprocess.Popen[bytes]) -> None:
+            process_handle = getattr(process, "_handle", None)
+            if process_handle is None or not kernel32.AssignProcessToJobObject(
+                self.handle, process_handle
+            ):
+                raise ctypes.WinError(ctypes.get_last_error())
+
+        def resume(self, process: subprocess.Popen[bytes]) -> None:
+            if ntdll.NtResumeProcess(getattr(process, "_handle", None)) != 0:
+                raise OSError("PROCESS_RESUME_FAILED")
+
+        def terminate(self) -> None:
+            if not kernel32.TerminateJobObject(self.handle, 1):
+                raise ctypes.WinError(ctypes.get_last_error())
+
+        def close(self) -> None:
+            if self.handle and not kernel32.CloseHandle(self.handle):
+                raise ctypes.WinError(ctypes.get_last_error())
+            self.handle = None
+
+    return WindowsJob()
+
+
+def _bounded_communicate(
+    process: subprocess.Popen[bytes], original: subprocess.TimeoutExpired
+) -> tuple[bytes, bytes]:
+    try:
+        return process.communicate(timeout=_TREE_SHUTDOWN_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as exc:
+        exc.output = exc.output or original.output or b""
+        exc.stderr = exc.stderr or original.stderr or b""
+        raise OSError("PROCESS_TREE_TERMINATION_FAILED") from exc
+
+
+def run_managed_process(
+    command: Sequence[str], *, timeout_seconds: float,
+    cwd: Path | None = None, env: Mapping[str, str] | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    """Run one worker; Windows descendants are owned before they can execute."""
+
+    arguments = [str(value) for value in command]
+    kwargs: dict[str, object] = {
+        "cwd": cwd, "env": None if env is None else dict(env),
+        "stdout": subprocess.PIPE, "stderr": subprocess.PIPE,
+    }
+    job = _create_windows_job() if os.name == "nt" else None
+    if job is not None:
+        kwargs["creationflags"] = (
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+            | getattr(subprocess, "CREATE_SUSPENDED", 0x00000004)
+        )
+    else:
+        kwargs["start_new_session"] = True
+    try:
+        process = subprocess.Popen(arguments, **kwargs)
+        if job is not None:
+            assigned = False
+            try:
+                job.assign(process)
+                assigned = True
+                job.resume(process)
+            except OSError:
+                job.terminate() if assigned else process.kill()
+                process.communicate(timeout=_TREE_SHUTDOWN_TIMEOUT_SECONDS)
+                raise
+        try:
+            stdout, stderr = process.communicate(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired as exc:
+            if job is not None:
+                job.terminate()
+            else:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+            stdout, stderr = _bounded_communicate(process, exc)
+            exc.output, exc.stderr = stdout, stderr
+            raise
+        return subprocess.CompletedProcess(
+            arguments, int(process.returncode or 0), stdout, stderr
+        )
+    finally:
+        active_error = sys.exc_info()[0]
+        if job is not None:
+            try:
+                job.close()
+            except OSError:
+                if active_error is None:
+                    raise
+
+
+__all__ = ["run_managed_process"]

--- a/runtime/media/managed_subprocess.py
+++ b/runtime/media/managed_subprocess.py
@@ -35,18 +35,15 @@ def _create_windows_job():
     class IoCounters(ctypes.Structure):
         _fields_ = [
             (name, ctypes.c_ulonglong)
-            for name in (
-                "read_operations", "write_operations", "other_operations",
-                "read_bytes", "write_bytes", "other_bytes",
-            )
+            for name in ("read_operations", "write_operations", "other_operations",
+                         "read_bytes", "write_bytes", "other_bytes")
         ]
 
     class ExtendedLimits(ctypes.Structure):
         _fields_ = [
             ("basic", BasicLimits), ("io", IoCounters),
             ("process_memory", ctypes.c_size_t), ("job_memory", ctypes.c_size_t),
-            ("peak_process_memory", ctypes.c_size_t),
-            ("peak_job_memory", ctypes.c_size_t),
+            ("peak_process_memory", ctypes.c_size_t), ("peak_job_memory", ctypes.c_size_t),
         ]
 
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
@@ -58,10 +55,8 @@ def _create_windows_job():
     kernel32.TerminateJobObject.argtypes = (wintypes.HANDLE, wintypes.UINT)
     kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
     for function in (
-        kernel32.SetInformationJobObject,
-        kernel32.AssignProcessToJobObject,
-        kernel32.TerminateJobObject,
-        kernel32.CloseHandle,
+        kernel32.SetInformationJobObject, kernel32.AssignProcessToJobObject,
+        kernel32.TerminateJobObject, kernel32.CloseHandle,
     ):
         function.restype = wintypes.BOOL
     ntdll = ctypes.WinDLL("ntdll")
@@ -144,6 +139,7 @@ def run_managed_process(
         kwargs["start_new_session"] = True
     process: subprocess.Popen[bytes] | None = None
     assigned = False
+    failures: list[tuple[str, BaseException]] = []
     try:
         process = subprocess.Popen(arguments, **kwargs)
         if job is not None:
@@ -153,8 +149,14 @@ def run_managed_process(
                 job.resume(process)
             except OSError:
                 if not assigned:
-                    process.kill()
-                    process.communicate(timeout=_TREE_SHUTDOWN_TIMEOUT_SECONDS)
+                    try:
+                        process.kill()
+                    except OSError as exc:
+                        failures.append(("kill", exc))
+                    try:
+                        process.communicate(timeout=_TREE_SHUTDOWN_TIMEOUT_SECONDS)
+                    except (OSError, subprocess.TimeoutExpired) as exc:
+                        failures.append(("reap", exc))
                 raise
         try:
             stdout, stderr = process.communicate(timeout=timeout_seconds)
@@ -166,7 +168,6 @@ def run_managed_process(
     finally:
         active_error = sys.exc_info()[1]
         if job is not None:
-            failures: list[tuple[str, BaseException]] = []
             if assigned and process is not None:
                 try:
                     job.terminate()

--- a/tests/media/test_managed_subprocess.py
+++ b/tests/media/test_managed_subprocess.py
@@ -91,24 +91,32 @@ def test_windows_job_creation_failure_does_not_launch(monkeypatch) -> None:
     assert not launched
 
 
-def test_windows_assign_failure_kills_suspended_parent_before_resume(monkeypatch) -> None:
+def test_windows_assign_failure_survives_cleanup_failures(monkeypatch) -> None:
     observed: list[str] = []
+    timeout_error = subprocess.TimeoutExpired(["worker"], 15.0)
     process = SimpleNamespace(
-        kill=lambda: observed.append("kill"),
-        communicate=lambda timeout: (observed.append(f"wait:{timeout}") or (b"", b"")),
+        kill=lambda: (observed.append("kill") or (_ for _ in ()).throw(OSError("kill"))),
+        communicate=lambda timeout: (
+            observed.append(f"wait:{timeout}") or (_ for _ in ()).throw(timeout_error)
+        ),
     )
     job = SimpleNamespace(
         assign=lambda _process: (_ for _ in ()).throw(OSError("assign")),
         resume=lambda _process: observed.append("resume"),
         terminate=lambda: observed.append("terminate"),
-        close=lambda: observed.append("close"),
+        close=lambda: (
+            observed.append("close") or (_ for _ in ()).throw(OSError("close"))
+        ),
     )
     monkeypatch.setattr(managed_subprocess.os, "name", "nt")
     monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
     monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
-    with pytest.raises(OSError, match="assign"):
+    with pytest.raises(OSError, match="assign") as caught:
         managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
     assert observed == ["kill", "wait:15.0", "close"]
+    assert caught.value.__notes__ == [
+        "PROCESS_TREE_CLEANUP_FAILED: kill, reap, close",
+    ]
 
 
 def test_windows_resume_failure_terminates_assigned_job_once(monkeypatch) -> None:

--- a/tests/media/test_managed_subprocess.py
+++ b/tests/media/test_managed_subprocess.py
@@ -4,11 +4,40 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import time
 from types import SimpleNamespace
 
 import pytest
 
 from runtime.media import managed_subprocess
+
+
+def test_windows_success_terminates_assigned_job_before_close(monkeypatch) -> None:
+    events: list[str] = []
+
+    class Process:
+        pid, returncode = 4242, 0
+
+        def communicate(self, timeout=None):
+            events.append(f"reap:{timeout}")
+            return b"out", b"err"
+
+    job = SimpleNamespace(
+        assign=lambda _process: events.append("assign"),
+        resume=lambda _process: events.append("resume"),
+        terminate=lambda: events.append("terminate"),
+        close=lambda: events.append("close"),
+    )
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: Process())
+
+    result = managed_subprocess.run_managed_process(["worker"], timeout_seconds=12)
+
+    assert result.stdout == b"out"
+    assert events == [
+        "assign", "resume", "reap:12", "terminate", "reap:15.0", "close",
+    ]
 
 
 def test_windows_timeout_owns_and_terminates_suspended_worker(monkeypatch) -> None:
@@ -82,36 +111,171 @@ def test_windows_assign_failure_kills_suspended_parent_before_resume(monkeypatch
     assert observed == ["kill", "wait:15.0", "close"]
 
 
-def test_windows_job_close_failure_is_reported(monkeypatch) -> None:
-    job = SimpleNamespace(
-        assign=lambda _process: None, resume=lambda _process: None,
-        terminate=lambda: None,
-        close=lambda: (_ for _ in ()).throw(OSError("close")),
+def test_windows_resume_failure_terminates_assigned_job_once(monkeypatch) -> None:
+    observed: list[str] = []
+    process = SimpleNamespace(
+        communicate=lambda timeout: (observed.append(f"reap:{timeout}") or (b"", b"")),
     )
-    process = SimpleNamespace(returncode=0, communicate=lambda timeout: (b"", b""))
+    job = SimpleNamespace(
+        assign=lambda _process: observed.append("assign"),
+        resume=lambda _process: (_ for _ in ()).throw(OSError("resume")),
+        terminate=lambda: observed.append("terminate"),
+        close=lambda: observed.append("close"),
+    )
     monkeypatch.setattr(managed_subprocess.os, "name", "nt")
     monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
     monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
-    with pytest.raises(OSError, match="close"):
+
+    with pytest.raises(OSError, match="resume"):
         managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
+
+    assert observed == ["assign", "terminate", "reap:15.0", "close"]
+
+
+def test_windows_cleanup_failures_do_not_swallow_resume_error(monkeypatch) -> None:
+    process = SimpleNamespace(
+        communicate=lambda timeout: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(["worker"], timeout)
+        ),
+    )
+    job = SimpleNamespace(
+        assign=lambda _process: None,
+        resume=lambda _process: (_ for _ in ()).throw(OSError("resume")),
+        terminate=lambda: (_ for _ in ()).throw(OSError("terminate")),
+        close=lambda: (_ for _ in ()).throw(OSError("close")),
+    )
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
+
+    with pytest.raises(OSError, match="resume") as caught:
+        managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
+
+    assert caught.value.__notes__ == [
+        "PROCESS_TREE_CLEANUP_FAILED: terminate, reap, close",
+    ]
+
+
+def test_windows_job_close_failure_is_reported(monkeypatch) -> None:
+    observed: list[str] = []
+    job = SimpleNamespace(
+        assign=lambda _process: None, resume=lambda _process: None,
+        terminate=lambda: observed.append("terminate"),
+        close=lambda: (_ for _ in ()).throw(OSError("close")),
+    )
+    process = SimpleNamespace(
+        returncode=0,
+        communicate=lambda timeout: (observed.append(f"reap:{timeout}") or (b"", b"")),
+    )
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
+    with pytest.raises(OSError, match="PROCESS_TREE_CLEANUP_FAILED: close"):
+        managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
+    assert observed == ["reap:1", "terminate", "reap:15.0"]
+
+
+def test_windows_terminate_failure_still_closes_and_is_explicit(monkeypatch) -> None:
+    observed: list[str] = []
+    process = SimpleNamespace(
+        returncode=0, communicate=lambda timeout: (b"", b""),
+    )
+    job = SimpleNamespace(
+        assign=lambda _process: None, resume=lambda _process: None,
+        terminate=lambda: (_ for _ in ()).throw(OSError("terminate")),
+        close=lambda: observed.append("close"),
+    )
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
+
+    with pytest.raises(OSError, match="PROCESS_TREE_CLEANUP_FAILED: terminate"):
+        managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
+
+    assert observed == ["close"]
+
+
+def test_posix_success_terminates_process_group_and_reaps(monkeypatch) -> None:
+    observed: list[str] = []
+
+    class Process:
+        pid, returncode = 4242, 0
+
+        def communicate(self, timeout=None):
+            observed.append(f"reap:{timeout}")
+            return b"out", b"err"
+
+    def popen(_command, **kwargs):
+        assert kwargs["start_new_session"] is True
+        return Process()
+
+    monkeypatch.setattr(managed_subprocess.os, "name", "posix")
+    monkeypatch.setattr(
+        managed_subprocess.os, "killpg",
+        lambda pid, sig: observed.append(f"kill:{pid}:{sig}"), raising=False,
+    )
+    monkeypatch.setattr(managed_subprocess.signal, "SIGKILL", 9, raising=False)
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", popen)
+
+    result = managed_subprocess.run_managed_process(["worker"], timeout_seconds=12)
+
+    assert result.stdout == b"out"
+    assert observed == [
+        "reap:12", f"kill:4242:{managed_subprocess.signal.SIGKILL}", "reap:15.0",
+    ]
+
+
+def test_posix_cleanup_failures_do_not_swallow_timeout(monkeypatch) -> None:
+    process = SimpleNamespace(
+        pid=4242,
+        communicate=lambda timeout: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(["worker"], timeout)
+        ),
+    )
+    monkeypatch.setattr(managed_subprocess.os, "name", "posix")
+    monkeypatch.setattr(
+        managed_subprocess.os, "killpg",
+        lambda _pid, _sig: (_ for _ in ()).throw(OSError("killpg")), raising=False,
+    )
+    monkeypatch.setattr(managed_subprocess.signal, "SIGKILL", 9, raising=False)
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
+
+    with pytest.raises(subprocess.TimeoutExpired) as caught:
+        managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
+
+    assert caught.value.__notes__ == [
+        "PROCESS_TREE_CLEANUP_FAILED: killpg, reap",
+    ]
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows Job Object contract")
-def test_real_windows_timeout_terminates_worker_and_child(tmp_path: Path) -> None:
+@pytest.mark.parametrize(("parent_sleep", "times_out"), [(30, True), (0, False)])
+def test_real_windows_terminates_worker_tree(
+    tmp_path: Path, parent_sleep: int, times_out: bool,
+) -> None:
     pid_file = tmp_path / "worker-pids.txt"
     script = (
         "import os,pathlib,subprocess,sys,time;"
-        "child=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)']);"
+        "child=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)'],"
+        "stdin=subprocess.DEVNULL,stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL);"
         "pathlib.Path(sys.argv[1]).write_text(f'{os.getpid()},{child.pid}');"
-        "time.sleep(30)"
+        "time.sleep(float(sys.argv[2]))"
     )
-    with pytest.raises(subprocess.TimeoutExpired):
-        managed_subprocess.run_managed_process(
-            [sys.executable, "-c", script, str(pid_file)], timeout_seconds=2,
-        )
+    command = [sys.executable, "-c", script, str(pid_file), str(parent_sleep)]
+    if times_out:
+        with pytest.raises(subprocess.TimeoutExpired):
+            managed_subprocess.run_managed_process(command, timeout_seconds=2)
+    else:
+        assert managed_subprocess.run_managed_process(command, timeout_seconds=2).returncode == 0
     for pid in (int(value) for value in pid_file.read_text().split(",")):
-        result = subprocess.run(
-            ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
-            capture_output=True, text=True, timeout=5, check=False,
-        )
+        deadline = time.monotonic() + 5
+        while True:
+            result = subprocess.run(
+                ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
+                capture_output=True, text=True, timeout=5, check=False,
+            )
+            assert result.returncode == 0
+            if str(pid) not in result.stdout or time.monotonic() >= deadline:
+                break
+            time.sleep(0.1)
         assert str(pid) not in result.stdout

--- a/tests/media/test_managed_subprocess.py
+++ b/tests/media/test_managed_subprocess.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from runtime.media import managed_subprocess
+
+
+def test_windows_timeout_owns_and_terminates_suspended_worker(monkeypatch) -> None:
+    observed: dict[str, object] = {"timeouts": []}
+
+    class Process:
+        pid, returncode = 4242, None
+
+        def communicate(self, timeout=None):
+            observed["timeouts"].append(timeout)
+            if len(observed["timeouts"]) == 1:
+                raise subprocess.TimeoutExpired(["worker"], timeout, stderr=b"busy")
+            return b"", b"stopped"
+
+    class Job:
+        def assign(self, process): observed["assigned"] = process.pid
+        def resume(self, process): observed["resumed"] = process.pid
+        def terminate(self): observed["terminated"] = True
+        def close(self): observed["closed"] = True
+
+    def popen(_command, **kwargs):
+        observed["kwargs"] = kwargs
+        return Process()
+
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess, "_create_windows_job", Job)
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", popen)
+    with pytest.raises(subprocess.TimeoutExpired):
+        managed_subprocess.run_managed_process(["worker"], timeout_seconds=12)
+    flags = observed["kwargs"]["creationflags"]
+    assert flags & subprocess.CREATE_NEW_PROCESS_GROUP and flags & subprocess.CREATE_NO_WINDOW
+    assert flags & getattr(subprocess, "CREATE_SUSPENDED", 4)
+    assert (observed["assigned"], observed["resumed"]) == (4242, 4242)
+    assert observed["terminated"] is True and observed["closed"] is True
+    assert observed["timeouts"] == [12, 15.0]
+
+
+def test_windows_job_creation_failure_does_not_launch(monkeypatch) -> None:
+    launched: list[bool] = []
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(
+        managed_subprocess, "_create_windows_job",
+        lambda: (_ for _ in ()).throw(OSError("job")),
+    )
+    monkeypatch.setattr(
+        managed_subprocess.subprocess, "Popen",
+        lambda *_args, **_kwargs: launched.append(True),
+    )
+    with pytest.raises(OSError, match="job"):
+        managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
+    assert not launched
+
+
+def test_windows_assign_failure_kills_suspended_parent_before_resume(monkeypatch) -> None:
+    observed: list[str] = []
+    process = SimpleNamespace(
+        kill=lambda: observed.append("kill"),
+        communicate=lambda timeout: (observed.append(f"wait:{timeout}") or (b"", b"")),
+    )
+    job = SimpleNamespace(
+        assign=lambda _process: (_ for _ in ()).throw(OSError("assign")),
+        resume=lambda _process: observed.append("resume"),
+        terminate=lambda: observed.append("terminate"),
+        close=lambda: observed.append("close"),
+    )
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
+    with pytest.raises(OSError, match="assign"):
+        managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
+    assert observed == ["kill", "wait:15.0", "close"]
+
+
+def test_windows_job_close_failure_is_reported(monkeypatch) -> None:
+    job = SimpleNamespace(
+        assign=lambda _process: None, resume=lambda _process: None,
+        terminate=lambda: None,
+        close=lambda: (_ for _ in ()).throw(OSError("close")),
+    )
+    process = SimpleNamespace(returncode=0, communicate=lambda timeout: (b"", b""))
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
+    with pytest.raises(OSError, match="close"):
+        managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows Job Object contract")
+def test_real_windows_timeout_terminates_worker_and_child(tmp_path: Path) -> None:
+    pid_file = tmp_path / "worker-pids.txt"
+    script = (
+        "import os,pathlib,subprocess,sys,time;"
+        "child=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)']);"
+        "pathlib.Path(sys.argv[1]).write_text(f'{os.getpid()},{child.pid}');"
+        "time.sleep(30)"
+    )
+    with pytest.raises(subprocess.TimeoutExpired):
+        managed_subprocess.run_managed_process(
+            [sys.executable, "-c", script, str(pid_file)], timeout_seconds=2,
+        )
+    for pid in (int(value) for value in pid_file.read_text().split(",")):
+        result = subprocess.run(
+            ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+        assert str(pid) not in result.stdout


### PR DESCRIPTION
## Result

- add one managed subprocess primitive for Windows Job Objects and POSIX process groups
- terminate and reap complete renderer trees on timeout, normal parent exit, and setup failures
- preserve the active error while attaching bounded cleanup failures

## Verification

- focused tests: 12 passed
- py_compile: passed
- git diff --check: passed
- frozen Standards review: PASS, P0/P1/P2 = 0/0/0
- frozen Spec review: PASS, P0/P1/P2 = 0/0/0
- frozen base: 808893169b87a4884e5f1844b828c2a0b9f3d154
- frozen head: 4fec119d8aa466afe4ae9384c855c7beaa5cdab0

## Scope

2 files, 499 changed lines. This PR adds the shared process primitive and tests only; renderer call-site migrations remain separate.