### PR TITLE
feat(installer): build private Lin Li voice payloads

### DIFF
--- a/contracts/offline_core_assets.schema.json
+++ b/contracts/offline_core_assets.schema.json
@@ -5,6 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": ["schema_version", "python_runtime", "pip_bootstrap", "requirements_sha256", "wheels"],
+  "dependentRequired": {"voice_reference": ["distribution"], "distribution": ["voice_reference"]},
   "$defs": {
     "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "local_asset": {
@@ -44,6 +45,29 @@
       }
     },
     "requirements_sha256": {"$ref": "#/$defs/digest"},
+    "distribution": {"const": "private"},
+    "voice_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "size_bytes", "sha256", "wave"],
+      "properties": {
+        "path": {"const": "voice/olivia-reference.wav"},
+        "size_bytes": {"type": "integer", "minimum": 45},
+        "sha256": {"$ref": "#/$defs/digest"},
+        "wave": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["channels", "sample_width_bytes", "sample_rate_hz", "frame_count", "compression_type"],
+          "properties": {
+            "channels": {"type": "integer", "minimum": 1, "maximum": 8},
+            "sample_width_bytes": {"type": "integer", "minimum": 1, "maximum": 4},
+            "sample_rate_hz": {"type": "integer", "minimum": 8000, "maximum": 192000},
+            "frame_count": {"type": "integer", "minimum": 1},
+            "compression_type": {"const": "NONE"}
+          }
+        }
+      }
+    },
     "wheels": {
       "type": "array",
       "minItems": 14,

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -52,9 +52,9 @@ python installer/build_windows_setup.py `
 
 公开与私有构建的文件名仍为 `Olivia-Setup-x64.exe`，不能靠文件名判断边界。私有产物必须只保存在专用 `dist-private` 目录，以该目录和构建生成的 `.sha256` 作为交付识别记录，不得与公开 `dist` artifact 共置、替换或上传到公开 Release。解包审计时，内嵌 manifest 的 `"distribution": "private"` 是第二层识别标记，不代表取得了公开分发授权。
 
-构建器只复制 Git 已跟踪且相对 `HEAD` 未修改的发布文件，排除 `.github`、`docs`、测试和构建/CI 元数据，并在编译前复验离线 manifest、requirements 哈希、每个资产的大小与 SHA-256，以及实际资产集合。输出为 `Olivia-Setup-x64.exe` 和对应 `.sha256` 文件。
+除私有模式显式传入的 WAV 外，构建器只复制 Git 已跟踪且相对 `HEAD` 未修改的发布文件，排除 `.github`、`docs`、测试和构建/CI 元数据，并在编译前复验离线 manifest、requirements 哈希、每个资产的大小与 SHA-256，以及实际资产集合。输出为 `Olivia-Setup-x64.exe` 和对应 `.sha256` 文件。
 
-GitHub Actions 会在 PR 和 `main` 更新时生成同样的可下载 artifact。当前产物未做商业代码签名；正式面向普通用户发布前应增加受信任的 Authenticode 签名，但签名不替代随包 SHA-256 校验。
+GitHub Actions 只生成公开安装器 artifact；它会在 PR 和 `main` 更新时执行默认公开构建，不接受私有 WAV，也不会生成私有安装器。当前产物未做商业代码签名；正式面向普通用户发布前应增加受信任的 Authenticode 签名，但签名不替代随包 SHA-256 校验。
 
 ## 启动器健康检查
 

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -1,13 +1,13 @@
 # Windows 完整版补丁（隔离安装）
 
-本补丁只复制并修改用户自己的正版 Steam 文件副本，不写入正版目录，也不分发原版游戏、可选模型或媒体。`Olivia-Setup-x64.exe` 内含固定版本的核心 Python 运行时和依赖，使首次安装不依赖 Python.org、PyPI 或 Hugging Face。安装目标默认是 `%LOCALAPPDATA%\BSideOliviaLocal\install`，用户数据和未来外部缓存保留在同一产品目录的 `data` / `third-party` 下。
+公开补丁只复制并修改用户自己的正版 Steam 文件副本，不写入正版目录，也不分发原版游戏、可选模型或媒体；经授权单独构建的私有安装器会额外内嵌下文指定的林离参考 WAV。`Olivia-Setup-x64.exe` 内含固定版本的核心 Python 运行时和依赖，使首次安装不依赖 Python.org、PyPI 或 Hugging Face。安装目标默认是 `%LOCALAPPDATA%\BSideOliviaLocal\install`，用户数据和未来外部缓存保留在同一产品目录的 `data` / `third-party` 下。
 
 ## 使用
 
 1. 下载 `Olivia-Setup-x64.exe` 及同目录的 `.sha256` 文件，并先核对 SHA-256。
 2. 双击 EXE，选择产品目录和正版 Steam 游戏目录。安装器按当前用户运行，不要求管理员权限；它在产品目录内分别创建 `install` 与 `runtime`，从 EXE 内置的离线资产安装受管 Python 3.12 runtime 和固定 wheel，不联网下载。正版目录可留空并按 Steam AppID `4532590` 自动发现。
 3. 安装成功后可从开始菜单的“Olivia 本地版”快捷方式启动；安装时勾选“创建桌面快捷方式”后也可从桌面启动。两个快捷方式都由 `%WINDIR%\System32\wscript.exe //B //Nologo "<安装目录>\START.vbs"` 隐藏启动，不会显示可被误关的命令行窗口；工作目录固定为安装目录。点击后会立即显示“Olivia 正在启动，请稍候”的短暂提示，实际启动同时开始，不会等待提示关闭。只有隐藏启动器最终返回非零退出码时才显示中文失败对话框；正常关闭返回 `0` 时不会弹出错误。`START.cmd` 仍保留为兼容入口。它只启动一个监听 `127.0.0.1` 的本机服务，再直接启动隔离副本的 `0.0.9.627\Olivia.exe`，并使用安装目录下的独立 profile。
-4. 首次登录后在原版客户端内完成 LLM key 与按需能力设置；后续在 Settings 的“本地陪伴”中管理。`CONFIGURE.cmd` 仍可用于管理参考音频/视频。这些文件不进入补丁包。
+4. 首次登录后在原版客户端内完成 LLM key 与按需能力设置；后续在 Settings 的“本地陪伴”中管理。`CONFIGURE.cmd` 仍可用于管理参考音频/视频。公开安装器不包含参考音频；只有下文由维护者显式构建的私有安装器才会内嵌指定 WAV。
 5. 卸载双击 `UNINSTALL.cmd`。受控卸载只删除安装器自己写入的 `app`、`local_backend`、启动脚本和 marker，保留 `data`、`logs`、`third-party`。
 
 兼容旧流程：源码/调试场景仍可解压发布内容后双击 `INSTALL.cmd`。EXE 只是图形化外壳，最终仍调用同一份 `installer/Install.ps1`，不会形成第二套安装逻辑。安装阶段不填写 API key，也不会下载 Mem0、BGE 或其他可选模型。
@@ -35,6 +35,22 @@ python installer/build_windows_setup.py `
   --version 0.1.0 `
   --iscc 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
 ```
+
+上面的默认构建是公开产物：不得传入参考音频，内嵌 offline manifest 也不含 `distribution` 或 `voice_reference`。需要经授权在私有渠道交付固定参考音色时，维护者必须使用隔离输出目录并同时显式提供两个参数：
+
+```powershell
+python installer/build_windows_setup.py `
+  --offline offline `
+  --output dist-private `
+  --version 0.1.0 `
+  --distribution private `
+  --voice-reference '<私有 WAV 的本机路径>' `
+  --iscc 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
+```
+
+私有构建器只接受显式 WAV：它读取并核对实际 PCM 帧，随后把音频、大小、SHA-256 和 WAV 元数据写入内嵌 `offline/offline-core-assets.json`，其中 `distribution` 固定为 `private`。输入的 `offline` 目录不得预先夹带 `voice_reference` manifest 字段或音频文件；公开模式传入 `--voice-reference`、私有模式缺少该参数都会拒绝构建。
+
+公开与私有构建的文件名仍为 `Olivia-Setup-x64.exe`，不能靠文件名判断边界。私有产物必须只保存在专用 `dist-private` 目录，以该目录和构建生成的 `.sha256` 作为交付识别记录，不得与公开 `dist` artifact 共置、替换或上传到公开 Release。解包审计时，内嵌 manifest 的 `"distribution": "private"` 是第二层识别标记，不代表取得了公开分发授权。
 
 构建器只复制 Git 已跟踪且相对 `HEAD` 未修改的发布文件，排除 `.github`、`docs`、测试和构建/CI 元数据，并在编译前复验离线 manifest、requirements 哈希、每个资产的大小与 SHA-256，以及实际资产集合。输出为 `Olivia-Setup-x64.exe` 和对应 `.sha256` 文件。
 

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -11,11 +11,13 @@ import stat
 import subprocess
 import sys
 import uuid
+import wave
 from pathlib import Path, PurePosixPath
 
 
 MANIFEST_NAME = "offline-core-assets.json"
 SETUP_NAME = "Olivia-Setup-x64.exe"
+VOICE_REFERENCE_PATH = "voice/olivia-reference.wav"
 BUILD_CONTROL_FILES = {
     "installer/build_windows_setup.py",
     "installer/setup-build-requirements.txt",
@@ -165,6 +167,37 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _voice_reference_metadata(path: Path) -> dict[str, object]:
+    try:
+        with wave.open(os.fspath(path), "rb") as source:
+            metadata = {
+                "channels": source.getnchannels(),
+                "sample_width_bytes": source.getsampwidth(),
+                "sample_rate_hz": source.getframerate(),
+                "frame_count": source.getnframes(),
+                "compression_type": source.getcomptype(),
+            }
+            frames = source.readframes(int(metadata["frame_count"]))
+            expected_size = (
+                int(metadata["frame_count"])
+                * int(metadata["channels"])
+                * int(metadata["sample_width_bytes"])
+            )
+            if len(frames) != expected_size:
+                raise SetupBuildError("SETUP_VOICE_REFERENCE_TRUNCATED")
+    except (EOFError, OSError, wave.Error) as exc:
+        raise SetupBuildError("SETUP_VOICE_REFERENCE_INVALID") from exc
+    if (
+        metadata["compression_type"] != "NONE"
+        or not 1 <= int(metadata["channels"]) <= 8
+        or not 1 <= int(metadata["sample_width_bytes"]) <= 4
+        or not 8_000 <= int(metadata["sample_rate_hz"]) <= 192_000
+        or int(metadata["frame_count"]) < 1
+    ):
+        raise SetupBuildError("SETUP_VOICE_REFERENCE_INVALID")
+    return metadata
+
+
 def _is_reparse_point(path: Path) -> bool:
     attributes = getattr(path.stat(follow_symlinks=False), "st_file_attributes", 0)
     return path.is_symlink() or bool(
@@ -263,6 +296,8 @@ def _load_and_verify_manifest(
         raise SetupBuildError("SETUP_OFFLINE_MANIFEST_INVALID") from exc
     if not isinstance(manifest, dict):
         raise SetupBuildError("SETUP_OFFLINE_MANIFEST_INVALID")
+    if "distribution" in manifest or "voice_reference" in manifest:
+        raise SetupBuildError("SETUP_INPUT_VOICE_REFERENCE_FORBIDDEN")
 
     if validate_schema:
         try:
@@ -328,11 +363,19 @@ def prepare_setup_payload(
     offline: Path,
     destination: Path,
     *,
+    distribution: str = "public",
+    voice_reference: Path | None = None,
     validate_schema: bool = True,
 ) -> None:
     source = source.expanduser().resolve()
     offline = offline.expanduser().resolve()
     destination = destination.expanduser().resolve()
+    if distribution not in {"public", "private"}:
+        raise SetupBuildError("SETUP_DISTRIBUTION_INVALID")
+    if voice_reference is not None and distribution != "private":
+        raise SetupBuildError("SETUP_VOICE_REFERENCE_PRIVATE_ONLY")
+    if distribution == "private" and voice_reference is None:
+        raise SetupBuildError("SETUP_PRIVATE_VOICE_REFERENCE_REQUIRED")
     if destination.exists():
         raise SetupBuildError("SETUP_PAYLOAD_EXISTS")
     _load_and_verify_manifest(source, offline, validate_schema=validate_schema)
@@ -354,6 +397,31 @@ def prepare_setup_payload(
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source_path, target)
         shutil.copytree(offline, staging / "offline")
+        if voice_reference is not None:
+            reference = voice_reference.expanduser().resolve()
+            if (
+                not reference.is_file()
+                or _is_reparse_point(reference)
+                or reference.stat().st_size < 1
+            ):
+                raise SetupBuildError("SETUP_VOICE_REFERENCE_INVALID")
+            target = staging / "offline" / Path(*VOICE_REFERENCE_PATH.split("/"))
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(reference, target)
+            manifest_path = staging / "offline" / MANIFEST_NAME
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["distribution"] = "private"
+            manifest["voice_reference"] = {
+                "path": VOICE_REFERENCE_PATH,
+                "size_bytes": target.stat().st_size,
+                "sha256": _sha256(target),
+                "wave": _voice_reference_metadata(target),
+            }
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True)
+                + "\n",
+                encoding="utf-8",
+            )
         os.replace(staging, destination)
     except SetupBuildError:
         raise
@@ -390,6 +458,8 @@ def build_windows_setup(
     *,
     version: str,
     iscc: Path | None = None,
+    distribution: str = "public",
+    voice_reference: Path | None = None,
 ) -> dict[str, object]:
     source = source.expanduser().resolve()
     output = output.expanduser().resolve()
@@ -401,7 +471,13 @@ def build_windows_setup(
     payload = output / f".setup-payload-{uuid.uuid4().hex}"
     compiler = _find_iscc(iscc)
     try:
-        prepare_setup_payload(source, offline, payload)
+        prepare_setup_payload(
+            source,
+            offline,
+            payload,
+            distribution=distribution,
+            voice_reference=voice_reference,
+        )
         command = [
             os.fspath(compiler),
             f"/DPayloadRoot={payload}",
@@ -435,6 +511,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--iscc", type=Path)
+    parser.add_argument("--distribution", choices=("public", "private"), default="public")
+    parser.add_argument("--voice-reference", type=Path)
     args = parser.parse_args(argv)
     try:
         result = build_windows_setup(
@@ -443,6 +521,8 @@ def main(argv: list[str] | None = None) -> int:
             args.output,
             version=args.version,
             iscc=args.iscc,
+            distribution=args.distribution,
+            voice_reference=args.voice_reference,
         )
         print(json.dumps(result, ensure_ascii=False, sort_keys=True))
         return 0

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -18,7 +18,21 @@ from pathlib import Path, PurePosixPath
 MANIFEST_NAME = "offline-core-assets.json"
 SETUP_NAME = "Olivia-Setup-x64.exe"
 VOICE_REFERENCE_PATH = "voice/olivia-reference.wav"
-PUBLIC_MEDIA_SUFFIXES = {".flac", ".mp3", ".mp4", ".wav"}
+FORBIDDEN_MEDIA_SUFFIXES = {
+    ".aac",
+    ".avi",
+    ".flac",
+    ".m4a",
+    ".mkv",
+    ".mov",
+    ".mp3",
+    ".mp4",
+    ".ogg",
+    ".opus",
+    ".wav",
+    ".webm",
+    ".wmv",
+}
 BUILD_CONTROL_FILES = {
     "installer/build_windows_setup.py",
     "installer/setup-build-requirements.txt",
@@ -384,11 +398,11 @@ def prepare_setup_payload(
     if not REQUIRED_PAYLOAD_FILES.issubset(tracked):
         raise SetupBuildError("SETUP_REQUIRED_PAYLOAD_MISSING")
     selected = sorted(relative for relative in tracked if _is_release_file(relative))
-    if distribution == "public" and any(
-        PurePosixPath(relative).suffix.lower() in PUBLIC_MEDIA_SUFFIXES
+    if any(
+        PurePosixPath(relative).suffix.lower() in FORBIDDEN_MEDIA_SUFFIXES
         for relative in selected
     ):
-        raise SetupBuildError("SETUP_PUBLIC_MEDIA_FORBIDDEN")
+        raise SetupBuildError("SETUP_TRACKED_MEDIA_FORBIDDEN")
     build_inputs = set(selected) | BUILD_CONTROL_FILES
     if not build_inputs.issubset(tracked):
         raise SetupBuildError("SETUP_REQUIRED_PAYLOAD_MISSING")

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -18,6 +18,7 @@ from pathlib import Path, PurePosixPath
 MANIFEST_NAME = "offline-core-assets.json"
 SETUP_NAME = "Olivia-Setup-x64.exe"
 VOICE_REFERENCE_PATH = "voice/olivia-reference.wav"
+PUBLIC_MEDIA_SUFFIXES = {".flac", ".mp3", ".mp4", ".wav"}
 BUILD_CONTROL_FILES = {
     "installer/build_windows_setup.py",
     "installer/setup-build-requirements.txt",
@@ -383,6 +384,11 @@ def prepare_setup_payload(
     if not REQUIRED_PAYLOAD_FILES.issubset(tracked):
         raise SetupBuildError("SETUP_REQUIRED_PAYLOAD_MISSING")
     selected = sorted(relative for relative in tracked if _is_release_file(relative))
+    if distribution == "public" and any(
+        PurePosixPath(relative).suffix.lower() in PUBLIC_MEDIA_SUFFIXES
+        for relative in selected
+    ):
+        raise SetupBuildError("SETUP_PUBLIC_MEDIA_FORBIDDEN")
     build_inputs = set(selected) | BUILD_CONTROL_FILES
     if not build_inputs.issubset(tracked):
         raise SetupBuildError("SETUP_REQUIRED_PAYLOAD_MISSING")
@@ -470,6 +476,7 @@ def build_windows_setup(
         raise SetupBuildError("SETUP_OUTPUT_EXISTS")
     payload = output / f".setup-payload-{uuid.uuid4().hex}"
     compiler = _find_iscc(iscc)
+    completed = False
     try:
         prepare_setup_payload(
             source,
@@ -490,18 +497,29 @@ def build_windows_setup(
             raise SetupBuildError("SETUP_COMPILE_FAILED")
         digest = _sha256(setup)
         checksum.write_text(f"{digest}  {SETUP_NAME}\n", encoding="ascii")
-        return {
+        result = {
             "status": "OK",
             "setup": os.fspath(setup),
             "size_bytes": setup.stat().st_size,
             "sha256": digest,
         }
+        completed = True
+        return result
     except SetupBuildError:
         raise
     except (OSError, subprocess.SubprocessError) as exc:
         raise SetupBuildError("SETUP_BUILD_FAILED") from exc
     finally:
         shutil.rmtree(payload, ignore_errors=True)
+        if not completed:
+            cleanup_failed = False
+            for artifact in (setup, checksum):
+                try:
+                    artifact.unlink(missing_ok=True)
+                except OSError:
+                    cleanup_failed = True
+            if cleanup_failed:
+                raise SetupBuildError("SETUP_OUTPUT_CLEANUP_FAILED")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -12,6 +12,7 @@ from installer.build_windows_setup import (
     SetupBuildError,
     _git_tracked_files,
     _is_release_file,
+    build_windows_setup,
     main as build_setup_main,
     prepare_setup_payload,
 )
@@ -210,6 +211,44 @@ def test_setup_build_cli_forwards_distributor_voice_reference(tmp_path: Path, mo
     assert captured["voice_reference"] == reference
 
 
+def test_failed_private_setup_compile_removes_partial_final_artifacts(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    output = tmp_path / "dist-private"
+    compiler = tmp_path / "ISCC.exe"
+    compiler.write_bytes(b"compiler")
+    contracts = source / "contracts"
+    contracts.mkdir()
+    (contracts / "offline_core_assets.schema.json").write_text(
+        json.dumps({"type": "object"}),
+        encoding="utf-8",
+    )
+
+    def fail_compile(_command, *, check, timeout):
+        assert check is False
+        assert timeout == 900
+        (output / "Olivia-Setup-x64.exe").write_bytes(b"partial private setup")
+        return type("Result", (), {"returncode": 1})()
+
+    monkeypatch.setattr("installer.build_windows_setup.subprocess.run", fail_compile)
+
+    with pytest.raises(SetupBuildError, match="SETUP_COMPILE_FAILED"):
+        build_windows_setup(
+            source,
+            offline,
+            output,
+            version="0.1.test",
+            iscc=compiler,
+            distribution="private",
+            voice_reference=reference,
+        )
+
+    assert not (output / "Olivia-Setup-x64.exe").exists()
+    assert not (output / "Olivia-Setup-x64.exe.sha256").exists()
+
+
 def test_windows_setup_docs_separate_public_and_private_voice_artifacts() -> None:
     documentation = (ROOT / "docs" / "WINDOWS_FULL_PATCH.md").read_text(
         encoding="utf-8"
@@ -220,6 +259,8 @@ def test_windows_setup_docs_separate_public_and_private_voice_artifacts() -> Non
     assert "--voice-reference" in documentation
     assert "dist-private" in documentation
     assert "文件名仍为 `Olivia-Setup-x64.exe`" in documentation
+    assert "除私有模式显式传入的 WAV 外" in documentation
+    assert "GitHub Actions 只生成公开安装器 artifact" in documentation
 
 
 def test_prepare_setup_payload_rejects_truncated_voice_reference(tmp_path: Path, monkeypatch) -> None:
@@ -233,6 +274,43 @@ def test_prepare_setup_payload_rejects_truncated_voice_reference(tmp_path: Path,
             tmp_path / "payload",
             distribution="private",
             voice_reference=reference,
+            validate_schema=False,
+        )
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        "linli_character/reference.wav",
+        "runtime/reference.flac",
+        "runtime/reference.mp3",
+        "runtime/reference.mp4",
+    ],
+)
+def test_public_setup_rejects_tracked_audio_and_video_payloads(
+    tmp_path: Path,
+    monkeypatch,
+    relative: str,
+) -> None:
+    source, offline, _reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    media = source.joinpath(*relative.split("/"))
+    media.parent.mkdir()
+    media.write_bytes(b"private media")
+    monkeypatch.setattr(
+        "installer.build_windows_setup._git_tracked_files",
+        lambda _source: {
+            "installer/Install.ps1",
+            "installer/runtime-requirements.txt",
+            *BUILD_CONTROL_FILES,
+            relative,
+        },
+    )
+
+    with pytest.raises(SetupBuildError, match="SETUP_PUBLIC_MEDIA_FORBIDDEN"):
+        prepare_setup_payload(
+            source,
+            offline,
+            tmp_path / "payload",
             validate_schema=False,
         )
 

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -249,6 +249,53 @@ def test_failed_private_setup_compile_removes_partial_final_artifacts(
     assert not (output / "Olivia-Setup-x64.exe.sha256").exists()
 
 
+def test_failed_private_setup_checksum_removes_setup_and_partial_checksum(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    output = tmp_path / "dist-private"
+    compiler = tmp_path / "ISCC.exe"
+    compiler.write_bytes(b"compiler")
+    contracts = source / "contracts"
+    contracts.mkdir()
+    (contracts / "offline_core_assets.schema.json").write_text(
+        json.dumps({"type": "object"}),
+        encoding="utf-8",
+    )
+
+    def compile_setup(_command, *, check, timeout):
+        assert check is False
+        assert timeout == 900
+        (output / "Olivia-Setup-x64.exe").write_bytes(b"complete private setup")
+        return type("Result", (), {"returncode": 0})()
+
+    original_write_text = Path.write_text
+
+    def fail_checksum_write(path: Path, content: str, *args, **kwargs):
+        if path.name == "Olivia-Setup-x64.exe.sha256":
+            original_write_text(path, "partial checksum", encoding="ascii")
+            raise OSError("checksum write failed")
+        return original_write_text(path, content, *args, **kwargs)
+
+    monkeypatch.setattr("installer.build_windows_setup.subprocess.run", compile_setup)
+    monkeypatch.setattr(Path, "write_text", fail_checksum_write)
+
+    with pytest.raises(SetupBuildError, match="SETUP_BUILD_FAILED"):
+        build_windows_setup(
+            source,
+            offline,
+            output,
+            version="0.1.test",
+            iscc=compiler,
+            distribution="private",
+            voice_reference=reference,
+        )
+
+    assert not (output / "Olivia-Setup-x64.exe").exists()
+    assert not (output / "Olivia-Setup-x64.exe.sha256").exists()
+
+
 def test_windows_setup_docs_separate_public_and_private_voice_artifacts() -> None:
     documentation = (ROOT / "docs" / "WINDOWS_FULL_PATCH.md").read_text(
         encoding="utf-8"
@@ -279,20 +326,32 @@ def test_prepare_setup_payload_rejects_truncated_voice_reference(tmp_path: Path,
 
 
 @pytest.mark.parametrize(
-    "relative",
+    "suffix",
     [
-        "linli_character/reference.wav",
-        "runtime/reference.flac",
-        "runtime/reference.mp3",
-        "runtime/reference.mp4",
+        ".aac",
+        ".avi",
+        ".flac",
+        ".m4a",
+        ".mkv",
+        ".mov",
+        ".mp3",
+        ".mp4",
+        ".ogg",
+        ".opus",
+        ".wav",
+        ".webm",
+        ".wmv",
     ],
 )
-def test_public_setup_rejects_tracked_audio_and_video_payloads(
+@pytest.mark.parametrize("distribution", ["public", "private"])
+def test_setup_rejects_git_selected_audio_and_video_payloads(
     tmp_path: Path,
     monkeypatch,
-    relative: str,
+    suffix: str,
+    distribution: str,
 ) -> None:
-    source, offline, _reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    relative = f"runtime/reference{suffix}"
     media = source.joinpath(*relative.split("/"))
     media.parent.mkdir()
     media.write_bytes(b"private media")
@@ -306,11 +365,13 @@ def test_public_setup_rejects_tracked_audio_and_video_payloads(
         },
     )
 
-    with pytest.raises(SetupBuildError, match="SETUP_PUBLIC_MEDIA_FORBIDDEN"):
+    with pytest.raises(SetupBuildError, match="SETUP_TRACKED_MEDIA_FORBIDDEN"):
         prepare_setup_payload(
             source,
             offline,
             tmp_path / "payload",
+            distribution=distribution,
+            voice_reference=reference if distribution == "private" else None,
             validate_schema=False,
         )
 

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+import wave
 
 import pytest
 
@@ -11,6 +12,7 @@ from installer.build_windows_setup import (
     SetupBuildError,
     _git_tracked_files,
     _is_release_file,
+    main as build_setup_main,
     prepare_setup_payload,
 )
 
@@ -27,6 +29,13 @@ def _write_asset(root: Path, relative: str, content: bytes) -> dict[str, object]
         "size_bytes": len(content),
         "sha256": hashlib.sha256(content).hexdigest(),
     }
+
+
+def _write_voice_reference(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as target:
+        target.setparams((1, 2, 16000, 0, "NONE", "not compressed"))
+        target.writeframes(b"\x00\x00" * 160)
 
 
 def _offline_fixture(root: Path, requirements: bytes) -> None:
@@ -47,6 +56,28 @@ def _offline_fixture(root: Path, requirements: bytes) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def _voice_setup_fixture(tmp_path: Path, monkeypatch) -> tuple[Path, Path, Path]:
+    source, offline = tmp_path / "source", tmp_path / "offline"
+    installer = source / "installer"
+    installer.mkdir(parents=True)
+    (installer / "Install.ps1").write_text("install", encoding="utf-8")
+    requirements = b"locked requirements"
+    (installer / "runtime-requirements.txt").write_bytes(requirements)
+    reference = tmp_path / "distributor" / "olivia-reference.wav"
+    _write_voice_reference(reference)
+    _offline_fixture(offline, requirements)
+    monkeypatch.setattr(
+        "installer.build_windows_setup._git_tracked_files",
+        lambda _source: {
+            "installer/Install.ps1",
+            "installer/runtime-requirements.txt",
+            *BUILD_CONTROL_FILES,
+        },
+    )
+    monkeypatch.setattr("installer.build_windows_setup._git_dirty_files", lambda _: set())
+    return source, offline, reference
 
 
 def test_prepare_setup_payload_copies_only_tracked_release_files_and_offline_assets(
@@ -111,6 +142,99 @@ def test_prepare_setup_payload_copies_only_tracked_release_files_and_offline_ass
     assert not (destination / "requirements-ci.txt").exists()
     assert not (destination / "pyproject.toml").exists()
     assert not (destination / "installer" / "build_windows_setup.py").exists()
+
+
+def test_prepare_setup_payload_injects_hash_locked_voice_reference(tmp_path: Path, monkeypatch) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    destination = tmp_path / "payload"
+
+    prepare_setup_payload(
+        source,
+        offline,
+        destination,
+        distribution="private",
+        voice_reference=reference,
+        validate_schema=False,
+    )
+
+    installed_reference = destination / "offline" / "voice" / "olivia-reference.wav"
+    manifest = json.loads((destination / "offline/offline-core-assets.json").read_text())
+    assert installed_reference.read_bytes() == reference.read_bytes()
+    assert manifest["distribution"] == "private"
+    assert manifest["voice_reference"] == {
+        "path": "voice/olivia-reference.wav",
+        "size_bytes": reference.stat().st_size,
+        "sha256": hashlib.sha256(reference.read_bytes()).hexdigest(),
+        "wave": {"channels": 1, "sample_width_bytes": 2, "sample_rate_hz": 16000,
+                 "frame_count": 160, "compression_type": "NONE"},
+    }
+    input_manifest_path = offline / "offline-core-assets.json"
+    input_manifest = json.loads(input_manifest_path.read_text())
+    input_manifest.update(distribution="private", voice_reference=manifest["voice_reference"])
+    input_manifest_path.write_text(json.dumps(input_manifest), encoding="utf-8")
+    prebundled = offline / "voice" / "olivia-reference.wav"
+    prebundled.parent.mkdir()
+    prebundled.write_bytes(reference.read_bytes())
+    with pytest.raises(SetupBuildError, match="SETUP_INPUT_VOICE_REFERENCE_FORBIDDEN"):
+        prepare_setup_payload(source, offline, tmp_path / "prebundled", validate_schema=False)
+    del input_manifest["distribution"], input_manifest["voice_reference"]
+    input_manifest_path.write_text(json.dumps(input_manifest), encoding="utf-8")
+    with pytest.raises(SetupBuildError, match="SETUP_OFFLINE_ASSET_SET_MISMATCH"):
+        prepare_setup_payload(source, offline, tmp_path / "orphan", validate_schema=False)
+    with pytest.raises(SetupBuildError, match="SETUP_VOICE_REFERENCE_PRIVATE_ONLY"):
+        prepare_setup_payload(
+            source, offline, tmp_path / "public", voice_reference=reference, validate_schema=False
+        )
+    with pytest.raises(SetupBuildError, match="SETUP_PRIVATE_VOICE_REFERENCE_REQUIRED"):
+        prepare_setup_payload(
+            source, offline, tmp_path / "private", distribution="private", validate_schema=False
+        )
+
+
+def test_setup_build_cli_forwards_distributor_voice_reference(tmp_path: Path, monkeypatch) -> None:
+    reference = tmp_path / "olivia-reference.wav"
+    reference.write_bytes(b"RIFF-voice")
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "installer.build_windows_setup.build_windows_setup",
+        lambda *args, **kwargs: captured.update(kwargs) or {"status": "OK"},
+    )
+
+    result = build_setup_main([
+        "--offline", str(tmp_path / "offline"), "--output", str(tmp_path / "output"),
+        "--version", "0.1.test", "--distribution", "private", "--voice-reference", str(reference),
+    ])
+
+    assert result == 0
+    assert captured["distribution"] == "private"
+    assert captured["voice_reference"] == reference
+
+
+def test_windows_setup_docs_separate_public_and_private_voice_artifacts() -> None:
+    documentation = (ROOT / "docs" / "WINDOWS_FULL_PATCH.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "公开安装器不包含参考音频" in documentation
+    assert "--distribution private" in documentation
+    assert "--voice-reference" in documentation
+    assert "dist-private" in documentation
+    assert "文件名仍为 `Olivia-Setup-x64.exe`" in documentation
+
+
+def test_prepare_setup_payload_rejects_truncated_voice_reference(tmp_path: Path, monkeypatch) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    reference.write_bytes(reference.read_bytes()[:-1])
+
+    with pytest.raises(SetupBuildError, match="SETUP_VOICE_REFERENCE_TRUNCATED"):
+        prepare_setup_payload(
+            source,
+            offline,
+            tmp_path / "payload",
+            distribution="private",
+            voice_reference=reference,
+            validate_schema=False,
+        )
 
 
 def test_prepare_setup_payload_rejects_dirty_tracked_release_file(


### PR DESCRIPTION
## Result

- add a private-only setup build mode that injects one explicit Lin Li PCM WAV
- lock the injected WAV by size, SHA-256, PCM metadata, and JSON schema
- reject pre-carried private assets and all Git-selected audio/video from both public and private builds
- clean partial EXE/checksum outputs after build failure

## Verification

- focused installer tests: 50 passed
- py_compile: passed
- git diff --check: passed
- frozen Standards review: PASS, P0/P1/P2 = 0/0/0
- frozen Spec review: PASS, P0/P1/P2 = 0/0/0
- mechanical rebase range-diff: 3 commits all equal
- frozen base: 57e8b8611f456fbb22c3e192d51c63177ba442cb
- frozen head: 37dfecd0486cffb77b33c2d15d3b21601047d90b

## Distribution boundary

The repository and public setup remain free of the private WAV. The maintainer supplies the WAV only at private build time. This PR builds the payload contract; installation into the managed runtime remains a separate stacked PR.