### PR TITLE
fix(media): harden LatentSync delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ flowchart LR
 
 当前目标是一首约 40–60 秒的完整短歌，而不是几句演示音频。MiniMax、分离、口型与合成均为后台串行任务，RTX 3080 10GB 主要面向离线生成，不承诺实时速度。
 
-LatentSync 单次渲染默认最多等待 1800 秒，可用 `OLIVIA_LATENTSYNC_TIMEOUT_SECONDS` 调整，最高 3600 秒；超时会终止整棵工作进程并在本机媒体日志记录脱敏原因。
+LatentSync 单次任务（FFmpeg 准备与口型渲染合计）默认最多等待 1800 秒，可用 `OLIVIA_LATENTSYNC_TIMEOUT_SECONDS` 调整，最高 3600 秒；任一阶段超时都会终止整棵工作进程并在本机媒体日志记录脱敏原因。
 
 ## Persona、记忆与 PrivateWorld
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ flowchart LR
 
 当前目标是一首约 40–60 秒的完整短歌，而不是几句演示音频。MiniMax、分离、口型与合成均为后台串行任务，RTX 3080 10GB 主要面向离线生成，不承诺实时速度。
 
+LatentSync 单次渲染默认最多等待 1800 秒，可用 `OLIVIA_LATENTSYNC_TIMEOUT_SECONDS` 调整，最高 3600 秒；超时会终止整棵工作进程并在本机媒体日志记录脱敏原因。
+
 ## Persona、记忆与 PrivateWorld
 
 Persona 不是一段无限增长的 system prompt。公开人格文件带有来源与版本信息，并通过预算器、上下文合同和质量门装配到单次回信中。

--- a/runtime/media/latentsync_reply.py
+++ b/runtime/media/latentsync_reply.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import math
 import os
@@ -67,6 +68,32 @@ def _process_diagnostic(
         f"stderr_bytes={len(payload)};"
         f"stderr_sha256={hashlib.sha256(payload).hexdigest()}"
     )[:240]
+
+
+def _reported_process_failure(
+    environment: Mapping[str, str], *, returncode: int | None,
+    stderr: bytes | str | None, timed_out: bool = False, start_failed: bool = False,
+) -> LatentSyncReplyError:
+    diagnostic = _process_diagnostic(
+        returncode=returncode, stderr=stderr,
+        timed_out=timed_out, start_failed=start_failed,
+    )
+    _LOGGER.warning("LatentSync process failed: %s", diagnostic)
+    data_root = resolve_media_path(environment.get("OLIVIA_LOCAL_DATA_ROOT", ""), environment)
+    if data_root is not None:
+        try:
+            log_root = data_root / "logs"
+            log_root.mkdir(parents=True, exist_ok=True)
+            record = {
+                "provider": "latentsync",
+                "error_code": "LATENTSYNC_FAILED",
+                "diagnostic": diagnostic,
+            }
+            with (log_root / "media-provider.jsonl").open("a", encoding="utf-8") as stream:
+                stream.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+        except OSError:
+            pass
+    return LatentSyncReplyError("LATENTSYNC_FAILED", diagnostic=diagnostic)
 
 
 def _latentsync_timeout_seconds(
@@ -318,36 +345,24 @@ def render_latentsync_video(
                 env=runtime_environment,
             )
         except subprocess.TimeoutExpired as exc:
-            diagnostic = _process_diagnostic(
+            failure = _reported_process_failure(
+                source_environment,
                 returncode=None,
                 stderr=exc.stderr,
                 timed_out=True,
             )
-            _LOGGER.warning("LatentSync process failed: %s", diagnostic)
-            raise LatentSyncReplyError(
-                "LATENTSYNC_FAILED",
-                diagnostic=diagnostic,
-            ) from exc
+            raise failure from exc
         except OSError as exc:
-            diagnostic = _process_diagnostic(
+            failure = _reported_process_failure(
+                source_environment,
                 returncode=None,
                 stderr=None,
                 start_failed=True,
             )
-            _LOGGER.warning("LatentSync process failed: %s", diagnostic)
-            raise LatentSyncReplyError(
-                "LATENTSYNC_FAILED",
-                diagnostic=diagnostic,
-            ) from exc
+            raise failure from exc
         if result.returncode != 0:
-            diagnostic = _process_diagnostic(
-                returncode=result.returncode,
-                stderr=result.stderr,
-            )
-            _LOGGER.warning("LatentSync process failed: %s", diagnostic)
-            raise LatentSyncReplyError(
-                "LATENTSYNC_FAILED",
-                diagnostic=diagnostic,
+            raise _reported_process_failure(
+                source_environment, returncode=result.returncode, stderr=result.stderr,
             )
         if not working_output.is_file() or working_output.stat().st_size == 0:
             raise LatentSyncReplyError("LATENTSYNC_OUTPUT_MISSING")

--- a/runtime/media/latentsync_reply.py
+++ b/runtime/media/latentsync_reply.py
@@ -119,18 +119,6 @@ def _latentsync_timeout_seconds(
     return min(value, _MAX_LATENTSYNC_TIMEOUT_SECONDS)
 
 
-def _remaining_timeout_seconds(
-    deadline: float,
-    environment: Mapping[str, str],
-) -> float:
-    remaining = deadline - time.monotonic()
-    if remaining <= 0:
-        raise _reported_process_failure(
-            environment, returncode=None, stderr=None, timed_out=True,
-        )
-    return remaining
-
-
 def resolve_ffmpeg_executable(env: Mapping[str, str] | None = None) -> Path:
     """Resolve the same FFmpeg executable used by the LatentSync renderer."""
 
@@ -205,7 +193,7 @@ def _prepare_source_clip(
     prepared_video: Path,
     *,
     environment: dict[str, str],
-    timeout_seconds: float,
+    deadline: float,
 ) -> None:
     """Decode only the needed span into a stable LatentSync input."""
 
@@ -246,7 +234,7 @@ def _prepare_source_clip(
     ]
     try:
         result = run_managed_process(
-            command, timeout_seconds=timeout_seconds, env=environment,
+            command, deadline=deadline, env=environment,
         )
     except subprocess.TimeoutExpired as exc:
         raise _reported_process_failure(
@@ -268,7 +256,7 @@ def _validate_rendered_video(
     video_path: Path,
     *,
     environment: dict[str, str],
-    timeout_seconds: float,
+    deadline: float,
 ) -> None:
     ffmpeg = shutil.which("ffmpeg", path=environment["PATH"])
     if ffmpeg is None:
@@ -280,7 +268,7 @@ def _validate_rendered_video(
     ]
     try:
         result = run_managed_process(
-            command, timeout_seconds=timeout_seconds, env=environment,
+            command, deadline=deadline, env=environment,
         )
     except subprocess.TimeoutExpired as exc:
         raise _reported_process_failure(
@@ -384,7 +372,7 @@ def render_latentsync_video(
             audio_path,
             prepared_video,
             environment=runtime_environment,
-            timeout_seconds=_remaining_timeout_seconds(deadline, source_environment),
+            deadline=deadline,
         )
         command = [
             str(python_path),
@@ -414,7 +402,7 @@ def render_latentsync_video(
             result = run_managed_process(
                 command,
                 cwd=latentsync_root,
-                timeout_seconds=_remaining_timeout_seconds(deadline, source_environment),
+                deadline=deadline,
                 env=runtime_environment,
             )
         except subprocess.TimeoutExpired as exc:
@@ -442,7 +430,7 @@ def render_latentsync_video(
         _validate_rendered_video(
             working_output,
             environment=runtime_environment,
-            timeout_seconds=_remaining_timeout_seconds(deadline, source_environment),
+            deadline=deadline,
         )
         partial_output = output_path.with_suffix(output_path.suffix + ".partial")
         try:

--- a/runtime/media/latentsync_reply.py
+++ b/runtime/media/latentsync_reply.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import hashlib
+from contextlib import suppress
 import json
 import logging
 import math
@@ -67,11 +67,8 @@ def _process_diagnostic(
         category = "external_process_failure"
     return (
         f"returncode={returncode if returncode is not None else 'unknown'};"
-        f"timed_out={str(timed_out).lower()};"
-        f"stderr_category={category};"
-        f"stderr_bytes={len(payload)};"
-        f"stderr_sha256={hashlib.sha256(payload).hexdigest()}"
-    )[:240]
+        f"stderr_category={category}"
+    )
 
 
 def _reported_process_failure(
@@ -120,6 +117,18 @@ def _latentsync_timeout_seconds(
     if not math.isfinite(value) or value <= 0:
         return _DEFAULT_LATENTSYNC_TIMEOUT_SECONDS
     return min(value, _MAX_LATENTSYNC_TIMEOUT_SECONDS)
+
+
+def _remaining_timeout_seconds(
+    deadline: float,
+    environment: Mapping[str, str],
+) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise _reported_process_failure(
+            environment, returncode=None, stderr=None, timed_out=True,
+        )
+    return remaining
 
 
 def resolve_ffmpeg_executable(env: Mapping[str, str] | None = None) -> Path:
@@ -247,8 +256,58 @@ def _prepare_source_clip(
         raise _reported_process_failure(
             environment, returncode=None, stderr=str(exc), management_failed=True,
         ) from exc
-    if result.returncode != 0 or not prepared_video.is_file():
+    if result.returncode != 0:
+        raise _reported_process_failure(
+            environment, returncode=result.returncode, stderr=result.stderr,
+        )
+    if not prepared_video.is_file():
         raise LatentSyncReplyError("LATENTSYNC_SOURCE_PREPARE_FAILED")
+
+
+def _validate_rendered_video(
+    video_path: Path,
+    *,
+    environment: dict[str, str],
+    timeout_seconds: float,
+) -> None:
+    ffmpeg = shutil.which("ffmpeg", path=environment["PATH"])
+    if ffmpeg is None:
+        raise LatentSyncReplyError("LATENTSYNC_FFMPEG_UNAVAILABLE")
+    command = [
+        ffmpeg, "-hide_banner", "-loglevel", "error", "-xerror", "-nostats",
+        "-progress", "pipe:1", "-i", str(video_path), "-map", "0:v:0",
+        "-map", "0:a:0", "-f", "null", os.devnull,
+    ]
+    try:
+        result = run_managed_process(
+            command, timeout_seconds=timeout_seconds, env=environment,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _reported_process_failure(
+            environment, returncode=None, stderr=exc.stderr, timed_out=True,
+        ) from exc
+    except OSError as exc:
+        raise _reported_process_failure(
+            environment, returncode=None, stderr=str(exc), management_failed=True,
+        ) from exc
+    if result.returncode != 0:
+        raise _reported_process_failure(
+            environment, returncode=result.returncode, stderr=result.stderr,
+        )
+    progress = dict(
+        line.split("=", 1)
+        for line in result.stdout.decode("utf-8", errors="replace").splitlines()
+        if "=" in line
+    )
+    try:
+        frames = int(progress.get("frame", "0"))
+        duration_us = int(progress.get("out_time_us", progress.get("out_time_ms", "0")))
+    except ValueError:
+        frames = duration_us = 0
+    if progress.get("progress") != "end" or frames <= 0 or duration_us <= 0:
+        raise _reported_process_failure(
+            environment, returncode=result.returncode, stderr="decoded_video_invalid",
+        )
 
 
 def render_latentsync_video(
@@ -325,7 +384,7 @@ def render_latentsync_video(
             audio_path,
             prepared_video,
             environment=runtime_environment,
-            timeout_seconds=max(0.1, deadline - time.monotonic()),
+            timeout_seconds=_remaining_timeout_seconds(deadline, source_environment),
         )
         command = [
             str(python_path),
@@ -355,7 +414,7 @@ def render_latentsync_video(
             result = run_managed_process(
                 command,
                 cwd=latentsync_root,
-                timeout_seconds=max(0.1, deadline - time.monotonic()),
+                timeout_seconds=_remaining_timeout_seconds(deadline, source_environment),
                 env=runtime_environment,
             )
         except subprocess.TimeoutExpired as exc:
@@ -380,12 +439,18 @@ def render_latentsync_video(
             )
         if not working_output.is_file() or working_output.stat().st_size == 0:
             raise LatentSyncReplyError("LATENTSYNC_OUTPUT_MISSING")
+        _validate_rendered_video(
+            working_output,
+            environment=runtime_environment,
+            timeout_seconds=_remaining_timeout_seconds(deadline, source_environment),
+        )
         partial_output = output_path.with_suffix(output_path.suffix + ".partial")
         try:
             shutil.copy2(working_output, partial_output)
             partial_output.replace(output_path)
         finally:
-            partial_output.unlink(missing_ok=True)
+            with suppress(OSError):
+                partial_output.unlink(missing_ok=True)
         metadata = {
             "visual_provider": "LatentSync-1.5",
             "inference_steps": 20,

--- a/runtime/media/latentsync_reply.py
+++ b/runtime/media/latentsync_reply.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import Mapping
 
@@ -37,6 +38,7 @@ def _process_diagnostic(
     stderr: bytes | str | None,
     timed_out: bool = False,
     start_failed: bool = False,
+    management_failed: bool = False,
 ) -> str:
     if isinstance(stderr, bytes):
         payload = stderr
@@ -49,6 +51,8 @@ def _process_diagnostic(
         category = "process_timeout"
     elif start_failed:
         category = "process_start_failure"
+    elif management_failed:
+        category = "process_management_failure"
     elif "cuda" in normalized and "out of memory" in normalized:
         category = "cuda_out_of_memory"
     elif "dll load failed" in normalized or "winerror 126" in normalized:
@@ -73,10 +77,12 @@ def _process_diagnostic(
 def _reported_process_failure(
     environment: Mapping[str, str], *, returncode: int | None,
     stderr: bytes | str | None, timed_out: bool = False, start_failed: bool = False,
+    management_failed: bool = False,
 ) -> LatentSyncReplyError:
     diagnostic = _process_diagnostic(
         returncode=returncode, stderr=stderr,
         timed_out=timed_out, start_failed=start_failed,
+        management_failed=management_failed,
     )
     _LOGGER.warning("LatentSync process failed: %s", diagnostic)
     data_root = resolve_media_path(environment.get("OLIVIA_LOCAL_DATA_ROOT", ""), environment)
@@ -190,6 +196,7 @@ def _prepare_source_clip(
     prepared_video: Path,
     *,
     environment: dict[str, str],
+    timeout_seconds: float,
 ) -> None:
     """Decode only the needed span into a stable LatentSync input."""
 
@@ -228,13 +235,18 @@ def _prepare_source_clip(
         "-shortest",
         str(prepared_video),
     ]
-    result = subprocess.run(
-        command,
-        capture_output=True,
-        check=False,
-        timeout=1800,
-        env=environment,
-    )
+    try:
+        result = run_managed_process(
+            command, timeout_seconds=timeout_seconds, env=environment,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _reported_process_failure(
+            environment, returncode=None, stderr=exc.stderr, timed_out=True,
+        ) from exc
+    except OSError as exc:
+        raise _reported_process_failure(
+            environment, returncode=None, stderr=str(exc), management_failed=True,
+        ) from exc
     if result.returncode != 0 or not prepared_video.is_file():
         raise LatentSyncReplyError("LATENTSYNC_SOURCE_PREPARE_FAILED")
 
@@ -279,6 +291,7 @@ def render_latentsync_video(
         timeout_seconds,
         source_environment,
     )
+    deadline = time.monotonic() + timeout_seconds
     cache_root = provider_cache_root
     if cache_root is None:
         cache_root = resolve_media_path(
@@ -312,6 +325,7 @@ def render_latentsync_video(
             audio_path,
             prepared_video,
             environment=runtime_environment,
+            timeout_seconds=max(0.1, deadline - time.monotonic()),
         )
         command = [
             str(python_path),
@@ -341,7 +355,7 @@ def render_latentsync_video(
             result = run_managed_process(
                 command,
                 cwd=latentsync_root,
-                timeout_seconds=timeout_seconds,
+                timeout_seconds=max(0.1, deadline - time.monotonic()),
                 env=runtime_environment,
             )
         except subprocess.TimeoutExpired as exc:
@@ -356,8 +370,8 @@ def render_latentsync_video(
             failure = _reported_process_failure(
                 source_environment,
                 returncode=None,
-                stderr=None,
-                start_failed=True,
+                stderr=str(exc),
+                management_failed=True,
             )
             raise failure from exc
         if result.returncode != 0:

--- a/runtime/media/latentsync_reply.py
+++ b/runtime/media/latentsync_reply.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
+import logging
+import math
 import os
 import shutil
 import subprocess
@@ -9,11 +12,81 @@ import tempfile
 from pathlib import Path
 from typing import Mapping
 
+from runtime.media.managed_subprocess import run_managed_process
 from runtime.media.media_paths import resolve_media_path
+
+
+_DEFAULT_LATENTSYNC_TIMEOUT_SECONDS = 1800.0
+_MAX_LATENTSYNC_TIMEOUT_SECONDS = 3600.0
+_LOGGER = logging.getLogger(__name__)
 
 
 class LatentSyncReplyError(RuntimeError):
     """Stable product error for the external LatentSync process."""
+
+    def __init__(self, code: str, *, diagnostic: str = "") -> None:
+        super().__init__(code)
+        self.code = code
+        self.diagnostic = diagnostic
+
+
+def _process_diagnostic(
+    *,
+    returncode: int | None,
+    stderr: bytes | str | None,
+    timed_out: bool = False,
+    start_failed: bool = False,
+) -> str:
+    if isinstance(stderr, bytes):
+        payload = stderr
+    elif stderr is None:
+        payload = b""
+    else:
+        payload = str(stderr).encode("utf-8", errors="replace")
+    normalized = payload.decode("utf-8", errors="replace").casefold()
+    if timed_out:
+        category = "process_timeout"
+    elif start_failed:
+        category = "process_start_failure"
+    elif "cuda" in normalized and "out of memory" in normalized:
+        category = "cuda_out_of_memory"
+    elif "dll load failed" in normalized or "winerror 126" in normalized:
+        category = "runtime_dependency_missing"
+    elif "no module named" in normalized or "modulenotfounderror" in normalized:
+        category = "python_module_missing"
+    elif "filenotfounderror" in normalized or "no such file" in normalized:
+        category = "configured_path_missing"
+    elif "cuda" in normalized:
+        category = "cuda_runtime_failure"
+    else:
+        category = "external_process_failure"
+    return (
+        f"returncode={returncode if returncode is not None else 'unknown'};"
+        f"timed_out={str(timed_out).lower()};"
+        f"stderr_category={category};"
+        f"stderr_bytes={len(payload)};"
+        f"stderr_sha256={hashlib.sha256(payload).hexdigest()}"
+    )[:240]
+
+
+def _latentsync_timeout_seconds(
+    requested: float | None,
+    environment: Mapping[str, str],
+) -> float:
+    raw: object = (
+        environment.get("OLIVIA_LATENTSYNC_TIMEOUT_SECONDS")
+        if requested is None
+        else requested
+    )
+    if raw in (None, ""):
+        return _DEFAULT_LATENTSYNC_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_LATENTSYNC_TIMEOUT_SECONDS
+    if not math.isfinite(value) or value <= 0:
+        return _DEFAULT_LATENTSYNC_TIMEOUT_SECONDS
+    return min(value, _MAX_LATENTSYNC_TIMEOUT_SECONDS)
 
 
 def resolve_ffmpeg_executable(env: Mapping[str, str] | None = None) -> Path:
@@ -146,7 +219,7 @@ def render_latentsync_video(
     *,
     python_path: Path,
     latentsync_root: Path,
-    timeout_seconds: float = 21600.0,
+    timeout_seconds: float | None = None,
     ffmpeg_path: Path | None = None,
     provider_cache_root: Path | None = None,
     environment: Mapping[str, str] | None = None,
@@ -175,6 +248,10 @@ def render_latentsync_video(
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     source_environment = os.environ if environment is None else environment
+    timeout_seconds = _latentsync_timeout_seconds(
+        timeout_seconds,
+        source_environment,
+    )
     cache_root = provider_cache_root
     if cache_root is None:
         cache_root = resolve_media_path(
@@ -188,7 +265,11 @@ def render_latentsync_video(
         raise LatentSyncReplyError("LATENTSYNC_INPUT_UNAVAILABLE")
     work_root = cache_root / "latentsync-work"
     work_root.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(prefix="job-", dir=work_root) as temporary:
+    with tempfile.TemporaryDirectory(
+        prefix="job-",
+        dir=work_root,
+        ignore_cleanup_errors=True,
+    ) as temporary:
         temporary_root = Path(temporary)
         runtime_environment = _environment_with_ffmpeg(
             temporary_root,
@@ -230,18 +311,44 @@ def render_latentsync_video(
             "--enable_deepcache",
         ]
         try:
-            result = subprocess.run(
+            result = run_managed_process(
                 command,
                 cwd=latentsync_root,
-                capture_output=True,
-                check=False,
-                timeout=timeout_seconds,
+                timeout_seconds=timeout_seconds,
                 env=runtime_environment,
             )
-        except (OSError, subprocess.TimeoutExpired) as exc:
-            raise LatentSyncReplyError("LATENTSYNC_FAILED") from exc
+        except subprocess.TimeoutExpired as exc:
+            diagnostic = _process_diagnostic(
+                returncode=None,
+                stderr=exc.stderr,
+                timed_out=True,
+            )
+            _LOGGER.warning("LatentSync process failed: %s", diagnostic)
+            raise LatentSyncReplyError(
+                "LATENTSYNC_FAILED",
+                diagnostic=diagnostic,
+            ) from exc
+        except OSError as exc:
+            diagnostic = _process_diagnostic(
+                returncode=None,
+                stderr=None,
+                start_failed=True,
+            )
+            _LOGGER.warning("LatentSync process failed: %s", diagnostic)
+            raise LatentSyncReplyError(
+                "LATENTSYNC_FAILED",
+                diagnostic=diagnostic,
+            ) from exc
         if result.returncode != 0:
-            raise LatentSyncReplyError("LATENTSYNC_FAILED")
+            diagnostic = _process_diagnostic(
+                returncode=result.returncode,
+                stderr=result.stderr,
+            )
+            _LOGGER.warning("LatentSync process failed: %s", diagnostic)
+            raise LatentSyncReplyError(
+                "LATENTSYNC_FAILED",
+                diagnostic=diagnostic,
+            )
         if not working_output.is_file() or working_output.stat().st_size == 0:
             raise LatentSyncReplyError("LATENTSYNC_OUTPUT_MISSING")
         partial_output = output_path.with_suffix(output_path.suffix + ".partial")
@@ -250,14 +357,15 @@ def render_latentsync_video(
             partial_output.replace(output_path)
         finally:
             partial_output.unlink(missing_ok=True)
-    return {
-        "visual_provider": "LatentSync-1.5",
-        "inference_steps": 20,
-        "guidance_scale": 1.5,
-        "deepcache": True,
-        "inference_profile": "stage2_efficient",
-        "scene_source": "official_motion_video",
-    }
+        metadata = {
+            "visual_provider": "LatentSync-1.5",
+            "inference_steps": 20,
+            "guidance_scale": 1.5,
+            "deepcache": True,
+            "inference_profile": "stage2_efficient",
+            "scene_source": "official_motion_video",
+        }
+    return metadata
 
 
 __all__ = [

--- a/runtime/media/managed_subprocess.py
+++ b/runtime/media/managed_subprocess.py
@@ -6,6 +6,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Mapping, Sequence
 
@@ -118,17 +119,32 @@ def _report_cleanup_failures(
 
 
 def run_managed_process(
-    command: Sequence[str], *, timeout_seconds: float,
+    command: Sequence[str], *, timeout_seconds: float | None = None,
+    deadline: float | None = None,
     cwd: Path | None = None, env: Mapping[str, str] | None = None,
 ) -> subprocess.CompletedProcess[bytes]:
     """Run one worker; Windows descendants are owned before they can execute."""
 
     arguments = [str(value) for value in command]
+    if (timeout_seconds is None) == (deadline is None):
+        raise TypeError("provide exactly one of timeout_seconds or deadline")
+    def wait_budget(fallback: float) -> float:
+        if deadline is None:
+            return fallback
+        return min(fallback, max(0.0, deadline - time.monotonic()))
+    def deadline_error() -> subprocess.TimeoutExpired:
+        return subprocess.TimeoutExpired(arguments, 0)
+    if deadline is not None and wait_budget(float("inf")) <= 0:
+        raise deadline_error()
     kwargs: dict[str, object] = {
         "cwd": cwd, "env": None if env is None else dict(env),
         "stdout": subprocess.PIPE, "stderr": subprocess.PIPE,
     }
     job = _create_windows_job() if os.name == "nt" else None
+    if deadline is not None and wait_budget(float("inf")) <= 0:
+        if job is not None:
+            job.close()
+        raise deadline_error()
     if job is not None:
         kwargs["creationflags"] = (
             getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
@@ -146,6 +162,8 @@ def run_managed_process(
             try:
                 job.assign(process)
                 assigned = True
+                if deadline is not None and wait_budget(float("inf")) <= 0:
+                    raise deadline_error()
                 job.resume(process)
             except OSError:
                 if not assigned:
@@ -154,12 +172,20 @@ def run_managed_process(
                     except OSError as exc:
                         failures.append(("kill", exc))
                     try:
-                        process.communicate(timeout=_TREE_SHUTDOWN_TIMEOUT_SECONDS)
+                        process.communicate(timeout=wait_budget(_TREE_SHUTDOWN_TIMEOUT_SECONDS))
                     except (OSError, subprocess.TimeoutExpired) as exc:
                         failures.append(("reap", exc))
                 raise
         try:
-            stdout, stderr = process.communicate(timeout=timeout_seconds)
+            process_timeout = (
+                timeout_seconds if timeout_seconds is not None
+                else wait_budget(float("inf"))
+            )
+            if deadline is not None:
+                process_timeout -= min(_TREE_SHUTDOWN_TIMEOUT_SECONDS, process_timeout / 2)
+            if process_timeout <= 0:
+                raise deadline_error()
+            stdout, stderr = process.communicate(timeout=process_timeout)
         except subprocess.TimeoutExpired:
             raise
         return subprocess.CompletedProcess(
@@ -175,7 +201,7 @@ def run_managed_process(
                     failures.append(("terminate", exc))
                 try:
                     reaped_stdout, reaped_stderr = process.communicate(
-                        timeout=_TREE_SHUTDOWN_TIMEOUT_SECONDS
+                        timeout=wait_budget(_TREE_SHUTDOWN_TIMEOUT_SECONDS)
                     )
                     if isinstance(active_error, subprocess.TimeoutExpired):
                         active_error.output = reaped_stdout or active_error.output
@@ -197,7 +223,7 @@ def run_managed_process(
                 failures.append(("killpg", exc))
             try:
                 reaped_stdout, reaped_stderr = process.communicate(
-                    timeout=_TREE_SHUTDOWN_TIMEOUT_SECONDS
+                    timeout=wait_budget(_TREE_SHUTDOWN_TIMEOUT_SECONDS)
                 )
                 if isinstance(active_error, subprocess.TimeoutExpired):
                     active_error.output = reaped_stdout or active_error.output

--- a/tests/media/test_latentsync_reply.py
+++ b/tests/media/test_latentsync_reply.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from runtime.media import latentsync_reply
+
+
+def _write(path: Path, content: bytes = b"synthetic") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def _latentsync_fixture(tmp_path: Path) -> SimpleNamespace:
+    root = tmp_path / "latentsync"
+    for path in (
+        root / "scripts" / "inference.py",
+        root / "configs" / "unet" / "stage2_efficient.yaml",
+        root / "checkpoints" / "latentsync_unet.pt",
+    ):
+        _write(path)
+    return SimpleNamespace(
+        root=root,
+        python=_write(tmp_path / "python.exe"),
+        source=_write(tmp_path / "source.mp4"),
+        audio=_write(tmp_path / "speech.wav"),
+        output=tmp_path / "reply.mp4",
+        ffmpeg=_write(tmp_path / "ffmpeg" / "ffmpeg.exe"),
+        cache=tmp_path / "provider-cache",
+    )
+
+
+def _prepare_source(
+    _source: Path,
+    _audio: Path,
+    prepared: Path,
+    *,
+    environment: dict[str, str],
+) -> None:
+    assert environment["TEMP"]
+    _write(prepared, b"prepared-video")
+
+
+def test_render_keeps_success_when_published_output_cleanup_is_locked(
+    tmp_path: Path, monkeypatch
+) -> None:
+    fixture = _latentsync_fixture(tmp_path)
+
+    observed: dict[str, object] = {}
+
+    class LockedTemporaryDirectory:
+        def __init__(
+            self,
+            *,
+            prefix: str,
+            dir: Path,
+            ignore_cleanup_errors: bool = False,
+        ) -> None:
+            observed["ignore_cleanup_errors"] = ignore_cleanup_errors
+            self.path = Path(dir) / f"{prefix}locked"
+
+        def __enter__(self) -> str:
+            self.path.mkdir(parents=True)
+            return str(self.path)
+
+        def __exit__(self, *_args: object) -> None:
+            if not observed["ignore_cleanup_errors"]:
+                raise PermissionError("synthetic Windows handle lock")
+
+    def run(command: list[str], **_kwargs: object) -> SimpleNamespace:
+        if "--video_out_path" in command:
+            _write(
+                Path(command[command.index("--video_out_path") + 1]),
+                b"rendered-video",
+            )
+        else:
+            _write(Path(command[-1]), b"prepared-video")
+        return SimpleNamespace(returncode=0, stderr=b"")
+
+    monkeypatch.setattr(
+        latentsync_reply.tempfile,
+        "TemporaryDirectory",
+        LockedTemporaryDirectory,
+    )
+    monkeypatch.setattr(latentsync_reply.subprocess, "run", run)
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
+
+    metadata = latentsync_reply.render_latentsync_video(
+        fixture.source,
+        fixture.audio,
+        fixture.output,
+        python_path=fixture.python,
+        latentsync_root=fixture.root,
+        ffmpeg_path=fixture.ffmpeg,
+        provider_cache_root=fixture.cache,
+    )
+
+    assert fixture.output.read_bytes() == b"rendered-video"
+    assert metadata["visual_provider"] == "LatentSync-1.5"
+    assert observed["ignore_cleanup_errors"] is True
+
+
+def test_managed_process_timeout_terminates_windows_process_tree(monkeypatch) -> None:
+    from runtime.media import managed_subprocess
+
+    observed: dict[str, object] = {}
+
+    class TimedOutProcess:
+        pid = 4242
+        returncode: int | None = None
+
+        def communicate(self, timeout: float | None = None):
+            timeouts = observed.setdefault("communicate_timeouts", [])
+            assert isinstance(timeouts, list)
+            timeouts.append(timeout)
+            assert timeout is not None
+            if len(timeouts) <= 2:
+                raise subprocess.TimeoutExpired(
+                    cmd=["synthetic-worker"],
+                    timeout=timeout,
+                    stderr=b"still running",
+                )
+            return b"", b"terminated"
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+        def kill(self) -> None:
+            observed["direct_kill"] = True
+            self.returncode = -9
+
+    def popen(command: list[str], **kwargs: object) -> TimedOutProcess:
+        observed["command"] = command
+        observed["popen_kwargs"] = kwargs
+        return TimedOutProcess()
+
+    def taskkill(command: list[str], **kwargs: object) -> SimpleNamespace:
+        observed["taskkill_command"] = command
+        observed["taskkill_kwargs"] = kwargs
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", popen)
+    monkeypatch.setattr(managed_subprocess.subprocess, "run", taskkill)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        managed_subprocess.run_managed_process(
+            ["synthetic-worker"],
+            timeout_seconds=12.0,
+        )
+
+    popen_kwargs = observed["popen_kwargs"]
+    assert isinstance(popen_kwargs, dict)
+    creationflags = int(popen_kwargs["creationflags"])
+    assert creationflags & subprocess.CREATE_NEW_PROCESS_GROUP
+    assert creationflags & subprocess.CREATE_NO_WINDOW
+    assert observed["taskkill_command"] == ["taskkill", "/PID", "4242", "/T", "/F"]
+    assert observed["direct_kill"] is True
+    assert all(value is not None for value in observed["communicate_timeouts"])
+
+
+@pytest.mark.parametrize(
+    ("configured_timeout", "expected_timeout"), [(None, 1800.0), ("999999", 3600.0)]
+)
+def test_render_uses_managed_process_with_bounded_timeout(
+    tmp_path: Path,
+    monkeypatch,
+    configured_timeout: str | None,
+    expected_timeout: float,
+) -> None:
+    fixture = _latentsync_fixture(tmp_path)
+    observed: dict[str, object] = {}
+
+    def run_managed(
+        command: list[str],
+        *,
+        timeout_seconds: float,
+        cwd: Path,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[bytes]:
+        observed["timeout_seconds"] = timeout_seconds
+        assert cwd == fixture.root
+        assert env["TEMP"]
+        _write(
+            Path(command[command.index("--video_out_path") + 1]),
+            b"rendered-video",
+        )
+        return subprocess.CompletedProcess(command, 0, b"", b"")
+
+    monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare_source)
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", run_managed)
+    environment = {"PATH": ""}
+    if configured_timeout is not None:
+        environment["OLIVIA_LATENTSYNC_TIMEOUT_SECONDS"] = configured_timeout
+
+    latentsync_reply.render_latentsync_video(
+        fixture.source,
+        fixture.audio,
+        fixture.output,
+        python_path=fixture.python,
+        latentsync_root=fixture.root,
+        ffmpeg_path=fixture.ffmpeg,
+        provider_cache_root=fixture.cache,
+        environment=environment,
+    )
+
+    assert fixture.output.read_bytes() == b"rendered-video"
+    assert observed["timeout_seconds"] == expected_timeout
+
+
+def test_render_failure_keeps_code_and_logs_redacted_stderr_diagnostic(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    fixture = _latentsync_fixture(tmp_path)
+
+    def run_managed(
+        command: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.CompletedProcess(
+            command,
+            23,
+            b"",
+            (
+                b"C:\\Users\\someone\\private\\config.yaml "
+                b"api_key=super-secret letter=private-words "
+                b"CUDA out of memory"
+            ),
+        )
+
+    monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare_source)
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", run_managed)
+
+    with caplog.at_level(logging.WARNING, logger=latentsync_reply.__name__):
+        with pytest.raises(latentsync_reply.LatentSyncReplyError) as failure:
+            latentsync_reply.render_latentsync_video(
+                fixture.source,
+                fixture.audio,
+                fixture.output,
+                python_path=fixture.python,
+                latentsync_root=fixture.root,
+                ffmpeg_path=fixture.ffmpeg,
+                provider_cache_root=fixture.cache,
+            )
+
+    assert str(failure.value) == "LATENTSYNC_FAILED"
+    diagnostic = failure.value.diagnostic
+    assert "returncode=23" in diagnostic
+    assert "stderr_category=cuda_out_of_memory" in diagnostic
+    assert len(diagnostic) <= 240
+    assert diagnostic in caplog.text
+    for private_value in (
+        "C:\\Users",
+        "super-secret",
+        "private-words",
+    ):
+        assert private_value not in diagnostic
+        assert private_value not in caplog.text

--- a/tests/media/test_latentsync_reply.py
+++ b/tests/media/test_latentsync_reply.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 import subprocess
-import sys
 from types import SimpleNamespace
 
 import pytest
@@ -29,8 +27,11 @@ def _fixture(tmp_path: Path) -> SimpleNamespace:
     )
 
 
-def _prepare(_source: Path, _audio: Path, target: Path, *, environment) -> None:
+def _prepare(
+    _source: Path, _audio: Path, target: Path, *, environment, timeout_seconds
+) -> None:
     assert environment["TEMP"]
+    assert timeout_seconds > 0
     _write(target)
 
 
@@ -70,72 +71,6 @@ def test_published_output_survives_locked_temp_cleanup(tmp_path: Path, monkeypat
     assert observed["ignored"] is True
 
 
-def test_timeout_terminates_windows_job_tree(monkeypatch) -> None:
-    from runtime.media import managed_subprocess
-
-    observed = {"timeouts": []}
-
-    class Process:
-        pid, returncode = 4242, None
-
-        def communicate(self, timeout=None):
-            observed["timeouts"].append(timeout)
-            if len(observed["timeouts"]) == 1:
-                raise subprocess.TimeoutExpired(["worker"], timeout, stderr=b"busy")
-            return b"", b"stopped"
-
-    class Job:
-        def assign(self, process): observed["assigned"] = process.pid
-        def terminate(self): observed["terminated"] = True
-        def close(self): observed["closed"] = True
-
-    def popen(_command, **kwargs):
-        observed["kwargs"] = kwargs
-        return Process()
-
-    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
-    monkeypatch.setattr(managed_subprocess, "_create_windows_job", Job)
-    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", popen)
-    with pytest.raises(subprocess.TimeoutExpired):
-        managed_subprocess.run_managed_process(["worker"], timeout_seconds=12)
-    flags = observed["kwargs"]["creationflags"]
-    assert flags & subprocess.CREATE_NEW_PROCESS_GROUP and flags & subprocess.CREATE_NO_WINDOW
-    assert (observed["assigned"], observed["terminated"], observed["closed"]) == (4242, True, True)
-    assert observed["timeouts"] == [12, 15.0]
-
-
-def test_windows_job_failure_does_not_launch(monkeypatch) -> None:
-    from runtime.media import managed_subprocess
-
-    launched = []
-    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
-    monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: (_ for _ in ()).throw(OSError("job")))
-    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: launched.append(True))
-    with pytest.raises(OSError):
-        managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
-    assert not launched
-
-
-def test_windows_job_close_failure_is_reported(monkeypatch) -> None:
-    from runtime.media import managed_subprocess
-
-    job = SimpleNamespace(assign=lambda _p: None, terminate=lambda: None, close=lambda: (_ for _ in ()).throw(OSError("close")))
-    process = SimpleNamespace(returncode=0, communicate=lambda timeout: (b"", b""))
-    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
-    monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
-    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
-    with pytest.raises(OSError, match="close"):
-        managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
-
-
-@pytest.mark.skipif(os.name != "nt", reason="Windows Job Object contract")
-def test_real_windows_job_terminates_worker() -> None:
-    from runtime.media.managed_subprocess import run_managed_process
-
-    with pytest.raises(subprocess.TimeoutExpired):
-        run_managed_process([sys.executable, "-c", "import time; time.sleep(30)"], timeout_seconds=0.2)
-
-
 @pytest.mark.parametrize(("configured", "expected"), [(None, 1800.0), ("999999", 3600.0)])
 def test_render_uses_bounded_timeout(tmp_path: Path, monkeypatch, configured, expected) -> None:
     fixture, observed = _fixture(tmp_path), {}
@@ -147,11 +82,32 @@ def test_render_uses_bounded_timeout(tmp_path: Path, monkeypatch, configured, ex
 
     monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare)
     monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
+    monkeypatch.setattr(latentsync_reply.time, "monotonic", lambda: 0.0)
     environment = {"PATH": ""}
     if configured is not None:
         environment["OLIVIA_LATENTSYNC_TIMEOUT_SECONDS"] = configured
     _render(fixture, environment=environment)
     assert observed["timeout"] == expected
+
+
+def test_prepare_and_worker_share_one_timeout_budget(tmp_path: Path, monkeypatch) -> None:
+    fixture, observed = _fixture(tmp_path), {}
+    moments = iter((0.0, 100.0, 300.0))
+
+    def prepare(_source, _audio, target, *, environment, timeout_seconds):
+        observed["prepare"] = timeout_seconds
+        _write(target)
+
+    def run(command, *, timeout_seconds, **_kwargs):
+        observed["worker"] = timeout_seconds
+        _write(Path(command[command.index("--video_out_path") + 1]), b"video")
+        return subprocess.CompletedProcess(command, 0, b"", b"")
+
+    monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", prepare)
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
+    monkeypatch.setattr(latentsync_reply.time, "monotonic", lambda: next(moments))
+    _render(fixture)
+    assert observed == {"prepare": 1700.0, "worker": 1500.0}
 
 
 def test_failure_persists_redacted_diagnostic(tmp_path: Path, monkeypatch) -> None:
@@ -172,3 +128,26 @@ def test_failure_persists_redacted_diagnostic(tmp_path: Path, monkeypatch) -> No
     assert "returncode=23" in record["diagnostic"] and "cuda_out_of_memory" in record["diagnostic"]
     assert len(record["diagnostic"]) <= 240
     assert not any(value in json.dumps(record) for value in ("C:\\private", "secret", "words"))
+
+
+@pytest.mark.parametrize(
+    ("failure", "category"),
+    (
+        (subprocess.TimeoutExpired(["ffmpeg"], 1, stderr=b"busy"), "process_timeout"),
+        (OSError("PROCESS_TREE_TERMINATION_FAILED"), "process_management_failure"),
+    ),
+)
+def test_prepare_process_failure_is_reported(
+    tmp_path: Path, monkeypatch, failure: Exception, category: str
+) -> None:
+    fixture = _fixture(tmp_path)
+    monkeypatch.setattr(
+        latentsync_reply, "run_managed_process",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(failure),
+    )
+    data_root = tmp_path / "data"
+    with pytest.raises(latentsync_reply.LatentSyncReplyError) as caught:
+        _render(fixture, environment={"PATH": "", "OLIVIA_LOCAL_DATA_ROOT": str(data_root)})
+    assert str(caught.value) == "LATENTSYNC_FAILED"
+    record = json.loads((data_root / "logs/media-provider.jsonl").read_text())
+    assert f"stderr_category={category}" in record["diagnostic"]

--- a/tests/media/test_latentsync_reply.py
+++ b/tests/media/test_latentsync_reply.py
@@ -1,263 +1,174 @@
 from __future__ import annotations
 
-import logging
+import json
+import os
 from pathlib import Path
 import subprocess
+import sys
 from types import SimpleNamespace
 
 import pytest
-
 from runtime.media import latentsync_reply
 
 
-def _write(path: Path, content: bytes = b"synthetic") -> Path:
+def _write(path: Path, data: bytes = b"x") -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(content)
+    path.write_bytes(data)
     return path
 
 
-def _latentsync_fixture(tmp_path: Path) -> SimpleNamespace:
+def _fixture(tmp_path: Path) -> SimpleNamespace:
     root = tmp_path / "latentsync"
-    for path in (
-        root / "scripts" / "inference.py",
-        root / "configs" / "unet" / "stage2_efficient.yaml",
-        root / "checkpoints" / "latentsync_unet.pt",
-    ):
-        _write(path)
+    for item in ("scripts/inference.py", "configs/unet/stage2_efficient.yaml", "checkpoints/latentsync_unet.pt"):
+        _write(root / item)
     return SimpleNamespace(
-        root=root,
-        python=_write(tmp_path / "python.exe"),
-        source=_write(tmp_path / "source.mp4"),
-        audio=_write(tmp_path / "speech.wav"),
-        output=tmp_path / "reply.mp4",
-        ffmpeg=_write(tmp_path / "ffmpeg" / "ffmpeg.exe"),
-        cache=tmp_path / "provider-cache",
+        root=root, python=_write(tmp_path / "python.exe"),
+        source=_write(tmp_path / "source.mp4"), audio=_write(tmp_path / "speech.wav"),
+        output=tmp_path / "reply.mp4", ffmpeg=_write(tmp_path / "ffmpeg/ffmpeg.exe"),
+        cache=tmp_path / "cache",
     )
 
 
-def _prepare_source(
-    _source: Path,
-    _audio: Path,
-    prepared: Path,
-    *,
-    environment: dict[str, str],
-) -> None:
+def _prepare(_source: Path, _audio: Path, target: Path, *, environment) -> None:
     assert environment["TEMP"]
-    _write(prepared, b"prepared-video")
+    _write(target)
 
 
-def test_render_keeps_success_when_published_output_cleanup_is_locked(
-    tmp_path: Path, monkeypatch
-) -> None:
-    fixture = _latentsync_fixture(tmp_path)
+def _render(fixture: SimpleNamespace, **kwargs):
+    return latentsync_reply.render_latentsync_video(
+        fixture.source, fixture.audio, fixture.output,
+        python_path=fixture.python, latentsync_root=fixture.root,
+        ffmpeg_path=fixture.ffmpeg, provider_cache_root=fixture.cache, **kwargs,
+    )
 
-    observed: dict[str, object] = {}
 
-    class LockedTemporaryDirectory:
-        def __init__(
-            self,
-            *,
-            prefix: str,
-            dir: Path,
-            ignore_cleanup_errors: bool = False,
-        ) -> None:
-            observed["ignore_cleanup_errors"] = ignore_cleanup_errors
+def test_published_output_survives_locked_temp_cleanup(tmp_path: Path, monkeypatch) -> None:
+    fixture, observed = _fixture(tmp_path), {}
+
+    class LockedTemp:
+        def __init__(self, *, prefix, dir, ignore_cleanup_errors=False):
+            observed["ignored"] = ignore_cleanup_errors
             self.path = Path(dir) / f"{prefix}locked"
 
-        def __enter__(self) -> str:
+        def __enter__(self):
             self.path.mkdir(parents=True)
             return str(self.path)
 
-        def __exit__(self, *_args: object) -> None:
-            if not observed["ignore_cleanup_errors"]:
-                raise PermissionError("synthetic Windows handle lock")
+        def __exit__(self, *_args):
+            if not observed["ignored"]:
+                raise PermissionError("locked")
 
-    def run(command: list[str], **_kwargs: object) -> SimpleNamespace:
-        if "--video_out_path" in command:
-            _write(
-                Path(command[command.index("--video_out_path") + 1]),
-                b"rendered-video",
-            )
-        else:
-            _write(Path(command[-1]), b"prepared-video")
+    def run(command, **_kwargs):
+        _write(Path(command[command.index("--video_out_path") + 1]), b"video")
         return SimpleNamespace(returncode=0, stderr=b"")
 
-    monkeypatch.setattr(
-        latentsync_reply.tempfile,
-        "TemporaryDirectory",
-        LockedTemporaryDirectory,
-    )
-    monkeypatch.setattr(latentsync_reply.subprocess, "run", run)
+    monkeypatch.setattr(latentsync_reply.tempfile, "TemporaryDirectory", LockedTemp)
+    monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare)
     monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
-
-    metadata = latentsync_reply.render_latentsync_video(
-        fixture.source,
-        fixture.audio,
-        fixture.output,
-        python_path=fixture.python,
-        latentsync_root=fixture.root,
-        ffmpeg_path=fixture.ffmpeg,
-        provider_cache_root=fixture.cache,
-    )
-
-    assert fixture.output.read_bytes() == b"rendered-video"
-    assert metadata["visual_provider"] == "LatentSync-1.5"
-    assert observed["ignore_cleanup_errors"] is True
+    assert _render(fixture)["visual_provider"] == "LatentSync-1.5"
+    assert fixture.output.read_bytes() == b"video"
+    assert observed["ignored"] is True
 
 
-def test_managed_process_timeout_terminates_windows_process_tree(monkeypatch) -> None:
+def test_timeout_terminates_windows_job_tree(monkeypatch) -> None:
     from runtime.media import managed_subprocess
 
-    observed: dict[str, object] = {}
+    observed = {"timeouts": []}
 
-    class TimedOutProcess:
-        pid = 4242
-        returncode: int | None = None
+    class Process:
+        pid, returncode = 4242, None
 
-        def communicate(self, timeout: float | None = None):
-            timeouts = observed.setdefault("communicate_timeouts", [])
-            assert isinstance(timeouts, list)
-            timeouts.append(timeout)
-            assert timeout is not None
-            if len(timeouts) <= 2:
-                raise subprocess.TimeoutExpired(
-                    cmd=["synthetic-worker"],
-                    timeout=timeout,
-                    stderr=b"still running",
-                )
-            return b"", b"terminated"
+        def communicate(self, timeout=None):
+            observed["timeouts"].append(timeout)
+            if len(observed["timeouts"]) == 1:
+                raise subprocess.TimeoutExpired(["worker"], timeout, stderr=b"busy")
+            return b"", b"stopped"
 
-        def poll(self) -> int | None:
-            return self.returncode
+    class Job:
+        def assign(self, process): observed["assigned"] = process.pid
+        def terminate(self): observed["terminated"] = True
+        def close(self): observed["closed"] = True
 
-        def kill(self) -> None:
-            observed["direct_kill"] = True
-            self.returncode = -9
-
-    def popen(command: list[str], **kwargs: object) -> TimedOutProcess:
-        observed["command"] = command
-        observed["popen_kwargs"] = kwargs
-        return TimedOutProcess()
-
-    def taskkill(command: list[str], **kwargs: object) -> SimpleNamespace:
-        observed["taskkill_command"] = command
-        observed["taskkill_kwargs"] = kwargs
-        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+    def popen(_command, **kwargs):
+        observed["kwargs"] = kwargs
+        return Process()
 
     monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess, "_create_windows_job", Job)
     monkeypatch.setattr(managed_subprocess.subprocess, "Popen", popen)
-    monkeypatch.setattr(managed_subprocess.subprocess, "run", taskkill)
+    with pytest.raises(subprocess.TimeoutExpired):
+        managed_subprocess.run_managed_process(["worker"], timeout_seconds=12)
+    flags = observed["kwargs"]["creationflags"]
+    assert flags & subprocess.CREATE_NEW_PROCESS_GROUP and flags & subprocess.CREATE_NO_WINDOW
+    assert (observed["assigned"], observed["terminated"], observed["closed"]) == (4242, True, True)
+    assert observed["timeouts"] == [12, 15.0]
+
+
+def test_windows_job_failure_does_not_launch(monkeypatch) -> None:
+    from runtime.media import managed_subprocess
+
+    launched = []
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: (_ for _ in ()).throw(OSError("job")))
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: launched.append(True))
+    with pytest.raises(OSError):
+        managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
+    assert not launched
+
+
+def test_windows_job_close_failure_is_reported(monkeypatch) -> None:
+    from runtime.media import managed_subprocess
+
+    job = SimpleNamespace(assign=lambda _p: None, terminate=lambda: None, close=lambda: (_ for _ in ()).throw(OSError("close")))
+    process = SimpleNamespace(returncode=0, communicate=lambda timeout: (b"", b""))
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
+    with pytest.raises(OSError, match="close"):
+        managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows Job Object contract")
+def test_real_windows_job_terminates_worker() -> None:
+    from runtime.media.managed_subprocess import run_managed_process
 
     with pytest.raises(subprocess.TimeoutExpired):
-        managed_subprocess.run_managed_process(
-            ["synthetic-worker"],
-            timeout_seconds=12.0,
-        )
-
-    popen_kwargs = observed["popen_kwargs"]
-    assert isinstance(popen_kwargs, dict)
-    creationflags = int(popen_kwargs["creationflags"])
-    assert creationflags & subprocess.CREATE_NEW_PROCESS_GROUP
-    assert creationflags & subprocess.CREATE_NO_WINDOW
-    assert observed["taskkill_command"] == ["taskkill", "/PID", "4242", "/T", "/F"]
-    assert observed["direct_kill"] is True
-    assert all(value is not None for value in observed["communicate_timeouts"])
+        run_managed_process([sys.executable, "-c", "import time; time.sleep(30)"], timeout_seconds=0.2)
 
 
-@pytest.mark.parametrize(
-    ("configured_timeout", "expected_timeout"), [(None, 1800.0), ("999999", 3600.0)]
-)
-def test_render_uses_managed_process_with_bounded_timeout(
-    tmp_path: Path,
-    monkeypatch,
-    configured_timeout: str | None,
-    expected_timeout: float,
-) -> None:
-    fixture = _latentsync_fixture(tmp_path)
-    observed: dict[str, object] = {}
+@pytest.mark.parametrize(("configured", "expected"), [(None, 1800.0), ("999999", 3600.0)])
+def test_render_uses_bounded_timeout(tmp_path: Path, monkeypatch, configured, expected) -> None:
+    fixture, observed = _fixture(tmp_path), {}
 
-    def run_managed(
-        command: list[str],
-        *,
-        timeout_seconds: float,
-        cwd: Path,
-        env: dict[str, str],
-    ) -> subprocess.CompletedProcess[bytes]:
-        observed["timeout_seconds"] = timeout_seconds
-        assert cwd == fixture.root
-        assert env["TEMP"]
-        _write(
-            Path(command[command.index("--video_out_path") + 1]),
-            b"rendered-video",
-        )
+    def run(command, *, timeout_seconds, **_kwargs):
+        observed["timeout"] = timeout_seconds
+        _write(Path(command[command.index("--video_out_path") + 1]), b"video")
         return subprocess.CompletedProcess(command, 0, b"", b"")
 
-    monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare_source)
-    monkeypatch.setattr(latentsync_reply, "run_managed_process", run_managed)
+    monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare)
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
     environment = {"PATH": ""}
-    if configured_timeout is not None:
-        environment["OLIVIA_LATENTSYNC_TIMEOUT_SECONDS"] = configured_timeout
-
-    latentsync_reply.render_latentsync_video(
-        fixture.source,
-        fixture.audio,
-        fixture.output,
-        python_path=fixture.python,
-        latentsync_root=fixture.root,
-        ffmpeg_path=fixture.ffmpeg,
-        provider_cache_root=fixture.cache,
-        environment=environment,
-    )
-
-    assert fixture.output.read_bytes() == b"rendered-video"
-    assert observed["timeout_seconds"] == expected_timeout
+    if configured is not None:
+        environment["OLIVIA_LATENTSYNC_TIMEOUT_SECONDS"] = configured
+    _render(fixture, environment=environment)
+    assert observed["timeout"] == expected
 
 
-def test_render_failure_keeps_code_and_logs_redacted_stderr_diagnostic(
-    tmp_path: Path, monkeypatch, caplog
-) -> None:
-    fixture = _latentsync_fixture(tmp_path)
+def test_failure_persists_redacted_diagnostic(tmp_path: Path, monkeypatch) -> None:
+    fixture, secret = _fixture(tmp_path), b"C:\\private api_key=secret letter=words CUDA out of memory"
 
-    def run_managed(
-        command: list[str],
-        **_kwargs: object,
-    ) -> subprocess.CompletedProcess[bytes]:
-        return subprocess.CompletedProcess(
-            command,
-            23,
-            b"",
-            (
-                b"C:\\Users\\someone\\private\\config.yaml "
-                b"api_key=super-secret letter=private-words "
-                b"CUDA out of memory"
-            ),
-        )
+    def run(command, **_kwargs):
+        return subprocess.CompletedProcess(command, 23, b"", secret)
 
-    monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare_source)
-    monkeypatch.setattr(latentsync_reply, "run_managed_process", run_managed)
-
-    with caplog.at_level(logging.WARNING, logger=latentsync_reply.__name__):
-        with pytest.raises(latentsync_reply.LatentSyncReplyError) as failure:
-            latentsync_reply.render_latentsync_video(
-                fixture.source,
-                fixture.audio,
-                fixture.output,
-                python_path=fixture.python,
-                latentsync_root=fixture.root,
-                ffmpeg_path=fixture.ffmpeg,
-                provider_cache_root=fixture.cache,
-            )
-
+    monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare)
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
+    data_root = tmp_path / "data"
+    with pytest.raises(latentsync_reply.LatentSyncReplyError) as failure:
+        _render(fixture, environment={"PATH": "", "OLIVIA_LOCAL_DATA_ROOT": str(data_root)})
     assert str(failure.value) == "LATENTSYNC_FAILED"
-    diagnostic = failure.value.diagnostic
-    assert "returncode=23" in diagnostic
-    assert "stderr_category=cuda_out_of_memory" in diagnostic
-    assert len(diagnostic) <= 240
-    assert diagnostic in caplog.text
-    for private_value in (
-        "C:\\Users",
-        "super-secret",
-        "private-words",
-    ):
-        assert private_value not in diagnostic
-        assert private_value not in caplog.text
+    record = json.loads((data_root / "logs/media-provider.jsonl").read_text())
+    assert record["diagnostic"] == failure.value.diagnostic
+    assert record["provider"] == "latentsync" and record["error_code"] == "LATENTSYNC_FAILED"
+    assert "returncode=23" in record["diagnostic"] and "cuda_out_of_memory" in record["diagnostic"]
+    assert len(record["diagnostic"]) <= 240
+    assert not any(value in json.dumps(record) for value in ("C:\\private", "secret", "words"))

--- a/tests/media/test_latentsync_reply.py
+++ b/tests/media/test_latentsync_reply.py
@@ -52,7 +52,7 @@ def test_published_output_survives_locked_temp_cleanup(tmp_path: Path, monkeypat
             self.path = Path(dir) / f"{prefix}locked"
 
         def __enter__(self):
-            self.path.mkdir(parents=True)
+            self.path.mkdir(parents=True, exist_ok=True)
             return str(self.path)
 
         def __exit__(self, *_args):
@@ -60,8 +60,13 @@ def test_published_output_survives_locked_temp_cleanup(tmp_path: Path, monkeypat
                 raise PermissionError("locked")
 
     def run(command, **_kwargs):
-        _write(Path(command[command.index("--video_out_path") + 1]), b"video")
-        return SimpleNamespace(returncode=0, stderr=b"")
+        if "--video_out_path" in command:
+            _write(Path(command[command.index("--video_out_path") + 1]), b"video")
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        observed["validation"] = command
+        return SimpleNamespace(
+            returncode=0, stdout=b"frame=25\nout_time_us=1000000\nprogress=end\n", stderr=b"",
+        )
 
     monkeypatch.setattr(latentsync_reply.tempfile, "TemporaryDirectory", LockedTemp)
     monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare)
@@ -69,6 +74,40 @@ def test_published_output_survives_locked_temp_cleanup(tmp_path: Path, monkeypat
     assert _render(fixture)["visual_provider"] == "LatentSync-1.5"
     assert fixture.output.read_bytes() == b"video"
     assert observed["ignored"] is True
+    assert all(flag in observed["validation"] for flag in ("-xerror", "-f", "-progress"))
+
+    def fail(error):
+        return lambda *_args, **_kwargs: (_ for _ in ()).throw(error)
+    monkeypatch.setattr(latentsync_reply.shutil, "copy2", fail(FileNotFoundError("copy failed")))
+    monkeypatch.setattr(Path, "unlink", fail(PermissionError("locked")))
+    with pytest.raises(FileNotFoundError, match="copy failed"):
+        _render(fixture)
+
+
+@pytest.mark.parametrize("failure", ("corrupt", "missing_audio"))
+def test_invalid_output_is_not_published(tmp_path: Path, monkeypatch, failure) -> None:
+    fixture = _fixture(tmp_path)
+
+    def run(command, **_kwargs):
+        if "--video_out_path" in command:
+            _write(Path(command[command.index("--video_out_path") + 1]), failure.encode())
+            return subprocess.CompletedProcess(command, 0, b"", b"")
+        if failure == "missing_audio":
+            return subprocess.CompletedProcess(
+                command, int("0:a:0" in command), b"frame=25\nout_time_us=1000000\nprogress=end\n",
+                b"missing audio",
+            )
+        return subprocess.CompletedProcess(
+            command, 0, b"frame=0\nout_time_us=0\nprogress=end\n", b"",
+        )
+
+    monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare)
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
+    data_root = tmp_path / "data"
+    with pytest.raises(latentsync_reply.LatentSyncReplyError) as caught:
+        _render(fixture, environment={"PATH": "", "OLIVIA_LOCAL_DATA_ROOT": str(data_root)})
+    assert str(caught.value) == "LATENTSYNC_FAILED"
+    assert not fixture.output.exists()
 
 
 @pytest.mark.parametrize(("configured", "expected"), [(None, 1800.0), ("999999", 3600.0)])
@@ -77,8 +116,11 @@ def test_render_uses_bounded_timeout(tmp_path: Path, monkeypatch, configured, ex
 
     def run(command, *, timeout_seconds, **_kwargs):
         observed["timeout"] = timeout_seconds
-        _write(Path(command[command.index("--video_out_path") + 1]), b"video")
-        return subprocess.CompletedProcess(command, 0, b"", b"")
+        if "--video_out_path" in command:
+            _write(Path(command[command.index("--video_out_path") + 1]), b"video")
+        return subprocess.CompletedProcess(
+            command, 0, b"frame=25\nout_time_us=1000000\nprogress=end\n", b"",
+        )
 
     monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare)
     monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
@@ -92,22 +134,59 @@ def test_render_uses_bounded_timeout(tmp_path: Path, monkeypatch, configured, ex
 
 def test_prepare_and_worker_share_one_timeout_budget(tmp_path: Path, monkeypatch) -> None:
     fixture, observed = _fixture(tmp_path), {}
-    moments = iter((0.0, 100.0, 300.0))
+    moments = iter((0.0, 100.0, 300.0, 400.0))
 
     def prepare(_source, _audio, target, *, environment, timeout_seconds):
         observed["prepare"] = timeout_seconds
         _write(target)
 
     def run(command, *, timeout_seconds, **_kwargs):
-        observed["worker"] = timeout_seconds
-        _write(Path(command[command.index("--video_out_path") + 1]), b"video")
-        return subprocess.CompletedProcess(command, 0, b"", b"")
+        phase = "worker" if "--video_out_path" in command else "validation"
+        observed[phase] = timeout_seconds
+        if phase == "worker":
+            _write(Path(command[command.index("--video_out_path") + 1]), b"video")
+        return subprocess.CompletedProcess(
+            command, 0, b"frame=25\nout_time_us=1000000\nprogress=end\n", b"",
+        )
 
     monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", prepare)
     monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
     monkeypatch.setattr(latentsync_reply.time, "monotonic", lambda: next(moments))
     _render(fixture)
-    assert observed == {"prepare": 1700.0, "worker": 1500.0}
+    assert observed == {"prepare": 1700.0, "worker": 1500.0, "validation": 1400.0}
+
+
+def test_exhausted_total_deadline_does_not_start_worker(tmp_path: Path, monkeypatch) -> None:
+    fixture = _fixture(tmp_path)
+
+    def unexpected_worker(*_args, **_kwargs):
+        raise AssertionError("worker started after the total deadline")
+
+    monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare)
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", unexpected_worker)
+    monkeypatch.setattr(latentsync_reply.time, "monotonic", lambda: next(iter_moments))
+    iter_moments = iter((0.0, 100.0, 1801.0))
+    data_root = tmp_path / "data"
+    with pytest.raises(latentsync_reply.LatentSyncReplyError) as caught:
+        _render(fixture, environment={"PATH": "", "OLIVIA_LOCAL_DATA_ROOT": str(data_root)})
+    assert str(caught.value) == "LATENTSYNC_FAILED"
+    assert caught.value.diagnostic == "returncode=unknown;stderr_category=process_timeout"
+
+
+def test_prepare_nonzero_uses_stable_reported_failure(tmp_path: Path, monkeypatch) -> None:
+    fixture = _fixture(tmp_path)
+
+    def run(command, **_kwargs):
+        return subprocess.CompletedProcess(command, 19, b"", b"ffmpeg failed")
+
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
+    data_root = tmp_path / "data"
+    with pytest.raises(latentsync_reply.LatentSyncReplyError) as caught:
+        _render(fixture, environment={"PATH": "", "OLIVIA_LOCAL_DATA_ROOT": str(data_root)})
+    assert str(caught.value) == "LATENTSYNC_FAILED"
+    record = json.loads((data_root / "logs/media-provider.jsonl").read_text())
+    assert "returncode=19" in record["diagnostic"]
+    assert "stderr_category=external_process_failure" in record["diagnostic"]
 
 
 def test_failure_persists_redacted_diagnostic(tmp_path: Path, monkeypatch) -> None:
@@ -125,8 +204,7 @@ def test_failure_persists_redacted_diagnostic(tmp_path: Path, monkeypatch) -> No
     record = json.loads((data_root / "logs/media-provider.jsonl").read_text())
     assert record["diagnostic"] == failure.value.diagnostic
     assert record["provider"] == "latentsync" and record["error_code"] == "LATENTSYNC_FAILED"
-    assert "returncode=23" in record["diagnostic"] and "cuda_out_of_memory" in record["diagnostic"]
-    assert len(record["diagnostic"]) <= 240
+    assert record["diagnostic"] == "returncode=23;stderr_category=cuda_out_of_memory"
     assert not any(value in json.dumps(record) for value in ("C:\\private", "secret", "words"))
 
 

--- a/tests/media/test_latentsync_reply.py
+++ b/tests/media/test_latentsync_reply.py
@@ -8,12 +8,10 @@ from types import SimpleNamespace
 import pytest
 from runtime.media import latentsync_reply
 
-
 def _write(path: Path, data: bytes = b"x") -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(data)
     return path
-
 
 def _fixture(tmp_path: Path) -> SimpleNamespace:
     root = tmp_path / "latentsync"
@@ -26,14 +24,9 @@ def _fixture(tmp_path: Path) -> SimpleNamespace:
         cache=tmp_path / "cache",
     )
 
-
-def _prepare(
-    _source: Path, _audio: Path, target: Path, *, environment, timeout_seconds
-) -> None:
-    assert environment["TEMP"]
-    assert timeout_seconds > 0
+def _prepare(_source: Path, _audio: Path, target: Path, *, environment, deadline) -> None:
+    assert environment["TEMP"] and deadline > 0
     _write(target)
-
 
 def _render(fixture: SimpleNamespace, **kwargs):
     return latentsync_reply.render_latentsync_video(
@@ -42,40 +35,30 @@ def _render(fixture: SimpleNamespace, **kwargs):
         ffmpeg_path=fixture.ffmpeg, provider_cache_root=fixture.cache, **kwargs,
     )
 
-
 def test_published_output_survives_locked_temp_cleanup(tmp_path: Path, monkeypatch) -> None:
     fixture, observed = _fixture(tmp_path), {}
-
     class LockedTemp:
         def __init__(self, *, prefix, dir, ignore_cleanup_errors=False):
             observed["ignored"] = ignore_cleanup_errors
             self.path = Path(dir) / f"{prefix}locked"
-
         def __enter__(self):
             self.path.mkdir(parents=True, exist_ok=True)
             return str(self.path)
-
         def __exit__(self, *_args):
             if not observed["ignored"]:
                 raise PermissionError("locked")
-
     def run(command, **_kwargs):
         if "--video_out_path" in command:
             _write(Path(command[command.index("--video_out_path") + 1]), b"video")
             return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
         observed["validation"] = command
-        return SimpleNamespace(
-            returncode=0, stdout=b"frame=25\nout_time_us=1000000\nprogress=end\n", stderr=b"",
-        )
-
+        return SimpleNamespace(returncode=0, stdout=b"frame=25\nout_time_us=1000000\nprogress=end\n", stderr=b"")
     monkeypatch.setattr(latentsync_reply.tempfile, "TemporaryDirectory", LockedTemp)
     monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare)
     monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
     assert _render(fixture)["visual_provider"] == "LatentSync-1.5"
-    assert fixture.output.read_bytes() == b"video"
-    assert observed["ignored"] is True
+    assert fixture.output.read_bytes() == b"video" and observed["ignored"] is True
     assert all(flag in observed["validation"] for flag in ("-xerror", "-f", "-progress"))
-
     def fail(error):
         return lambda *_args, **_kwargs: (_ for _ in ()).throw(error)
     monkeypatch.setattr(latentsync_reply.shutil, "copy2", fail(FileNotFoundError("copy failed")))
@@ -83,45 +66,31 @@ def test_published_output_survives_locked_temp_cleanup(tmp_path: Path, monkeypat
     with pytest.raises(FileNotFoundError, match="copy failed"):
         _render(fixture)
 
-
 @pytest.mark.parametrize("failure", ("corrupt", "missing_audio"))
 def test_invalid_output_is_not_published(tmp_path: Path, monkeypatch, failure) -> None:
     fixture = _fixture(tmp_path)
-
     def run(command, **_kwargs):
         if "--video_out_path" in command:
             _write(Path(command[command.index("--video_out_path") + 1]), failure.encode())
             return subprocess.CompletedProcess(command, 0, b"", b"")
         if failure == "missing_audio":
-            return subprocess.CompletedProcess(
-                command, int("0:a:0" in command), b"frame=25\nout_time_us=1000000\nprogress=end\n",
-                b"missing audio",
-            )
-        return subprocess.CompletedProcess(
-            command, 0, b"frame=0\nout_time_us=0\nprogress=end\n", b"",
-        )
-
+            return subprocess.CompletedProcess(command, int("0:a:0" in command), b"frame=25\nout_time_us=1000000\nprogress=end\n", b"missing audio")
+        return subprocess.CompletedProcess(command, 0, b"frame=0\nout_time_us=0\nprogress=end\n", b"")
     monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare)
     monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
     data_root = tmp_path / "data"
     with pytest.raises(latentsync_reply.LatentSyncReplyError) as caught:
         _render(fixture, environment={"PATH": "", "OLIVIA_LOCAL_DATA_ROOT": str(data_root)})
-    assert str(caught.value) == "LATENTSYNC_FAILED"
-    assert not fixture.output.exists()
-
+    assert str(caught.value) == "LATENTSYNC_FAILED" and not fixture.output.exists()
 
 @pytest.mark.parametrize(("configured", "expected"), [(None, 1800.0), ("999999", 3600.0)])
 def test_render_uses_bounded_timeout(tmp_path: Path, monkeypatch, configured, expected) -> None:
     fixture, observed = _fixture(tmp_path), {}
-
-    def run(command, *, timeout_seconds, **_kwargs):
-        observed["timeout"] = timeout_seconds
+    def run(command, *, deadline, **_kwargs):
+        observed["timeout"] = deadline
         if "--video_out_path" in command:
             _write(Path(command[command.index("--video_out_path") + 1]), b"video")
-        return subprocess.CompletedProcess(
-            command, 0, b"frame=25\nout_time_us=1000000\nprogress=end\n", b"",
-        )
-
+        return subprocess.CompletedProcess(command, 0, b"frame=25\nout_time_us=1000000\nprogress=end\n", b"")
     monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare)
     monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
     monkeypatch.setattr(latentsync_reply.time, "monotonic", lambda: 0.0)
@@ -131,101 +100,69 @@ def test_render_uses_bounded_timeout(tmp_path: Path, monkeypatch, configured, ex
     _render(fixture, environment=environment)
     assert observed["timeout"] == expected
 
-
-def test_prepare_and_worker_share_one_timeout_budget(tmp_path: Path, monkeypatch) -> None:
+def test_prepare_worker_validation_share_one_absolute_deadline(tmp_path: Path, monkeypatch) -> None:
     fixture, observed = _fixture(tmp_path), {}
-    moments = iter((0.0, 100.0, 300.0, 400.0))
-
-    def prepare(_source, _audio, target, *, environment, timeout_seconds):
-        observed["prepare"] = timeout_seconds
+    def prepare(_source, _audio, target, *, environment, deadline):
+        observed["prepare"] = deadline
         _write(target)
-
-    def run(command, *, timeout_seconds, **_kwargs):
+    def run(command, *, deadline, **_kwargs):
         phase = "worker" if "--video_out_path" in command else "validation"
-        observed[phase] = timeout_seconds
+        observed[phase] = deadline
         if phase == "worker":
             _write(Path(command[command.index("--video_out_path") + 1]), b"video")
-        return subprocess.CompletedProcess(
-            command, 0, b"frame=25\nout_time_us=1000000\nprogress=end\n", b"",
-        )
-
+        return subprocess.CompletedProcess(command, 0, b"frame=25\nout_time_us=1000000\nprogress=end\n", b"")
     monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", prepare)
     monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
-    monkeypatch.setattr(latentsync_reply.time, "monotonic", lambda: next(moments))
+    monkeypatch.setattr(latentsync_reply.time, "monotonic", lambda: 0.0)
     _render(fixture)
-    assert observed == {"prepare": 1700.0, "worker": 1500.0, "validation": 1400.0}
+    assert observed == {"prepare": 1800.0, "worker": 1800.0, "validation": 1800.0}
 
-
-def test_exhausted_total_deadline_does_not_start_worker(tmp_path: Path, monkeypatch) -> None:
-    fixture = _fixture(tmp_path)
-
-    def unexpected_worker(*_args, **_kwargs):
-        raise AssertionError("worker started after the total deadline")
-
-    monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare)
-    monkeypatch.setattr(latentsync_reply, "run_managed_process", unexpected_worker)
-    monkeypatch.setattr(latentsync_reply.time, "monotonic", lambda: next(iter_moments))
-    iter_moments = iter((0.0, 100.0, 1801.0))
+def test_exhausted_total_deadline_is_redacted(tmp_path: Path, monkeypatch) -> None:
+    fixture, clock = _fixture(tmp_path), [0.0]
+    def prepare(_source, _audio, target, *, environment, deadline):
+        _write(target)
+        clock[0] = deadline
+    def expired(command, **_kwargs):
+        raise subprocess.TimeoutExpired(command, 0, stderr=b"private")
+    monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", prepare)
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", expired)
+    monkeypatch.setattr(latentsync_reply.time, "monotonic", lambda: clock[0])
     data_root = tmp_path / "data"
     with pytest.raises(latentsync_reply.LatentSyncReplyError) as caught:
         _render(fixture, environment={"PATH": "", "OLIVIA_LOCAL_DATA_ROOT": str(data_root)})
     assert str(caught.value) == "LATENTSYNC_FAILED"
     assert caught.value.diagnostic == "returncode=unknown;stderr_category=process_timeout"
 
-
 def test_prepare_nonzero_uses_stable_reported_failure(tmp_path: Path, monkeypatch) -> None:
     fixture = _fixture(tmp_path)
-
-    def run(command, **_kwargs):
-        return subprocess.CompletedProcess(command, 19, b"", b"ffmpeg failed")
-
-    monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", lambda command, **_kwargs: subprocess.CompletedProcess(command, 19, b"", b"ffmpeg failed"))
     data_root = tmp_path / "data"
     with pytest.raises(latentsync_reply.LatentSyncReplyError) as caught:
         _render(fixture, environment={"PATH": "", "OLIVIA_LOCAL_DATA_ROOT": str(data_root)})
-    assert str(caught.value) == "LATENTSYNC_FAILED"
     record = json.loads((data_root / "logs/media-provider.jsonl").read_text())
-    assert "returncode=19" in record["diagnostic"]
+    assert str(caught.value) == "LATENTSYNC_FAILED" and "returncode=19" in record["diagnostic"]
     assert "stderr_category=external_process_failure" in record["diagnostic"]
-
 
 def test_failure_persists_redacted_diagnostic(tmp_path: Path, monkeypatch) -> None:
     fixture, secret = _fixture(tmp_path), b"C:\\private api_key=secret letter=words CUDA out of memory"
-
-    def run(command, **_kwargs):
-        return subprocess.CompletedProcess(command, 23, b"", secret)
-
     monkeypatch.setattr(latentsync_reply, "_prepare_source_clip", _prepare)
-    monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", lambda command, **_kwargs: subprocess.CompletedProcess(command, 23, b"", secret))
     data_root = tmp_path / "data"
     with pytest.raises(latentsync_reply.LatentSyncReplyError) as failure:
         _render(fixture, environment={"PATH": "", "OLIVIA_LOCAL_DATA_ROOT": str(data_root)})
-    assert str(failure.value) == "LATENTSYNC_FAILED"
     record = json.loads((data_root / "logs/media-provider.jsonl").read_text())
-    assert record["diagnostic"] == failure.value.diagnostic
+    assert str(failure.value) == "LATENTSYNC_FAILED" and record["diagnostic"] == failure.value.diagnostic
     assert record["provider"] == "latentsync" and record["error_code"] == "LATENTSYNC_FAILED"
     assert record["diagnostic"] == "returncode=23;stderr_category=cuda_out_of_memory"
     assert not any(value in json.dumps(record) for value in ("C:\\private", "secret", "words"))
 
-
-@pytest.mark.parametrize(
-    ("failure", "category"),
-    (
-        (subprocess.TimeoutExpired(["ffmpeg"], 1, stderr=b"busy"), "process_timeout"),
-        (OSError("PROCESS_TREE_TERMINATION_FAILED"), "process_management_failure"),
-    ),
-)
-def test_prepare_process_failure_is_reported(
-    tmp_path: Path, monkeypatch, failure: Exception, category: str
-) -> None:
+@pytest.mark.parametrize(("failure", "category"), ((subprocess.TimeoutExpired(["ffmpeg"], 1, stderr=b"busy"), "process_timeout"), (OSError("PROCESS_TREE_TERMINATION_FAILED"), "process_management_failure")))
+def test_prepare_process_failure_is_reported(tmp_path: Path, monkeypatch, failure: Exception, category: str) -> None:
     fixture = _fixture(tmp_path)
-    monkeypatch.setattr(
-        latentsync_reply, "run_managed_process",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(failure),
-    )
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", lambda *_a, **_k: (_ for _ in ()).throw(failure))
     data_root = tmp_path / "data"
     with pytest.raises(latentsync_reply.LatentSyncReplyError) as caught:
         _render(fixture, environment={"PATH": "", "OLIVIA_LOCAL_DATA_ROOT": str(data_root)})
-    assert str(caught.value) == "LATENTSYNC_FAILED"
     record = json.loads((data_root / "logs/media-provider.jsonl").read_text())
+    assert str(caught.value) == "LATENTSYNC_FAILED"
     assert f"stderr_category={category}" in record["diagnostic"]

--- a/tests/media/test_managed_subprocess.py
+++ b/tests/media/test_managed_subprocess.py
@@ -75,6 +75,37 @@ def test_windows_timeout_owns_and_terminates_suspended_worker(monkeypatch) -> No
     assert observed["timeouts"] == [12, 15.0]
 
 
+def test_absolute_deadline_includes_start_timeout_and_cleanup(monkeypatch) -> None:
+    clock, waits = [0.0], []
+    def spend(seconds):
+        clock[0] += seconds
+    class Process:
+        pid, returncode = 4242, None
+        def communicate(self, timeout):
+            waits.append(timeout)
+            spend(timeout)
+            if len(waits) == 1:
+                raise subprocess.TimeoutExpired(["worker"], timeout)
+            return b"", b"stopped"
+    class Job:
+        def assign(self, _process): spend(1)
+        def resume(self, _process): spend(1)
+        def terminate(self): spend(1)
+        def close(self): pass
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess, "_TREE_SHUTDOWN_TIMEOUT_SECONDS", 2.0)
+    monkeypatch.setattr(managed_subprocess.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: (spend(1) or Job()))
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: (spend(1) or Process()))
+    with pytest.raises(subprocess.TimeoutExpired):
+        managed_subprocess.run_managed_process(["worker"], deadline=10.0)
+    assert clock[0] <= 10.0
+    assert waits == [4.0, 1.0]
+    with pytest.raises(subprocess.TimeoutExpired):
+        managed_subprocess.run_managed_process(["worker"], deadline=10.0)
+    assert clock[0] == 10.0
+
+
 def test_windows_job_creation_failure_does_not_launch(monkeypatch) -> None:
     launched: list[bool] = []
     monkeypatch.setattr(managed_subprocess.os, "name", "nt")

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -727,6 +727,7 @@ def test_latentsync_process_receives_bundled_ffmpeg(tmp_path, monkeypatch):
         return SimpleNamespace(returncode=0)
 
     monkeypatch.setattr(latentsync_reply.subprocess, "run", run)
+    monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
 
     render_latentsync_video(
         source,

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -711,9 +711,16 @@ def test_latentsync_process_receives_bundled_ffmpeg(tmp_path, monkeypatch):
 
     def run(command, **kwargs):
         if Path(command[0]).name.casefold() == "ffmpeg.exe":
+            if "-progress" in command:
+                observed["validation_command"] = command
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=b"frame=25\nout_time_us=1000000\nprogress=end\n",
+                    stderr=b"",
+                )
             Path(command[-1]).write_bytes(b"prepared-video")
             observed["prepare_command"] = command
-            return SimpleNamespace(returncode=0)
+            return SimpleNamespace(returncode=0, stderr=b"")
         observed["environment"] = kwargs.get("env")
         observed["config_path"] = command[
             command.index("--unet_config_path") + 1
@@ -724,7 +731,7 @@ def test_latentsync_process_receives_bundled_ffmpeg(tmp_path, monkeypatch):
         Path(command[command.index("--video_out_path") + 1]).write_bytes(
             b"synthetic-video"
         )
-        return SimpleNamespace(returncode=0)
+        return SimpleNamespace(returncode=0, stderr=b"")
 
     monkeypatch.setattr(latentsync_reply.subprocess, "run", run)
     monkeypatch.setattr(latentsync_reply, "run_managed_process", run)
@@ -745,6 +752,7 @@ def test_latentsync_process_receives_bundled_ffmpeg(tmp_path, monkeypatch):
     assert Path(environment["TEMP"]).is_relative_to(tmp_path)
     assert output.read_bytes() == b"synthetic-video"
     assert Path(observed["prepare_command"][0]).name.casefold() == "ffmpeg.exe"
+    assert Path(observed["validation_command"][0]).name.casefold() == "ffmpeg.exe"
     assert "libx264" in observed["prepare_command"]
     assert Path(observed["config_path"]).name == "stage2_efficient.yaml"
 


### PR DESCRIPTION
## Scope
- enforce one absolute render deadline across preparation, worker, termination, reap, and validation
- contain the full Windows process tree and preserve bounded cleanup
- validate final audio/video decodability before atomic publication
- expose stable diagnostic categories without leaking paths or stderr

## Frozen evidence
- exact pair: fe0c6c641d97864abffaaad265617c2f39eabcf3...fce93b22c2dcbe085e28bad1c11bd74304e48efe
- focused tests: 46 passed
- pycompile and git diff --check: pass
- Standards review: PASS, P0/P1/P2=0/0/0
- Spec review: PASS, P0/P1/P2=0/0/0

## Boundary
Synthetic tests do not replace real Windows Job Object, FFmpeg, GPU LatentSync, or human media acceptance.