### PR TITLE
fix(state): preserve mailbox across corrupt snapshots

### DIFF
--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -23,7 +23,7 @@
 | 501 | `ROUTE_NOT_IMPLEMENTED` | NOT_IMPLEMENTED | 否 | 未登记 route |
 | 200 detail | `LLM_TIMEOUT` / `LLM_UNAVAILABLE` | FAILED | 是 | 发信先确认 PENDING；provider 超时/不可用后 detail 显示 FAILED |
 | 200 detail | `LLM_INTERRUPTED` | FAILED | 是 | 进程在 provider 调用终态落盘前中断；不自动重复生成 |
-| 503 | `STORE_STATE_UNAVAILABLE` | FAILED | 否 | 信箱状态损坏或原子持久化不可用；拒绝新写入且不回显正文、本机路径或底层异常 |
+| 503 | `STORE_STATE_UNAVAILABLE` | FAILED | 否 | 当前信箱状态损坏或原子持久化不可用；拒绝 current 读写且不回显正文、本机路径或底层异常 |
 | 503 | `MEMORY_UNAVAILABLE` | UNAVAILABLE | 是 | legacy import 的 SQLite 存储不可用；不回显正文、路径或密钥 |
 | 503 | `OFFICIAL_LETTER_IMPORT_UNAVAILABLE` | UNAVAILABLE | 是 | 官方登录日志或文字信件接口暂不可用；不回显凭证、正文或本机路径 |
 | 503 | `OFFICIAL_HISTORY_MEMORY_UNAVAILABLE` | UNAVAILABLE | 是 | Mem0 未安装、未启用或状态不可用；在采集官方历史前拒绝导入 |

--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -23,6 +23,7 @@
 | 501 | `ROUTE_NOT_IMPLEMENTED` | NOT_IMPLEMENTED | 否 | 未登记 route |
 | 200 detail | `LLM_TIMEOUT` / `LLM_UNAVAILABLE` | FAILED | 是 | 发信先确认 PENDING；provider 超时/不可用后 detail 显示 FAILED |
 | 200 detail | `LLM_INTERRUPTED` | FAILED | 是 | 进程在 provider 调用终态落盘前中断；不自动重复生成 |
+| 503 | `STORE_STATE_UNAVAILABLE` | FAILED | 否 | 信箱状态损坏或原子持久化不可用；拒绝新写入且不回显正文、本机路径或底层异常 |
 | 503 | `MEMORY_UNAVAILABLE` | UNAVAILABLE | 是 | legacy import 的 SQLite 存储不可用；不回显正文、路径或密钥 |
 | 503 | `OFFICIAL_LETTER_IMPORT_UNAVAILABLE` | UNAVAILABLE | 是 | 官方登录日志或文字信件接口暂不可用；不回显凭证、正文或本机路径 |
 | 503 | `OFFICIAL_HISTORY_MEMORY_UNAVAILABLE` | UNAVAILABLE | 是 | Mem0 未安装、未启用或状态不可用；在采集官方历史前拒绝导入 |

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -56,7 +56,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 - 找不到信件或 MIDI job：404，不返回空的成功对象。
 - 空信箱、无匹配歌曲、空 playlist：200，但 `source=local-memory|empty`、列表和计数明确为空。
 - LLM timeout/error：发信确认保持 200/PENDING，detail 随后标记 `FAILED` 并带错误码；不得写入 `reply_text` 占位符。
-- 信箱状态损坏或原子写入在 replace 前失败：503 `STORE_STATE_UNAVAILABLE`，拒绝新信且保留已有快照；replace 后仅目录同步失败时保留已提交信并继续调度，日志只记录脱敏诊断码。
+- 当前信箱状态损坏或原子写入在 replace 前失败：current list/unread/detail/send 返回 503 `STORE_STATE_UNAVAILABLE`，legacy 只读信箱保持独立；replace 后仅目录同步失败时保留已提交信并继续调度，日志只记录脱敏诊断码。
 - 同一时间只接收一封未交付信：上一封仍为 PENDING/PROCESSING，或虽已生成但尚未到 `reply_not_before` 时，不同的新信返回 409 `LETTER_IN_PROGRESS`；相同请求的网络重试仍复用原信，回信可见后允许继续寄信。
 - 相同正文和素材在短窗口内失败后重试成功时，旧 FAILED 记录保留在本地审计状态，但从 current list 隐藏；直接查询旧 ID 返回 410 `LETTER_SUPERSEDED` 和替代信件 ID，不回显旧正文。
 - `/letter/resend` 当前未实现；重复请求返回相同 501，不改变信件内容或状态。

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -56,6 +56,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 - 找不到信件或 MIDI job：404，不返回空的成功对象。
 - 空信箱、无匹配歌曲、空 playlist：200，但 `source=local-memory|empty`、列表和计数明确为空。
 - LLM timeout/error：发信确认保持 200/PENDING，detail 随后标记 `FAILED` 并带错误码；不得写入 `reply_text` 占位符。
+- 信箱状态损坏或原子写入在 replace 前失败：503 `STORE_STATE_UNAVAILABLE`，拒绝新信且保留已有快照；replace 后仅目录同步失败时保留已提交信并继续调度，日志只记录脱敏诊断码。
 - 同一时间只接收一封未交付信：上一封仍为 PENDING/PROCESSING，或虽已生成但尚未到 `reply_not_before` 时，不同的新信返回 409 `LETTER_IN_PROGRESS`；相同请求的网络重试仍复用原信，回信可见后允许继续寄信。
 - 相同正文和素材在短窗口内失败后重试成功时，旧 FAILED 记录保留在本地审计状态，但从 current list 隐藏；直接查询旧 ID 返回 410 `LETTER_SUPERSEDED` 和替代信件 ID，不回显旧正文。
 - `/letter/resend` 当前未实现；重复请求返回相同 501，不改变信件内容或状态。

--- a/http_contract.py
+++ b/http_contract.py
@@ -45,6 +45,7 @@ ERROR_CODES: dict[str, dict[str, Any]] = {
     "VIDEO_REPLY_SETTING_UNAVAILABLE": {"http_status": 503, "retryable": True},
     "LETTER_SUPERSEDED": {"http_status": 410, "retryable": False},
     "INTERNAL_ERROR": {"http_status": 500, "retryable": False},
+    "STORE_STATE_UNAVAILABLE": {"http_status": 503, "retryable": False},
     "LLM_UNAVAILABLE": {"http_status": 503, "retryable": True},
     "LLM_TIMEOUT": {"http_status": 503, "retryable": True},
     "LLM_INTERRUPTED": {"http_status": 503, "retryable": True},

--- a/local_server.py
+++ b/local_server.py
@@ -926,7 +926,10 @@ def _load_store_state() -> None:
     if isinstance(loaded.get("request_keys"), dict):
         store.request_keys = loaded["request_keys"]
     if needs_persist or recovered_from_backup:
-        _persist_store_state()
+        try:
+            _persist_store_state()
+        except StoreStateUnavailable:
+            _safe_log("store_primary_repair_failed", error_code=StoreStateUnavailable.code)
 
 
 def _persist_store_state() -> None:

--- a/local_server.py
+++ b/local_server.py
@@ -839,22 +839,32 @@ def _fsync_store_directory(root: Path) -> None:
 
 
 def _atomic_write_store_file(path: Path, serialized: str) -> None:
-    descriptor, temporary_name = _tempfile.mkstemp(
-        dir=path.parent,
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-    )
-    temporary = Path(temporary_name)
+    descriptor: int | None = None
+    temporary: Path | None = None
     try:
-        with _os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
+        descriptor, temporary_name = _tempfile.mkstemp(
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+        )
+        temporary = Path(temporary_name)
+        handle = _os.fdopen(descriptor, "w", encoding="utf-8", newline="")
+        descriptor = None
+        with handle:
             handle.write(serialized)
             handle.flush()
             _os.fsync(handle.fileno())
         _os.replace(temporary, path)
         _fsync_store_directory(path.parent)
-    except OSError:
+    except (OSError, UnicodeError):
+        if descriptor is not None:
+            try:
+                _os.close(descriptor)
+            except OSError:
+                pass
         try:
-            temporary.unlink(missing_ok=True)
+            if temporary is not None:
+                temporary.unlink(missing_ok=True)
         except OSError:
             pass
         raise StoreStateUnavailable(StoreStateUnavailable.code) from None
@@ -914,7 +924,11 @@ def _persist_store_state() -> None:
     root = _state_root()
     if root is None:
         return
-    root.mkdir(parents=True, exist_ok=True)
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        _store_state_error_code = StoreStateUnavailable.code
+        raise StoreStateUnavailable(StoreStateUnavailable.code) from None
     payload = {
         "letters": store.letters,
         "legacy_letters": store.legacy_letters,
@@ -2921,9 +2935,26 @@ async def route(
             ),
         }
         store.letters.insert(0, letter)
+        previous_request_id = (
+            store.request_keys.get(idempotency_key)
+            if idempotency_key is not None
+            else None
+        )
+        had_request_key = (
+            idempotency_key is not None and idempotency_key in store.request_keys
+        )
         if idempotency_key is not None:
             store.request_keys[idempotency_key] = lid
-        _persist_store_state()
+        try:
+            _persist_store_state()
+        except StoreStateUnavailable:
+            store.letters.remove(letter)
+            if idempotency_key is not None:
+                if had_request_key:
+                    store.request_keys[idempotency_key] = previous_request_id
+                else:
+                    store.request_keys.pop(idempotency_key, None)
+            raise
         if defer_reply or not _conversation_memory_ready_for_reply():
             _schedule_reply_job(lid, content, idempotency_key=idempotency_key)
             return _send_result_for_letter(letter)

--- a/local_server.py
+++ b/local_server.py
@@ -17,6 +17,7 @@ import uuid
 import hashlib
 import inspect
 import threading
+import tempfile as _tempfile
 import webbrowser as _webbrowser
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -746,6 +747,16 @@ class Store:
         self.request_keys = {}
 
 store = Store()
+_store_state_error_code: str | None = None
+
+
+class StoreStateUnavailable(RuntimeError):
+    code = "STORE_STATE_UNAVAILABLE"
+
+
+def _require_store_state_available() -> None:
+    if _store_state_error_code is not None:
+        raise StoreStateUnavailable(_store_state_error_code)
 
 
 def _local_data_root(environment: Mapping[str, str] | None = None) -> Path | None:
@@ -797,16 +808,80 @@ def _mark_media_not_requested(letter: dict) -> None:
     letter["media_retryable"] = False
 
 
+def _read_store_state(path: Path) -> dict:
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict) or "letters" not in loaded:
+        raise ValueError("store state must be an object")
+    normalized: dict[str, object] = {}
+    for name in ("letters", "legacy_letters", "midi_jobs"):
+        value = loaded.get(name, [])
+        if not isinstance(value, list) or not all(
+            isinstance(item, dict) for item in value
+        ):
+            raise ValueError("store state contains an invalid collection")
+        normalized[name] = value
+    for name in ("settings", "request_keys"):
+        value = loaded.get(name, {})
+        if not isinstance(value, dict):
+            raise ValueError("store state contains invalid metadata")
+        normalized[name] = value
+    return normalized
+
+
+def _fsync_store_directory(root: Path) -> None:
+    if _os.name == "nt":
+        return
+    descriptor = _os.open(root, _os.O_RDONLY)
+    try:
+        _os.fsync(descriptor)
+    finally:
+        _os.close(descriptor)
+
+
+def _atomic_write_store_file(path: Path, serialized: str) -> None:
+    descriptor, temporary_name = _tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    try:
+        with _os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
+            handle.write(serialized)
+            handle.flush()
+            _os.fsync(handle.fileno())
+        _os.replace(temporary, path)
+        _fsync_store_directory(path.parent)
+    except OSError:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise StoreStateUnavailable(StoreStateUnavailable.code) from None
+
+
 def _load_store_state() -> None:
+    global _store_state_error_code
     root = _state_root()
     if root is None:
         return
+    recovered_from_backup = False
     try:
-        loaded = json.loads((root / "state.json").read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError):
-        return
-    if not isinstance(loaded, dict):
-        return
+        loaded = _read_store_state(root / "state.json")
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as primary_error:
+        try:
+            loaded = _read_store_state(root / "state.json.bak")
+            recovered_from_backup = True
+        except FileNotFoundError:
+            if isinstance(primary_error, FileNotFoundError):
+                _store_state_error_code = None
+                return
+            _store_state_error_code = StoreStateUnavailable.code
+            return
+        except (OSError, UnicodeError, json.JSONDecodeError, ValueError):
+            _store_state_error_code = StoreStateUnavailable.code
+            return
+    _store_state_error_code = None
     needs_persist = False
     for name in ("letters", "legacy_letters", "midi_jobs"):
         value = loaded.get(name)
@@ -829,11 +904,13 @@ def _load_store_state() -> None:
         store.settings = loaded["settings"]
     if isinstance(loaded.get("request_keys"), dict):
         store.request_keys = loaded["request_keys"]
-    if needs_persist:
+    if needs_persist or recovered_from_backup:
         _persist_store_state()
 
 
 def _persist_store_state() -> None:
+    global _store_state_error_code
+    _require_store_state_available()
     root = _state_root()
     if root is None:
         return
@@ -845,9 +922,17 @@ def _persist_store_state() -> None:
         "settings": store.settings,
         "request_keys": store.request_keys,
     }
-    temporary = root / ".state.json.tmp"
-    temporary.write_text(json.dumps(payload, ensure_ascii=False, sort_keys=True), encoding="utf-8")
-    temporary.replace(root / "state.json")
+    serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    try:
+        _atomic_write_store_file(root / "state.json", serialized)
+    except StoreStateUnavailable:
+        _store_state_error_code = StoreStateUnavailable.code
+        raise
+    _store_state_error_code = None
+    try:
+        _atomic_write_store_file(root / "state.json.bak", serialized)
+    except StoreStateUnavailable:
+        _safe_log("store_backup_failed", error_code=StoreStateUnavailable.code)
 
 
 _memory_config = load_memory_config()
@@ -1403,6 +1488,23 @@ async def handler(request: web.Request):
                 companion_confirmed=(
                     request.headers.get("X-Olivia-Companion-Action") == "confirmed"
                 ),
+            )
+        except StoreStateUnavailable:
+            _load_store_state()
+            _safe_log(
+                "route_failure",
+                method=method,
+                path=path,
+                error_code=StoreStateUnavailable.code,
+            )
+            result = err(
+                503,
+                StoreStateUnavailable.code,
+                {
+                    "status": "FAILED",
+                    "error_code": StoreStateUnavailable.code,
+                    "retryable": False,
+                },
             )
         except Exception as e:
             code = _diagnostic_code('ROUTE', e)
@@ -2738,6 +2840,7 @@ async def route(
                 "error_code": "READ_ONLY_SCOPE",
                 "scope": "legacy",
             })
+        _require_store_state_available()
         if "content" not in body:
             return _missing_field("content")
         content = body.get("content")

--- a/local_server.py
+++ b/local_server.py
@@ -855,7 +855,6 @@ def _atomic_write_store_file(path: Path, serialized: str) -> None:
             handle.flush()
             _os.fsync(handle.fileno())
         _os.replace(temporary, path)
-        _fsync_store_directory(path.parent)
     except (OSError, UnicodeError):
         if descriptor is not None:
             try:
@@ -868,6 +867,13 @@ def _atomic_write_store_file(path: Path, serialized: str) -> None:
         except OSError:
             pass
         raise StoreStateUnavailable(StoreStateUnavailable.code) from None
+    try:
+        _fsync_store_directory(path.parent)
+    except OSError:
+        _safe_log(
+            "store_directory_sync_failed",
+            error_code="STORE_STATE_DURABILITY_UNCERTAIN",
+        )
 
 
 def _load_store_state() -> None:

--- a/local_server.py
+++ b/local_server.py
@@ -754,6 +754,11 @@ class StoreStateUnavailable(RuntimeError):
     code = "STORE_STATE_UNAVAILABLE"
 
 
+_CURRENT_STORE_CAPABILITIES = frozenset(
+    {"letters.read", "letters.unread", "letters.send"}
+)
+
+
 def _require_store_state_available() -> None:
     if _store_state_error_code is not None:
         raise StoreStateUnavailable(_store_state_error_code)
@@ -2396,6 +2401,11 @@ async def route(
         })
     if query is None:
         query = {}
+    if (
+        spec["capability"] in _CURRENT_STORE_CAPABILITIES
+        and query.get("scope", "current") == "current"
+    ):
+        _require_store_state_available()
     if p == "/health":
         return _health_result(query.get("profile", contract.HEALTH_PROFILE_CORE))
     if p == "/toy/companion/memory/retry":
@@ -2860,7 +2870,6 @@ async def route(
                 "error_code": "READ_ONLY_SCOPE",
                 "scope": "legacy",
             })
-        _require_store_state_available()
         if "content" not in body:
             return _missing_field("content")
         content = body.get("content")

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -55,7 +55,9 @@ def _post_current_letter(local_server, content: str) -> tuple[int, dict]:
     return asyncio.run(exercise())
 
 
-def _get_mailbox_responses(local_server) -> list[tuple[int, dict]]:
+def _get_mailbox_responses(
+    local_server, detail_id: str = "synthetic-missing"
+) -> list[tuple[int, dict]]:
     from aiohttp import web
     from aiohttp.test_utils import TestClient, TestServer
 
@@ -67,7 +69,7 @@ def _get_mailbox_responses(local_server) -> list[tuple[int, dict]]:
             for path, params in (
                 ("/toy/letter/list", {}),
                 ("/toy/letter/unread_count", {}),
-                ("/toy/letter/detail", {"letter_id": "synthetic-missing"}),
+                ("/toy/letter/detail", {"letter_id": detail_id}),
                 ("/toy/letter/list", {"scope": "legacy"}),
             ):
                 response = await client.get(path, params=params)
@@ -957,59 +959,53 @@ def test_corrupt_state_blocks_public_letter_mutation_without_overwrite(
         "retryable": False,
     }
     error_table = (ROOT / "docs" / "B02_ERROR_CODES.md").read_text(encoding="utf-8")
-    assert any(
-        "| 503 | `STORE_STATE_UNAVAILABLE` | FAILED | 否 |" in row
-        for row in error_table.splitlines()
-    )
+    assert "| 503 | `STORE_STATE_UNAVAILABLE` | FAILED | 否 |" in error_table
 
 
+@pytest.mark.parametrize("rewrite_fails", [False, True])
 def test_corrupt_primary_state_recovers_from_durable_backup(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    rewrite_fails: bool,
 ) -> None:
-    from aiohttp import web
-    from aiohttp.test_utils import TestClient, TestServer
-
     import local_server
 
     monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
     monkeypatch.setattr(local_server, "_store_state_error_code", None, raising=False)
     letter = {
         "letter_id": "synthetic-backup-letter",
-        "content": "synthetic backup input",
-        "material": {},
         "letter_status": "COMPLETED",
-        "audit_status": 2,
-        "is_read": 1,
-        "created_at": 100,
         "reply_text": "synthetic backup reply",
-        "reply_mode": "text_letter",
-        "triage": {"status": "completed"},
-        "music_duration_seconds": 60,
     }
     local_server.store.letters.append(letter)
     local_server._persist_store_state()
-    (tmp_path / "state.json").write_bytes(b'{"letters":[')
+    state_path = tmp_path / "state.json"
+    state_path.write_bytes(b'{"letters":[')
     local_server.store.letters.clear()
+    if rewrite_fails:
+        real_replace = local_server._os.replace
+
+        def reject_primary_rewrite(source, destination) -> None:
+            if Path(destination) == state_path:
+                raise OSError("synthetic primary rewrite failure")
+            real_replace(source, destination)
+
+        monkeypatch.setattr(local_server._os, "replace", reject_primary_rewrite)
     local_server._load_store_state()
 
-    async def exercise() -> tuple[int, dict]:
-        app = web.Application()
-        app.router.add_route("*", "/{tail:.*}", local_server.handler)
-        async with TestClient(TestServer(app, access_log=None)) as client:
-            response = await client.get(
-                "/toy/letter/detail",
-                params={"letter_id": letter["letter_id"]},
-            )
-            return response.status, await response.json()
+    *current_reads, legacy_read = _get_mailbox_responses(local_server, letter["letter_id"])
+    status, payload = current_reads[2]
 
-    status, payload = asyncio.run(exercise())
-
-    assert status == 200
-    assert payload["data"]["reply_text"] == "synthetic backup reply"
-    assert json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))[
-        "letters"
-    ][0]["letter_id"] == letter["letter_id"]
+    if rewrite_fails:
+        assert all(item[0] == 503 for item in current_reads)
+        assert legacy_read[0] == 200
+        assert state_path.read_bytes() == b'{"letters":['
+    else:
+        assert status == 200
+        assert payload["data"]["reply_text"] == "synthetic backup reply"
+        assert json.loads(state_path.read_text(encoding="utf-8"))["letters"][0][
+            "letter_id"
+        ] == letter["letter_id"]
 
 
 @pytest.mark.parametrize("existing_snapshot", [True, False])

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -55,6 +55,28 @@ def _post_current_letter(local_server, content: str) -> tuple[int, dict]:
     return asyncio.run(exercise())
 
 
+def _get_mailbox_responses(local_server) -> list[tuple[int, dict]]:
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    async def exercise() -> list[tuple[int, dict]]:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            responses = []
+            for path, params in (
+                ("/toy/letter/list", {}),
+                ("/toy/letter/unread_count", {}),
+                ("/toy/letter/detail", {"letter_id": "synthetic-missing"}),
+                ("/toy/letter/list", {"scope": "legacy"}),
+            ):
+                response = await client.get(path, params=params)
+                responses.append((response.status, await response.json()))
+            return responses
+
+    return asyncio.run(exercise())
+
+
 def test_core_health_is_versioned_and_reports_unavailable_optional_capabilities() -> None:
     import local_server
 
@@ -913,10 +935,18 @@ def test_corrupt_state_blocks_public_letter_mutation_without_overwrite(
     monkeypatch.setattr(local_server, "_schedule_reply_job", lambda *_args, **_kwargs: None)
     local_server._load_store_state()
 
+    *current_reads, legacy_read = _get_mailbox_responses(local_server)
     status, payload = _post_current_letter(
         local_server, "synthetic state recovery letter"
     )
 
+    assert all(
+        read_status == 503
+        and read_payload["data"]["error_code"] == "STORE_STATE_UNAVAILABLE"
+        for read_status, read_payload in current_reads
+    )
+    assert legacy_read[0] == 200
+    assert legacy_read[1]["data"]["scope"] == "legacy"
     assert status == 503
     assert payload["data"]["error_code"] == "STORE_STATE_UNAVAILABLE"
     assert state_path.read_bytes() == corrupt_state

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -877,6 +877,179 @@ def test_persisted_pending_reply_resumes_when_http_runtime_starts(
     assert persisted["request_keys"]["restart-key"] == pending["letter_id"]
 
 
+@pytest.mark.parametrize(
+    "corrupt_state",
+    [b'{"letters":[', b'{"letters":"not-a-list"}'],
+)
+def test_corrupt_state_blocks_public_letter_mutation_without_overwrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    corrupt_state: bytes,
+) -> None:
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    import local_server
+
+    state_path = tmp_path / "state.json"
+    state_path.write_bytes(corrupt_state)
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(local_server, "_store_state_error_code", None, raising=False)
+    monkeypatch.setattr(local_server, "_schedule_reply_job", lambda *_args, **_kwargs: None)
+    local_server._load_store_state()
+
+    async def exercise() -> tuple[int, dict]:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            response = await client.post(
+                "/toy/letter/send",
+                json={"content": "synthetic state recovery letter"},
+            )
+            return response.status, await response.json()
+
+    status, payload = asyncio.run(exercise())
+
+    assert status == 503
+    assert payload["data"]["error_code"] == "STORE_STATE_UNAVAILABLE"
+    assert state_path.read_bytes() == corrupt_state
+    assert local_server.store.letters == []
+    assert local_server.store.request_keys == {}
+
+
+def test_corrupt_primary_state_recovers_from_durable_backup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    import local_server
+
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(local_server, "_store_state_error_code", None, raising=False)
+    letter = {
+        "letter_id": "synthetic-backup-letter",
+        "content": "synthetic backup input",
+        "material": {},
+        "letter_status": "COMPLETED",
+        "audit_status": 2,
+        "is_read": 1,
+        "created_at": 100,
+        "reply_text": "synthetic backup reply",
+        "reply_mode": "text_letter",
+        "triage": {"status": "completed"},
+        "music_duration_seconds": 60,
+    }
+    local_server.store.letters.append(letter)
+    local_server._persist_store_state()
+    (tmp_path / "state.json").write_bytes(b'{"letters":[')
+    local_server.store.letters.clear()
+    local_server._load_store_state()
+
+    async def exercise() -> tuple[int, dict]:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            response = await client.get(
+                "/toy/letter/detail",
+                params={"letter_id": letter["letter_id"]},
+            )
+            return response.status, await response.json()
+
+    status, payload = asyncio.run(exercise())
+
+    assert status == 200
+    assert payload["data"]["reply_text"] == "synthetic backup reply"
+    assert json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))[
+        "letters"
+    ][0]["letter_id"] == letter["letter_id"]
+
+
+def test_public_letter_mutation_rolls_back_when_state_replace_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import os
+
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    import local_server
+
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(local_server, "_store_state_error_code", None, raising=False)
+    monkeypatch.setattr(local_server, "_schedule_reply_job", lambda *_args, **_kwargs: None)
+    local_server._persist_store_state()
+    state_path = tmp_path / "state.json"
+    previous_state = state_path.read_bytes()
+    real_replace = os.replace
+
+    def reject_primary_replace(source, destination) -> None:
+        if Path(destination) == state_path:
+            raise OSError("synthetic replace failure")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", reject_primary_replace)
+
+    async def exercise() -> tuple[int, dict]:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            response = await client.post(
+                "/toy/letter/send",
+                json={"content": "synthetic failed persistence letter"},
+            )
+            return response.status, await response.json()
+
+    status, payload = asyncio.run(exercise())
+
+    assert status == 503
+    assert payload["data"]["error_code"] == "STORE_STATE_UNAVAILABLE"
+    assert state_path.read_bytes() == previous_state
+    assert local_server.store.letters == []
+    assert not tuple(tmp_path.glob("*.tmp"))
+
+
+def test_state_persist_fsyncs_unique_snapshots_before_replace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import os
+
+    import local_server
+
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(local_server, "_store_state_error_code", None, raising=False)
+    events: list[tuple[str, str]] = []
+    real_fsync = os.fsync
+    real_replace = os.replace
+
+    def record_fsync(descriptor: int) -> None:
+        events.append(("fsync", ""))
+        real_fsync(descriptor)
+
+    def record_replace(source, destination) -> None:
+        events.append(("replace", Path(source).name))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(os, "fsync", record_fsync)
+    monkeypatch.setattr(os, "replace", record_replace)
+
+    local_server._persist_store_state()
+
+    assert [event[0] for event in events] == [
+        "fsync",
+        "replace",
+        "fsync",
+        "replace",
+    ]
+    temporary_names = [value for event, value in events if event == "replace"]
+    assert len(set(temporary_names)) == 2
+    assert ".state.json.tmp" not in temporary_names
+    assert ".state.json.bak.tmp" not in temporary_names
+
+
 def test_failed_idempotent_request_can_retry_with_same_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -38,6 +38,23 @@ def reset_local_store():
     local_server.store.request_keys.clear()
 
 
+def _post_current_letter(local_server, content: str) -> tuple[int, dict]:
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    async def exercise() -> tuple[int, dict]:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            response = await client.post(
+                "/toy/letter/send",
+                json={"content": content},
+            )
+            return response.status, await response.json()
+
+    return asyncio.run(exercise())
+
+
 def test_core_health_is_versioned_and_reports_unavailable_optional_capabilities() -> None:
     import local_server
 
@@ -886,9 +903,7 @@ def test_corrupt_state_blocks_public_letter_mutation_without_overwrite(
     monkeypatch: pytest.MonkeyPatch,
     corrupt_state: bytes,
 ) -> None:
-    from aiohttp import web
-    from aiohttp.test_utils import TestClient, TestServer
-
+    import http_contract
     import local_server
 
     state_path = tmp_path / "state.json"
@@ -898,23 +913,24 @@ def test_corrupt_state_blocks_public_letter_mutation_without_overwrite(
     monkeypatch.setattr(local_server, "_schedule_reply_job", lambda *_args, **_kwargs: None)
     local_server._load_store_state()
 
-    async def exercise() -> tuple[int, dict]:
-        app = web.Application()
-        app.router.add_route("*", "/{tail:.*}", local_server.handler)
-        async with TestClient(TestServer(app, access_log=None)) as client:
-            response = await client.post(
-                "/toy/letter/send",
-                json={"content": "synthetic state recovery letter"},
-            )
-            return response.status, await response.json()
-
-    status, payload = asyncio.run(exercise())
+    status, payload = _post_current_letter(
+        local_server, "synthetic state recovery letter"
+    )
 
     assert status == 503
     assert payload["data"]["error_code"] == "STORE_STATE_UNAVAILABLE"
     assert state_path.read_bytes() == corrupt_state
     assert local_server.store.letters == []
     assert local_server.store.request_keys == {}
+    assert http_contract.error_metadata("STORE_STATE_UNAVAILABLE") == {
+        "http_status": 503,
+        "retryable": False,
+    }
+    error_table = (ROOT / "docs" / "B02_ERROR_CODES.md").read_text(encoding="utf-8")
+    assert any(
+        "| 503 | `STORE_STATE_UNAVAILABLE` | FAILED | 否 |" in row
+        for row in error_table.splitlines()
+    )
 
 
 def test_corrupt_primary_state_recovers_from_durable_backup(
@@ -974,9 +990,6 @@ def test_public_letter_mutation_rolls_back_when_state_replace_fails(
 ) -> None:
     import os
 
-    from aiohttp import web
-    from aiohttp.test_utils import TestClient, TestServer
-
     import local_server
 
     monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
@@ -995,17 +1008,9 @@ def test_public_letter_mutation_rolls_back_when_state_replace_fails(
 
     monkeypatch.setattr(os, "replace", reject_primary_replace)
 
-    async def exercise() -> tuple[int, dict]:
-        app = web.Application()
-        app.router.add_route("*", "/{tail:.*}", local_server.handler)
-        async with TestClient(TestServer(app, access_log=None)) as client:
-            response = await client.post(
-                "/toy/letter/send",
-                json={"content": "synthetic failed persistence letter"},
-            )
-            return response.status, await response.json()
-
-    status, payload = asyncio.run(exercise())
+    status, payload = _post_current_letter(
+        local_server, "synthetic failed persistence letter"
+    )
 
     assert status == 503
     assert payload["data"]["error_code"] == "STORE_STATE_UNAVAILABLE"
@@ -1044,25 +1049,52 @@ def test_state_persist_fsyncs_unique_snapshots_before_replace(
 
     local_server._persist_store_state()
 
-    assert [event[0] for event in events] == [
-        "fsync",
-        "replace",
-        "fsync",
-        "replace",
-    ]
+    write_events = ["fsync", "replace"]
+    if os.name != "nt":
+        write_events.append("fsync")
+    assert [event[0] for event in events] == write_events * 2
     temporary_names = [value for event, value in events if event == "replace"]
     assert len(set(temporary_names)) == 2
     assert ".state.json.tmp" not in temporary_names
     assert ".state.json.bak.tmp" not in temporary_names
 
 
+def test_directory_fsync_failure_keeps_committed_letter_scheduled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    scheduled: list[str] = []
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(local_server, "_store_state_error_code", None, raising=False)
+    monkeypatch.setattr(
+        local_server,
+        "_schedule_reply_job",
+        lambda letter_id, *_args, **_kwargs: scheduled.append(letter_id),
+    )
+    monkeypatch.setattr(
+        local_server,
+        "_fsync_store_directory",
+        lambda *_args: (_ for _ in ()).throw(OSError("synthetic directory fsync failure")),
+    )
+
+    status, payload = _post_current_letter(
+        local_server, "synthetic durability uncertain letter"
+    )
+
+    assert status == 200
+    assert payload["data"]["status"] == "PENDING"
+    assert scheduled == [payload["data"]["letter_id"]]
+    assert local_server.store.letters == json.loads(
+        (tmp_path / "state.json").read_text(encoding="utf-8")
+    )["letters"]
+
+
 def test_public_letter_mutation_normalizes_state_root_creation_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from aiohttp import web
-    from aiohttp.test_utils import TestClient, TestServer
-
     import local_server
 
     blocked_root = tmp_path / "blocked-state-root"
@@ -1071,17 +1103,9 @@ def test_public_letter_mutation_normalizes_state_root_creation_failure(
     monkeypatch.setattr(local_server, "_store_state_error_code", None, raising=False)
     monkeypatch.setattr(local_server, "_schedule_reply_job", lambda *_args, **_kwargs: None)
 
-    async def exercise() -> tuple[int, dict]:
-        app = web.Application()
-        app.router.add_route("*", "/{tail:.*}", local_server.handler)
-        async with TestClient(TestServer(app, access_log=None)) as client:
-            response = await client.post(
-                "/toy/letter/send",
-                json={"content": "synthetic blocked state root letter"},
-            )
-            return response.status, await response.json()
-
-    status, payload = asyncio.run(exercise())
+    status, payload = _post_current_letter(
+        local_server, "synthetic blocked state root letter"
+    )
 
     assert status == 503
     assert payload["data"]["error_code"] == "STORE_STATE_UNAVAILABLE"
@@ -1099,9 +1123,6 @@ def test_state_temp_creation_failure_preserves_primary_commit_boundary(
     failed_target: str,
     expected_status: int,
 ) -> None:
-    from aiohttp import web
-    from aiohttp.test_utils import TestClient, TestServer
-
     import local_server
 
     monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
@@ -1116,17 +1137,9 @@ def test_state_temp_creation_failure_preserves_primary_commit_boundary(
 
     monkeypatch.setattr(local_server._tempfile, "mkstemp", selective_mkstemp)
 
-    async def exercise() -> tuple[int, dict]:
-        app = web.Application()
-        app.router.add_route("*", "/{tail:.*}", local_server.handler)
-        async with TestClient(TestServer(app, access_log=None)) as client:
-            response = await client.post(
-                "/toy/letter/send",
-                json={"content": "synthetic temp failure letter"},
-            )
-            return response.status, await response.json()
-
-    status, payload = asyncio.run(exercise())
+    status, payload = _post_current_letter(
+        local_server, "synthetic temp failure letter"
+    )
 
     assert status == expected_status
     if failed_target == "state.json":
@@ -1144,26 +1157,13 @@ def test_public_letter_mutation_normalizes_unencodable_state_text(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from aiohttp import web
-    from aiohttp.test_utils import TestClient, TestServer
-
     import local_server
 
     monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
     monkeypatch.setattr(local_server, "_store_state_error_code", None, raising=False)
     monkeypatch.setattr(local_server, "_schedule_reply_job", lambda *_args, **_kwargs: None)
 
-    async def exercise() -> tuple[int, dict]:
-        app = web.Application()
-        app.router.add_route("*", "/{tail:.*}", local_server.handler)
-        async with TestClient(TestServer(app, access_log=None)) as client:
-            response = await client.post(
-                "/toy/letter/send",
-                json={"content": "synthetic\ud800state text"},
-            )
-            return response.status, await response.json()
-
-    status, payload = asyncio.run(exercise())
+    status, payload = _post_current_letter(local_server, "synthetic\ud800state text")
 
     assert status == 503
     assert payload["data"]["error_code"] == "STORE_STATE_UNAVAILABLE"

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -966,9 +966,11 @@ def test_corrupt_primary_state_recovers_from_durable_backup(
     ][0]["letter_id"] == letter["letter_id"]
 
 
+@pytest.mark.parametrize("existing_snapshot", [True, False])
 def test_public_letter_mutation_rolls_back_when_state_replace_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    existing_snapshot: bool,
 ) -> None:
     import os
 
@@ -980,9 +982,10 @@ def test_public_letter_mutation_rolls_back_when_state_replace_fails(
     monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
     monkeypatch.setattr(local_server, "_store_state_error_code", None, raising=False)
     monkeypatch.setattr(local_server, "_schedule_reply_job", lambda *_args, **_kwargs: None)
-    local_server._persist_store_state()
     state_path = tmp_path / "state.json"
-    previous_state = state_path.read_bytes()
+    if existing_snapshot:
+        local_server._persist_store_state()
+    previous_state = state_path.read_bytes() if existing_snapshot else None
     real_replace = os.replace
 
     def reject_primary_replace(source, destination) -> None:
@@ -1006,7 +1009,10 @@ def test_public_letter_mutation_rolls_back_when_state_replace_fails(
 
     assert status == 503
     assert payload["data"]["error_code"] == "STORE_STATE_UNAVAILABLE"
-    assert state_path.read_bytes() == previous_state
+    if previous_state is None:
+        assert not state_path.exists()
+    else:
+        assert state_path.read_bytes() == previous_state
     assert local_server.store.letters == []
     assert not tuple(tmp_path.glob("*.tmp"))
 
@@ -1048,6 +1054,120 @@ def test_state_persist_fsyncs_unique_snapshots_before_replace(
     assert len(set(temporary_names)) == 2
     assert ".state.json.tmp" not in temporary_names
     assert ".state.json.bak.tmp" not in temporary_names
+
+
+def test_public_letter_mutation_normalizes_state_root_creation_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    import local_server
+
+    blocked_root = tmp_path / "blocked-state-root"
+    blocked_root.write_text("synthetic blocker", encoding="utf-8")
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(blocked_root))
+    monkeypatch.setattr(local_server, "_store_state_error_code", None, raising=False)
+    monkeypatch.setattr(local_server, "_schedule_reply_job", lambda *_args, **_kwargs: None)
+
+    async def exercise() -> tuple[int, dict]:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            response = await client.post(
+                "/toy/letter/send",
+                json={"content": "synthetic blocked state root letter"},
+            )
+            return response.status, await response.json()
+
+    status, payload = asyncio.run(exercise())
+
+    assert status == 503
+    assert payload["data"]["error_code"] == "STORE_STATE_UNAVAILABLE"
+    assert str(blocked_root) not in json.dumps(payload)
+    assert local_server.store.letters == []
+
+
+@pytest.mark.parametrize(
+    ("failed_target", "expected_status"),
+    [("state.json", 503), ("state.json.bak", 200)],
+)
+def test_state_temp_creation_failure_preserves_primary_commit_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failed_target: str,
+    expected_status: int,
+) -> None:
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    import local_server
+
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(local_server, "_store_state_error_code", None, raising=False)
+    monkeypatch.setattr(local_server, "_schedule_reply_job", lambda *_args, **_kwargs: None)
+    real_mkstemp = local_server._tempfile.mkstemp
+
+    def selective_mkstemp(*args, **kwargs):
+        if kwargs.get("prefix", "").startswith(f".{failed_target}."):
+            raise OSError("synthetic temp creation failure")
+        return real_mkstemp(*args, **kwargs)
+
+    monkeypatch.setattr(local_server._tempfile, "mkstemp", selective_mkstemp)
+
+    async def exercise() -> tuple[int, dict]:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            response = await client.post(
+                "/toy/letter/send",
+                json={"content": "synthetic temp failure letter"},
+            )
+            return response.status, await response.json()
+
+    status, payload = asyncio.run(exercise())
+
+    assert status == expected_status
+    if failed_target == "state.json":
+        assert payload["data"]["error_code"] == "STORE_STATE_UNAVAILABLE"
+        assert local_server.store.letters == []
+        assert not (tmp_path / "state.json").exists()
+    else:
+        assert payload["code"] == 0
+        assert json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))[
+            "letters"
+        ][0]["content"] == "synthetic temp failure letter"
+
+
+def test_public_letter_mutation_normalizes_unencodable_state_text(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    import local_server
+
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(local_server, "_store_state_error_code", None, raising=False)
+    monkeypatch.setattr(local_server, "_schedule_reply_job", lambda *_args, **_kwargs: None)
+
+    async def exercise() -> tuple[int, dict]:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            response = await client.post(
+                "/toy/letter/send",
+                json={"content": "synthetic\ud800state text"},
+            )
+            return response.status, await response.json()
+
+    status, payload = asyncio.run(exercise())
+
+    assert status == 503
+    assert payload["data"]["error_code"] == "STORE_STATE_UNAVAILABLE"
+    assert local_server.store.letters == []
 
 
 def test_failed_idempotent_request_can_retry_with_same_key(


### PR DESCRIPTION
Summary<br>- Fail closed on corrupt or semantically invalid current mailbox state without overwriting the snapshot; current list, unread, detail, and send return sanitized STORE_STATE_UNAVAILABLE while legacy read-only data remains independent.<br>- Recover from a valid backup, contain failed primary repair, and persist through unique temporary files with file fsync, atomic replace, backup refresh, and POSIX directory fsync.<br>- Roll back pre-commit send failures; treat post-replace directory-sync uncertainty as committed so the PENDING letter is scheduled exactly once.<br><br>Focused validation<br>- 18 focused HTTP/state cases passed in 0.92s on Python 3.12 after the final main sync.<br>- py_compile passed for local_server.py, http_contract.py, and tests/http/test_contract.py.<br>- git diff --check passed.<br>- Diff: 5 files, 498 changed lines (+486/-12).<br>- Both mechanical rebases preserved all five commits byte-semantically; final range-diff entries are all equal.<br><br>Frozen review evidence<br>- base: fb4a089fb3ddeee2a34f7f46867cc9934def6902<br>- head: 624254d1779d9184ef5dbe3b43b19bc0b022a30f<br>- Standards: PASS (P0=0, P1=0, P2=0)<br>- Spec: PASS (P0=0, P1=0, P2=0)<br><br>Boundary<br>- Tests and evidence use synthetic data only; no private letter body, credential, provider payload, or local path is logged or committed.<br>- No Live, media implementation, installer, video runtime, voice branch, or persona semantics changed.<br>- Local evidence is focused Windows execution, not real user-mailbox or power-loss acceptance; CI remains required.