### PR TITLE
fix(ui): make offline video recovery one clear action

### DIFF
--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -1315,15 +1315,39 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       downloaded_bytes: 0,
       total_bytes: 0,
     });
-    const { state, downloadable, runtimeRequired } = videoCapabilityViewState(bundles);
+    const { state, downloadable } = videoCapabilityViewState(bundles);
     const downloadedBytes = bundles.reduce((total, item) => total + (Number(item.downloaded_bytes) || 0), 0);
     const totalBytes = bundles.reduce((total, item) => total + (Number(item.total_bytes) || 0), 0);
     const runtimeProgress = payload && payload.runtime_import && typeof payload.runtime_import === "object"
       ? payload.runtime_import
       : { state: "idle", checked_bytes: 0, total_bytes: 0 };
     const runtimePreparing = ["queued", "extracting", "checking", "testing"].includes(runtimeProgress.state);
+    const runtimeReasonLabels = {
+      VIDEO_RUNTIME_ARCHIVE_REQUIRED: "当前安装中缺少视频运行环境包",
+      VIDEO_RUNTIME_ARCHIVE_INVALID: "所选 ZIP 不是完整的视频运行环境包",
+      VIDEO_RUNTIME_ROOT_INVALID: "运行环境清单或文件校验失败",
+      VIDEO_RUNTIME_NOT_PORTABLE: "运行环境不能在这台电脑上独立启动",
+      VIDEO_RUNTIME_TTS_CONFIG_UNAVAILABLE: "林离语音运行环境未准备完整",
+      VIDEO_RUNTIME_PROBE_FAILED: "运行环境自检未通过",
+      VIDEO_RUNTIME_ENVIRONMENT_WRITE_FAILED: "运行环境配置保存失败",
+      VIDEO_RUNTIME_ENVIRONMENT_ACTIVATION_FAILED: "运行环境已安装，但本次启用失败",
+      VIDEO_RUNTIME_IMPORT_FAILED: "视频运行环境安装失败",
+    };
+    const runtimeStepMessage = (progress) => {
+      const checked = Math.max(0, Number(progress.checked_bytes) || 0);
+      const total = Math.max(0, Number(progress.total_bytes) || 0);
+      const amount = total > 0 ? ` ${formatBytes(checked)} / ${formatBytes(total)}` : "";
+      if (progress.state === "queued") return "视频运行环境等待安装。";
+      if (progress.state === "extracting") return `正在解压视频运行环境${amount}。`;
+      if (progress.state === "checking") return `正在检查视频运行环境${amount}。`;
+      if (progress.state === "testing") return "正在测试视频运行环境。";
+      if (progress.state === "ready") return "视频运行环境已安装并启用。";
+      if (["required", "failed"].includes(progress.state)) {
+        return runtimeReasonLabels[progress.reason_code] || "视频运行环境尚未安装完成。";
+      }
+      return "";
+    };
     let videoSourceMode = "auto";
-    let runtimeArchive = "";
     const heading = text("h3", "视频回信一键安装", "text-text-title text-title-m");
     const summary = text(
       "p",
@@ -1369,35 +1393,67 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       progressText
     );
     item.append(sourceControls);
-    const importOffline = button("导入组件离线包", async () => {
+    const runtimeStatusText = text(
+      "div",
+      runtimeStepMessage(runtimeProgress),
+      "text-text-secondary text-caption-m font-regular"
+    );
+    const importOffline = button("断网恢复：导入离线包（ZIP）", async () => {
       setButtonsBusy([importOffline], true);
-      result.textContent = "请选择已经下载好的视频组件 ZIP，无需解压。";
+      result.textContent = "请选择 Olivia 完整离线包（ZIP），无需解压。";
+      let importFinished = false;
+      const updateImportProgress = async () => {
+        try {
+          const statusPayload = await requestJson(VIDEO_CAPABILITY_PATH);
+          if (importFinished) return;
+          const progress = statusPayload && statusPayload.runtime_import;
+          if (progress && typeof progress === "object") {
+            result.textContent = runtimeStepMessage(progress) || "正在导入离线包。";
+          }
+        } catch (_error) {
+          // The active import request remains authoritative; retry on the next tick.
+        }
+      };
+      const progressTimer = window.setInterval(updateImportProgress, 1000);
       try {
         const response = await requestCapability(
           VIDEO_CAPABILITY_ACTION_PATH,
           { action: "import_offline" },
-          310000
+          30 * 60 * 1000
         );
         if (response.status === "CANCELLED") {
           result.textContent = "已取消导入。";
           return;
         }
+        importFinished = true;
         await renderVideoCapabilityPanel(panel);
       } catch (_error) {
-        result.textContent = "组件包无法导入，请确认选择的是 Olivia 视频组件 ZIP。";
+        importFinished = true;
+        try {
+          const failed = await requestJson(VIDEO_CAPABILITY_PATH);
+          const progress = failed && failed.runtime_import;
+          result.textContent = progress && typeof progress === "object"
+            ? runtimeStepMessage(progress) || "离线包导入失败，请重新选择完整 ZIP。"
+            : "离线包导入失败，请重新选择完整 ZIP。";
+        } catch (_statusError) {
+          result.textContent = "离线包导入失败，请重新选择完整 ZIP。";
+        }
       } finally {
+        importFinished = true;
+        window.clearInterval(progressTimer);
         setButtonsBusy([importOffline], false);
       }
     });
-    importOffline.disabled = state === "downloading" || state === "ready";
+    importOffline.disabled = state === "downloading" || state === "ready" || runtimePreparing;
     item.append(
       text(
         "div",
         state === "downloading"
-          ? "也可导入组件 ZIP；请先暂停当前下载。"
-          : "已有组件 ZIP 可直接导入，无需解压。",
+          ? "请先暂停当前下载，再导入离线包。"
+          : "正常下载会自动安装并启用；仅断网恢复时选择 Olivia 离线包，无需解压。",
         "text-text-secondary text-caption-m font-regular"
       ),
+      runtimeStatusText,
       importOffline
     );
     if (state === "downloading") {
@@ -1434,102 +1490,6 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         }
       });
       item.append(install);
-    }
-    if (runtimeRequired) {
-      const runtimeNote = text(
-        "p",
-        runtimePreparing
-          ? "Olivia 正在自动准备视频运行环境。这个过程会解压并逐个检查文件，请保持 Olivia 开启。"
-          : "高级恢复：仅当你已经拿到 Olivia 提供的“视频运行环境离线包”时使用。这里不是选择成片保存位置，也不是选择缓存目录。",
-        "text-text-secondary text-caption-m font-regular"
-      );
-      const selectedRuntime = text(
-        "p",
-        runtimePreparing ? "正在准备，无需操作。" : "尚未选择视频运行环境离线包。",
-        "text-text-secondary text-caption-m font-regular"
-      );
-      const chooseRuntime = button("选择视频运行环境离线包（ZIP）", async () => {
-        setButtonsBusy([chooseRuntime], true);
-        try {
-          const selected = await requestCapability(
-            VIDEO_CAPABILITY_ACTION_PATH,
-            { action: "select_runtime_archive" },
-            310000
-          );
-          if (
-            selected.status === "SELECTED"
-            && typeof selected.runtime_archive === "string"
-          ) {
-            runtimeArchive = selected.runtime_archive;
-            selectedRuntime.textContent = `已选择：${runtimeArchive.split(/[\\/]/).pop()}`;
-          }
-        } catch (_error) {
-          result.textContent = "无法读取视频运行环境离线包，请确认选择的是 Olivia 提供的 ZIP。";
-        } finally {
-          setButtonsBusy([chooseRuntime], false);
-        }
-      });
-      const importRuntime = button("校验并启用", async () => {
-        if (!runtimeArchive) {
-          result.textContent = "请先选择 Olivia 视频运行环境离线包（ZIP）。";
-          return;
-        }
-        setButtonsBusy([chooseRuntime, importRuntime], true);
-        result.textContent = "正在解压并检查视频运行环境，文件较多时可能需要几十分钟，请勿关闭 Olivia。";
-        let runtimeImportFinished = false;
-        const updateRuntimeProgress = async () => {
-          try {
-            const statusPayload = await requestJson(VIDEO_CAPABILITY_PATH);
-            if (runtimeImportFinished) return;
-            const progress = statusPayload && statusPayload.runtime_import;
-            if (!progress || typeof progress !== "object") return;
-            const checkedBytes = Math.max(0, Number(progress.checked_bytes) || 0);
-            const totalBytes = Math.max(0, Number(progress.total_bytes) || 0);
-            if (["extracting", "checking"].includes(progress.state)) {
-              const percent = totalBytes > 0
-                ? Math.min(100, Math.floor((checkedBytes / totalBytes) * 100))
-                : 0;
-              result.textContent = totalBytes > 0
-                ? `${progress.state === "extracting" ? "已解压" : "已检查"} ${formatBytes(checkedBytes)} / ${formatBytes(totalBytes)}（${percent}%），请勿关闭 Olivia。`
-                : "正在读取视频运行环境离线包，请勿关闭 Olivia。";
-            } else if (progress.state === "testing") {
-              result.textContent = "文件检查完成，正在测试视频运行环境……";
-            }
-          } catch (_error) {
-            // The active import request remains authoritative; retry on the next tick.
-          }
-        };
-        const progressTimer = window.setInterval(updateRuntimeProgress, 1000);
-        void updateRuntimeProgress();
-        try {
-          await requestCapability(
-            VIDEO_CAPABILITY_ACTION_PATH,
-            {
-              action: "import_runtime_archive",
-              runtime_archive: runtimeArchive,
-            },
-            30 * 60 * 1000
-          );
-          runtimeImportFinished = true;
-          result.textContent = "离线包已检查并安装完成。请重启 Olivia 一次以启用视频回信。";
-          setButtonsBusy([chooseRuntime, importRuntime], false);
-        } catch (_error) {
-          runtimeImportFinished = true;
-          result.textContent = "离线包检查未通过，请重新下载并完整解压后再试。";
-          setButtonsBusy([chooseRuntime, importRuntime], false);
-        } finally {
-          runtimeImportFinished = true;
-          window.clearInterval(progressTimer);
-        }
-      });
-      item.append(
-        runtimeNote,
-        selectedRuntime,
-        chooseRuntime,
-        importRuntime
-      );
-      chooseRuntime.disabled = runtimePreparing;
-      importRuntime.disabled = runtimePreparing;
     }
     item.append(result);
     const list = stack();

--- a/original_client_video_capability_api.py
+++ b/original_client_video_capability_api.py
@@ -90,6 +90,18 @@ def _offline_archive_path(value: object) -> Path:
         raise VideoCapabilityAPIError("VIDEO_OFFLINE_ARCHIVE_INVALID", status=400) from exc
 
 
+def _is_runtime_archive(path: Path) -> bool:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            return "runtime-manifest.json" in {
+                name.replace("\\", "/").casefold() for name in archive.namelist()
+            }
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise VideoCapabilityAPIError(
+            "VIDEO_OFFLINE_ARCHIVE_INVALID", status=400
+        ) from exc
+
+
 def _select_windows_runtime_root() -> Path | None:
     if os.name != "nt":
         raise VideoCapabilityAPIError("VIDEO_RUNTIME_PICKER_UNAVAILABLE", status=503)
@@ -338,6 +350,22 @@ def mount_original_client_video_capability_api(
             archive = _offline_archive_path(selected)
             try:
                 async with control_lock:
+                    if _is_runtime_archive(archive):
+                        result = await asyncio.to_thread(
+                            installer.import_runtime_archive,
+                            runtime_archive=archive,
+                        )
+                        if result not in {"APPLIED", "NOOP", "REJECTED"}:
+                            raise VideoCapabilityAPIError(
+                                "VIDEO_CAPABILITY_RESULT_INVALID", status=503
+                            )
+                        return web.json_response(
+                            {"status": result},
+                            headers={
+                                "Access-Control-Allow-Origin": origin,
+                                "Cache-Control": "no-store",
+                            },
+                        )
                     results = [
                         await asyncio.to_thread(
                             installer.import_offline,

--- a/tests/installer/test_original_settings_javascript.py
+++ b/tests/installer/test_original_settings_javascript.py
@@ -317,39 +317,28 @@ def test_video_reply_setting_mutation_waits_for_probe_and_uses_committed_value()
     assert "enabled = payload.enabled;" in setting
 
 
-def test_video_capability_offers_clear_advanced_runtime_archive_recovery() -> None:
+def test_video_capability_offers_one_offline_zip_entry_for_components_or_runtime() -> None:
     source = BOOTSTRAP_JAVASCRIPT
-    runtime_import = source.split(
-        'const importRuntime = button("校验并启用"', 1
-    )[1].split("item.append(", 1)[0]
+    video_panel = source.split(
+        "const renderVideoCapabilityPanel = async (panel) => {", 1
+    )[1].split("const renderCapabilityPanel = async (panel) => {", 1)[0]
 
-    assert '{ action: "select_runtime_archive" }' in source
-    assert 'action: "import_runtime_archive"' in source
-    assert "runtime_archive: runtimeArchive" in source
+    assert video_panel.count('button("断网恢复：导入离线包（ZIP）"') == 1
+    assert '{ action: "import_offline" }' in video_panel
+    assert "正常下载会自动安装并启用" in video_panel
+    assert "select_runtime_archive" not in video_panel
+    assert "import_runtime_archive" not in video_panel
+    assert "选择视频运行环境离线包（ZIP）" not in video_panel
+    assert "校验并启用" not in video_panel
     assert 'source: videoSourceMode' in source
     assert "国内源优先" in source
     assert "仅官方源" in source
-    assert "高级恢复" in source
-    assert "不是选择成片保存位置，也不是选择缓存目录" in source
-    assert "选择视频运行环境离线包（ZIP）" in source
-    assert "校验并启用" in source
-    assert "文件较多时可能需要几十分钟，请勿关闭 Olivia" in source
     assert "runtime_import" in source
-    assert 'progress.state === "extracting" ? "已解压" : "已检查"' in source
-    assert "window.setInterval(updateRuntimeProgress, 1000)" in source
-    assert "window.clearInterval(progressTimer)" in source
-    assert "离线包已检查并安装完成。请重启 Olivia 一次" in runtime_import
-    assert "await renderVideoCapabilityPanel(panel)" not in runtime_import
-    assert "let runtimeImportFinished = false;" in runtime_import
-    assert "if (runtimeImportFinished) return;" in runtime_import
-    assert runtime_import.index("await requestJson(VIDEO_CAPABILITY_PATH)") < runtime_import.index(
-        "if (runtimeImportFinished) return;"
-    )
-    assert runtime_import.index("runtimeImportFinished = true;") < runtime_import.index(
-        "离线包已检查并安装完成"
-    )
-    assert "尚未提供可迁移运行时归档" not in source
-    assert "runtimeDigest" not in source
+    assert "VIDEO_RUNTIME_ARCHIVE_REQUIRED" in video_panel
+    assert "reason_code" in video_panel
+    assert "正在解压" in video_panel
+    assert "正在检查" in video_panel
+    assert "正在测试" in video_panel
     assert 'accept_licenses: dependency.id === "music_video"' in source
 
 
@@ -359,7 +348,7 @@ def test_video_capability_offers_direct_offline_zip_import() -> None:
         "const renderVideoCapabilityPanel = async (panel) => {", 1
     )[1].split("const renderCapabilityPanel = async (panel) => {", 1)[0]
 
-    assert 'button("导入组件离线包"' in video_panel
+    assert 'button("断网恢复：导入离线包（ZIP）"' in video_panel
     assert '{ action: "import_offline" }' in video_panel
     assert "无需解压" in video_panel
     assert "选择解压后的离线包" not in video_panel

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -1673,6 +1673,59 @@ def test_video_capability_api_selects_and_imports_runtime_archive(tmp_path: Path
     )
 
 
+def test_video_capability_api_single_offline_import_detects_runtime_archive(
+    tmp_path: Path,
+) -> None:
+    archive = (tmp_path / "Olivia-video-runtime-fixture.zip").resolve()
+    with zipfile.ZipFile(archive, "w") as payload:
+        payload.writestr("runtime-manifest.json", "{}")
+    observed: list[Path] = []
+
+    class FakeInstaller:
+        def status(self):
+            return {
+                "schema_version": "olivia.video-capability-status.v1",
+                "status": "UNAVAILABLE",
+                "capability": "video",
+                "install_locations": [],
+                "bundles": [],
+            }
+
+        def import_runtime_archive(self, *, runtime_archive: Path):
+            observed.append(runtime_archive)
+            return "APPLIED"
+
+        def import_offline(self, **_kwargs):
+            raise AssertionError("runtime archives must not be treated as component ZIPs")
+
+    async def call():
+        app = web.Application()
+        mount_original_client_video_capability_api(
+            app,
+            FakeInstaller(),
+            trusted_origins=(),
+            authorize_session=lambda _token: None,
+            select_offline_archive=lambda: archive,
+        )
+        headers = {
+            "Origin": "http://localhost:3000",
+            "X-Olivia-Capability-Action": "confirmed",
+            "X-Olivia-Setup-Session": "session",
+        }
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(
+                "/toy/capabilities/video/action",
+                json={"action": "import_offline"},
+                headers=headers,
+            )
+            return response.status, await response.json()
+
+    status, payload = asyncio.run(call())
+    assert status == 200
+    assert payload == {"status": "APPLIED"}
+    assert observed == [archive]
+
+
 def test_video_capability_api_selects_and_imports_one_offline_zip_for_both_bundles(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Scope
- replace the duplicate offline runtime picker flows with one offline ZIP import action
- route the selected ZIP automatically as either a complete runtime archive or a component archive
- keep normal one-click download and automatic enablement unchanged

## Evidence
- exact pair: 71d4069eab7c5b2459a44e9aa45cdc6bfd287564...564ad9657cfbe44c8baa73e9ec8f08290a44fffb
- mechanical range-diff from reviewed commit 14502e6: exact equals
- focused UI/install tests: 98 passed
- git diff --check: pass
- static precheck: PASS, no P0/P1

## Boundary
This verifies the UI/API contract and focused tests; it does not replace real installer or offline ZIP acceptance.