### PR TITLE
fix: harden reply review inputs

### DIFF
--- a/runtime/reply/reply_model_quality.py
+++ b/runtime/reply/reply_model_quality.py
@@ -1100,7 +1100,7 @@ def _layer_messages(
             if layer.name in _EVIDENCE_BOUND_LAYERS
             else (
                 f'{{"layer":"{layer.name}","score":2,'
-                '"hard_violations":[],"drift_detected":false}}'
+                '"hard_violations":[],"drift_detected":false}'
             )
         )
     )
@@ -2117,7 +2117,7 @@ def _safe_text(
             "\r",
             "\t",
         }
-        or ord(character) >= 32
+        or (ord(character) >= 32 and character != "\x7f")
     ).strip()
     return cleaned[:limit]
 

--- a/tests/persona/test_reply_model_quality.py
+++ b/tests/persona/test_reply_model_quality.py
@@ -1019,16 +1019,9 @@ class PromptContractQualityGateway(Gateway):
             request = json.loads(str(messages[-1].get("content", "")))
             layer = str(request["layer"])
             self.call_kinds.append("review")
-            if layer in {
-                "identity_boundary",
-                "voice_style",
-                "continuity_memory",
-            }:
-                marker = "Return ONLY compact JSON with exactly: "
-                text = system.split(marker, 1)[1].split(".", 1)[0]
-                self.contract_layers.append(layer)
-            else:
-                text = _layer_payload(layer)
+            marker = "Return ONLY compact JSON with exactly: "
+            text = system.split(marker, 1)[1].split(".", 1)[0]
+            self.contract_layers.append(layer)
         elif (
             "P02_REPLY_EVIDENCE_ADJUDICATION_JSON" in system
             or "P02_REPLY_REWRITE_TEXT" in system
@@ -1198,11 +1191,33 @@ def test_provider_exact_clean_response_contract_is_accepted_by_the_same_pipeline
     assert result.reviewer_calls == 1
     assert result.rewrite_calls == 0
     assert gateway.call_kinds == ["generation", *("review",) * 5]
-    assert gateway.contract_layers == [
-        "identity_boundary",
-        "voice_style",
-        "continuity_memory",
-    ]
+    assert gateway.contract_layers == list(_REVIEW_LAYERS)
+
+
+def test_reply_pipeline_sanitizes_del_from_current_input_before_review(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = SequencedQualityGateway(
+        candidate="Synthetic clean candidate.",
+        reviews=_passing_layer_payloads(),
+    )
+
+    result = asyncio.run(
+        _pipeline(gateway, monkeypatch).run(
+            ReplyRequest(
+                content="Synthetic\x7f current input.",
+                request_id="del-character-input",
+            ),
+            _context(),
+        )
+    )
+
+    assert result.state is ReplyState.COMPLETED
+    assert result.quality_status == "accepted"
+    assert all(
+        request["current_user_input"] == "Synthetic current input."
+        for request in gateway.review_requests
+    )
 
 
 def test_identity_review_receives_only_bounded_relationship_evidence() -> None:


### PR DESCRIPTION
## Summary

- Fix the non-evidence reviewer response contract so `focus_response` and `autonomy_life` examples are valid JSON.
- Strip U+007F from reviewer reference text before `ReviewReference` validation.
- Exercise all five production prompt contracts and the DEL path through the real reply pipeline.

## TDD evidence

RED:
- Exact production contract replay ended `FAILED / REVIEWER_UNAVAILABLE`.
- A synthetic letter containing U+007F raised `ValueError: reference summary is invalid` through the quality gate.

GREEN:
- `python -m pytest tests/persona/test_reply_model_quality.py -q` -> `116 passed`
- `python -m py_compile runtime/reply/reply_model_quality.py tests/persona/test_reply_model_quality.py` -> PASS
- `git diff --check` -> PASS

No full local test suite was run.

## Frozen review

- Base: `d7573e4d7044359803c04a55d0c8186b6c524b96`
- Head: `3cd7b16da676ae3b308bfac77d8bb5164473ea2c`
- Standards: PASS, P0/P1/P2 = 0/0/0
- Spec: PASS, P0/P1/P2 = 0/0/0
- Scope: 2 files, 49 changed lines

## Privacy and scope

All fixtures are synthetic. No private letter text, secrets, provider payloads, or local paths are included. No persona semantics, Live, media, installer, video runtime, or voice implementation is changed.

## Acceptance boundary

This proves deterministic local parser/pipeline behavior with synthetic data. It does not claim real-provider conformance or private-letter acceptance.