### PR TITLE
fix(media): validate reusable music stages

### DIFF
--- a/runtime/media/music_reply.py
+++ b/runtime/media/music_reply.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import json
 import hashlib
 import os
+import re
 import shutil
 import subprocess
 import tempfile
 import time
+import wave
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
@@ -36,10 +38,45 @@ from .voice_direction import VoicePerformancePlan
 _MINIMAX_WORKER_TIMEOUT_SECONDS = 7500.0
 _MUSIC_STAGE_MANIFEST_VERSION = 3
 _RUNTIME_PROBE_TIMEOUT_SECONDS = 60.0
+_PROVIDER_DIAGNOSTIC_LIMIT = 512
+_MEDIA_VALIDATION_TIMEOUT_SECONDS = 180.0
 
 
 class MusicReplyError(RuntimeError):
     """Stable product error raised when a song stage cannot complete."""
+
+    def __init__(self, error_code: str, *, diagnostic: str = "") -> None:
+        super().__init__(error_code)
+        self.diagnostic = str(diagnostic)[:_PROVIDER_DIAGNOSTIC_LIMIT]
+
+
+def _provider_failure_diagnostic(*, returncode: object, stderr: object) -> str:
+    text = stderr.decode("utf-8", errors="replace") if isinstance(stderr, bytes) else str(stderr or "")
+    patterns = ((r"TimeoutExpired", "process timeout"), (r"CUDA out of memory|CUDNN_STATUS_ALLOC_FAILED", "CUDA out of memory"),
+                (r"DLL load failed|\.dll\b.*(?:missing|not found)", "DLL load failed"), (r"No module named|ModuleNotFoundError", "Python module missing"),
+                (r"(?:config|configuration).*(?:invalid|missing|not found)", "configuration unavailable"),
+                (r"FileNotFoundError|No such file or directory", "file unavailable"), (r"PermissionError|Access is denied", "permission denied"))
+    summary = ", ".join(label for pattern, label in patterns if re.search(pattern, text, re.I)) or "provider stderr redacted"
+    return f"returncode={returncode}; stderr={summary}"[:_PROVIDER_DIAGNOSTIC_LIMIT]
+
+
+def _persist_provider_failure(error_code: str, diagnostic: str, environment: Mapping[str, str] | None) -> None:
+    data_root = configured_media_path(os.environ if environment is None else environment, "OLIVIA_LOCAL_DATA_ROOT")
+    if data_root is None: return
+    try:
+        log_root = data_root / "logs"; log_root.mkdir(parents=True, exist_ok=True)
+        with (log_root / "media-provider.jsonl").open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps({"timestamp": int(time.time()), "error_code": error_code, "diagnostic": diagnostic[:_PROVIDER_DIAGNOSTIC_LIMIT]}, ensure_ascii=False, sort_keys=True) + "\n")
+    except OSError: return
+
+
+def _provider_exception_failure(error_code: str, exc: BaseException, environment: Mapping[str, str] | None = None) -> MusicReplyError:
+    chain, current = [], exc
+    while current is not None and current not in chain: chain.append(current); current = current.__cause__ or current.__context__
+    root = chain[-1]; category = "TimeoutExpired" if any(isinstance(item, (TimeoutError, subprocess.TimeoutExpired)) for item in chain) else type(root).__name__
+    diagnostic = _provider_failure_diagnostic(returncode=getattr(root, "returncode", "unavailable"), stderr=category)
+    _persist_provider_failure(error_code, diagnostic, environment)
+    return MusicReplyError(error_code, diagnostic=diagnostic)
 
 
 @dataclass(frozen=True)
@@ -573,6 +610,7 @@ class MiniMaxMusic3Worker:
                 ],
                 "MINIMAX_MUSIC3_FAILED",
                 timeout=self.timeout_seconds,
+                cleanup_path=destination,
             )
         if not destination.is_file() or destination.stat().st_size == 0:
             raise MusicReplyError("MINIMAX_MUSIC3_OUTPUT_MISSING")
@@ -609,13 +647,16 @@ class AceStepClient:
             headers={"Content-Type": "application/json", "Accept": "application/json"},
             method="POST",
         )
+        failure = None
         try:
             # The first local request may download and initialize several GB
             # of model weights before the API flushes its response body.
             with urlopen(request, timeout=min(600.0, self.timeout_seconds)) as response:
                 result = json.loads(response.read().decode("utf-8"))
         except (HTTPError, URLError, TimeoutError, UnicodeError, json.JSONDecodeError) as exc:
-            raise MusicReplyError("ACESTEP_UNAVAILABLE") from exc
+            failure = _provider_exception_failure("ACESTEP_UNAVAILABLE", exc)
+        if failure is not None:
+            raise failure
         if not isinstance(result, dict) or result.get("code") != 200:
             raise MusicReplyError("ACESTEP_PROTOCOL_ERROR")
         return result
@@ -625,11 +666,14 @@ class AceStepClient:
         parsed = urlsplit(resolved)
         if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
             raise MusicReplyError("ACESTEP_AUDIO_URL_NOT_LOOPBACK")
+        failure = None
         try:
             with urlopen(resolved, timeout=min(60.0, self.timeout_seconds)) as response:
                 payload = response.read()
         except (HTTPError, URLError, TimeoutError) as exc:
-            raise MusicReplyError("ACESTEP_AUDIO_UNAVAILABLE") from exc
+            failure = _provider_exception_failure("ACESTEP_AUDIO_UNAVAILABLE", exc)
+        if failure is not None:
+            raise failure
         if not payload:
             raise MusicReplyError("ACESTEP_AUDIO_EMPTY")
         destination.parent.mkdir(parents=True, exist_ok=True)
@@ -696,10 +740,13 @@ class AceStepClient:
             if status == 2:
                 raise MusicReplyError("ACESTEP_GENERATION_FAILED")
             if status == 1:
+                failure = None
                 try:
                     items = json.loads(str(row.get("result", "")))
                 except json.JSONDecodeError as exc:
-                    raise MusicReplyError("ACESTEP_RESULT_INVALID") from exc
+                    failure = _provider_exception_failure("ACESTEP_RESULT_INVALID", exc)
+                if failure is not None:
+                    raise failure
                 item = items[0] if isinstance(items, list) and items and isinstance(items[0], dict) else None
                 if item is None or not isinstance(item.get("file"), str):
                     raise MusicReplyError("ACESTEP_RESULT_INVALID")
@@ -732,6 +779,7 @@ def _run(
     *,
     timeout: float = 900.0,
     env: dict[str, str] | None = None,
+    cleanup_path: Path | None = None,
 ) -> None:
     try:
         result = subprocess.run(
@@ -742,9 +790,21 @@ def _run(
             env=env,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
-        raise MusicReplyError(error_code) from exc
-    if result.returncode != 0:
-        raise MusicReplyError(error_code)
+        failure_category = "TimeoutExpired" if isinstance(exc, subprocess.TimeoutExpired) else getattr(exc, "stderr", None) or type(exc).__name__
+        diagnostic = _provider_failure_diagnostic(returncode="unavailable", stderr=failure_category)
+        _persist_provider_failure(error_code, diagnostic, env)
+        failure = MusicReplyError(error_code, diagnostic=diagnostic)
+    else:
+        failure = None
+    if failure is None and result.returncode != 0:
+        diagnostic = _provider_failure_diagnostic(returncode=result.returncode, stderr=result.stderr)
+        _persist_provider_failure(error_code, diagnostic, env)
+        failure = MusicReplyError(error_code, diagnostic=diagnostic)
+    if failure is not None:
+        if cleanup_path is not None:
+            try: cleanup_path.unlink(missing_ok=True)
+            except OSError: pass
+        raise failure
 
 
 def prepare_official_spoken_base(
@@ -759,7 +819,9 @@ def prepare_official_spoken_base(
     destination = Path(destination)
     if not reference_path.is_file():
         raise MusicReplyError("MUSIC_REPLY_SPOKEN_REFERENCE_UNAVAILABLE")
-    if _completed_stage(destination):
+    spoken_gate = {"required_streams": ("0:v:0",), "ffmpeg_path": ffmpeg_path,
+                   "minimum_duration_seconds": 30.0, "forbidden_streams": ("0:a:0",)}
+    if _completed_stage(destination, **spoken_gate):
         return destination
     destination.parent.mkdir(parents=True, exist_ok=True)
     partial = destination.with_name(f"{destination.stem}.partial{destination.suffix}")
@@ -795,7 +857,7 @@ def prepare_official_spoken_base(
         "MUSIC_REPLY_SPOKEN_REFERENCE_FAILED",
         timeout=900.0,
     )
-    if not _completed_stage(partial):
+    if not _completed_stage(partial, **spoken_gate):
         raise MusicReplyError("MUSIC_REPLY_SPOKEN_REFERENCE_FAILED")
     partial.replace(destination)
     return destination
@@ -865,8 +927,15 @@ def separate_vocals(
         candidates = sorted(outputs.rglob("*vocals*.wav"))
         if not candidates:
             raise MusicReplyError("ROFORMER_OUTPUT_MISSING")
+        if not _valid_wave_audio(candidates[0]):
+            raise MusicReplyError("ROFORMER_OUTPUT_INVALID")
         vocals_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(candidates[0], vocals_path)
+
+
+def _valid_wave_audio(path: Path, *, minimum_duration_seconds: float = 0.1) -> bool:
+    duration = _media_duration_seconds(path, required_streams=("0:a:0",))
+    return duration is not None and duration >= minimum_duration_seconds
 
 
 def render_full_face_performance(
@@ -886,6 +955,7 @@ def render_full_face_performance(
         raise MusicReplyError("LATENTSYNC_INPUT_UNAVAILABLE")
     with tempfile.TemporaryDirectory(prefix="olivia-music-face-", dir=output_path.parent) as temporary:
         raw_video = Path(temporary) / "latentsync-vocals.mp4"
+        failure = None
         try:
             metadata = render_latentsync_video(
                 performance_video_path,
@@ -898,7 +968,9 @@ def render_full_face_performance(
                 environment=environment,
             )
         except LatentSyncReplyError as exc:
-            raise MusicReplyError(str(exc)) from exc
+            failure = _provider_exception_failure(str(exc), exc, environment)
+        if failure is not None:
+            raise failure
         _run(
             [
                 _ffmpeg(ffmpeg_path), "-hide_banner", "-loglevel", "error", "-y",
@@ -909,6 +981,7 @@ def render_full_face_performance(
             ],
             "MUSIC_REPLY_AUDIO_MUX_FAILED",
             timeout=900.0,
+            cleanup_path=output_path,
         )
     return {**metadata, "face_model": "LatentSync-1.5", "mouth_refiner": "native_face_paste"}
 
@@ -1051,9 +1124,55 @@ def concat_videos(
         result.replace(output_path)
 
 
-def _completed_stage(path: Path) -> bool:
+def _media_duration_seconds(path: Path, *, required_streams: tuple[str, ...], ffmpeg_path: Path | None = None,
+                            forbidden_streams: tuple[str, ...] = ()) -> float | None:
+    if not path.is_file():
+        return None
+    if path.suffix.casefold() == ".wav":
+        if required_streams != ("0:a:0",):
+            return None
+        try:
+            with wave.open(str(path), "rb") as stream:
+                frame_rate, frame_count = stream.getframerate(), stream.getnframes()
+                expected_size = frame_count * stream.getnchannels() * stream.getsampwidth()
+                payload = stream.readframes(frame_count)
+            if frame_rate <= 0 or expected_size <= 0 or len(payload) < expected_size: return None
+            return frame_count / frame_rate
+        except (EOFError, OSError, wave.Error): return None
+    def decode(stream: str) -> subprocess.CompletedProcess[bytes] | None:
+        try:
+            return subprocess.run([
+                _ffmpeg(ffmpeg_path), "-hide_banner", "-loglevel", "error", "-nostdin", "-xerror",
+                "-i", str(path), "-map", stream, "-progress", "pipe:1", "-nostats", "-f", "null", os.devnull,
+            ], capture_output=True, check=False, timeout=_MEDIA_VALIDATION_TIMEOUT_SECONDS,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+        except (MusicReplyError, OSError, subprocess.TimeoutExpired): return None
+
+    durations: list[float] = []
+    for stream in required_streams:
+        result = decode(stream)
+        if result is None or result.returncode != 0: return None
+        stdout = result.stdout.decode("utf-8", errors="replace") if isinstance(result.stdout, bytes) else str(result.stdout)
+        timestamps = [line.partition("=")[2].strip() for line in stdout.splitlines() if line.startswith("out_time=")]
+        try:
+            hours, minutes, seconds = timestamps[-1].split(":", 2)
+            durations.append(int(hours) * 3600 + int(minutes) * 60 + float(seconds))
+        except (IndexError, TypeError, ValueError): return None
+    for stream in forbidden_streams:
+        result = decode(stream)
+        stderr = result.stderr.decode("utf-8", errors="replace").casefold() if result and isinstance(result.stderr, bytes) else str(result.stderr if result else "").casefold()
+        if result is None or result.returncode == 0 or "matches no streams" not in stderr:
+            return None
+    return min(durations, default=None)
+
+
+def _completed_stage(path: Path, *, required_streams: tuple[str, ...], ffmpeg_path: Path | None = None,
+                     minimum_duration_seconds: float = 0.1,
+                     forbidden_streams: tuple[str, ...] = ()) -> bool:
     try:
-        return path.is_file() and path.stat().st_size > 0
+        duration = _media_duration_seconds(path, required_streams=required_streams, ffmpeg_path=ffmpeg_path, forbidden_streams=forbidden_streams)
+        return bool(path.stat().st_size > 0 and duration is not None and duration >= minimum_duration_seconds)
     except OSError:
         return False
 
@@ -1269,10 +1388,16 @@ def _stage_reusable(
     path: Path,
     *,
     upstream: dict[str, Path] | None = None,
+    required_streams: tuple[str, ...],
+    ffmpeg_path: Path | None = None,
+    minimum_duration_seconds: float = 0.1,
+    forbidden_streams: tuple[str, ...] = (),
 ) -> bool:
     artifacts = manifest.get("artifacts")
     expected = artifacts.get(artifact_name) if isinstance(artifacts, dict) else None
-    return _completed_stage(path) and expected == _stage_record(path, upstream)
+    return _completed_stage(path, required_streams=required_streams, ffmpeg_path=ffmpeg_path,
+                            minimum_duration_seconds=minimum_duration_seconds,
+                            forbidden_streams=forbidden_streams) and expected == _stage_record(path, upstream)
 
 
 def _stage_record(
@@ -1288,6 +1413,28 @@ def _stage_record(
     }
 
 
+def _require_stage(path: Path, artifact_name: str, required_streams: tuple[str, ...],
+                   ffmpeg_path: Path | None, minimum_duration_seconds: float,
+                   forbidden_streams: tuple[str, ...] = ()) -> None:
+    try:
+        duration, size = _media_duration_seconds(path, required_streams=required_streams, ffmpeg_path=ffmpeg_path, forbidden_streams=forbidden_streams), path.stat().st_size
+    except OSError:
+        duration, size = None, 0
+    if size <= 0 or duration is None or duration < minimum_duration_seconds:
+        observed = "unavailable" if duration is None else f"{duration:.3f}"
+        raise MusicReplyError("MUSIC_STAGE_OUTPUT_INVALID", diagnostic=f"stage={artifact_name};observed_seconds={observed};required_seconds={minimum_duration_seconds:.3f}")
+
+
+def _publish_stage(partial: Path, destination: Path, artifact_name: str, required_streams: tuple[str, ...],
+                   ffmpeg_path: Path | None, minimum_duration_seconds: float) -> None:
+    try:
+        _require_stage(partial, artifact_name, required_streams, ffmpeg_path, minimum_duration_seconds)
+        partial.replace(destination)
+    finally:
+        try: partial.unlink(missing_ok=True)
+        except OSError: pass
+
+
 def _record_stage(
     manifest: dict[str, object],
     manifest_path: Path,
@@ -1295,7 +1442,12 @@ def _record_stage(
     path: Path,
     *,
     upstream: dict[str, Path] | None = None,
+    required_streams: tuple[str, ...],
+    ffmpeg_path: Path | None = None,
+    minimum_duration_seconds: float = 0.1,
+    forbidden_streams: tuple[str, ...] = (),
 ) -> None:
+    _require_stage(path, artifact_name, required_streams, ffmpeg_path, minimum_duration_seconds, forbidden_streams)
     artifacts = manifest.setdefault("artifacts", {})
     if not isinstance(artifacts, dict):
         artifacts = {}
@@ -1388,17 +1540,25 @@ def render_musical_reply(
     )
     if spoken_action_base_path is not None and not spoken_base.is_file():
         raise MusicReplyError("MUSIC_REPLY_SPOKEN_REFERENCE_UNAVAILABLE")
-    if _stage_reusable(
+    spoken_gate = {"required_streams": ("0:v:0",), "ffmpeg_path": ffmpeg_path,
+                   "minimum_duration_seconds": 30.0, "forbidden_streams": ("0:a:0",)}
+    normal_gate = {"required_streams": ("0:v:0", "0:a:0"),
+                   "ffmpeg_path": ffmpeg_path, "minimum_duration_seconds": 1.0}
+    spoken_ready = _completed_stage(spoken_base, **spoken_gate)
+    if spoken_action_base_path is not None and not spoken_ready:
+        raise MusicReplyError("MUSIC_REPLY_SPOKEN_REFERENCE_FAILED")
+    if spoken_ready and _stage_reusable(
         manifest,
         "normal_video",
         normal_video_path,
         upstream={"spoken_base": spoken_base},
+        **normal_gate,
     ):
         normal_metadata = {"spoken_stage": "reused"}
     else:
         if (
             spoken_action_base_path is None
-            and not _stage_reusable(manifest, "spoken_base", spoken_base)
+            and not _stage_reusable(manifest, "spoken_base", spoken_base, **spoken_gate)
         ):
             spoken_base.unlink(missing_ok=True)
             prepare_official_spoken_base(
@@ -1406,33 +1566,50 @@ def render_musical_reply(
                 spoken_base,
                 ffmpeg_path=ffmpeg_path,
             )
-            _record_stage(manifest, manifest_path, "spoken_base", spoken_base)
-        normal_metadata = render_reply_video(
-            reply_text,
-            normal_video_path,
-            tts_config_path=tts_config_path,
-            visual_config_path=visual_config_path,
-            worker_path=worker_path,
-            scene_path=spoken_base,
-            latentsync_python_path=latentsync_python,
-            latentsync_root=latentsync_root,
-            adaptive_delivery=True,
-            voice_performance_plan=voice_performance_plan,
-            environment=provider_paths.environment,
-            ffmpeg_path=ffmpeg_path,
-            provider_cache_root=provider_cache_root,
-        )
+            _record_stage(manifest, manifest_path, "spoken_base", spoken_base, **spoken_gate)
+        partial_normal = normal_video_path.with_name(f"{normal_video_path.stem}.partial{normal_video_path.suffix}")
+        partial_normal.unlink(missing_ok=True)
+        normal_failure = None
+        try:
+            normal_metadata = render_reply_video(
+                reply_text,
+                partial_normal,
+                tts_config_path=tts_config_path,
+                visual_config_path=visual_config_path,
+                worker_path=worker_path,
+                scene_path=spoken_base,
+                latentsync_python_path=latentsync_python,
+                latentsync_root=latentsync_root,
+                adaptive_delivery=True,
+                voice_performance_plan=voice_performance_plan,
+                environment=provider_paths.environment,
+                ffmpeg_path=ffmpeg_path,
+                provider_cache_root=provider_cache_root,
+            )
+        except ReplyMediaError as exc:
+            normal_failure = _provider_exception_failure("MUSIC_REPLY_NORMAL_VIDEO_FAILED", exc, provider_paths.environment)
+        if normal_failure is not None:
+            try: partial_normal.unlink(missing_ok=True)
+            except OSError: pass
+            raise normal_failure from None
+        _publish_stage(partial_normal, normal_video_path, "normal_video", ("0:v:0", "0:a:0"), ffmpeg_path, 1.0)
         _record_stage(
             manifest,
             manifest_path,
             "normal_video",
             normal_video_path,
             upstream={"spoken_base": spoken_base},
+            **normal_gate,
         )
 
     song_audio = stage_root / "song.flac"
     vocals = stage_root / "vocals.wav"
-    if _stage_reusable(manifest, "song_audio", song_audio):
+    music_stage_minimum = max(1.0, duration_seconds - 5.0)
+    audio_gate = {"required_streams": ("0:a:0",), "ffmpeg_path": ffmpeg_path,
+                  "minimum_duration_seconds": music_stage_minimum}
+    video_gate = {"required_streams": ("0:v:0", "0:a:0"), "ffmpeg_path": ffmpeg_path,
+                  "minimum_duration_seconds": music_stage_minimum}
+    if _stage_reusable(manifest, "song_audio", song_audio, **audio_gate):
         song_metadata = {
             "audio_model": "MiniMax-Music-3",
             "requested_duration_seconds": duration_seconds,
@@ -1454,14 +1631,16 @@ def render_musical_reply(
             lyrics=song_plan.lyrics,
             caption=song_plan.caption,
         )
-        partial_song.replace(song_audio)
-        _record_stage(manifest, manifest_path, "song_audio", song_audio)
+        _publish_stage(partial_song, song_audio, "song_audio", ("0:a:0",),
+                       ffmpeg_path, music_stage_minimum)
+        _record_stage(manifest, manifest_path, "song_audio", song_audio, **audio_gate)
 
     if not _stage_reusable(
         manifest,
         "vocals",
         vocals,
         upstream={"song_audio": song_audio},
+        **audio_gate,
     ):
         partial_vocals = stage_root / "vocals.partial.wav"
         partial_vocals.unlink(missing_ok=True)
@@ -1474,13 +1653,15 @@ def render_musical_reply(
             environment=provider_paths.environment,
             ffmpeg_path=ffmpeg_path,
         )
-        partial_vocals.replace(vocals)
+        _publish_stage(partial_vocals, vocals, "vocals", ("0:a:0",),
+                       ffmpeg_path, music_stage_minimum)
         _record_stage(
             manifest,
             manifest_path,
             "vocals",
             vocals,
             upstream={"song_audio": song_audio},
+            **audio_gate,
         )
 
     if _stage_reusable(
@@ -1488,6 +1669,7 @@ def render_musical_reply(
         "song_video",
         song_video_path,
         upstream={"song_audio": song_audio, "vocals": vocals},
+        **video_gate,
     ):
         face_metadata = {"performance_stage": "reused"}
     else:
@@ -1506,28 +1688,37 @@ def render_musical_reply(
             provider_cache_root=provider_cache_root,
             environment=provider_paths.environment,
         )
-        partial_video.replace(song_video_path)
+        _publish_stage(partial_video, song_video_path, "song_video",
+                       ("0:v:0", "0:a:0"), ffmpeg_path, music_stage_minimum)
         _record_stage(
             manifest,
             manifest_path,
             "song_video",
             song_video_path,
             upstream={"song_audio": song_audio, "vocals": vocals},
+            **video_gate,
         )
 
+    partial_output = output_path.with_name(f"{output_path.stem}.partial{output_path.suffix}")
+    partial_output.unlink(missing_ok=True)
     concat_videos(
         normal_video_path,
         song_video_path,
-        output_path,
+        partial_output,
         transition_video_path=transition_reference,
         ffmpeg_path=ffmpeg_path,
     )
+    final_stage_minimum = music_stage_minimum + 8.0 + float(normal_gate["minimum_duration_seconds"])
+    _publish_stage(partial_output, output_path, "final_output",
+                   ("0:v:0", "0:a:0"), ffmpeg_path, final_stage_minimum)
     _record_stage(
         manifest,
         manifest_path,
         "final_output",
         output_path,
         upstream={"normal_video": normal_video_path, "song_video": song_video_path},
+        required_streams=("0:v:0", "0:a:0"), ffmpeg_path=ffmpeg_path,
+        minimum_duration_seconds=final_stage_minimum,
     )
     return {
         **normal_metadata,

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from contextlib import nullcontext
 from pathlib import Path
 import subprocess
 from types import SimpleNamespace
@@ -316,6 +317,68 @@ def test_python_runtime_probe_checks_version_imports_cuda_and_has_hard_timeout(
     )
 
 
+def test_provider_failures_are_stable_private_safe_and_unchained(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    python, worker, comfy = _write(tmp_path / "python.exe"), _write(tmp_path / "worker.py"), tmp_path / "comfy"; song = tmp_path / "song.flac"
+    _write(comfy / "main.py"); private = "private-letter-200717"; data_root = tmp_path / "data"
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(data_root)); sensitive = (str(tmp_path), private, "secret-token", "unlisted-private-fragment")
+    def failed(command, **_kwargs):
+        stderr = f"CUDA out of memory {tmp_path / 'voice.wav'}; {private}; secret-token; unlisted-private-fragment".encode()
+        _write(Path(command[-1]), b"partial"); return subprocess.CompletedProcess(command, 23, stdout=b"", stderr=stderr)
+    adapter = music_reply.MiniMaxMusic3Worker(python_path=python, worker_path=worker, comfy_root=comfy)
+    monkeypatch.setattr(music_reply.subprocess, "run", failed)
+    with pytest.raises(music_reply.MusicReplyError) as captured: adapter.generate(private, private, song, duration_seconds=40, lyrics=private, caption=private)
+    diagnostic = captured.value.diagnostic
+    assert str(captured.value) == "MINIMAX_MUSIC3_FAILED" and "returncode=23" in diagnostic and "CUDA out of memory" in diagnostic and not song.exists()
+    persisted = (data_root / "logs" / "media-provider.jsonl").read_text(encoding="utf-8")
+    assert "MINIMAX_MUSIC3_FAILED" in persisted and "returncode=23" in persisted and len(diagnostic) <= 512
+    assert all(value not in diagnostic and value not in persisted for value in sensitive)
+    def stable(error, code, detail="returncode=unavailable; stderr=process timeout"): assert (str(error), error.diagnostic, error.__cause__, error.__context__) == (code, detail, None, None)
+    monkeypatch.setattr(music_reply.subprocess, "run", lambda command, **_kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired(command, 1, stderr=private.encode())))
+    with pytest.raises(music_reply.MusicReplyError) as caught: adapter.generate(private, private, tmp_path / "song.flac", duration_seconds=40)
+    stable(caught.value, "MINIMAX_MUSIC3_FAILED")
+    def latentsync_timeout(*_args, **_kwargs):
+        try: raise subprocess.TimeoutExpired([str(tmp_path / "private.exe")], 1, stderr=private.encode())
+        except subprocess.TimeoutExpired as exc: raise music_reply.LatentSyncReplyError("LATENTSYNC_FAILED") from exc
+    monkeypatch.setattr(music_reply, "render_latentsync_video", latentsync_timeout)
+    with pytest.raises(music_reply.MusicReplyError) as caught: music_reply.render_full_face_performance(tmp_path / "base", tmp_path / "voice", tmp_path / "song", tmp_path / "out", latentsync_python_path=python, latentsync_root=comfy)
+    stable(caught.value, "LATENTSYNC_FAILED")
+    ace = lambda: music_reply.AceStepClient("http://127.0.0.1:8001").generate(private, private, tmp_path / "ace.wav", duration_seconds=40)
+    def response(payload): return nullcontext(SimpleNamespace(read=lambda: json.dumps(payload).encode()))
+    def ace_error(provider, code, detail="returncode=unavailable; stderr=process timeout"):
+        monkeypatch.setattr(music_reply, "urlopen", provider)
+        with pytest.raises(music_reply.MusicReplyError) as caught: ace()
+        stable(caught.value, code, detail)
+    ace_error(lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError(private)), "ACESTEP_UNAVAILABLE")
+    responses = iter(({"code": 200, "data": {"task_id": "id"}}, {"code": 200, "data": [{"status": 1, "result": json.dumps([{"file": "/voice.wav"}])}]}))
+    ace_error(lambda request, **_kwargs: response(next(responses)) if isinstance(request, music_reply.Request) else (_ for _ in ()).throw(TimeoutError(private)), "ACESTEP_AUDIO_UNAVAILABLE")
+    responses = iter(({"code": 200, "data": {"task_id": "id"}}, {"code": 200, "data": [{"status": 1, "result": private}]}))
+    ace_error(lambda *_args, **_kwargs: response(next(responses)), "ACESTEP_RESULT_INVALID", "returncode=unavailable; stderr=provider stderr redacted")
+
+
+def test_truncated_video_is_not_recorded_as_completed_stage(tmp_path: Path) -> None:
+    import imageio_ffmpeg
+    manifest, manifest_path = {"artifacts": {}}, tmp_path / "manifest.json"
+    truncated = _write(tmp_path / "song-video.mp4", b"\0\0\0\x18ftypmp42\0\0\0\0mp42isom")
+    with pytest.raises(music_reply.MusicReplyError, match="MUSIC_STAGE_OUTPUT_INVALID"):
+        music_reply._record_stage(manifest, manifest_path, "song_video", truncated, required_streams=("0:v:0", "0:a:0"), ffmpeg_path=Path(imageio_ffmpeg.get_ffmpeg_exe()))
+    assert not manifest_path.exists()
+
+
+def test_short_required_video_stream_is_not_recorded_as_completed_stage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ffmpeg, video = _write(tmp_path / "ffmpeg.exe", b"runtime"), _write(tmp_path / "short-audio.mp4", b"container")
+    manifest, manifest_path = {"artifacts": {}}, tmp_path / "manifest.json"
+    observed: list[list[str]] = []
+    def decode(command, **_kwargs):
+        observed.append(list(command))
+        mapped = [command[index + 1] for index, item in enumerate(command) if item == "-map"]; return subprocess.CompletedProcess(command, 0, stdout=f"out_time=00:00:{40 if mapped == ['0:a:0'] else 60}.000000\n".encode(), stderr=b"")
+    monkeypatch.setattr(music_reply.subprocess, "run", decode)
+    with pytest.raises(music_reply.MusicReplyError, match="MUSIC_STAGE_OUTPUT_INVALID"):
+        music_reply._record_stage(manifest, manifest_path, "song_video", video, required_streams=("0:v:0", "0:a:0"), ffmpeg_path=ffmpeg, minimum_duration_seconds=55)
+    assert not manifest_path.exists()
+    assert [[command[command.index("-map") + 1]] for command in observed] == [["0:v:0"], ["0:a:0"]]
+    assert all("-xerror" in command for command in observed)
+
+
 def _value_after(command: list[str], flag: str) -> str:
     return command[command.index(flag) + 1]
 
@@ -327,8 +390,14 @@ def test_prepare_official_spoken_base_uses_only_first_35_seconds(
     reference = _write(tmp_path / "official-complete-reply.mp4")
     destination = tmp_path / "stages" / "official-spoken-000-035s.mp4"
     observed: list[tuple[list[str], str]] = []
+    decoded: list[str] = []
 
     monkeypatch.setattr(music_reply, "_ffmpeg", lambda *_args: "ffmpeg")
+
+    def decode(command, **_kwargs):
+        stream = command[command.index("-map") + 1]
+        decoded.append(stream)
+        return subprocess.CompletedProcess(command, 0 if stream == "0:v:0" else 1, stdout=b"out_time=00:00:35.000000\n", stderr=b"Stream map '0:a:0' matches no streams" if stream == "0:a:0" else b"")
 
     def fake_run(command, error_code, *, timeout=900.0):
         del timeout
@@ -336,6 +405,7 @@ def test_prepare_official_spoken_base_uses_only_first_35_seconds(
         _write(Path(command[-1]), b"official-spoken")
 
     monkeypatch.setattr(music_reply, "_run", fake_run)
+    monkeypatch.setattr(music_reply.subprocess, "run", decode)
 
     result = music_reply.prepare_official_spoken_base(reference, destination)
 
@@ -347,6 +417,7 @@ def test_prepare_official_spoken_base_uses_only_first_35_seconds(
     assert _value_after(command, "-t") == "35"
     assert _value_after(command, "-i") == str(reference)
     assert "-an" in command
+    assert decoded == ["0:v:0", "0:a:0"]
 
 
 def test_concat_videos_inserts_silent_transition_between_spoken_and_performance(
@@ -475,6 +546,9 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
     monkeypatch.setenv("OLIVIA_LATENTSYNC_PYTHON", "synthetic-python")
     monkeypatch.setenv("OLIVIA_LATENTSYNC_ROOT", "synthetic-root")
     monkeypatch.setenv("OLIVIA_SPOKEN_SCENE_CANDIDATES", str(stale_candidate))
+    audio_present = True
+    normal_error = True
+    monkeypatch.setattr(music_reply, "_media_duration_seconds", lambda path, **kwargs: None if audio_present and Path(path) == spoken_action_base and kwargs.get("forbidden_streams") else 60.0)
 
     def fake_plan(content, reply_text, duration_seconds):
         order.append("plan")
@@ -483,6 +557,9 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
 
     def fake_normal(text, destination, **kwargs):
         order.append("spoken")
+        if normal_error:
+            try: raise subprocess.TimeoutExpired([str(tmp_path / "private.exe")], 1, stderr=b"private-stderr")
+            except subprocess.TimeoutExpired as exc: raise music_reply.ReplyMediaError(str(tmp_path / "private.wav")) from exc
         observed["spoken"] = (text, Path(destination), kwargs)
         _write(Path(destination), b"spoken")
         return {"spoken_stage": "completed"}
@@ -534,10 +611,9 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
     monkeypatch.setattr(music_reply, "render_full_face_performance", fake_face)
     monkeypatch.setattr(music_reply, "concat_videos", fake_concat)
 
-    result = music_reply.render_musical_reply(
-        "synthetic letter",
-        "synthetic canonical reply",
-        output,
+    def render():
+        return music_reply.render_musical_reply(
+        "synthetic letter", "synthetic canonical reply", output,
         normal_video_path=normal,
         official_reply_reference_path=official_reference,
         song_video_path=song_video,
@@ -548,6 +624,17 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
         duration_seconds=40,
         spoken_action_base_path=spoken_action_base,
     )
+
+    with pytest.raises(music_reply.MusicReplyError, match="MUSIC_REPLY_SPOKEN_REFERENCE_FAILED"):
+        render()
+    audio_present = False
+    with pytest.raises(music_reply.MusicReplyError) as caught:
+        render()
+    assert (str(caught.value), caught.value.diagnostic, caught.value.__cause__, caught.value.__context__) == \
+        ("MUSIC_REPLY_NORMAL_VIDEO_FAILED", "returncode=unavailable; stderr=process timeout", None, None)
+    normal_error = False
+    order.clear()
+    result = render()
 
     assert order == [
         "plan",
@@ -564,7 +651,7 @@ def test_render_musical_reply_keeps_spoken_then_transition_then_performance(
     assert observed["concat"] == (
         normal,
         song_video,
-        output,
+        output.with_name("final.partial.mp4"),
         {
             "transition_video_path": official_reference,
             "ffmpeg_path": tmp_path / "ffmpeg.exe",
@@ -651,6 +738,7 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     )
     monkeypatch.setenv("OLIVIA_LATENTSYNC_PYTHON", "synthetic-python")
     monkeypatch.setenv("OLIVIA_LATENTSYNC_ROOT", "synthetic-root")
+    monkeypatch.setattr(music_reply, "_media_duration_seconds", lambda path, **kwargs: None if Path(path).read_bytes() == b"poisoned-spoken" and kwargs.get("forbidden_streams") else 60.0)
     monkeypatch.setattr(
         music_reply,
         "plan_song_content",
@@ -731,6 +819,12 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     assert result["music_stage"] == "reused"
     assert (stage_root / "manifest.json").is_file()
 
+    spoken_base = _write(stage_root / "official-spoken-000-035s.mp4", b"poisoned-spoken")
+    manifest_path = stage_root / "manifest.json"; manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["artifacts"]["normal_video"] = music_reply._stage_record(normal, {"spoken_base": spoken_base})
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8"); music_reply.render_musical_reply("letter", "reply", output, **kwargs)
+    assert calls == {"spoken": 2, "minimax": 1, "separate": 2}
+
     monkeypatch.setattr(
         music_reply,
         "plan_song_content",
@@ -743,36 +837,36 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     )
     music_reply.render_musical_reply("letter", "reply", output, **kwargs)
 
-    assert calls == {"spoken": 1, "minimax": 2, "separate": 3}
+    assert calls == {"spoken": 2, "minimax": 2, "separate": 3}
 
     music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
 
-    assert calls == {"spoken": 2, "minimax": 3, "separate": 4}
+    assert calls == {"spoken": 3, "minimax": 3, "separate": 4}
 
     minimax_worker.write_bytes(b"provider-v2")
     music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
 
-    assert calls == {"spoken": 2, "minimax": 4, "separate": 5}
+    assert calls == {"spoken": 3, "minimax": 4, "separate": 5}
 
     visual_config.write_bytes(b"visual-v2")
     music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
 
-    assert calls == {"spoken": 3, "minimax": 5, "separate": 6}
+    assert calls == {"spoken": 4, "minimax": 5, "separate": 6}
 
     visual_worker.write_bytes(b"worker-v2")
     music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
 
-    assert calls == {"spoken": 4, "minimax": 6, "separate": 7}
+    assert calls == {"spoken": 5, "minimax": 6, "separate": 7}
 
 
-def test_render_musical_reply_rebuilds_downstream_stages_when_song_audio_is_rebuilt(
+def test_render_musical_reply_invalidates_manifest_cached_short_song_audio(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     output = tmp_path / "letter.mp4"
     normal = tmp_path / "letter-spoken.mp4"
     song_video = tmp_path / "letter-song.mp4"
-    stage_root = tmp_path / "letter-music-v2-40s-stages"
+    stage_root = tmp_path / "letter-music-v2-60s-stages"
     minimax_worker = _write(tmp_path / "minimax-worker.py", b"provider-v1")
     calls = {"minimax": 0, "separate": 0, "performance": 0}
 
@@ -786,6 +880,11 @@ def test_render_musical_reply_rebuilds_downstream_stages_when_song_audio_is_rebu
     )
     monkeypatch.setenv("OLIVIA_LATENTSYNC_PYTHON", "synthetic-python")
     monkeypatch.setenv("OLIVIA_LATENTSYNC_ROOT", "synthetic-root")
+
+    def fake_duration(path, **_kwargs):
+        return 40.0 if Path(path).read_bytes() == b"cached-too-short-song" else 70.0
+
+    monkeypatch.setattr(music_reply, "_media_duration_seconds", fake_duration)
     monkeypatch.setattr(
         music_reply,
         "plan_song_content",
@@ -793,7 +892,7 @@ def test_render_musical_reply_rebuilds_downstream_stages_when_song_audio_is_rebu
             emotion="gentle_reassurance",
             lyrics="[Verse]\\nStay here",
             caption="gentle piano ballad",
-            duration_seconds=40,
+            duration_seconds=60,
         ),
     )
     monkeypatch.setattr(
@@ -842,14 +941,70 @@ def test_render_musical_reply_rebuilds_downstream_stages_when_song_audio_is_rebu
         "visual_config_path": tmp_path / "visual.json",
         "worker_path": tmp_path / "visual-worker.py",
         "performance_video_path": tmp_path / "base-performance.mp4",
-        "duration_seconds": 40,
+        "duration_seconds": 60,
     }
 
     music_reply.render_musical_reply("letter", "reply", output, **kwargs)
-    (stage_root / "song.flac").unlink()
+    song_audio = stage_root / "song.flac"
+    song_audio.write_bytes(b"cached-too-short-song")
+    manifest_path = stage_root / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["artifacts"]["song_audio"] = music_reply._stage_record(song_audio)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
     music_reply.render_musical_reply("letter", "reply", output, **kwargs)
 
     assert calls == {"minimax": 2, "separate": 2, "performance": 2}
+
+
+def test_invalid_partials_preserve_every_published_music_stage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    output, stage_root = tmp_path / "letter.mp4", tmp_path / "letter-music-v2-40s-stages"
+    normal = _write(tmp_path / "normal.mp4", b"last-known-good-normal")
+    old_song = _write(stage_root / "song.flac", b"last-known-good")
+    monkeypatch.setenv("OLIVIA_FFMPEG_EXE", str(_write(tmp_path / "ffmpeg.exe")))
+    monkeypatch.setenv("OLIVIA_PROVIDER_CACHE_ROOT", str(tmp_path / "provider-cache"))
+    monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_PYTHON", str(_write(tmp_path / "minimax-python.exe")))
+    monkeypatch.setenv("OLIVIA_MINIMAX_COMFY_ROOT", str(tmp_path / "minimax-root"))
+    monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", str(_write(tmp_path / "minimax-worker.py")))
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_PYTHON", str(_write(tmp_path / "latentsync-python.exe")))
+    monkeypatch.setenv("OLIVIA_LATENTSYNC_ROOT", str(tmp_path / "latentsync-root"))
+    monkeypatch.setattr(music_reply, "plan_song_content", lambda *_args: SongContentPlan(emotion="gentle_reassurance", lyrics="[Verse]\\nStay here", caption="gentle piano ballad", duration_seconds=40))
+    monkeypatch.setattr(music_reply, "_media_duration_seconds", lambda path, **_kwargs: 0.5 if Path(path).read_bytes() == b"short-normal" else (40.0 if Path(path).read_bytes() == b"short-final" else (5.0 if Path(path).read_bytes().startswith(b"short-") else 60.0)))
+    monkeypatch.setattr(music_reply, "render_reply_video", lambda _text, destination, **_kwargs: (_write(Path(destination), b"short-normal") and {"spoken_stage": "completed"}))
+    monkeypatch.setattr(music_reply.MiniMaxMusic3Worker, "generate", lambda _self, _content, _reply, destination, **_kwargs: (_write(Path(destination), b"short-song") and {"music_stage": "completed"}))
+    monkeypatch.setattr(music_reply, "separate_vocals", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("short song reached RoFormer")))
+
+    def render():
+        return music_reply.render_musical_reply(
+            "letter", "reply", output, normal_video_path=normal,
+            official_reply_reference_path=_write(tmp_path / "official.mp4"),
+            song_video_path=tmp_path / "song-video.mp4", tts_config_path=tmp_path / "tts.json",
+            visual_config_path=tmp_path / "visual.json", worker_path=tmp_path / "visual-worker.py",
+            performance_video_path=tmp_path / "performance.mp4", duration_seconds=40,
+            spoken_action_base_path=_write(tmp_path / "spoken-base.mp4"),
+    )
+    def rejected(stage, old, expected, partial):
+        with pytest.raises(music_reply.MusicReplyError, match="MUSIC_STAGE_OUTPUT_INVALID") as caught: render()
+        assert f"stage={stage}" in caught.value.diagnostic
+        assert old.read_bytes() == expected and not partial.exists()
+        return caught.value
+    rejected("normal_video", normal, b"last-known-good-normal", tmp_path / "normal.partial.mp4")
+    monkeypatch.setattr(music_reply, "render_reply_video", lambda _text, destination, **_kwargs: (_write(Path(destination), b"valid-normal") and {"spoken_stage": "completed"}))
+    error = rejected("song_audio", old_song, b"last-known-good", stage_root / "song.partial.flac")
+    assert "observed_seconds=5.000" in error.diagnostic and "required_seconds=35.000" in error.diagnostic
+    assert "song_audio" not in json.loads((stage_root / "manifest.json").read_text(encoding="utf-8"))["artifacts"]
+    old_vocals = _write(stage_root / "vocals.wav", b"last-known-good-vocals")
+    monkeypatch.setattr(music_reply.MiniMaxMusic3Worker, "generate", lambda _self, _content, _reply, destination, **_kwargs: (_write(Path(destination), b"valid-song") and {"music_stage": "completed"}))
+    monkeypatch.setattr(music_reply, "separate_vocals", lambda _source, destination, **_kwargs: _write(Path(destination), b"short-vocals"))
+    rejected("vocals", old_vocals, b"last-known-good-vocals", stage_root / "vocals.partial.wav")
+    old_video = _write(tmp_path / "song-video.mp4", b"last-known-good-video")
+    monkeypatch.setattr(music_reply, "separate_vocals", lambda _source, destination, **_kwargs: _write(Path(destination), b"valid-vocals"))
+    monkeypatch.setattr(music_reply, "render_full_face_performance", lambda _base, _vocals, _song, destination, **_kwargs: (_write(Path(destination), b"short-video") and {"performance_stage": "completed"}))
+    rejected("song_video", old_video, b"last-known-good-video", tmp_path / "song-video.partial.mp4")
+    old_output = _write(output, b"last-known-good-final")
+    monkeypatch.setattr(music_reply, "render_full_face_performance", lambda _base, _vocals, _song, destination, **_kwargs: (_write(Path(destination), b"valid-video") and {"performance_stage": "completed"}))
+    monkeypatch.setattr(music_reply, "concat_videos", lambda _normal, _song, destination, **_kwargs: _write(Path(destination), b"short-final"))
+    error = rejected("final_output", old_output, b"last-known-good-final", tmp_path / "final.partial.mp4")
+    assert "observed_seconds=40.000" in error.diagnostic and "required_seconds=44.000" in error.diagnostic
 
 
 def test_render_musical_reply_invalidates_cache_when_configured_provider_assets_change(
@@ -893,6 +1048,7 @@ def test_render_musical_reply_invalidates_cache_when_configured_provider_assets_
     monkeypatch.setenv("OLIVIA_MINIMAX_WORKER", str(minimax_worker))
     monkeypatch.setenv("OLIVIA_LATENTSYNC_PYTHON", str(tmp_path / "latentsync-python.exe"))
     monkeypatch.setenv("OLIVIA_LATENTSYNC_ROOT", str(latentsync_root))
+    monkeypatch.setattr(music_reply, "_media_duration_seconds", lambda *_args, **_kwargs: 60.0)
     monkeypatch.setattr(
         music_reply,
         "plan_song_content",

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -316,6 +316,7 @@ def test_musical_render_uses_one_immutable_provider_path_snapshot(
     for name, value in environment.items():
         monkeypatch.setenv(name, value)
     monkeypatch.chdir(unrelated_cwd)
+    monkeypatch.setattr(music_reply, "_media_duration_seconds", lambda *_args, **_kwargs: 60.0)
     observed: dict[str, object] = {}
     output = tmp_path / "output.mp4"
 
@@ -437,7 +438,11 @@ def test_roformer_uses_explicit_f_drive_assets_and_utf8(tmp_path, monkeypatch):
         observed.append((command, error_code, env))
         if "--store_dir" in command:
             output_root = Path(command[command.index("--store_dir") + 1])
-            (output_root / "synthetic_vocals.wav").write_bytes(b"vocals")
+            with wave.open(str(output_root / "synthetic_vocals.wav"), "wb") as stream:
+                stream.setnchannels(1)
+                stream.setsampwidth(2)
+                stream.setframerate(16000)
+                stream.writeframes(b"\0\0" * 1600)
 
     monkeypatch.setattr(music_reply, "_run", fake_run)
 
@@ -465,7 +470,41 @@ def test_roformer_uses_explicit_f_drive_assets_and_utf8(tmp_path, monkeypatch):
     ]
     assert observed[1][2]["PYTHONUTF8"] == "1"
     assert observed[1][2]["PYTHONIOENCODING"] == "utf-8"
-    assert vocals.read_bytes() == b"vocals"
+    with wave.open(str(vocals), "rb") as stream:
+        assert stream.getnframes() == 1600
+
+
+def test_roformer_zero_duration_wav_is_rejected_before_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "python.exe"
+    model, config = tmp_path / "model.ckpt", tmp_path / "config.yaml"
+    song = tmp_path / "song.flac"
+    for path in (executable, model, config, song):
+        path.write_bytes(b"synthetic")
+    vocals = tmp_path / "vocals.wav"
+    monkeypatch.setattr(music_reply, "_ffmpeg", lambda *_args: "ffmpeg")
+    def fake_run(command, _error_code, **_kwargs):
+        if "--store_dir" not in command:
+            return
+        candidate = Path(command[command.index("--store_dir") + 1]) / "synthetic_vocals.wav"
+        with wave.open(str(candidate), "wb") as stream:
+            stream.setparams((1, 2, 16000, 0, "NONE", "not compressed"))
+
+    monkeypatch.setattr(music_reply, "_run", fake_run)
+
+    with pytest.raises(music_reply.MusicReplyError, match="ROFORMER_OUTPUT_INVALID"):
+        music_reply.separate_vocals(
+            song,
+            vocals,
+            executable=executable,
+            model_path=model,
+            config_path=config,
+            environment={"OLIVIA_ROFORMER_PYTHON": str(executable)},
+        )
+
+    assert not vocals.exists()
 
 
 def test_official_voice_reference_is_bounded_for_cosyvoice(tmp_path, monkeypatch):
@@ -919,7 +958,11 @@ def test_musical_renderer_resolves_all_provider_paths_from_project_root(
         observed.setdefault("commands", []).append((command, error_code))
         if error_code == "ROFORMER_FAILED":
             output_root = Path(command[command.index("--store_dir") + 1])
-            (output_root / "synthetic_vocals.wav").write_bytes(b"vocals")
+            with wave.open(str(output_root / "synthetic_vocals.wav"), "wb") as stream:
+                stream.setnchannels(1)
+                stream.setsampwidth(2)
+                stream.setframerate(16000)
+                stream.writeframes(b"\0\0" * 1600)
         elif error_code == "ROFORMER_INPUT_CONVERSION_FAILED":
             Path(command[-1]).write_bytes(b"wav")
         elif error_code == "MUSIC_REPLY_AUDIO_MUX_FAILED":
@@ -942,6 +985,7 @@ def test_musical_renderer_resolves_all_provider_paths_from_project_root(
     monkeypatch.setattr(music_reply, "MiniMaxMusic3Worker", FakeMiniMaxWorker)
     monkeypatch.setattr(music_reply, "_run", fake_run)
     monkeypatch.setattr(music_reply, "_ffmpeg", lambda *_args: str(ffmpeg))
+    monkeypatch.setattr(music_reply, "_media_duration_seconds", lambda *_args, **_kwargs: 60.0)
     monkeypatch.setattr(music_reply, "render_reply_video", fake_render_reply)
     monkeypatch.setattr(music_reply, "render_latentsync_video", fake_latentsync)
     monkeypatch.setattr(music_reply, "prepare_official_spoken_base", fake_prepare)


### PR DESCRIPTION
## Scope
- require reusable spoken bases to be video-only before normal-stage reuse
- normalize provider failures to stable diagnostics without path/stderr causes
- render ordinary/song/vocal/final stages to validated partials before atomic publication
- validate final duration against spoken + transition + song targets

## Evidence
- exact pair: ad7c3fe459dabddc03ba58156495b9c16424c8ec...0a5a4e75398c6f62dbd27536e70fe3422d696eae
- mechanical range-diff from reviewed/fixed patch: exact equals
- focused media tests: 40 passed
- pycompile and git diff --check: pass
- size: 499 changed lines

## Boundary
No full suite or real provider/GPU/human media acceptance was run. Final static review remains separate from CI.