### PR TITLE
fix: restart retryable reply runs

### DIFF
--- a/docs/B03_LLM_GATEWAY.md
+++ b/docs/B03_LLM_GATEWAY.md
@@ -96,7 +96,7 @@ calls = await gateway.complete_with_tools(
 
 ## 回信事件与并发语义
 
-`reply_orchestrator.py` 提供 `ReplyRequest`、`ReplyOrchestrator.start()`、`ReplyRun.events()` 和 `ReplyRun.cancel()`。每个 request 具有 request ID；给出相同 `idempotency_key` 且输入一致时复用同一个结果，输入不一致返回 `IDEMPOTENCY_CONFLICT`。
+`reply_orchestrator.py` 提供 `ReplyRequest`、`ReplyOrchestrator.start()`、`ReplyRun.events()` 和 `ReplyRun.cancel()`。每个 request 具有 request ID；给出相同 `idempotency_key` 且输入一致时复用同一个在途或终态结果，输入不一致返回 `IDEMPOTENCY_CONFLICT`。唯一例外是已终止且标记 `retryable=true` 的失败：下一次相同输入会在锁内原子替换旧 run 并重新调用 provider，同时到达的重试仍共享这个 replacement run；replacement 沿用旧 run 的 request ID，以保留 provider 幂等边界。
 
 事件顺序和终态：
 

--- a/runtime/reply/reply_orchestrator.py
+++ b/runtime/reply/reply_orchestrator.py
@@ -104,6 +104,12 @@ class ReplyRun:
     async def wait(self) -> ReplyResult:
         return await self._result
 
+    def _has_retryable_failure(self) -> bool:
+        if not self._result.done() or self._result.cancelled():
+            return False
+        result = self._result.result()
+        return result.state is ReplyState.FAILED and result.retryable
+
     def cancel(self) -> bool:
         if self.task is None or self.task.done():
             return False
@@ -146,7 +152,9 @@ class ReplyOrchestrator:
                         name=f"reply-conflict-{request.request_id}",
                     )
                     return conflict
-                return existing
+                if not existing._has_retryable_failure():
+                    return existing
+                request = existing.request
             run = ReplyRun(request, queue_size=self.queue_size)
             self._runs[key] = run
             run.task = asyncio.create_task(

--- a/tests/llm/test_orchestrator.py
+++ b/tests/llm/test_orchestrator.py
@@ -41,9 +41,24 @@ class BurstGateway(Gateway):
 class ErrorGateway(Gateway):
     def __init__(self, error: GatewayError):
         self.error = error
+        self.calls = 0
 
     async def complete(self, messages, *, request_id=None):
+        self.calls += 1
         raise self.error
+
+
+class RetryOnceGateway(Gateway):
+    def __init__(self) -> None:
+        self.calls = 0
+        self.request_ids: list[str | None] = []
+
+    async def complete(self, messages, *, request_id=None):
+        self.calls += 1
+        self.request_ids.append(request_id)
+        if self.calls == 1:
+            raise GatewayError("PROVIDER_RETRYABLE", retryable=True)
+        return GatewayResponse("recovered", request_id or "request", "mock", "model")
 
 
 def test_stream_success_emits_ordered_events_and_completed_result() -> None:
@@ -146,6 +161,109 @@ def test_idempotency_reuses_result_and_conflict_is_terminal() -> None:
     assert second == first
     assert conflict.error_code == "IDEMPOTENCY_CONFLICT"
     assert conflict.state is ReplyState.FAILED
+
+
+def test_retryable_idempotent_failure_starts_one_new_run() -> None:
+    async def exercise():
+        gateway = RetryOnceGateway()
+        orchestrator = ReplyOrchestrator(gateway)
+        request = ReplyRequest(
+            content="same",
+            request_id="retryable-request",
+            idempotency_key="retryable-key",
+        )
+
+        first = await orchestrator.run(request)
+        conflict = await orchestrator.run(
+            ReplyRequest(
+                content="different",
+                request_id="conflicting-request",
+                idempotency_key="retryable-key",
+            )
+        )
+        retry, duplicate = await asyncio.gather(
+            orchestrator.start(
+                ReplyRequest(
+                    content="same",
+                    request_id="retryable-request-2",
+                    idempotency_key="retryable-key",
+                )
+            ),
+            orchestrator.start(
+                ReplyRequest(
+                    content="same",
+                    request_id="retryable-request-3",
+                    idempotency_key="retryable-key",
+                )
+            ),
+        )
+        second = await retry.wait()
+        return (
+            gateway.calls,
+            gateway.request_ids,
+            first,
+            conflict,
+            second,
+            retry is duplicate,
+        )
+
+    calls, request_ids, first, conflict, second, shared_retry = run(exercise())
+    assert first.state is ReplyState.FAILED
+    assert first.retryable is True
+    assert conflict.state is ReplyState.FAILED
+    assert conflict.error_code == "IDEMPOTENCY_CONFLICT"
+    assert second.state is ReplyState.COMPLETED
+    assert second.text == "recovered"
+    assert calls == 2
+    assert request_ids == ["retryable-request", "retryable-request"]
+    assert shared_retry is True
+
+
+def test_non_retryable_idempotent_failure_remains_cached() -> None:
+    async def exercise():
+        gateway = ErrorGateway(GatewayError("PROVIDER_PROTOCOL", retryable=False))
+        orchestrator = ReplyOrchestrator(gateway)
+        request = ReplyRequest(
+            content="same",
+            request_id="terminal-request",
+            idempotency_key="terminal-key",
+        )
+
+        first = await orchestrator.run(request)
+        second = await orchestrator.run(request)
+        return gateway.calls, first, second
+
+    calls, first, second = run(exercise())
+    assert first.state is ReplyState.FAILED
+    assert first.retryable is False
+    assert second == first
+    assert calls == 1
+
+
+def test_cancelled_waiter_keeps_existing_run_without_result_lookup() -> None:
+    async def exercise():
+        orchestrator = ReplyOrchestrator(SlowGateway(), timeout_seconds=2)
+        request = ReplyRequest(
+            content="same",
+            request_id="cancelled-waiter-request",
+            idempotency_key="cancelled-waiter-key",
+        )
+        run_handle = await orchestrator.start(request)
+        waiter = asyncio.create_task(run_handle.wait())
+        await asyncio.sleep(0)
+        waiter.cancel()
+        try:
+            await waiter
+        except asyncio.CancelledError:
+            pass
+
+        reused = await orchestrator.start(request)
+        run_handle.cancel()
+        if run_handle.task is not None:
+            await run_handle.task
+        return reused is run_handle
+
+    assert run(exercise()) is True
 
 
 def test_invalid_role_is_rejected_without_provider_call() -> None:


### PR DESCRIPTION
## Summary

- Restart a same-key, same-fingerprint reply run only after a terminal `FAILED` result marked `retryable=true`.
- Keep replacement atomic under the orchestrator lock so concurrent retries share one new provider call.
- Reuse the original `ReplyRequest` for the replacement, preserving payload, scope, limits, idempotency key, and provider request ID.
- Document the retryable exception to normal in-process result replay.

## TDD evidence

RED 1:
- First provider call returned `PROVIDER_RETRYABLE`.
- A second same-key call reused the cached `FAILED` result; provider calls remained 1.

GREEN 1:
- The next call creates one replacement run; two concurrent retries share it.
- The replacement completes and total provider calls are 2.
- Different content with the same key remains `IDEMPOTENCY_CONFLICT`.
- Successful and non-retryable terminal results retain existing replay behavior.

RED 2:
- Concurrent retry requests carrying new request IDs caused the second provider call to receive a new ID.

GREEN 2:
- The replacement inherits the original request.
- Synthetic gateway evidence records the same original provider request ID for both calls.

Focused verification:
- `python -m pytest tests/llm/test_orchestrator.py -q` -> `9 passed`
- `python -m py_compile runtime/reply/reply_orchestrator.py tests/llm/test_orchestrator.py` -> PASS
- `git diff --check` -> PASS

No full local test suite was run.

## Frozen review trail

Final pair:
- Base: `f1a617e7c376393cedd7aa4c41548a9a77897f78`
- Head: `21a662f99b147bba63b2d739b8c355f9e0d8f2ee`
- Standards: PASS, P0/P1/P2 = 0/0/0
- Spec: PASS, P0/P1/P2 = 0/0/0

Earlier heads were not promoted:
- `b28f857`: BLOCKED for documentation/coverage gaps.
- `db225a1`: BLOCKED because replacement could change the provider request ID.
- Both findings were repaired and reviewed again on the final head.

## Scope and privacy

3 files, 130 changed lines. Fixtures are synthetic. No private letter text, credentials, provider payloads, or local paths are included. No persona, review/rewrite semantics, Live, media, installer, video runtime, or voice implementation changes.

## Acceptance boundary

This proves deterministic orchestrator concurrency and idempotency behavior locally. It does not claim real-provider or private-letter acceptance. The existing unbounded lifetime of completed cached runs and cancelled-waiter lifecycle are intentionally unchanged and remain separate follow-up risks.