### PR TITLE
feat(installer): build portable video runtime archive

### DIFF
--- a/installer/build_video_runtime.py
+++ b/installer/build_video_runtime.py
@@ -1,0 +1,312 @@
+"""Build the private portable-Python closure used by video replies."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+import zipfile
+
+from video_capability_install import (
+    VideoCapabilityError,
+    _load_runtime_root_manifest,
+    _reject_reparse_tree,
+    _safe_relative,
+    _safe_sha,
+    _sha256_file,
+    write_runtime_root_manifest,
+)
+
+class VideoRuntimeBuildError(ValueError):
+    """Stable fail-closed build error."""
+
+_COMPONENT_ENVIRONMENT = {
+    "cosyvoice": "OLIVIA_COSYVOICE_PYTHON",
+    "latentsync": "OLIVIA_LATENTSYNC_PYTHON",
+    "minimax": "OLIVIA_MINIMAX_COMFY_PYTHON",
+    "roformer": "OLIVIA_ROFORMER_PYTHON",
+}
+_COMPONENT_IMPORTS = {
+    "cosyvoice": ("torch", "torchaudio", "cosyvoice.cli.cosyvoice"),
+    "latentsync": ("torch", "diffusers", "latentsync"),
+    "minimax": ("torch", "comfy", "comfy_extras.nodes_minimax_music"),
+    "roformer": ("torch", "mel_band_roformer.inference"),
+}
+_BOM_SCHEMA = "olivia.video-runtime-build-inputs.v1"
+_VERSION = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}\Z")
+_REVISION = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})\Z")
+_MODEL_DIRECTORIES = {"checkpoint", "checkpoints", "downloads", "ffmpeg", "model", "models", "pretrained_models", "source", "sources", "weight", "weights"}
+_MODEL_SUFFIXES = {".ckpt", ".engine", ".gguf", ".h5", ".hdf5", ".onnx", ".pb", ".pt", ".safetensors", ".tflite", ".weights"}
+_AUDIO_SUFFIXES = {".aac", ".aif", ".aiff", ".alac", ".amr", ".caf", ".flac", ".m4a", ".mka", ".mp3", ".ogg", ".opus", ".wav", ".webm", ".wma"}
+_MAX_EXPANDED_BYTES = 64 * 1024 * 1024 * 1024
+
+def _load_bom(path: Path | None) -> dict[str, object]:
+    if path is None:
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_REQUIRED")
+    try:
+        if not isinstance(path, Path) or not path.is_absolute() or not path.is_file():
+            raise OSError
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID") from exc
+    if not isinstance(payload, dict) or set(payload) != {"schema_version", "components"} or payload.get("schema_version") != _BOM_SCHEMA or not isinstance(payload.get("components"), dict):
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
+    return payload
+
+def _checked_item(root: Path, item: object) -> tuple[int, list[dict[str, object]]]:
+    required = {"upstream", "revision", "tree_sha256", "dependencies", "license", "notice", "files"}
+    try:
+        if not isinstance(item, dict) or set(item) != required:
+            raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
+        upstream, revision, dependencies = item["upstream"], item["revision"], item["dependencies"]
+        if not isinstance(upstream, str) or re.fullmatch(r"https://[^/@\s]+(?:/[^\s]*)?", upstream) is None or not isinstance(revision, str) or _REVISION.fullmatch(revision) is None:
+            raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
+        if not isinstance(dependencies, list) or not dependencies or len(dependencies) != len({value.casefold() for value in dependencies if isinstance(value, str)}) or not all(isinstance(value, str) and re.fullmatch(r"[A-Za-z0-9_.-]+==[A-Za-z0-9+_.-]+", value) for value in dependencies):
+            raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
+        legal: list[tuple[str, str]] = []
+        for key, names in (("license", ("license", "copying")), ("notice", ("notice",))):
+            meta = item[key]
+            if not isinstance(meta, dict) or set(meta) != {"path", "sha256"}:
+                raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
+            relative, digest = _safe_relative(meta["path"]), _safe_sha(meta["sha256"])
+            if not Path(relative).name.casefold().startswith(names):
+                raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
+            legal.append((relative, digest))
+    except (KeyError, TypeError, VideoCapabilityError) as exc:
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID") from exc
+
+    source_roots = (root,) if (root / "python.exe").is_file() else (root / "python", root / "site-packages")
+    try:
+        sources = {path for source_root in source_roots for path in source_root.rglob("*") if path.is_file()}
+        sources.update(root / relative for relative, _digest in legal)
+        files: list[dict[str, object]] = []
+        for path in sorted(sources, key=lambda value: value.relative_to(root).as_posix().casefold()):
+            relative = path.relative_to(root).as_posix()
+            size, digest = _sha256_file(path)
+            suffix = path.suffix.casefold()
+            with path.open("rb") as stream:
+                header = stream.read(16)
+            audio_magic = header.startswith((b"fLaC", b"OggS", b"caff", b"ID3", b"#!AMR", b"\x30\x26\xb2\x75\x8e\x66\xcf\x11")) or (header[:4] in {b"RIFF", b"FORM"} and header[8:12] in {b"WAVE", b"AIFF", b"AIFC"}) or (len(header) > 1 and header[0] == 0xFF and header[1] & 0xE0 == 0xE0) or (header[4:8] == b"ftyp" and header[8:12] in {b"M4A ", b"M4B ", b"M4P "})
+            if suffix in _AUDIO_SUFFIXES or audio_magic:
+                raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_PRIVATE_MEDIA_FORBIDDEN")
+            pth_config = False
+            if suffix == ".pth" and size <= 64 * 1024 and Path(relative).parent.name.casefold() == "site-packages" and not header.startswith((b"PK\x03\x04", b"GGUF", b"\x89HDF", b"\x80")):
+                try:
+                    text = path.read_text(encoding="utf-8")
+                    pth_config = bool(text) and all(character >= " " or character in "\t\r\n" for character in text)
+                except UnicodeError:
+                    pass
+            parents = tuple(part.casefold() for part in Path(relative).parent.parts)
+            runtime_bin = suffix == ".bin" and parents[-3:] in {("site-packages", "sentencepiece", "package_data"), ("site-packages", "chardet", "models")}
+            if (any(part.casefold() in _MODEL_DIRECTORIES for part in Path(relative).parts[:-1]) and not runtime_bin) or suffix in _MODEL_SUFFIXES or (suffix == ".bin" and not runtime_bin) or (suffix == ".pth" and not pth_config):
+                raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BUNDLE_CONTENT_FORBIDDEN")
+            files.append({"path": relative, "size_bytes": size, "sha256": digest})
+    except OSError as exc:
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_MISMATCH") from exc
+    if not files or len(files) != len({str(value["path"]).casefold() for value in files}):
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
+    tree = hashlib.sha256(json.dumps(files, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    indexed = {str(value["path"]): str(value["sha256"]) for value in files}
+    try:
+        matches = files == item["files"] and tree == _safe_sha(item["tree_sha256"]) and all(indexed[path] == digest for path, digest in legal)
+    except (KeyError, TypeError, VideoCapabilityError):
+        matches = False
+    if not matches:
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_MISMATCH")
+    return sum(int(value["size_bytes"]) for value in files), files
+
+def _checked_inputs(version: str, output: Path, roots: Mapping[str, Path], bom: Mapping[str, object]) -> tuple[Path, dict[str, Path]]:
+    if not isinstance(version, str) or _VERSION.fullmatch(version) is None:
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_VERSION_INVALID")
+    if not isinstance(output, Path) or not output.is_absolute():
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_OUTPUT_INVALID")
+    components = bom["components"]
+    if not isinstance(components, dict) or set(roots) != set(_COMPONENT_ENVIRONMENT) or set(components) != set(_COMPONENT_ENVIRONMENT):
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_COMPONENTS_INVALID")
+    output_root, checked, total = output.resolve(), {}, 0
+    for component in _COMPONENT_ENVIRONMENT:
+        raw = roots[component]
+        if not isinstance(raw, Path) or not raw.is_absolute() or not raw.is_dir():
+            raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_COMPONENT_INVALID")
+        try:
+            root = raw.resolve(strict=True)
+            _reject_reparse_tree(root)
+        except (OSError, VideoCapabilityError) as exc:
+            raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_COMPONENT_INVALID") from exc
+        if output_root == root or root in output_root.parents:
+            raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_OUTPUT_INVALID")
+        if not ((root / "python.exe").is_file() or ((root / "python" / "python.exe").is_file() and (root / "site-packages").is_dir())):
+            raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_PYTHON_MISSING")
+        if root in checked.values():
+            raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_COMPONENT_DUPLICATE")
+        size, _inventory = _checked_item(root, components[component])
+        checked[component] = root
+        total += size
+    if total > _MAX_EXPANDED_BYTES:
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_TOO_LARGE")
+    return output_root, checked
+
+def _probe_environments(environment: Mapping[str, str], runtime_root: Path) -> bool:
+    clean = {key: value for key, value in os.environ.items() if key.upper() not in {"PYTHONHOME", "PYTHONPATH"}}
+    clean.update(PYTHONNOUSERSITE="1", PYTHONSAFEPATH="1")
+    try:
+        for component, key in _COMPONENT_ENVIRONMENT.items():
+            allowed_root = runtime_root / component / "runtime"
+            script = (
+                "from pathlib import Path; import importlib,sys; root=Path(sys.argv[1]).resolve(); "
+                "inside=lambda value:(path:=Path(value).resolve())==root or root in path.parents; "
+                "assert inside(sys.executable) and inside(sys.prefix) and inside(sys.base_prefix); assert all(inside(value) for value in sys.path if value); "
+                f"[importlib.import_module(name) for name in {_COMPONENT_IMPORTS[component]!r}]; import torch; "
+                "assert torch.version.cuda and torch.cuda.is_available(); assert torch.ones(1,device='cuda').is_cuda"
+            )
+            if subprocess.run([environment[key], "-I", "-c", script, str(allowed_root)], cwd=allowed_root, capture_output=True, check=False, timeout=30, env=clean, creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0)).returncode:
+                return False
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return True
+
+def _write_zip(runtime_root: Path, target: Path) -> None:
+    try:
+        with zipfile.ZipFile(target, "x", compression=zipfile.ZIP_DEFLATED, compresslevel=1, allowZip64=True) as archive:
+            for source in sorted((path for path in runtime_root.rglob("*") if path.is_file()), key=lambda path: path.relative_to(runtime_root).as_posix().casefold()):
+                relative = source.relative_to(runtime_root).as_posix()
+                info = zipfile.ZipInfo(relative, date_time=(1980, 1, 1, 0, 0, 0))
+                info.compress_type, info.external_attr = zipfile.ZIP_DEFLATED, 0o100644 << 16
+                with source.open("rb") as input_stream, archive.open(info, "w", force_zip64=True) as output_stream:
+                    shutil.copyfileobj(input_stream, output_stream, length=1024 * 1024)
+    except (OSError, zipfile.BadZipFile, zipfile.LargeZipFile) as exc:
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_ARCHIVE_FAILED") from exc
+
+def _verify_zip(target: Path, manifest_sha256: str) -> None:
+    try:
+        with zipfile.ZipFile(target) as archive:
+            names = archive.namelist()
+            if len(names) != len({name.casefold() for name in names}) or any(_safe_relative(name) != name for name in names):
+                raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_ARCHIVE_INVALID")
+            manifest_bytes = archive.read("runtime-manifest.json")
+            payload = json.loads(manifest_bytes)
+            expected = {item["path"]: (item["size_bytes"], item["sha256"]) for item in payload["files"]}
+            if hashlib.sha256(manifest_bytes).hexdigest() != manifest_sha256 or set(names) != {*expected, "runtime-manifest.json"}:
+                raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_ARCHIVE_INVALID")
+            for relative, expected_value in expected.items():
+                digest, size = hashlib.sha256(), 0
+                with archive.open(relative) as stream:
+                    while chunk := stream.read(1024 * 1024):
+                        size += len(chunk)
+                        digest.update(chunk)
+                if (size, digest.hexdigest()) != expected_value:
+                    raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_ARCHIVE_INVALID")
+    except VideoRuntimeBuildError:
+        raise
+    except (KeyError, TypeError, ValueError, OSError, UnicodeError, json.JSONDecodeError, zipfile.BadZipFile, VideoCapabilityError) as exc:
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_ARCHIVE_INVALID") from exc
+
+def build_video_runtime_archive(*, version: str, output_directory: Path, component_roots: Mapping[str, Path], build_input_bom: Path | None = None) -> Path:
+    """Build, verify, then atomically publish one locked runtime ZIP."""
+
+    bom = _load_bom(build_input_bom)
+    output_root, checked = _checked_inputs(version, output_directory, component_roots, bom)
+    output_root.mkdir(parents=True, exist_ok=True)
+    target = output_root / f"Olivia-video-runtime-{version}.zip"
+    lock = output_root / f".{target.name}.lock"
+    try:
+        lock_fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError as exc:
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_LOCKED") from exc
+    except OSError as exc:
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_FAILED") from exc
+    try:
+        if target.exists():
+            raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_OUTPUT_EXISTS")
+        with tempfile.TemporaryDirectory(prefix=".olivia-video-runtime-", dir=output_root, ignore_cleanup_errors=True) as temporary:
+            runtime_root = Path(temporary).resolve() / "root"
+            runtime_root.mkdir()
+            environment = {}
+            for component, key in _COMPONENT_ENVIRONMENT.items():
+                source = checked[component]
+                relative, destination = f"{component}/runtime", runtime_root / f"{component}/runtime"
+                if (source / "python.exe").is_file():
+                    shutil.copytree(source, destination)
+                else:
+                    destination.mkdir(parents=True)
+                    shutil.copytree(source / "python", destination / "python")
+                    shutil.copytree(source / "site-packages", destination / "site-packages")
+                    for legal in ("license", "notice"):
+                        legal_path = _safe_relative(bom["components"][component][legal]["path"])
+                        target_path = destination / legal_path
+                        target_path.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(source / legal_path, target_path)
+                _checked_item(destination, bom["components"][component])
+                executable = "python.exe" if (source / "python.exe").is_file() else "python/python.exe"
+                environment[key] = f"{relative}/{executable}"
+            manifest_sha = write_runtime_root_manifest(runtime_root, version=version, environment=environment, build_inputs=bom)
+            verified = _load_runtime_root_manifest(runtime_root, manifest_sha, verify_files=False)
+            if set(verified) != set(_COMPONENT_ENVIRONMENT.values()) or not _probe_environments(verified, runtime_root):
+                raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_NOT_PORTABLE")
+            staging = output_root / f".{target.name}.{uuid.uuid4().hex}.tmp"
+            try:
+                _write_zip(runtime_root, staging)
+                _verify_zip(staging, manifest_sha)
+                os.link(staging, target)
+            except FileExistsError as exc:
+                raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_OUTPUT_EXISTS") from exc
+            finally:
+                try:
+                    staging.unlink(missing_ok=True)
+                except OSError:
+                    pass
+    except VideoRuntimeBuildError:
+        raise
+    except (OSError, VideoCapabilityError) as exc:
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_FAILED") from exc
+    finally:
+        try:
+            os.close(lock_fd)
+            lock.unlink(missing_ok=True)
+        except OSError:
+            pass
+    return target.resolve()
+
+class _Parser(argparse.ArgumentParser):
+    def error(self, _message: str) -> None:
+        raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_ARGUMENTS_INVALID")
+
+def _parser() -> argparse.ArgumentParser:
+    parser = _Parser(description="Build a verified private Olivia video Python runtime archive.")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--build-input-bom", required=True, type=Path)
+    for component in _COMPONENT_ENVIRONMENT:
+        parser.add_argument(f"--{component}-root", required=True, type=Path)
+    return parser
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        arguments = _parser().parse_args(argv)
+        archive = build_video_runtime_archive(
+            version=arguments.version,
+            output_directory=arguments.output_dir.expanduser().resolve(),
+            component_roots={component: getattr(arguments, f"{component}_root").expanduser().resolve() for component in _COMPONENT_ENVIRONMENT},
+            build_input_bom=arguments.build_input_bom.expanduser().resolve(),
+        )
+        size, digest = _sha256_file(archive)
+        print(json.dumps({"status": "READY", "path": str(archive), "size_bytes": size, "sha256": digest}, sort_keys=True))
+        return 0
+    except VideoRuntimeBuildError as exc:
+        print(json.dumps({"status": "ERROR", "code": str(exc)}, sort_keys=True), file=sys.stderr)
+        return 2
+    except Exception:
+        print(json.dumps({"status": "ERROR", "code": "VIDEO_RUNTIME_BUILD_FAILED"}, sort_keys=True), file=sys.stderr)
+        return 2
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/installer/build_video_runtime.py
+++ b/installer/build_video_runtime.py
@@ -17,6 +17,10 @@ from urllib.parse import urlsplit
 import uuid
 import zipfile
 
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPOSITORY_ROOT))
+
 from video_capability_install import (
     VideoCapabilityError,
     _load_runtime_root_manifest,
@@ -63,7 +67,7 @@ def _load_bom(path: Path | None) -> dict[str, object]:
         raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
     return payload
 
-def _checked_item(root: Path, item: object) -> tuple[int, list[dict[str, object]]]:
+def _checked_item(root: Path, item: object, component: str) -> tuple[int, list[dict[str, object]]]:
     required = {"upstream", "revision", "tree_sha256", "dependencies", "license", "notice", "files"}
     try:
         if not isinstance(item, dict) or set(item) != required:
@@ -81,6 +85,12 @@ def _checked_item(root: Path, item: object) -> tuple[int, list[dict[str, object]
                 raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
             relative, digest = _safe_relative(meta["path"]), _safe_sha(meta["sha256"])
             if not Path(relative).name.casefold().startswith(names):
+                raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
+            parts = tuple(part.casefold() for part in Path(relative).parts)
+            dedicated = parts[:3] == ("site-packages", "olivia_upstream", component)
+            distribution = next((part for part in parts if part.endswith(".dist-info")), "")
+            packaged = parts[:1] == ("site-packages",) and parts[-2:-1] == ("licenses",) and component.replace("-", "_") in distribution.replace("-", "_")
+            if key == "license" and not (dedicated or packaged):
                 raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
             legal.append((relative, digest))
     except (KeyError, TypeError, ValueError, VideoCapabilityError) as exc:
@@ -152,7 +162,7 @@ def _checked_inputs(version: str, output: Path, roots: Mapping[str, Path], bom: 
         if root in checked.values():
             raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_COMPONENT_DUPLICATE")
         checked[component] = root
-    total = sum(_checked_item(root, components[component])[0] for component, root in checked.items())
+    total = sum(_checked_item(root, components[component], component)[0] for component, root in checked.items())
     if total > _MAX_EXPANDED_BYTES:
         raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_TOO_LARGE")
     environment = {_COMPONENT_ENVIRONMENT[component]: str(root / ("python.exe" if (root / "python.exe").is_file() else "python/python.exe")) for component, root in checked.items()}
@@ -217,6 +227,12 @@ def _verify_zip(target: Path, manifest_sha256: str) -> None:
     except (KeyError, TypeError, ValueError, OSError, UnicodeError, json.JSONDecodeError, zipfile.BadZipFile, VideoCapabilityError) as exc:
         raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_ARCHIVE_INVALID") from exc
 
+def _open_build_lock(path: Path) -> int:
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    if sys.platform == "win32":
+        flags |= os.O_TEMPORARY
+    return os.open(path, flags)
+
 def build_video_runtime_archive(*, version: str, output_directory: Path, component_roots: Mapping[str, Path], build_input_bom: Path | None = None) -> Path:
     """Build, verify, then atomically publish one locked runtime ZIP."""
 
@@ -226,7 +242,7 @@ def build_video_runtime_archive(*, version: str, output_directory: Path, compone
     target = output_root / f"Olivia-video-runtime-{version}.zip"
     lock = output_root / f".{target.name}.lock"
     try:
-        lock_fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        lock_fd = _open_build_lock(lock)
     except FileExistsError as exc:
         raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_LOCKED") from exc
     except OSError as exc:
@@ -252,7 +268,7 @@ def build_video_runtime_archive(*, version: str, output_directory: Path, compone
                         target_path = destination / legal_path
                         target_path.parent.mkdir(parents=True, exist_ok=True)
                         shutil.copy2(source / legal_path, target_path)
-                _checked_item(destination, bom["components"][component])
+                _checked_item(destination, bom["components"][component], component)
                 executable = "python.exe" if (source / "python.exe").is_file() else "python/python.exe"
                 environment[key] = f"{relative}/{executable}"
             manifest_sha = write_runtime_root_manifest(runtime_root, version=version, environment=environment, build_inputs=bom)

--- a/installer/build_video_runtime.py
+++ b/installer/build_video_runtime.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from urllib.parse import urlsplit
 import uuid
 import zipfile
 
@@ -46,7 +47,7 @@ _VERSION = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}\Z")
 _REVISION = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})\Z")
 _MODEL_DIRECTORIES = {"checkpoint", "checkpoints", "downloads", "ffmpeg", "model", "models", "pretrained_models", "source", "sources", "weight", "weights"}
 _MODEL_SUFFIXES = {".ckpt", ".engine", ".gguf", ".h5", ".hdf5", ".onnx", ".pb", ".pt", ".safetensors", ".tflite", ".weights"}
-_AUDIO_SUFFIXES = {".aac", ".aif", ".aiff", ".alac", ".amr", ".caf", ".flac", ".m4a", ".mka", ".mp3", ".ogg", ".opus", ".wav", ".webm", ".wma"}
+_MEDIA_SUFFIXES = {".3g2", ".3gp", ".aac", ".aif", ".aiff", ".alac", ".amr", ".asf", ".avi", ".caf", ".flac", ".flv", ".m2ts", ".m2v", ".m4a", ".m4v", ".mka", ".mkv", ".mov", ".mp3", ".mp4", ".mpeg", ".mpg", ".mts", ".mxf", ".ogg", ".ogv", ".opus", ".vob", ".wav", ".webm", ".wma", ".wmv"}
 _MAX_EXPANDED_BYTES = 64 * 1024 * 1024 * 1024
 
 def _load_bom(path: Path | None) -> dict[str, object]:
@@ -68,7 +69,8 @@ def _checked_item(root: Path, item: object) -> tuple[int, list[dict[str, object]
         if not isinstance(item, dict) or set(item) != required:
             raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
         upstream, revision, dependencies = item["upstream"], item["revision"], item["dependencies"]
-        if not isinstance(upstream, str) or re.fullmatch(r"https://[^/@\s]+(?:/[^\s]*)?", upstream) is None or not isinstance(revision, str) or _REVISION.fullmatch(revision) is None:
+        parsed = urlsplit(upstream) if isinstance(upstream, str) else None
+        if parsed is None or parsed.scheme not in {"http", "https"} or not parsed.hostname or parsed.username is not None or parsed.password is not None or "?" in upstream or "#" in upstream or re.search(r"\s", upstream) is not None or not isinstance(revision, str) or _REVISION.fullmatch(revision) is None:
             raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
         if not isinstance(dependencies, list) or not dependencies or len(dependencies) != len({value.casefold() for value in dependencies if isinstance(value, str)}) or not all(isinstance(value, str) and re.fullmatch(r"[A-Za-z0-9_.-]+==[A-Za-z0-9+_.-]+", value) for value in dependencies):
             raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
@@ -81,7 +83,7 @@ def _checked_item(root: Path, item: object) -> tuple[int, list[dict[str, object]
             if not Path(relative).name.casefold().startswith(names):
                 raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID")
             legal.append((relative, digest))
-    except (KeyError, TypeError, VideoCapabilityError) as exc:
+    except (KeyError, TypeError, ValueError, VideoCapabilityError) as exc:
         raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BOM_INVALID") from exc
 
     source_roots = (root,) if (root / "python.exe").is_file() else (root / "python", root / "site-packages")
@@ -94,9 +96,9 @@ def _checked_item(root: Path, item: object) -> tuple[int, list[dict[str, object]
             size, digest = _sha256_file(path)
             suffix = path.suffix.casefold()
             with path.open("rb") as stream:
-                header = stream.read(16)
-            audio_magic = header.startswith((b"fLaC", b"OggS", b"caff", b"ID3", b"#!AMR", b"\x30\x26\xb2\x75\x8e\x66\xcf\x11")) or (header[:4] in {b"RIFF", b"FORM"} and header[8:12] in {b"WAVE", b"AIFF", b"AIFC"}) or (len(header) > 1 and header[0] == 0xFF and header[1] & 0xE0 == 0xE0) or (header[4:8] == b"ftyp" and header[8:12] in {b"M4A ", b"M4B ", b"M4P "})
-            if suffix in _AUDIO_SUFFIXES or audio_magic:
+                header = stream.read(377)
+            media_magic = header.startswith((b"fLaC", b"OggS", b"caff", b"ID3", b"#!AMR", b"FLV\x01", b"\x1a\x45\xdf\xa3", b"\x30\x26\xb2\x75\x8e\x66\xcf\x11")) or (header[:4] in {b"RIFF", b"FORM"} and header[8:12] in {b"WAVE", b"AIFF", b"AIFC", b"AVI "}) or (len(header) > 1 and header[0] == 0xFF and header[1] & 0xE0 == 0xE0) or header[4:8] == b"ftyp" or (len(header) > 376 and header[0] == header[188] == header[376] == 0x47)
+            if suffix in _MEDIA_SUFFIXES or media_magic:
                 raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_PRIVATE_MEDIA_FORBIDDEN")
             pth_config = False
             if suffix == ".pth" and size <= 64 * 1024 and Path(relative).parent.name.casefold() == "site-packages" and not header.startswith((b"PK\x03\x04", b"GGUF", b"\x89HDF", b"\x80")):
@@ -107,7 +109,8 @@ def _checked_item(root: Path, item: object) -> tuple[int, list[dict[str, object]
                     pass
             parents = tuple(part.casefold() for part in Path(relative).parent.parts)
             runtime_bin = suffix == ".bin" and parents[-3:] in {("site-packages", "sentencepiece", "package_data"), ("site-packages", "chardet", "models")}
-            if (any(part.casefold() in _MODEL_DIRECTORIES for part in Path(relative).parts[:-1]) and not runtime_bin) or suffix in _MODEL_SUFFIXES or (suffix == ".bin" and not runtime_bin) or (suffix == ".pth" and not pth_config):
+            package_code = "site-packages" in parents and not any(part in _MODEL_DIRECTORIES for part in parents[:parents.index("site-packages")]) and suffix in {".py", ".pyc", ".pyi", ".pyx", ".yaml", ".yml"}
+            if (any(part in _MODEL_DIRECTORIES for part in parents) and not (runtime_bin or package_code)) or suffix in _MODEL_SUFFIXES or (suffix == ".bin" and not runtime_bin) or (suffix == ".pth" and not pth_config):
                 raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_BUNDLE_CONTENT_FORBIDDEN")
             files.append({"path": relative, "size_bytes": size, "sha256": digest})
     except OSError as exc:
@@ -132,7 +135,7 @@ def _checked_inputs(version: str, output: Path, roots: Mapping[str, Path], bom: 
     components = bom["components"]
     if not isinstance(components, dict) or set(roots) != set(_COMPONENT_ENVIRONMENT) or set(components) != set(_COMPONENT_ENVIRONMENT):
         raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_COMPONENTS_INVALID")
-    output_root, checked, total = output.resolve(), {}, 0
+    output_root, checked = output.resolve(), {}
     for component in _COMPONENT_ENVIRONMENT:
         raw = roots[component]
         if not isinstance(raw, Path) or not raw.is_absolute() or not raw.is_dir():
@@ -148,31 +151,35 @@ def _checked_inputs(version: str, output: Path, roots: Mapping[str, Path], bom: 
             raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_PYTHON_MISSING")
         if root in checked.values():
             raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_COMPONENT_DUPLICATE")
-        size, _inventory = _checked_item(root, components[component])
         checked[component] = root
-        total += size
+    total = sum(_checked_item(root, components[component])[0] for component, root in checked.items())
     if total > _MAX_EXPANDED_BYTES:
         raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_TOO_LARGE")
+    environment = {_COMPONENT_ENVIRONMENT[component]: str(root / ("python.exe" if (root / "python.exe").is_file() else "python/python.exe")) for component, root in checked.items()}
+    _probe_environments(environment, checked)
     return output_root, checked
 
-def _probe_environments(environment: Mapping[str, str], runtime_root: Path) -> bool:
-    clean = {key: value for key, value in os.environ.items() if key.upper() not in {"PYTHONHOME", "PYTHONPATH"}}
-    clean.update(PYTHONNOUSERSITE="1", PYTHONSAFEPATH="1")
-    try:
-        for component, key in _COMPONENT_ENVIRONMENT.items():
-            allowed_root = runtime_root / component / "runtime"
-            script = (
-                "from pathlib import Path; import importlib,sys; root=Path(sys.argv[1]).resolve(); "
-                "inside=lambda value:(path:=Path(value).resolve())==root or root in path.parents; "
-                "assert inside(sys.executable) and inside(sys.prefix) and inside(sys.base_prefix); assert all(inside(value) for value in sys.path if value); "
-                f"[importlib.import_module(name) for name in {_COMPONENT_IMPORTS[component]!r}]; import torch; "
-                "assert torch.version.cuda and torch.cuda.is_available(); assert torch.ones(1,device='cuda').is_cuda"
-            )
-            if subprocess.run([environment[key], "-I", "-c", script, str(allowed_root)], cwd=allowed_root, capture_output=True, check=False, timeout=30, env=clean, creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0)).returncode:
-                return False
-    except (OSError, subprocess.SubprocessError):
-        return False
-    return True
+def _probe_environments(environment: Mapping[str, str], roots: Mapping[str, Path]) -> None:
+    clean = {key: value for key, value in os.environ.items() if key.upper() not in {"PATH", "PYTHONHOME", "PYTHONPATH"}}
+    clean.update(PYTHONNOUSERSITE="1", PYTHONSAFEPATH="1", PYTHONDONTWRITEBYTECODE="1")
+    windows_root = Path(os.environ.get("SystemRoot", os.environ.get("WINDIR", r"C:\Windows")))
+    for component, allowed_root in roots.items():
+        executable = Path(environment[_COMPONENT_ENVIRONMENT[component]])
+        probe_environment = dict(clean)
+        probe_environment["PATH"] = os.pathsep.join(str(path) for path in (executable.parent, allowed_root, allowed_root / "Library/bin", allowed_root / "python/Library/bin", allowed_root / "site-packages/torch/lib", allowed_root / "python/site-packages/torch/lib", windows_root, windows_root / "System32") if path.is_dir())
+        script = (
+            "from pathlib import Path; import importlib,sys; root=Path(sys.argv[1]).resolve(); "
+            "inside=lambda value:(path:=Path(value).resolve())==root or root in path.parents; "
+            "assert inside(sys.executable) and inside(sys.prefix) and inside(sys.base_prefix); assert all(inside(value) for value in sys.path if value); "
+            f"[importlib.import_module(name) for name in {_COMPONENT_IMPORTS[component]!r}]; import torch; "
+            "assert torch.version.cuda and torch.cuda.is_available(); assert torch.ones(1,device='cuda').is_cuda"
+        )
+        try:
+            failed = subprocess.run([str(executable), "-I", "-B", "-c", script, str(allowed_root)], cwd=allowed_root, capture_output=True, check=False, timeout=120, env=probe_environment, creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0)).returncode
+        except (OSError, subprocess.SubprocessError):
+            failed = True
+        if failed:
+            raise VideoRuntimeBuildError(f"VIDEO_RUNTIME_BUILD_{component.upper()}_NOT_PORTABLE")
 
 def _write_zip(runtime_root: Path, target: Path) -> None:
     try:
@@ -250,8 +257,9 @@ def build_video_runtime_archive(*, version: str, output_directory: Path, compone
                 environment[key] = f"{relative}/{executable}"
             manifest_sha = write_runtime_root_manifest(runtime_root, version=version, environment=environment, build_inputs=bom)
             verified = _load_runtime_root_manifest(runtime_root, manifest_sha, verify_files=False)
-            if set(verified) != set(_COMPONENT_ENVIRONMENT.values()) or not _probe_environments(verified, runtime_root):
+            if set(verified) != set(_COMPONENT_ENVIRONMENT.values()):
                 raise VideoRuntimeBuildError("VIDEO_RUNTIME_BUILD_NOT_PORTABLE")
+            _probe_environments(verified, {component: runtime_root / component / "runtime" for component in _COMPONENT_ENVIRONMENT})
             staging = output_root / f".{target.name}.{uuid.uuid4().hex}.tmp"
             try:
                 _write_zip(runtime_root, staging)

--- a/tests/installer/test_build_video_runtime.py
+++ b/tests/installer/test_build_video_runtime.py
@@ -18,9 +18,12 @@ def _roots(tmp_path: Path) -> dict[str, Path]:
         (root / "python").mkdir(parents=True)
         (root / "site-packages").mkdir()
         (root / "python/python.exe").write_bytes(f"{component}-python".encode())
+        (root / "python/LICENSE.txt").write_text("python license must not identify the component\n", encoding="utf-8")
         (root / f"site-packages/{component}.py").write_text(f"COMPONENT={component!r}\n", encoding="utf-8")
         (root / "component-source.py").write_text("must stay in the 26 GiB bundle\n", encoding="utf-8")
-        (root / "LICENSE").write_text(f"{component} license\n", encoding="utf-8")
+        license_path = root / f"site-packages/olivia_upstream/{component}/LICENSE"
+        license_path.parent.mkdir(parents=True)
+        license_path.write_text(f"{component} license\n", encoding="utf-8")
         (root / "NOTICE").write_text(f"{component} notice\n", encoding="utf-8")
         for relative, content in (("site-packages/distutils-precedence.pth", b"import _distutils_hack\n"), ("site-packages/sentencepiece/package_data/runtime.bin", b"runtime data"), ("site-packages/chardet/models/runtime.bin", b"runtime data"), ("site-packages/chardet/models/__init__.py", b""), ("site-packages/chardet/models/training_metadata.yaml", b"safe: true\n"), ("site-packages/transformers/models/runtime.pyc", b"compiled"), ("site-packages/modelscope/source/runtime.pyx", b"pass\n"), ("site-packages/lightning/useLightningState.ts", b"export const ready = true;\n")):
             target = root / relative
@@ -30,14 +33,15 @@ def _roots(tmp_path: Path) -> dict[str, Path]:
 def _bom(tmp_path: Path, roots: dict[str, Path]) -> Path:
     components = {}
     for component, root in roots.items():
-        paths = [root / "LICENSE", root / "NOTICE"] + [path for folder in (root / "python", root / "site-packages") for path in folder.rglob("*") if path.is_file()]
+        paths = [root / "NOTICE"] + [path for folder in (root / "python", root / "site-packages") for path in folder.rglob("*") if path.is_file()]
         files = [{"path": path.relative_to(root).as_posix(), "size_bytes": path.stat().st_size, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()} for path in sorted(paths)]
+        indexed = {item["path"]: item for item in files}
         components[component] = {
             "upstream": f"{'http' if component == 'cosyvoice' else 'https'}://example.invalid/{component}", "revision": "1" * 40,
             "tree_sha256": hashlib.sha256(json.dumps(files, sort_keys=True, separators=(",", ":")).encode()).hexdigest(),
             "dependencies": [f"{component}==1.0"], "files": files,
-            "license": {key: files[0][key] for key in ("path", "sha256")},
-            "notice": {key: files[1][key] for key in ("path", "sha256")},
+            "license": {key: next(item for path, item in indexed.items() if path.startswith("site-packages/olivia_upstream/") and path.endswith("/LICENSE"))[key] for key in ("path", "sha256")},
+            "notice": {key: indexed["NOTICE"][key] for key in ("path", "sha256")},
         }
     path = (tmp_path / "build-input-bom.json").resolve()
     path.write_text(json.dumps({"schema_version": "olivia.video-runtime-build-inputs.v1", "components": components}), encoding="utf-8")
@@ -75,7 +79,7 @@ def test_rejects_bare_python_without_locked_bom(tmp_path: Path) -> None:
     with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_BOM_REQUIRED"):
         _build(tmp_path, _roots(tmp_path), None)  # type: ignore[arg-type]
 
-@pytest.mark.parametrize("fault", ("source-drift", "missing-license-hash", "main", "latest", "userinfo", "query", "fragment", "ftp", "empty-host"))
+@pytest.mark.parametrize("fault", ("source-drift", "missing-license-hash", "foreign-license", "main", "latest", "userinfo", "query", "fragment", "ftp", "empty-host"))
 def test_bom_provenance_and_inventory_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fault: str) -> None:
     roots = _roots(tmp_path); bom = _bom(tmp_path, roots)
     expected = "VIDEO_RUNTIME_BUILD_BOM_MISMATCH"
@@ -84,6 +88,7 @@ def test_bom_provenance_and_inventory_fail_closed(tmp_path: Path, monkeypatch: p
     else:
         payload = json.loads(bom.read_text(encoding="utf-8"))
         if fault == "missing-license-hash": payload["components"]["cosyvoice"]["license"].pop("sha256")
+        elif fault == "foreign-license": payload["components"]["cosyvoice"]["license"] = next({key: item[key] for key in ("path", "sha256")} for item in payload["components"]["cosyvoice"]["files"] if item["path"] == "python/LICENSE.txt")
         elif fault in {"main", "latest"}: payload["components"]["cosyvoice"]["revision"] = fault
         else: payload["components"]["cosyvoice"]["upstream"] = {"userinfo": "https://secret-token@example.invalid/cosyvoice", "query": "https://example.invalid/cosyvoice?token=private", "fragment": "https://example.invalid/cosyvoice#private", "ftp": "ftp://example.invalid/cosyvoice", "empty-host": "https:///cosyvoice"}[fault]
         bom.write_text(json.dumps(payload), encoding="utf-8")
@@ -149,6 +154,13 @@ def test_cross_process_lock_and_no_overwrite_preserve_existing_owner(tmp_path: P
         _build(tmp_path, roots, _bom(tmp_path, roots), "owned")
     assert path.read_bytes() == b"owner"
 
+@pytest.mark.skipif(sys.platform != "win32", reason="private runtime builder targets Windows")
+def test_build_lock_is_deleted_if_owner_process_exits(tmp_path: Path) -> None:
+    lock = (tmp_path / "crash-safe.lock").resolve()
+    script = "import os,sys; from pathlib import Path; from installer.build_video_runtime import _open_build_lock; _open_build_lock(Path(sys.argv[1])); os._exit(0)"
+    result = builder.subprocess.run([sys.executable, "-c", script, str(lock)], cwd=Path(builder.__file__).resolve().parents[1])
+    assert result.returncode == 0 and not lock.exists()
+
 def test_output_inside_input_and_oversize_fail_before_copy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     roots = _roots(tmp_path); bom = _bom(tmp_path, roots)
     with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_OUTPUT_INVALID"):
@@ -157,7 +169,8 @@ def test_output_inside_input_and_oversize_fail_before_copy(tmp_path: Path, monke
     with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_TOO_LARGE"):
         _build(tmp_path, roots, bom, "large")
 
-def test_public_cli_returns_sanitized_stable_json_error() -> None:
-    result = builder.subprocess.run([sys.executable, "-m", "installer.build_video_runtime"], capture_output=True, text=True)
+@pytest.mark.parametrize("entry", (("-m", "installer.build_video_runtime"), (str(Path(builder.__file__).resolve()),)))
+def test_public_cli_returns_sanitized_stable_json_error(entry: tuple[str, ...]) -> None:
+    result = builder.subprocess.run([sys.executable, *entry], cwd=Path(builder.__file__).resolve().parents[1], capture_output=True, text=True)
     assert result.returncode == 2
     assert json.loads(result.stderr) == {"status": "ERROR", "code": "VIDEO_RUNTIME_BUILD_ARGUMENTS_INVALID"}

--- a/tests/installer/test_build_video_runtime.py
+++ b/tests/installer/test_build_video_runtime.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import sys
+import zipfile
+
+import pytest
+import installer.build_video_runtime as builder
+
+_COMPONENTS = ("cosyvoice", "latentsync", "minimax", "roformer")
+
+def _roots(tmp_path: Path) -> dict[str, Path]:
+    result = {}
+    for component in _COMPONENTS:
+        root = (tmp_path / "portable" / component).resolve()
+        (root / "python").mkdir(parents=True)
+        (root / "site-packages").mkdir()
+        (root / "python/python.exe").write_bytes(f"{component}-python".encode())
+        (root / f"site-packages/{component}.py").write_text(f"COMPONENT={component!r}\n", encoding="utf-8")
+        (root / "component-source.py").write_text("must stay in the 26 GiB bundle\n", encoding="utf-8")
+        (root / "LICENSE").write_text(f"{component} license\n", encoding="utf-8")
+        (root / "NOTICE").write_text(f"{component} notice\n", encoding="utf-8")
+        for relative, content in (("site-packages/distutils-precedence.pth", b"import _distutils_hack\n"), ("site-packages/sentencepiece/package_data/runtime.bin", b"runtime data"), ("site-packages/chardet/models/runtime.bin", b"runtime data")):
+            target = root / relative
+            target.parent.mkdir(parents=True, exist_ok=True); target.write_bytes(content)
+        result[component] = root
+    return result
+
+def _bom(tmp_path: Path, roots: dict[str, Path]) -> Path:
+    components = {}
+    for component, root in roots.items():
+        paths = [root / "LICENSE", root / "NOTICE"] + [path for folder in (root / "python", root / "site-packages") for path in folder.rglob("*") if path.is_file()]
+        files = [{"path": path.relative_to(root).as_posix(), "size_bytes": path.stat().st_size, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()} for path in sorted(paths)]
+        components[component] = {
+            "upstream": f"https://example.invalid/{component}", "revision": "1" * 40,
+            "tree_sha256": hashlib.sha256(json.dumps(files, sort_keys=True, separators=(",", ":")).encode()).hexdigest(),
+            "dependencies": [f"{component}==1.0"], "files": files,
+            "license": {key: files[0][key] for key in ("path", "sha256")},
+            "notice": {key: files[1][key] for key in ("path", "sha256")},
+        }
+    path = (tmp_path / "build-input-bom.json").resolve()
+    path.write_text(json.dumps({"schema_version": "olivia.video-runtime-build-inputs.v1", "components": components}), encoding="utf-8")
+    return path
+
+def _allow_probes(monkeypatch: pytest.MonkeyPatch, calls: list[list[str]] | None = None) -> None:
+    def run(command, **_kwargs):
+        if calls is not None: calls.append(command)
+        return builder.subprocess.CompletedProcess(command, 0)
+    monkeypatch.setattr(builder.subprocess, "run", run)
+
+def _build(tmp_path: Path, roots: dict[str, Path], bom: Path, version: str = "test") -> Path:
+    return builder.build_video_runtime_archive(version=version, output_directory=(tmp_path / "out").resolve(), component_roots=roots, build_input_bom=bom)
+
+def test_duplicate_component_roots_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    roots = _roots(tmp_path)
+    roots["roformer"] = roots["minimax"]
+    _allow_probes(monkeypatch)
+    with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_COMPONENT_DUPLICATE"):
+        _build(tmp_path, roots, _bom(tmp_path, roots))
+
+def test_builds_verified_v2_archive_and_confines_four_role_probes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    roots, calls = _roots(tmp_path), []
+    _allow_probes(monkeypatch, calls)
+    archive = _build(tmp_path, roots, _bom(tmp_path, roots))
+    with zipfile.ZipFile(archive) as payload:
+        manifest, names = json.loads(payload.read("runtime-manifest.json")), set(payload.namelist())
+        assert payload.testzip() is None
+        assert all((len(content := payload.read(item["path"])), hashlib.sha256(content).hexdigest()) == (item["size_bytes"], item["sha256"]) for item in manifest["files"])
+    scripts = "\n".join(command[3] for command in calls)
+    assert len(calls) == len({command[4] for command in calls}) == len(set(manifest["environment"].values())) == 4
+    assert all(Path(command[0]).is_relative_to(Path(command[4])) for command in calls)
+    assert all(name in scripts for name in ("cosyvoice.cli.cosyvoice", "latentsync", "comfy_extras.nodes_minimax_music", "mel_band_roformer.inference", "device='cuda'"))
+    assert all(any(name.startswith(f"{component}/runtime/") for name in names) for component in roots)
+
+def test_rejects_bare_python_without_locked_bom(tmp_path: Path) -> None:
+    with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_BOM_REQUIRED"):
+        _build(tmp_path, _roots(tmp_path), None)  # type: ignore[arg-type]
+
+@pytest.mark.parametrize("fault", ("source-drift", "missing-license-hash", "main", "latest"))
+def test_bom_provenance_and_inventory_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fault: str) -> None:
+    roots = _roots(tmp_path); bom = _bom(tmp_path, roots)
+    expected = "VIDEO_RUNTIME_BUILD_BOM_MISMATCH"
+    if fault == "source-drift":
+        (roots["cosyvoice"] / "site-packages/cosyvoice.py").write_text("drift\n")
+    else:
+        payload = json.loads(bom.read_text(encoding="utf-8"))
+        if fault == "missing-license-hash":
+            payload["components"]["cosyvoice"]["license"].pop("sha256")
+        else:
+            payload["components"]["cosyvoice"]["revision"] = fault
+        bom.write_text(json.dumps(payload), encoding="utf-8")
+        expected = "VIDEO_RUNTIME_BUILD_BOM_INVALID"
+    _allow_probes(monkeypatch)
+    with pytest.raises(builder.VideoRuntimeBuildError, match=expected):
+        _build(tmp_path, roots, bom)
+
+@pytest.mark.parametrize(
+    ("relative", "size", "error"),
+    (("site-packages/pkg/renamed-private.opus", 1, "PRIVATE_MEDIA"), ("site-packages/pkg/models/config.json", 1, "BUNDLE_CONTENT"), ("site-packages/pkg/data/model.pt", 1, "BUNDLE_CONTENT"), ("site-packages/pkg/data/model.bin", 1, "BUNDLE_CONTENT"), ("site-packages/not-site-packages/sentencepiece/package_data/model.bin", 1, "BUNDLE_CONTENT")),
+)
+def test_locked_inventory_rejects_audio_recursive_models_and_weights(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, relative: str, size: int, error: str) -> None:
+    roots = _roots(tmp_path)
+    target = roots["minimax"] / relative
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"x" * size)
+    bom = _bom(tmp_path, roots)
+    _allow_probes(monkeypatch)
+    with pytest.raises(builder.VideoRuntimeBuildError, match=f"VIDEO_RUNTIME_BUILD_{error}_FORBIDDEN"):
+        _build(tmp_path, roots, bom)
+
+@pytest.mark.parametrize("header", (b"RIFF\x00\x00\x00\x00WAVE", b"FORM\x00\x00\x00\x00AIFF", b"fLaC", b"OggS", b"ID3", b"\xff\xfb"))
+def test_renamed_common_audio_signatures_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, header: bytes) -> None:
+    roots = _roots(tmp_path)
+    (roots["minimax"] / "site-packages/private.dat").write_bytes(header + b"private")
+    _allow_probes(monkeypatch)
+    with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_PRIVATE_MEDIA_FORBIDDEN"):
+        _build(tmp_path, roots, _bom(tmp_path, roots))
+
+@pytest.mark.parametrize(("relative", "content"), (("site-packages/model.pth", b"PK\x03\x04binary"), pytest.param("site-packages/large.pth", b"x" * (64 * 1024 + 1), id="oversize"), ("python/config.pth", b"relative-path\n")))
+def test_pth_rejects_binary_oversize_or_non_site_packages_content(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, relative: str, content: bytes) -> None:
+    roots = _roots(tmp_path)
+    (roots["minimax"] / relative).write_bytes(content)
+    _allow_probes(monkeypatch)
+    with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_BUNDLE_CONTENT_FORBIDDEN"):
+        _build(tmp_path, roots, _bom(tmp_path, roots))
+
+def test_failed_component_cuda_probe_leaves_no_archive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    roots = _roots(tmp_path)
+    monkeypatch.setattr(builder.subprocess, "run", lambda command, **_kwargs: builder.subprocess.CompletedProcess(command, 1 if "mel_band_roformer" in command[3] else 0))
+    with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_NOT_PORTABLE"):
+        _build(tmp_path, roots, _bom(tmp_path, roots), "probe-fails")
+    assert not list((tmp_path / "out").glob("*.zip"))
+
+def test_verifies_staging_before_atomic_publish(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    roots, output = _roots(tmp_path), (tmp_path / "out").resolve()
+    final = output / "Olivia-video-runtime-atomic.zip"
+    _allow_probes(monkeypatch)
+    def reject(staging: Path, _sha: str) -> None:
+        assert staging != final and not final.exists()
+        raise builder.VideoRuntimeBuildError("VERIFY_FAILED")
+    monkeypatch.setattr(builder, "_verify_zip", reject)
+    with pytest.raises(builder.VideoRuntimeBuildError, match="VERIFY_FAILED"):
+        _build(tmp_path, roots, _bom(tmp_path, roots), "atomic")
+    assert not final.exists()
+
+@pytest.mark.parametrize("occupied", ("lock", "target"))
+def test_cross_process_lock_and_no_overwrite_preserve_existing_owner(tmp_path: Path, occupied: str) -> None:
+    roots, output = _roots(tmp_path), (tmp_path / "out").resolve()
+    output.mkdir()
+    target = output / "Olivia-video-runtime-owned.zip"
+    path = output / f".{target.name}.lock" if occupied == "lock" else target
+    path.write_bytes(b"owner")
+    expected = "LOCKED" if occupied == "lock" else "OUTPUT_EXISTS"
+    with pytest.raises(builder.VideoRuntimeBuildError, match=f"VIDEO_RUNTIME_BUILD_{expected}"):
+        _build(tmp_path, roots, _bom(tmp_path, roots), "owned")
+    assert path.read_bytes() == b"owner"
+
+def test_output_inside_input_and_oversize_fail_before_copy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    roots = _roots(tmp_path); bom = _bom(tmp_path, roots)
+    with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_OUTPUT_INVALID"):
+        builder.build_video_runtime_archive(version="nested", output_directory=(roots["cosyvoice"] / "out").resolve(), component_roots=roots, build_input_bom=bom)
+    monkeypatch.setattr(builder, "_MAX_EXPANDED_BYTES", 1)
+    with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_TOO_LARGE"):
+        _build(tmp_path, roots, bom, "large")
+
+def test_public_cli_returns_sanitized_stable_json_error() -> None:
+    result = builder.subprocess.run([sys.executable, "-m", "installer.build_video_runtime"], capture_output=True, text=True)
+    assert result.returncode == 2
+    assert json.loads(result.stderr) == {"status": "ERROR", "code": "VIDEO_RUNTIME_BUILD_ARGUMENTS_INVALID"}

--- a/tests/installer/test_build_video_runtime.py
+++ b/tests/installer/test_build_video_runtime.py
@@ -22,19 +22,18 @@ def _roots(tmp_path: Path) -> dict[str, Path]:
         (root / "component-source.py").write_text("must stay in the 26 GiB bundle\n", encoding="utf-8")
         (root / "LICENSE").write_text(f"{component} license\n", encoding="utf-8")
         (root / "NOTICE").write_text(f"{component} notice\n", encoding="utf-8")
-        for relative, content in (("site-packages/distutils-precedence.pth", b"import _distutils_hack\n"), ("site-packages/sentencepiece/package_data/runtime.bin", b"runtime data"), ("site-packages/chardet/models/runtime.bin", b"runtime data")):
+        for relative, content in (("site-packages/distutils-precedence.pth", b"import _distutils_hack\n"), ("site-packages/sentencepiece/package_data/runtime.bin", b"runtime data"), ("site-packages/chardet/models/runtime.bin", b"runtime data"), ("site-packages/chardet/models/__init__.py", b""), ("site-packages/chardet/models/training_metadata.yaml", b"safe: true\n"), ("site-packages/transformers/models/runtime.pyc", b"compiled"), ("site-packages/modelscope/source/runtime.pyx", b"pass\n"), ("site-packages/lightning/useLightningState.ts", b"export const ready = true;\n")):
             target = root / relative
             target.parent.mkdir(parents=True, exist_ok=True); target.write_bytes(content)
         result[component] = root
     return result
-
 def _bom(tmp_path: Path, roots: dict[str, Path]) -> Path:
     components = {}
     for component, root in roots.items():
         paths = [root / "LICENSE", root / "NOTICE"] + [path for folder in (root / "python", root / "site-packages") for path in folder.rglob("*") if path.is_file()]
         files = [{"path": path.relative_to(root).as_posix(), "size_bytes": path.stat().st_size, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()} for path in sorted(paths)]
         components[component] = {
-            "upstream": f"https://example.invalid/{component}", "revision": "1" * 40,
+            "upstream": f"{'http' if component == 'cosyvoice' else 'https'}://example.invalid/{component}", "revision": "1" * 40,
             "tree_sha256": hashlib.sha256(json.dumps(files, sort_keys=True, separators=(",", ":")).encode()).hexdigest(),
             "dependencies": [f"{component}==1.0"], "files": files,
             "license": {key: files[0][key] for key in ("path", "sha256")},
@@ -43,34 +42,32 @@ def _bom(tmp_path: Path, roots: dict[str, Path]) -> Path:
     path = (tmp_path / "build-input-bom.json").resolve()
     path.write_text(json.dumps({"schema_version": "olivia.video-runtime-build-inputs.v1", "components": components}), encoding="utf-8")
     return path
-
-def _allow_probes(monkeypatch: pytest.MonkeyPatch, calls: list[list[str]] | None = None) -> None:
+def _allow_probes(monkeypatch: pytest.MonkeyPatch, calls: list[tuple[list[str], dict[str, object]]] | None = None) -> None:
     def run(command, **_kwargs):
-        if calls is not None: calls.append(command)
+        if calls is not None: calls.append((command, _kwargs))
         return builder.subprocess.CompletedProcess(command, 0)
     monkeypatch.setattr(builder.subprocess, "run", run)
-
 def _build(tmp_path: Path, roots: dict[str, Path], bom: Path, version: str = "test") -> Path:
     return builder.build_video_runtime_archive(version=version, output_directory=(tmp_path / "out").resolve(), component_roots=roots, build_input_bom=bom)
-
 def test_duplicate_component_roots_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    roots = _roots(tmp_path)
-    roots["roformer"] = roots["minimax"]
+    roots = _roots(tmp_path); roots["roformer"] = roots["minimax"]
     _allow_probes(monkeypatch)
     with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_COMPONENT_DUPLICATE"):
         _build(tmp_path, roots, _bom(tmp_path, roots))
 
 def test_builds_verified_v2_archive_and_confines_four_role_probes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    roots, calls = _roots(tmp_path), []
-    _allow_probes(monkeypatch, calls)
+    roots, calls = _roots(tmp_path), []; monkeypatch.setenv("PATH", r"C:\host-only-poison"); _allow_probes(monkeypatch, calls)
     archive = _build(tmp_path, roots, _bom(tmp_path, roots))
     with zipfile.ZipFile(archive) as payload:
         manifest, names = json.loads(payload.read("runtime-manifest.json")), set(payload.namelist())
         assert payload.testzip() is None
         assert all((len(content := payload.read(item["path"])), hashlib.sha256(content).hexdigest()) == (item["size_bytes"], item["sha256"]) for item in manifest["files"])
-    scripts = "\n".join(command[3] for command in calls)
-    assert len(calls) == len({command[4] for command in calls}) == len(set(manifest["environment"].values())) == 4
-    assert all(Path(command[0]).is_relative_to(Path(command[4])) for command in calls)
+    commands, environments = [call[0] for call in calls], [call[1]["env"] for call in calls]
+    scripts = "\n".join(command[-2] for command in commands)
+    assert len(commands) == len({command[-1] for command in commands}) == 8 and len(set(manifest["environment"].values())) == 4
+    assert all(command[1:3] == ["-I", "-B"] and Path(command[0]).is_relative_to(Path(command[-1])) for command in commands)
+    assert all(r"C:\host-only-poison" not in environment["PATH"] and str(Path(command[0]).parent) in environment["PATH"] for command, environment in zip(commands, environments, strict=True))
+    assert all(call[1]["timeout"] == 120 and environment["PYTHONDONTWRITEBYTECODE"] == "1" for call, environment in zip(calls, environments, strict=True))
     assert all(name in scripts for name in ("cosyvoice.cli.cosyvoice", "latentsync", "comfy_extras.nodes_minimax_music", "mel_band_roformer.inference", "device='cuda'"))
     assert all(any(name.startswith(f"{component}/runtime/") for name in names) for component in roots)
 
@@ -78,7 +75,7 @@ def test_rejects_bare_python_without_locked_bom(tmp_path: Path) -> None:
     with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_BOM_REQUIRED"):
         _build(tmp_path, _roots(tmp_path), None)  # type: ignore[arg-type]
 
-@pytest.mark.parametrize("fault", ("source-drift", "missing-license-hash", "main", "latest"))
+@pytest.mark.parametrize("fault", ("source-drift", "missing-license-hash", "main", "latest", "userinfo", "query", "fragment", "ftp", "empty-host"))
 def test_bom_provenance_and_inventory_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fault: str) -> None:
     roots = _roots(tmp_path); bom = _bom(tmp_path, roots)
     expected = "VIDEO_RUNTIME_BUILD_BOM_MISMATCH"
@@ -86,50 +83,45 @@ def test_bom_provenance_and_inventory_fail_closed(tmp_path: Path, monkeypatch: p
         (roots["cosyvoice"] / "site-packages/cosyvoice.py").write_text("drift\n")
     else:
         payload = json.loads(bom.read_text(encoding="utf-8"))
-        if fault == "missing-license-hash":
-            payload["components"]["cosyvoice"]["license"].pop("sha256")
-        else:
-            payload["components"]["cosyvoice"]["revision"] = fault
+        if fault == "missing-license-hash": payload["components"]["cosyvoice"]["license"].pop("sha256")
+        elif fault in {"main", "latest"}: payload["components"]["cosyvoice"]["revision"] = fault
+        else: payload["components"]["cosyvoice"]["upstream"] = {"userinfo": "https://secret-token@example.invalid/cosyvoice", "query": "https://example.invalid/cosyvoice?token=private", "fragment": "https://example.invalid/cosyvoice#private", "ftp": "ftp://example.invalid/cosyvoice", "empty-host": "https:///cosyvoice"}[fault]
         bom.write_text(json.dumps(payload), encoding="utf-8")
         expected = "VIDEO_RUNTIME_BUILD_BOM_INVALID"
-    _allow_probes(monkeypatch)
-    with pytest.raises(builder.VideoRuntimeBuildError, match=expected):
-        _build(tmp_path, roots, bom)
+    monkeypatch.setattr(builder, "_probe_environments", lambda *_args: pytest.fail("BOM validation must precede probe"))
+    with pytest.raises(builder.VideoRuntimeBuildError, match=expected): _build(tmp_path, roots, bom)
+    assert not list((tmp_path / "out").glob("*.zip"))
 
 @pytest.mark.parametrize(
     ("relative", "size", "error"),
-    (("site-packages/pkg/renamed-private.opus", 1, "PRIVATE_MEDIA"), ("site-packages/pkg/models/config.json", 1, "BUNDLE_CONTENT"), ("site-packages/pkg/data/model.pt", 1, "BUNDLE_CONTENT"), ("site-packages/pkg/data/model.bin", 1, "BUNDLE_CONTENT"), ("site-packages/not-site-packages/sentencepiece/package_data/model.bin", 1, "BUNDLE_CONTENT")),
+    (("site-packages/pkg/renamed-private.opus", 1, "PRIVATE_MEDIA"), ("site-packages/pkg/private.mp4", 1, "PRIVATE_MEDIA"), ("site-packages/pkg/models/config.json", 1, "BUNDLE_CONTENT"), ("python/models/runtime.py", 1, "BUNDLE_CONTENT"), ("site-packages/pkg/data/model.pt", 1, "BUNDLE_CONTENT"), ("site-packages/pkg/data/model.bin", 1, "BUNDLE_CONTENT"), ("site-packages/not-site-packages/sentencepiece/package_data/model.bin", 1, "BUNDLE_CONTENT")),
 )
 def test_locked_inventory_rejects_audio_recursive_models_and_weights(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, relative: str, size: int, error: str) -> None:
-    roots = _roots(tmp_path)
-    target = roots["minimax"] / relative
-    target.parent.mkdir(parents=True)
-    target.write_bytes(b"x" * size)
-    bom = _bom(tmp_path, roots)
-    _allow_probes(monkeypatch)
+    roots = _roots(tmp_path); target = roots["minimax"] / relative
+    target.parent.mkdir(parents=True); target.write_bytes(b"x" * size)
+    bom = _bom(tmp_path, roots); _allow_probes(monkeypatch)
     with pytest.raises(builder.VideoRuntimeBuildError, match=f"VIDEO_RUNTIME_BUILD_{error}_FORBIDDEN"):
         _build(tmp_path, roots, bom)
 
-@pytest.mark.parametrize("header", (b"RIFF\x00\x00\x00\x00WAVE", b"FORM\x00\x00\x00\x00AIFF", b"fLaC", b"OggS", b"ID3", b"\xff\xfb"))
-def test_renamed_common_audio_signatures_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, header: bytes) -> None:
-    roots = _roots(tmp_path)
-    (roots["minimax"] / "site-packages/private.dat").write_bytes(header + b"private")
+@pytest.mark.parametrize("header", (b"RIFF\x00\x00\x00\x00WAVE", b"FORM\x00\x00\x00\x00AIFF", b"RIFF\x00\x00\x00\x00AVI ", b"fLaC", b"OggS", b"ID3", b"FLV\x01", b"\xff\xfb", b"\x00\x00\x00\x18ftypisom", b"\x1a\x45\xdf\xa3", b"G" + b"\x00" * 187 + b"G" + b"\x00" * 187 + b"G", b"G" + b"\x00" * 187 + b"G" + b"\x00" * 187 + b"G\x00"))
+def test_renamed_common_media_signatures_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, header: bytes) -> None:
+    roots = _roots(tmp_path); (roots["minimax"] / ("site-packages/private.ts" if len(header) == 378 else "site-packages/private.dat")).write_bytes(header + b"private")
     _allow_probes(monkeypatch)
     with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_PRIVATE_MEDIA_FORBIDDEN"):
         _build(tmp_path, roots, _bom(tmp_path, roots))
 
 @pytest.mark.parametrize(("relative", "content"), (("site-packages/model.pth", b"PK\x03\x04binary"), pytest.param("site-packages/large.pth", b"x" * (64 * 1024 + 1), id="oversize"), ("python/config.pth", b"relative-path\n")))
 def test_pth_rejects_binary_oversize_or_non_site_packages_content(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, relative: str, content: bytes) -> None:
-    roots = _roots(tmp_path)
-    (roots["minimax"] / relative).write_bytes(content)
+    roots = _roots(tmp_path); (roots["minimax"] / relative).write_bytes(content)
     _allow_probes(monkeypatch)
     with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_BUNDLE_CONTENT_FORBIDDEN"):
         _build(tmp_path, roots, _bom(tmp_path, roots))
-
-def test_failed_component_cuda_probe_leaves_no_archive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("component", _COMPONENTS)
+def test_failed_component_cuda_probe_leaves_no_archive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, component: str) -> None:
     roots = _roots(tmp_path)
-    monkeypatch.setattr(builder.subprocess, "run", lambda command, **_kwargs: builder.subprocess.CompletedProcess(command, 1 if "mel_band_roformer" in command[3] else 0))
-    with pytest.raises(builder.VideoRuntimeBuildError, match="VIDEO_RUNTIME_BUILD_NOT_PORTABLE"):
+    monkeypatch.setattr(builder.subprocess, "run", lambda command, **_kwargs: builder.subprocess.CompletedProcess(command, 1 if builder._COMPONENT_IMPORTS[component][-1] in command[-2] else 0))
+    monkeypatch.setattr(builder.shutil, "copytree", lambda *_args, **_kwargs: pytest.fail("probe must precede copy"))
+    with pytest.raises(builder.VideoRuntimeBuildError, match=f"VIDEO_RUNTIME_BUILD_{component.upper()}_NOT_PORTABLE"):
         _build(tmp_path, roots, _bom(tmp_path, roots), "probe-fails")
     assert not list((tmp_path / "out").glob("*.zip"))
 
@@ -146,8 +138,8 @@ def test_verifies_staging_before_atomic_publish(tmp_path: Path, monkeypatch: pyt
     assert not final.exists()
 
 @pytest.mark.parametrize("occupied", ("lock", "target"))
-def test_cross_process_lock_and_no_overwrite_preserve_existing_owner(tmp_path: Path, occupied: str) -> None:
-    roots, output = _roots(tmp_path), (tmp_path / "out").resolve()
+def test_cross_process_lock_and_no_overwrite_preserve_existing_owner(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, occupied: str) -> None:
+    roots, output = _roots(tmp_path), (tmp_path / "out").resolve(); _allow_probes(monkeypatch)
     output.mkdir()
     target = output / "Olivia-video-runtime-owned.zip"
     path = output / f".{target.name}.lock" if occupied == "lock" else target

--- a/tests/installer/test_build_video_runtime.py
+++ b/tests/installer/test_build_video_runtime.py
@@ -63,7 +63,9 @@ def test_builds_verified_v2_archive_and_confines_four_role_probes(tmp_path: Path
     roots, calls = _roots(tmp_path), []; monkeypatch.setenv("PATH", r"C:\host-only-poison"); _allow_probes(monkeypatch, calls)
     archive = _build(tmp_path, roots, _bom(tmp_path, roots))
     with zipfile.ZipFile(archive) as payload:
-        manifest, names = json.loads(payload.read("runtime-manifest.json")), set(payload.namelist())
+        manifest_bytes = payload.read("runtime-manifest.json")
+        manifest, names = json.loads(manifest_bytes), set(payload.namelist())
+        assert manifest_bytes == (json.dumps(manifest, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode()
         assert payload.testzip() is None
         assert all((len(content := payload.read(item["path"])), hashlib.sha256(content).hexdigest()) == (item["size_bytes"], item["sha256"]) for item in manifest["files"])
     commands, environments = [call[0] for call in calls], [call[1]["env"] for call in calls]

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -403,8 +403,15 @@ def _load_runtime_root_manifest(
         raise VideoCapabilityError("VIDEO_RUNTIME_ROOT_INVALID")
     if (
         not isinstance(payload, dict)
-        or set(payload) != {"schema_version", "version", "environment", "files"}
-        or payload.get("schema_version") != "olivia.video-runtime-root.v1"
+        or set(payload) != {"schema_version", "version", "environment", "files"} | ({"build_inputs"} if payload.get("schema_version") == "olivia.video-runtime-root.v2" else set())
+        or payload.get("schema_version") not in {"olivia.video-runtime-root.v1", "olivia.video-runtime-root.v2"}
+        or (payload.get("schema_version") == "olivia.video-runtime-root.v2" and (
+            not isinstance(payload.get("build_inputs"), dict)
+            or set(payload["build_inputs"]) != {"schema_version", "components"}
+            or payload["build_inputs"].get("schema_version") != "olivia.video-runtime-build-inputs.v1"
+            or not isinstance(payload["build_inputs"].get("components"), dict)
+            or set(payload["build_inputs"]["components"]) != {"cosyvoice", "latentsync", "minimax", "roformer"}
+        ))
         or not isinstance(payload.get("version"), str)
         or not 1 <= len(payload["version"]) <= 64
         or not isinstance(payload.get("environment"), dict)
@@ -511,6 +518,7 @@ def write_runtime_root_manifest(
     *,
     version: str,
     environment: Mapping[str, str],
+    build_inputs: Mapping[str, object] | None = None,
 ) -> str:
     """Hash an exact portable runtime tree and return its manifest SHA-256."""
 
@@ -521,6 +529,7 @@ def write_runtime_root_manifest(
         or not 1 <= len(version) <= 64
         or not environment
         or set(environment) - _RUNTIME_ENVIRONMENT_KEYS
+        or (build_inputs is not None and (not isinstance(build_inputs, Mapping) or set(build_inputs) != {"schema_version", "components"} or build_inputs.get("schema_version") != "olivia.video-runtime-build-inputs.v1" or not isinstance(build_inputs.get("components"), dict) or set(build_inputs["components"]) != {"cosyvoice", "latentsync", "minimax", "roformer"}))
     ):
         raise VideoCapabilityError("VIDEO_RUNTIME_ROOT_INVALID")
     root = runtime_root.resolve(strict=True)
@@ -550,11 +559,13 @@ def write_runtime_root_manifest(
     if not files:
         raise VideoCapabilityError("VIDEO_RUNTIME_ROOT_INVALID")
     payload = {
-        "schema_version": "olivia.video-runtime-root.v1",
+        "schema_version": "olivia.video-runtime-root.v2" if build_inputs is not None else "olivia.video-runtime-root.v1",
         "version": version,
         "environment": dict(sorted(normalized_environment.items())),
         "files": files,
     }
+    if build_inputs is not None:
+        payload["build_inputs"] = dict(build_inputs)
     target = root / "runtime-manifest.json"
     temporary = target.with_name(f"{target.name}.{uuid.uuid4().hex}.tmp")
     try:

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -570,8 +570,15 @@ def write_runtime_root_manifest(
     temporary = target.with_name(f"{target.name}.{uuid.uuid4().hex}.tmp")
     try:
         temporary.write_text(
-            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            json.dumps(
+                payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n",
             encoding="utf-8",
+            newline="\n",
         )
         os.replace(temporary, target)
         return _sha256_file(target)[1]


### PR DESCRIPTION
## Scope
- build one verified portable video runtime ZIP from four pinned component roots
- require an exact build-input BOM, component-specific legal files, locked dependencies/revisions, and full file hashes
- reject model weights and private audio/video, including renamed media signatures
- probe all four isolated runtimes with host-PATH-clean GPU imports before and after copy
- publish atomically and emit a compact canonical v2 manifest that remains within the setup consumer's 64 MiB bound

## Frozen evidence
- exact pair: `035d84037902efb864129522d2a538d71da6a1ec...d6e58cc41b2b5947bd2b9cc251527862a3f5de61`
- rebase range-diff: all three pre-existing commits exact `=`; compact-manifest closure added after the real consumer preflight exposed the final P0
- focused tests: builder `46 passed`; video capability installer `70 passed`; Windows setup consumer `97 passed`
- `py_compile` and `git diff --check`: pass
- final diff: 3 files, 536 additions / 4 deletions (540 changed lines)

The diff is 40 lines above the normal 500-line target because first-review fail-closed fixes and the real producer-to-consumer manifest closure stay in the same portable-runtime lifecycle. It remains confined to one producer module, its focused tests, and the existing activation module.

## Review
- round 1: BLOCK; setup v1-only P0 was fixed separately by #312/#313, and the producer's crash-safe lock, component license provenance, direct CLI, media signatures, and probe isolation were repaired here
- round 2 Spec: PASS, P0/P1/P2 = 0
- round 2 Standards: P0 = 0; one residual P1 (producer does not duplicate every setup ZIP bound) and one P2 (maintainer CLI documentation) recorded without a third repair under the project's two-round cap

## Real-build evidence
The earlier 12.5 GB r2 archive passed producer-side full hash/probe verification but correctly failed the real setup consumer because its pretty-printed manifest was 83,105,243 bytes, above the 64 MiB consumer bound. It will not be distributed.

Fresh r3 from the frozen head completed all four isolated GPU/import probes, post-copy BOM validation, full ZIP entry/hash verification, atomic publication, and the setup consumer's full `_video_runtime_metadata()` validation:

- archive size: `12,502,150,571` bytes
- archive SHA-256: `e5705ed97f430f3badcbc483b03a3f17e846226a20d64a0ca4e54b0baaf13e7c`
- schema: `olivia.video-runtime-root.v2`
- build-input schema: `olivia.video-runtime-build-inputs.v1`
- ZIP entries / declared files: `178,819 / 178,818`
- expanded bytes: `21,398,108,211`
- compact manifest: `63,786,451` bytes (below 64 MiB by `3,322,413` bytes)
- overall compression ratio: `1.7116` (limit `200`)
- maximum single-entry ratio: `320.997` (limit `512`)
- setup consumer result: accepted with the same size and SHA-256
- output directory after publication: the final ZIP only; no temporary tree or lock remains
