### PR TITLE
feat(installer): package private video runtime payload

### DIFF
--- a/contracts/offline_core_assets.schema.json
+++ b/contracts/offline_core_assets.schema.json
@@ -5,7 +5,11 @@
   "type": "object",
   "additionalProperties": false,
   "required": ["schema_version", "python_runtime", "pip_bootstrap", "requirements_sha256", "wheels"],
-  "dependentRequired": {"voice_reference": ["distribution"], "distribution": ["voice_reference"]},
+  "dependentRequired": {
+    "distribution": ["voice_reference", "video_runtime"],
+    "voice_reference": ["distribution", "video_runtime"],
+    "video_runtime": ["distribution", "voice_reference"]
+  },
   "$defs": {
     "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "local_asset": {
@@ -66,6 +70,16 @@
             "compression_type": {"const": "NONE"}
           }
         }
+      }
+    },
+    "video_runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "size_bytes", "sha256"],
+      "properties": {
+        "path": {"const": "video-runtime/Olivia-video-runtime-private.zip"},
+        "size_bytes": {"type": "integer", "minimum": 1},
+        "sha256": {"$ref": "#/$defs/digest"}
       }
     },
     "wheels": {

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -4,10 +4,10 @@
 
 ## 使用
 
-1. 下载 `Olivia-Setup-x64.exe` 及同目录的 `.sha256` 文件，并先核对 SHA-256。
+1. 公开包：下载 EXE 和 `.sha256`。私有视频包：下载完整 ZIP，解压后把 EXE、全部 `.bin` 分卷和 `.sha256` 保持在同一目录。运行前先核对 SHA-256。
 2. 双击 EXE，选择产品目录和正版 Steam 游戏目录。安装器按当前用户运行，不要求管理员权限；它在产品目录内分别创建 `install` 与 `runtime`，从 EXE 内置的离线资产安装受管 Python 3.12 runtime 和固定 wheel，不联网下载。正版目录可留空并按 Steam AppID `4532590` 自动发现。
 3. 安装成功后可从开始菜单的“Olivia 本地版”快捷方式启动；安装时勾选“创建桌面快捷方式”后也可从桌面启动。两个快捷方式都由 `%WINDIR%\System32\wscript.exe //B //Nologo "<安装目录>\START.vbs"` 隐藏启动，不会显示可被误关的命令行窗口；工作目录固定为安装目录。点击后会立即显示“Olivia 正在启动，请稍候”的短暂提示，实际启动同时开始，不会等待提示关闭。只有隐藏启动器最终返回非零退出码时才显示中文失败对话框；正常关闭返回 `0` 时不会弹出错误。`START.cmd` 仍保留为兼容入口。它只启动一个监听 `127.0.0.1` 的本机服务，再直接启动隔离副本的 `0.0.9.627\Olivia.exe`，并使用安装目录下的独立 profile。
-4. 首次登录后在原版客户端内完成 LLM key 与按需能力设置；后续在 Settings 的“本地陪伴”中管理。`CONFIGURE.cmd` 仍可用于管理参考音频/视频。公开安装器不包含参考音频；只有下文由维护者显式构建的私有安装器才会内嵌指定 WAV。
+4. 首次登录后在原版客户端内完成 LLM key 与按需能力设置；后续在 Settings 的“本地陪伴”中管理。公开安装器不包含参考音频或视频运行时；私有视频包已包含，无需用户再选离线包。
 5. 卸载双击 `UNINSTALL.cmd`。受控卸载只删除安装器自己写入的 `app`、`local_backend`、启动脚本和 marker，保留 `data`、`logs`、`third-party`。
 
 兼容旧流程：源码/调试场景仍可解压发布内容后双击 `INSTALL.cmd`。EXE 只是图形化外壳，最终仍调用同一份 `installer/Install.ps1`，不会形成第二套安装逻辑。安装阶段不填写 API key，也不会下载 Mem0、BGE 或其他可选模型。
@@ -24,7 +24,7 @@ python installer/build_offline_core_assets.py --output offline
 
 构建器只接受哈希锁定的二进制 wheel；pip 源仍兼容标准 `PIP_INDEX_URL` / pip 配置，因此发布构建可使用可信镜像，最终产物仍按仓库固定 SHA-256 验证。公开清单契约见 `contracts/offline_core_assets.schema.json` 和 `contracts/offline_core_assets.example.json`。
 
-## 构建单文件安装器
+## 构建 Windows 安装包
 
 构建机需要 Python 3.12、`jsonschema` 和 Inno Setup 6.7.1 或兼容的新版本。先生成离线核心资产，再执行：
 

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -1,6 +1,6 @@
 # Windows 完整版补丁（隔离安装）
 
-公开补丁只复制并修改用户自己的正版 Steam 文件副本，不写入正版目录，也不分发原版游戏、可选模型或媒体；经授权单独构建的私有安装器会额外内嵌下文指定的林离参考 WAV。`Olivia-Setup-x64.exe` 内含固定版本的核心 Python 运行时和依赖，使首次安装不依赖 Python.org、PyPI 或 Hugging Face。安装目标默认是 `%LOCALAPPDATA%\BSideOliviaLocal\install`，用户数据和未来外部缓存保留在同一产品目录的 `data` / `third-party` 下。
+公开补丁只复制并修改用户自己的正版 Steam 文件副本，不写入正版目录，也不分发原版游戏、可选模型或媒体；经授权单独构建的私有安装包会额外内嵌下文指定的林离参考 WAV 和视频运行时。`Olivia-Setup-x64.exe` 内含固定版本的核心 Python 运行时和依赖，使首次安装不依赖 Python.org、PyPI 或 Hugging Face。安装目标默认是 `%LOCALAPPDATA%\BSideOliviaLocal\install`，用户数据和未来外部缓存保留在同一产品目录的 `data` / `third-party` 下。
 
 ## 使用
 
@@ -36,7 +36,7 @@ python installer/build_windows_setup.py `
   --iscc 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
 ```
 
-上面的默认构建是公开产物：不得传入参考音频，内嵌 offline manifest 也不含 `distribution` 或 `voice_reference`。需要经授权在私有渠道交付固定参考音色时，维护者必须使用隔离输出目录并同时显式提供两个参数：
+上面的默认构建是公开产物：不得传入参考音频或视频运行时，内嵌 offline manifest 也不含 `distribution`、`voice_reference` 或 `video_runtime`。需要经授权在私有渠道交付完整视频回信能力时，维护者必须使用隔离输出目录并同时显式提供私有分发、音色和运行时：
 
 ```powershell
 python installer/build_windows_setup.py `
@@ -45,16 +45,17 @@ python installer/build_windows_setup.py `
   --version 0.1.0 `
   --distribution private `
   --voice-reference '<私有 WAV 的本机路径>' `
+  --video-runtime '<Olivia-video-runtime-*.zip 的本机路径>' `
   --iscc 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
 ```
 
-私有构建器只接受显式 WAV：它读取并核对实际 PCM 帧，随后把音频、大小、SHA-256 和 WAV 元数据写入内嵌 `offline/offline-core-assets.json`，其中 `distribution` 固定为 `private`。输入的 `offline` 目录不得预先夹带 `voice_reference` manifest 字段或音频文件；公开模式传入 `--voice-reference`、私有模式缺少该参数都会拒绝构建。
+私有构建器只接受显式 WAV 和完整视频运行时 ZIP：它核对 PCM 帧、视频运行时根 manifest 与四个独立 Python 入口，随后把两项资产的大小和 SHA-256 写入内嵌 `offline/offline-core-assets.json`，其中 `distribution` 固定为 `private`。输入的 `offline` 目录不得预先夹带私有字段或资产；公开模式传入任一私有资产、私有模式缺少任一资产都会拒绝构建。
 
-公开与私有构建的文件名仍为 `Olivia-Setup-x64.exe`，不能靠文件名判断边界。私有产物必须只保存在专用 `dist-private` 目录，以该目录和构建生成的 `.sha256` 作为交付识别记录，不得与公开 `dist` artifact 共置、替换或上传到公开 Release。解包审计时，内嵌 manifest 的 `"distribution": "private"` 是第二层识别标记，不代表取得了公开分发授权。
+公开构建仍是单个 `Olivia-Setup-x64.exe`。私有视频运行时超过单个安装程序容量上限，因此私有产物是一个完整目录：`Olivia-Setup-x64.exe`、同名前缀的全部 `.bin` 分卷和 `.sha256`。交付时必须把整个目录压成一个 ZIP，用户完整解压后再运行 EXE；缺少任一分卷都不能安装。私有产物只保存在专用 `dist-private`，不得与公开 `dist` artifact 共置、替换或上传到公开 Release。
 
-除私有模式显式传入的 WAV 外，构建器只复制 Git 已跟踪且相对 `HEAD` 未修改的发布文件，排除 `.github`、`docs`、测试和构建/CI 元数据，并在编译前复验离线 manifest、requirements 哈希、每个资产的大小与 SHA-256，以及实际资产集合。输出为 `Olivia-Setup-x64.exe` 和对应 `.sha256` 文件。
+除私有模式显式传入的 WAV 与视频运行时 ZIP 外，构建器只复制 Git 已跟踪且相对 `HEAD` 未修改的发布文件，排除 `.github`、`docs`、测试和构建/CI 元数据，并在编译前复验离线 manifest、requirements 哈希、每个资产的大小与 SHA-256，以及实际资产集合。私有构建使用约 2.1 GB 的安装分卷；`.sha256` 会逐项记录 EXE 与全部分卷。
 
-GitHub Actions 只生成公开安装器 artifact；它会在 PR 和 `main` 更新时执行默认公开构建，不接受私有 WAV，也不会生成私有安装器。当前产物未做商业代码签名；正式面向普通用户发布前应增加受信任的 Authenticode 签名，但签名不替代随包 SHA-256 校验。
+GitHub Actions 只生成公开安装器 artifact；它会在 PR 和 `main` 更新时执行默认公开构建，不接受私有 WAV 或视频运行时，也不会生成私有安装器。私有安装包只能由维护者在隔离环境手工构建。当前产物未做商业代码签名；正式面向普通用户发布前应增加受信任的 Authenticode 签名，但签名不替代随包 SHA-256 校验。
 
 ## 启动器健康检查
 

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -742,11 +742,16 @@ function Get-OfflineCoreAssets {
     }
     $manifestNames = @('schema_version', 'python_runtime', 'pip_bootstrap', 'requirements_sha256', 'wheels')
     $hasVoiceReference = $manifest.PSObject.Properties.Name -ccontains 'voice_reference'
+    $hasVideoRuntime = $manifest.PSObject.Properties.Name -ccontains 'video_runtime'
     $hasDistribution = $manifest.PSObject.Properties.Name -ccontains 'distribution'
-    if ($hasVoiceReference -ne $hasDistribution -or ($hasDistribution -and $manifest.distribution -cne 'private')) {
+    if (
+        $hasVideoRuntime -ne $hasVoiceReference -or
+        $hasVoiceReference -ne $hasDistribution -or
+        ($hasDistribution -and $manifest.distribution -cne 'private')
+    ) {
         throw 'VOICE_REFERENCE_PRIVATE_MANIFEST_REQUIRED'
     }
-    if ($hasVoiceReference) { $manifestNames += @('distribution', 'voice_reference') }
+    if ($hasVoiceReference) { $manifestNames += @('distribution', 'voice_reference', 'video_runtime') }
     Assert-OfflineObjectShape -Value $manifest -Names $manifestNames
     Assert-OfflineObjectShape -Value $manifest.python_runtime -Names @('path', 'size_bytes', 'sha256', 'source_url')
     Assert-OfflineObjectShape -Value $manifest.pip_bootstrap -Names @('path', 'size_bytes', 'sha256', 'package', 'version')
@@ -785,6 +790,7 @@ function Get-OfflineCoreAssets {
     $runtime = Resolve-OfflineAsset -Root $Root -Asset $manifest.python_runtime
     $pipBootstrap = Resolve-OfflineAsset -Root $Root -Asset $manifest.pip_bootstrap
     $voiceReference = $null
+    $videoRuntime = $null
     if ($hasVoiceReference) {
         Assert-OfflineObjectShape -Value $manifest.voice_reference -Names @('path', 'size_bytes', 'sha256', 'wave')
         Assert-OfflineObjectShape -Value $manifest.voice_reference.wave -Names @('channels', 'sample_width_bytes', 'sample_rate_hz', 'frame_count', 'compression_type')
@@ -804,6 +810,11 @@ function Get-OfflineCoreAssets {
         }
         $voiceReference = $manifest.voice_reference
         $voiceReference.path = $voiceReferencePath
+        Assert-OfflineObjectShape -Value $manifest.video_runtime -Names @('path', 'size_bytes', 'sha256')
+        if ($manifest.video_runtime.path -cne 'video-runtime/Olivia-video-runtime-private.zip') {
+            throw 'OFFLINE_CORE_MANIFEST_INVALID'
+        }
+        $videoRuntime = Resolve-OfflineAsset -Root $Root -Asset $manifest.video_runtime
     }
     $expectedWheelAssets = Get-ExpectedOfflineWheels
     $wheelPaths = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
@@ -843,6 +854,7 @@ function Get-OfflineCoreAssets {
         PipBootstrap = $pipBootstrap
         Wheelhouse = (Join-Path $Root 'wheelhouse')
         VoiceReference = $voiceReference
+        VideoRuntime = $videoRuntime
     }
 }
 

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -15,6 +15,8 @@ import wave
 import zipfile
 from pathlib import Path, PurePosixPath
 
+from installer.component_update import ComponentUpdateError, _validate_relative_path
+
 
 MANIFEST_NAME = "offline-core-assets.json"
 SETUP_NAME = "Olivia-Setup-x64.exe"
@@ -222,58 +224,103 @@ def _voice_reference_metadata(path: Path) -> dict[str, object]:
     return metadata
 
 
+def _video_runtime_relative(value: object) -> str:
+    try:
+        return _validate_relative_path(value)
+    except ComponentUpdateError as exc:
+        raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID") from exc
+
+
 def _video_runtime_metadata(path: Path) -> dict[str, object]:
     try:
         with zipfile.ZipFile(path) as archive:
-            entries = archive.infolist()
-            if sum(entry.filename == "runtime-manifest.json" for entry in entries) != 1:
+            archive_files: dict[str, tuple[str, zipfile.ZipInfo]] = {}
+            seen_entries: set[str] = set()
+            for entry in archive.infolist():
+                raw = entry.filename[:-1] if entry.is_dir() and entry.filename.endswith("/") else entry.filename
+                relative = _video_runtime_relative(raw)
+                folded = relative.casefold()
+                mode = stat.S_IFMT(entry.external_attr >> 16)
+                if folded in seen_entries or mode == stat.S_IFLNK:
+                    raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+                seen_entries.add(folded)
+                if not entry.is_dir():
+                    archive_files[folded] = (relative, entry)
+            manifest_entry = archive_files.get("runtime-manifest.json")
+            if manifest_entry is None or manifest_entry[0] != "runtime-manifest.json":
                 raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
-            manifest = json.loads(archive.read("runtime-manifest.json"))
-            archive_entries = {entry.filename: entry for entry in entries}
+            manifest = json.loads(archive.read(manifest_entry[1]))
     except SetupBuildError:
         raise
     except (OSError, UnicodeError, json.JSONDecodeError, zipfile.BadZipFile) as exc:
         raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID") from exc
-    if not isinstance(manifest, dict) or manifest.get("schema_version") != "olivia.video-runtime-root.v1":
+    if (
+        not isinstance(manifest, dict)
+        or set(manifest) != {"schema_version", "version", "environment", "files"}
+        or manifest.get("schema_version") != "olivia.video-runtime-root.v1"
+        or not isinstance(manifest.get("version"), str)
+        or not 1 <= len(manifest["version"]) <= 64
+    ):
         raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
     environment = manifest.get("environment")
     if not isinstance(environment, dict) or set(environment) != VIDEO_RUNTIME_ENVIRONMENT_KEYS:
         raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
-    for relative in environment.values():
-        if not isinstance(relative, str):
+    environment_paths: set[str] = set()
+    for raw_relative in environment.values():
+        relative = _video_runtime_relative(raw_relative)
+        environment_paths.add(relative.casefold())
+        archived = archive_files.get(relative.casefold())
+        if archived is None or archived[0] != relative or archived[1].file_size < 1:
             raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
-        logical = PurePosixPath(relative)
-        if logical.is_absolute() or any(part in {"", ".", ".."} for part in logical.parts):
-            raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
-        entry = archive_entries.get(relative)
-        if entry is None or entry.is_dir() or entry.file_size < 1:
-            raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+    if len(environment_paths) != len(VIDEO_RUNTIME_ENVIRONMENT_KEYS):
+        raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
     files = manifest.get("files")
     if not isinstance(files, list) or not files:
         raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
     declared: set[str] = set()
+    expected_hashes: dict[str, str] = {}
     for item in files:
-        if not isinstance(item, dict):
+        if not isinstance(item, dict) or set(item) != {"path", "size_bytes", "sha256"}:
             raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
-        relative = item.get("path")
+        relative = _video_runtime_relative(item.get("path"))
         size = item.get("size_bytes")
         digest = item.get("sha256")
-        entry = archive_entries.get(relative) if isinstance(relative, str) else None
+        archived = archive_files.get(relative.casefold())
+        entry = None if archived is None or archived[0] != relative else archived[1]
+        folded = relative.casefold()
         if (
-            entry is None
+            folded == "runtime-manifest.json"
+            or entry is None
             or entry.is_dir()
             or type(size) is not int
-            or size < 1
+            or size < 0
             or entry.file_size != size
             or not isinstance(digest, str)
             or len(digest) != 64
             or any(character not in "0123456789abcdef" for character in digest)
-            or relative in declared
+            or folded in declared
         ):
             raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
-        declared.add(relative)
-    if not set(environment.values()).issubset(declared):
+        declared.add(folded)
+        expected_hashes[folded] = digest
+    if (
+        not environment_paths.issubset(declared)
+        or set(archive_files) != declared | {"runtime-manifest.json"}
+    ):
         raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+    try:
+        with zipfile.ZipFile(path) as archive:
+            for folded, expected in expected_hashes.items():
+                digest = hashlib.sha256()
+                with archive.open(archive_files[folded][0]) as source:
+                    for block in iter(lambda: source.read(1 << 20), b""):
+                        digest.update(block)
+                if digest.hexdigest() != expected:
+                    raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+    except SetupBuildError:
+        raise
+    except (OSError, RuntimeError, zipfile.BadZipFile) as exc:
+        raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID") from exc
     return {"size_bytes": path.stat().st_size, "sha256": _sha256(path)}
 
 
@@ -601,6 +648,20 @@ def build_windows_setup(
             path for path in output.glob("Olivia-Setup-x64*")
             if path.is_file() and path != checksum
         )
+        if video_runtime is not None:
+            part_numbers: list[int] = []
+            for artifact in artifacts:
+                if artifact == setup:
+                    continue
+                prefix, suffix = "Olivia-Setup-x64-", ".bin"
+                if not artifact.name.startswith(prefix) or not artifact.name.endswith(suffix):
+                    raise SetupBuildError("SETUP_COMPILE_FAILED")
+                number = artifact.name[len(prefix):-len(suffix)]
+                if not number.isdecimal() or str(int(number)) != number:
+                    raise SetupBuildError("SETUP_COMPILE_FAILED")
+                part_numbers.append(int(number))
+            if not part_numbers or sorted(part_numbers) != list(range(1, len(part_numbers) + 1)):
+                raise SetupBuildError("SETUP_COMPILE_FAILED")
         records = [
             {"path": os.fspath(path), "size_bytes": path.stat().st_size, "sha256": _sha256(path)}
             for path in artifacts
@@ -627,7 +688,7 @@ def build_windows_setup(
         shutil.rmtree(payload, ignore_errors=True)
         if not completed:
             cleanup_failed = False
-            for artifact in (setup, checksum):
+            for artifact in output.glob("Olivia-Setup-x64*"):
                 try:
                     artifact.unlink(missing_ok=True)
                 except OSError:

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import uuid
 import wave
+import zipfile
 from pathlib import Path, PurePosixPath
 
 
@@ -32,6 +33,13 @@ FORBIDDEN_MEDIA_SUFFIXES = {
     ".wav",
     ".webm",
     ".wmv",
+}
+VIDEO_RUNTIME_PATH = "video-runtime/Olivia-video-runtime-private.zip"
+VIDEO_RUNTIME_ENVIRONMENT_KEYS = {
+    "OLIVIA_COSYVOICE_PYTHON",
+    "OLIVIA_LATENTSYNC_PYTHON",
+    "OLIVIA_MINIMAX_COMFY_PYTHON",
+    "OLIVIA_ROFORMER_PYTHON",
 }
 BUILD_CONTROL_FILES = {
     "installer/build_windows_setup.py",
@@ -214,6 +222,61 @@ def _voice_reference_metadata(path: Path) -> dict[str, object]:
     return metadata
 
 
+def _video_runtime_metadata(path: Path) -> dict[str, object]:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            entries = archive.infolist()
+            if sum(entry.filename == "runtime-manifest.json" for entry in entries) != 1:
+                raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+            manifest = json.loads(archive.read("runtime-manifest.json"))
+            archive_entries = {entry.filename: entry for entry in entries}
+    except SetupBuildError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError, zipfile.BadZipFile) as exc:
+        raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID") from exc
+    if not isinstance(manifest, dict) or manifest.get("schema_version") != "olivia.video-runtime-root.v1":
+        raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+    environment = manifest.get("environment")
+    if not isinstance(environment, dict) or set(environment) != VIDEO_RUNTIME_ENVIRONMENT_KEYS:
+        raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+    for relative in environment.values():
+        if not isinstance(relative, str):
+            raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+        logical = PurePosixPath(relative)
+        if logical.is_absolute() or any(part in {"", ".", ".."} for part in logical.parts):
+            raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+        entry = archive_entries.get(relative)
+        if entry is None or entry.is_dir() or entry.file_size < 1:
+            raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+    files = manifest.get("files")
+    if not isinstance(files, list) or not files:
+        raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+    declared: set[str] = set()
+    for item in files:
+        if not isinstance(item, dict):
+            raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+        relative = item.get("path")
+        size = item.get("size_bytes")
+        digest = item.get("sha256")
+        entry = archive_entries.get(relative) if isinstance(relative, str) else None
+        if (
+            entry is None
+            or entry.is_dir()
+            or type(size) is not int
+            or size < 1
+            or entry.file_size != size
+            or not isinstance(digest, str)
+            or len(digest) != 64
+            or any(character not in "0123456789abcdef" for character in digest)
+            or relative in declared
+        ):
+            raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+        declared.add(relative)
+    if not set(environment.values()).issubset(declared):
+        raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+    return {"size_bytes": path.stat().st_size, "sha256": _sha256(path)}
+
+
 def _is_reparse_point(path: Path) -> bool:
     attributes = getattr(path.stat(follow_symlinks=False), "st_file_attributes", 0)
     return path.is_symlink() or bool(
@@ -312,7 +375,7 @@ def _load_and_verify_manifest(
         raise SetupBuildError("SETUP_OFFLINE_MANIFEST_INVALID") from exc
     if not isinstance(manifest, dict):
         raise SetupBuildError("SETUP_OFFLINE_MANIFEST_INVALID")
-    if "distribution" in manifest or "voice_reference" in manifest:
+    if any(key in manifest for key in ("distribution", "voice_reference", "video_runtime")):
         raise SetupBuildError("SETUP_INPUT_VOICE_REFERENCE_FORBIDDEN")
 
     if validate_schema:
@@ -381,6 +444,7 @@ def prepare_setup_payload(
     *,
     distribution: str = "public",
     voice_reference: Path | None = None,
+    video_runtime: Path | None = None,
     validate_schema: bool = True,
 ) -> None:
     source = source.expanduser().resolve()
@@ -392,6 +456,10 @@ def prepare_setup_payload(
         raise SetupBuildError("SETUP_VOICE_REFERENCE_PRIVATE_ONLY")
     if distribution == "private" and voice_reference is None:
         raise SetupBuildError("SETUP_PRIVATE_VOICE_REFERENCE_REQUIRED")
+    if video_runtime is not None and distribution != "private":
+        raise SetupBuildError("SETUP_VIDEO_RUNTIME_PRIVATE_ONLY")
+    if distribution == "private" and video_runtime is None:
+        raise SetupBuildError("SETUP_PRIVATE_VIDEO_RUNTIME_REQUIRED")
     if destination.exists():
         raise SetupBuildError("SETUP_PAYLOAD_EXISTS")
     _load_and_verify_manifest(source, offline, validate_schema=validate_schema)
@@ -418,7 +486,7 @@ def prepare_setup_payload(
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source_path, target)
         shutil.copytree(offline, staging / "offline")
-        if voice_reference is not None:
+        if voice_reference is not None and video_runtime is not None:
             reference = voice_reference.expanduser().resolve()
             if (
                 not reference.is_file()
@@ -429,6 +497,17 @@ def prepare_setup_payload(
             target = staging / "offline" / Path(*VOICE_REFERENCE_PATH.split("/"))
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(reference, target)
+            runtime_source = video_runtime.expanduser()
+            if (
+                not runtime_source.is_file()
+                or _is_reparse_point(runtime_source)
+                or runtime_source.stat().st_size < 1
+            ):
+                raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+            runtime_target = staging / "offline" / Path(*VIDEO_RUNTIME_PATH.split("/"))
+            runtime_target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(runtime_source.resolve(), runtime_target)
+            runtime_metadata = _video_runtime_metadata(runtime_target)
             manifest_path = staging / "offline" / MANIFEST_NAME
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             manifest["distribution"] = "private"
@@ -437,6 +516,10 @@ def prepare_setup_payload(
                 "size_bytes": target.stat().st_size,
                 "sha256": _sha256(target),
                 "wave": _voice_reference_metadata(target),
+            }
+            manifest["video_runtime"] = {
+                "path": VIDEO_RUNTIME_PATH,
+                **runtime_metadata,
             }
             manifest_path.write_text(
                 json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True)
@@ -481,13 +564,14 @@ def build_windows_setup(
     iscc: Path | None = None,
     distribution: str = "public",
     voice_reference: Path | None = None,
+    video_runtime: Path | None = None,
 ) -> dict[str, object]:
     source = source.expanduser().resolve()
     output = output.expanduser().resolve()
     output.mkdir(parents=True, exist_ok=True)
     setup = output / SETUP_NAME
     checksum = output / f"{SETUP_NAME}.sha256"
-    if setup.exists() or checksum.exists():
+    if any(output.glob("Olivia-Setup-x64*")):
         raise SetupBuildError("SETUP_OUTPUT_EXISTS")
     payload = output / f".setup-payload-{uuid.uuid4().hex}"
     compiler = _find_iscc(iscc)
@@ -499,6 +583,7 @@ def build_windows_setup(
             payload,
             distribution=distribution,
             voice_reference=voice_reference,
+            video_runtime=video_runtime,
         )
         command = [
             os.fspath(compiler),
@@ -507,16 +592,30 @@ def build_windows_setup(
             f"/DAppVersion={version}",
             os.fspath(source / "installer" / "windows_setup.iss"),
         ]
+        if video_runtime is not None:
+            command.insert(-1, "/DPrivatePayload=1")
         result = subprocess.run(command, check=False, timeout=900)
         if result.returncode != 0 or not setup.is_file():
             raise SetupBuildError("SETUP_COMPILE_FAILED")
-        digest = _sha256(setup)
-        checksum.write_text(f"{digest}  {SETUP_NAME}\n", encoding="ascii")
+        artifacts = sorted(
+            path for path in output.glob("Olivia-Setup-x64*")
+            if path.is_file() and path != checksum
+        )
+        records = [
+            {"path": os.fspath(path), "size_bytes": path.stat().st_size, "sha256": _sha256(path)}
+            for path in artifacts
+        ]
+        digest = next(record["sha256"] for record in records if Path(record["path"]) == setup)
+        checksum.write_text(
+            "".join(f"{record['sha256']}  {Path(record['path']).name}\n" for record in records),
+            encoding="ascii",
+        )
         result = {
             "status": "OK",
             "setup": os.fspath(setup),
             "size_bytes": setup.stat().st_size,
             "sha256": digest,
+            "artifacts": records,
         }
         completed = True
         return result
@@ -546,6 +645,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--iscc", type=Path)
     parser.add_argument("--distribution", choices=("public", "private"), default="public")
     parser.add_argument("--voice-reference", type=Path)
+    parser.add_argument("--video-runtime", type=Path)
     args = parser.parse_args(argv)
     try:
         result = build_windows_setup(
@@ -556,6 +656,7 @@ def main(argv: list[str] | None = None) -> int:
             iscc=args.iscc,
             distribution=args.distribution,
             voice_reference=args.voice_reference,
+            video_runtime=args.video_runtime,
         )
         print(json.dumps(result, ensure_ascii=False, sort_keys=True))
         return 0

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -15,6 +15,9 @@ import wave
 import zipfile
 from pathlib import Path, PurePosixPath
 
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from installer.component_update import ComponentUpdateError, _validate_relative_path
 
 

--- a/installer/windows_setup.iss
+++ b/installer/windows_setup.iss
@@ -22,6 +22,10 @@ OutputDir={#OutputDir}
 OutputBaseFilename=Olivia-Setup-x64
 Compression=lzma2/max
 SolidCompression=yes
+#ifdef PrivatePayload
+DiskSpanning=yes
+DiskSliceSize=2100000000
+#endif
 WizardStyle=modern
 LicenseFile={#PayloadRoot}\LICENSE
 SetupIconFile={#PayloadRoot}\installer\assets\olivia.ico
@@ -33,7 +37,10 @@ Name: "chinesesimp"; MessagesFile: "compiler:Languages\ChineseSimplified.isl"
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
-Source: "{#PayloadRoot}\*"; DestDir: "{tmp}\OliviaPayload"; Flags: recursesubdirs createallsubdirs dontcopy noencryption ignoreversion
+Source: "{#PayloadRoot}\*"; Excludes: "offline\video-runtime\*"; DestDir: "{tmp}\OliviaPayload"; Flags: recursesubdirs createallsubdirs dontcopy noencryption ignoreversion
+#ifdef PrivatePayload
+Source: "{#PayloadRoot}\offline\video-runtime\*"; DestDir: "{tmp}\OliviaPayload\offline\video-runtime"; Flags: recursesubdirs createallsubdirs dontcopy noencryption ignoreversion nocompression
+#endif
 
 [Tasks]
 Name: "desktopicon"; Description: "创建桌面快捷方式"; GroupDescription: "附加选项："; Flags: unchecked

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -56,6 +56,18 @@ def test_first_install_consumes_only_bundled_core_assets() -> None:
     assert "VOICE_REFERENCE_PRIVATE_MANIFEST_REQUIRED" in script
 
 
+def test_installer_accepts_only_complete_private_video_runtime_manifest() -> None:
+    script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
+
+    assert "$hasVideoRuntime = $manifest.PSObject.Properties.Name -ccontains 'video_runtime'" in script
+    assert "$hasVideoRuntime -ne $hasVoiceReference" in script
+    assert "$manifestNames += @('distribution', 'voice_reference', 'video_runtime')" in script
+    assert "Assert-OfflineObjectShape -Value $manifest.video_runtime -Names @('path', 'size_bytes', 'sha256')" in script
+    assert "$manifest.video_runtime.path -cne 'video-runtime/Olivia-video-runtime-private.zip'" in script
+    assert "$videoRuntime = Resolve-OfflineAsset -Root $Root -Asset $manifest.video_runtime" in script
+    assert "VideoRuntime = $videoRuntime" in script
+
+
 def test_offline_core_asset_example_matches_its_public_schema() -> None:
     schema = json.loads(
         (ROOT / "contracts" / "offline_core_assets.schema.json").read_text(
@@ -72,13 +84,21 @@ def test_offline_core_asset_example_matches_its_public_schema() -> None:
     assert not list(Draft202012Validator(schema).iter_errors(example))
 
 
-def test_public_schema_accepts_only_hash_locked_managed_voice_reference() -> None:
+def test_public_schema_accepts_only_complete_hash_locked_private_assets() -> None:
     schema = json.loads((ROOT / "contracts/offline_core_assets.schema.json").read_text())
     example = json.loads((ROOT / "contracts/offline_core_assets.example.json").read_text())
     validator = Draft202012Validator(schema)
     example["distribution"] = "private"
     example["voice_reference"] = {"path": "voice/olivia-reference.wav", "size_bytes": 155278, "sha256": "7bd846a55265d5ceb4dcf0ef164dc954066b8b056ac1e40d554b1e41d844a5bf", "wave": _wave_metadata(frame_count=77600)}
+    example["video_runtime"] = {
+        "path": "video-runtime/Olivia-video-runtime-private.zip",
+        "size_bytes": 1,
+        "sha256": "0" * 64,
+    }
     assert not list(validator.iter_errors(example))
+    missing_runtime = deepcopy(example)
+    del missing_runtime["video_runtime"]
+    assert list(validator.iter_errors(missing_runtime))
     missing_marker = deepcopy(example)
     del missing_marker["distribution"]
     assert list(validator.iter_errors(missing_marker))

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+import subprocess
+import sys
 from types import SimpleNamespace
 import wave
 import zipfile
@@ -22,6 +24,19 @@ from installer.build_windows_setup import (
 
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_setup_builder_direct_entrypoint_reaches_argument_parser() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "installer" / "build_windows_setup.py"), "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "--video-runtime" in result.stdout
 
 
 def _write_asset(root: Path, relative: str, content: bytes) -> dict[str, object]:

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -14,6 +14,7 @@ from installer.build_windows_setup import (
     SetupBuildError,
     _git_tracked_files,
     _is_release_file,
+    _video_runtime_relative,
     build_windows_setup,
     main as build_setup_main,
     prepare_setup_payload,
@@ -49,20 +50,37 @@ def _write_video_runtime(path: Path) -> None:
         "OLIVIA_MINIMAX_COMFY_PYTHON": "minimax/python/python.exe",
         "OLIVIA_ROFORMER_PYTHON": "roformer/python/python.exe",
     }
+    files = {relative: b"x" for relative in [*environment.values(), "fixture.bin"]}
+    files["empty.marker"] = b""
     manifest = {
         "schema_version": "olivia.video-runtime-root.v1",
         "version": "fixture",
         "environment": environment,
         "files": [
-            {"path": relative, "size_bytes": 1,
-             "sha256": hashlib.sha256(b"x").hexdigest()}
-            for relative in [*environment.values(), "fixture.bin"]
+            {"path": relative, "size_bytes": len(content),
+             "sha256": hashlib.sha256(content).hexdigest()}
+            for relative, content in files.items()
         ],
     }
     with zipfile.ZipFile(path, "w") as archive:
         archive.writestr("runtime-manifest.json", json.dumps(manifest))
-        for item in manifest["files"]:
-            archive.writestr(item["path"], b"x")
+        for relative, content in files.items():
+            archive.writestr(relative, content)
+
+
+def _mutate_video_runtime_manifest(path: Path, mutate) -> None:
+    with zipfile.ZipFile(path) as archive:
+        files = {
+            item.filename: archive.read(item)
+            for item in archive.infolist()
+            if not item.is_dir() and item.filename != "runtime-manifest.json"
+        }
+        manifest = json.loads(archive.read("runtime-manifest.json"))
+    mutate(manifest)
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("runtime-manifest.json", json.dumps(manifest))
+        for relative, content in files.items():
+            archive.writestr(relative, content)
 
 
 def _offline_fixture(root: Path, requirements: bytes) -> None:
@@ -266,6 +284,8 @@ def test_failed_private_setup_compile_removes_partial_final_artifacts(
     monkeypatch,
 ) -> None:
     source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "video-runtime.zip"
+    _write_video_runtime(runtime)
     output = tmp_path / "dist-private"
     compiler = tmp_path / "ISCC.exe"
     compiler.write_bytes(b"compiler")
@@ -280,6 +300,7 @@ def test_failed_private_setup_compile_removes_partial_final_artifacts(
         assert check is False
         assert timeout == 900
         (output / "Olivia-Setup-x64.exe").write_bytes(b"partial private setup")
+        (output / "Olivia-Setup-x64-1.bin").write_bytes(b"partial runtime")
         return type("Result", (), {"returncode": 1})()
 
     monkeypatch.setattr("installer.build_windows_setup.subprocess.run", fail_compile)
@@ -293,9 +314,11 @@ def test_failed_private_setup_compile_removes_partial_final_artifacts(
             iscc=compiler,
             distribution="private",
             voice_reference=reference,
+            video_runtime=runtime,
         )
 
     assert not (output / "Olivia-Setup-x64.exe").exists()
+    assert not (output / "Olivia-Setup-x64-1.bin").exists()
     assert not (output / "Olivia-Setup-x64.exe.sha256").exists()
 
 
@@ -304,6 +327,8 @@ def test_failed_private_setup_checksum_removes_setup_and_partial_checksum(
     monkeypatch,
 ) -> None:
     source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "video-runtime.zip"
+    _write_video_runtime(runtime)
     output = tmp_path / "dist-private"
     compiler = tmp_path / "ISCC.exe"
     compiler.write_bytes(b"compiler")
@@ -318,6 +343,7 @@ def test_failed_private_setup_checksum_removes_setup_and_partial_checksum(
         assert check is False
         assert timeout == 900
         (output / "Olivia-Setup-x64.exe").write_bytes(b"complete private setup")
+        (output / "Olivia-Setup-x64-1.bin").write_bytes(b"complete runtime")
         return type("Result", (), {"returncode": 0})()
 
     original_write_text = Path.write_text
@@ -340,9 +366,11 @@ def test_failed_private_setup_checksum_removes_setup_and_partial_checksum(
             iscc=compiler,
             distribution="private",
             voice_reference=reference,
+            video_runtime=runtime,
         )
 
     assert not (output / "Olivia-Setup-x64.exe").exists()
+    assert not (output / "Olivia-Setup-x64-1.bin").exists()
     assert not (output / "Olivia-Setup-x64.exe.sha256").exists()
 
 
@@ -357,6 +385,7 @@ def test_windows_setup_docs_separate_public_and_private_voice_artifacts() -> Non
     assert "--video-runtime" in documentation
     assert "dist-private" in documentation
     assert "全部 `.bin` 分卷" in documentation
+    assert "私有视频包：下载完整 ZIP" in documentation
     assert "除私有模式显式传入的 WAV 与视频运行时 ZIP 外" in documentation
     assert "GitHub Actions 只生成公开安装器 artifact" in documentation
 
@@ -420,29 +449,79 @@ def test_private_build_hashes_exe_and_all_disk_spanning_parts(tmp_path: Path, mo
     assert "Olivia-Setup-x64-1.bin" in checksum and "Olivia-Setup-x64.exe" in checksum
 
 
-def test_prepare_setup_payload_rejects_runtime_without_exact_python_set(
-    tmp_path: Path, monkeypatch
+@pytest.mark.parametrize("parts", [(), (1, 3)])
+def test_private_build_requires_contiguous_disk_spanning_parts(
+    tmp_path: Path, monkeypatch, parts: tuple[int, ...]
+) -> None:
+    output = tmp_path / "output"
+
+    def compile_setup(_command: list[str], **_: object) -> SimpleNamespace:
+        (output / "Olivia-Setup-x64.exe").write_bytes(b"setup")
+        for part in parts:
+            (output / f"Olivia-Setup-x64-{part}.bin").write_bytes(b"runtime")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("installer.build_windows_setup._find_iscc", lambda _: tmp_path / "ISCC.exe")
+    monkeypatch.setattr("installer.build_windows_setup.prepare_setup_payload", lambda *args, **kwargs: None)
+    monkeypatch.setattr("installer.build_windows_setup.subprocess.run", compile_setup)
+
+    with pytest.raises(SetupBuildError, match="SETUP_COMPILE_FAILED"):
+        build_windows_setup(
+            tmp_path / "source", tmp_path / "offline", output, version="fixture",
+            distribution="private", voice_reference=tmp_path / "voice.wav",
+            video_runtime=tmp_path / "runtime.zip",
+        )
+
+    assert not list(output.glob("Olivia-Setup-x64*"))
+
+
+@pytest.mark.parametrize("case", [
+    "missing-version", "missing-python", "duplicate-python", "traversal", "backslash",
+    "duplicate", "case-alias", "undeclared", "self-reference", "bad-hash", "file-shape",
+])
+def test_prepare_setup_payload_rejects_invalid_runtime_zip(
+    tmp_path: Path, monkeypatch, case: str
 ) -> None:
     source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
     runtime = tmp_path / "runtime.zip"
-    with zipfile.ZipFile(runtime, "w") as archive:
-        archive.writestr("runtime-manifest.json", json.dumps({
-            "schema_version": "olivia.video-runtime-root.v1",
-            "environment": {},
-            "files": [{"path": "fixture.bin", "size_bytes": 1, "sha256": "0" * 64}],
-        }))
-        archive.writestr("fixture.bin", b"x")
+    _write_video_runtime(runtime)
+
+    def mutate(manifest: dict[str, object]) -> None:
+        fixture = next(item for item in manifest["files"] if item["path"] == "fixture.bin")
+        if case == "missing-version":
+            manifest.pop("version")
+        elif case == "missing-python":
+            manifest["environment"].pop("OLIVIA_ROFORMER_PYTHON")
+        elif case == "duplicate-python":
+            manifest["environment"] = dict.fromkeys(
+                manifest["environment"], "cosyvoice/python/python.exe"
+            )
+        elif case in {"traversal", "backslash"}:
+            fixture["path"] = "../escape.bin" if case == "traversal" else "dir\\escape.bin"
+        elif case == "self-reference":
+            fixture["path"] = "runtime-manifest.json"
+        elif case == "bad-hash":
+            fixture["sha256"] = "0" * 64
+        elif case == "file-shape":
+            fixture["extra"] = True
+
+    _mutate_video_runtime_manifest(runtime, mutate)
+    extras = {"duplicate": "fixture.bin", "case-alias": "FIXTURE.BIN", "undeclared": "extra.bin"}
+    if case in extras:
+        with zipfile.ZipFile(runtime, "a") as archive:
+            archive.writestr(extras[case], b"x")
 
     with pytest.raises(SetupBuildError, match="SETUP_VIDEO_RUNTIME_INVALID"):
         prepare_setup_payload(
-            source,
-            offline,
-            tmp_path / "payload",
-            distribution="private",
-            voice_reference=reference,
-            video_runtime=runtime,
-            validate_schema=False,
+            source, offline, tmp_path / "payload", distribution="private",
+            voice_reference=reference, video_runtime=runtime, validate_schema=False,
         )
+
+
+@pytest.mark.parametrize("unsafe", ["NUL/file.bin", "bad:name.bin", "trailing./file.bin"])
+def test_video_runtime_paths_follow_windows_rules(unsafe: str) -> None:
+    with pytest.raises(SetupBuildError, match="SETUP_VIDEO_RUNTIME_INVALID"):
+        _video_runtime_relative(unsafe)
 
 
 @pytest.mark.parametrize(
@@ -471,6 +550,8 @@ def test_setup_rejects_git_selected_audio_and_video_payloads(
     distribution: str,
 ) -> None:
     source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "video-runtime.zip"
+    _write_video_runtime(runtime)
     relative = f"runtime/reference{suffix}"
     media = source.joinpath(*relative.split("/"))
     media.parent.mkdir()
@@ -492,6 +573,7 @@ def test_setup_rejects_git_selected_audio_and_video_payloads(
             tmp_path / "payload",
             distribution=distribution,
             voice_reference=reference if distribution == "private" else None,
+            video_runtime=runtime if distribution == "private" else None,
             validate_schema=False,
         )
 

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+from types import SimpleNamespace
 import wave
+import zipfile
 
 import pytest
 
@@ -37,6 +39,30 @@ def _write_voice_reference(path: Path) -> None:
     with wave.open(str(path), "wb") as target:
         target.setparams((1, 2, 16000, 0, "NONE", "not compressed"))
         target.writeframes(b"\x00\x00" * 160)
+
+
+def _write_video_runtime(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    environment = {
+        "OLIVIA_COSYVOICE_PYTHON": "cosyvoice/python/python.exe",
+        "OLIVIA_LATENTSYNC_PYTHON": "latentsync/python/python.exe",
+        "OLIVIA_MINIMAX_COMFY_PYTHON": "minimax/python/python.exe",
+        "OLIVIA_ROFORMER_PYTHON": "roformer/python/python.exe",
+    }
+    manifest = {
+        "schema_version": "olivia.video-runtime-root.v1",
+        "version": "fixture",
+        "environment": environment,
+        "files": [
+            {"path": relative, "size_bytes": 1,
+             "sha256": hashlib.sha256(b"x").hexdigest()}
+            for relative in [*environment.values(), "fixture.bin"]
+        ],
+    }
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("runtime-manifest.json", json.dumps(manifest))
+        for item in manifest["files"]:
+            archive.writestr(item["path"], b"x")
 
 
 def _offline_fixture(root: Path, requirements: bytes) -> None:
@@ -147,6 +173,8 @@ def test_prepare_setup_payload_copies_only_tracked_release_files_and_offline_ass
 
 def test_prepare_setup_payload_injects_hash_locked_voice_reference(tmp_path: Path, monkeypatch) -> None:
     source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "distributor" / "Olivia-video-runtime-fixture.zip"
+    _write_video_runtime(runtime)
     destination = tmp_path / "payload"
 
     prepare_setup_payload(
@@ -155,6 +183,7 @@ def test_prepare_setup_payload_injects_hash_locked_voice_reference(tmp_path: Pat
         destination,
         distribution="private",
         voice_reference=reference,
+        video_runtime=runtime,
         validate_schema=False,
     )
 
@@ -169,16 +198,27 @@ def test_prepare_setup_payload_injects_hash_locked_voice_reference(tmp_path: Pat
         "wave": {"channels": 1, "sample_width_bytes": 2, "sample_rate_hz": 16000,
                  "frame_count": 160, "compression_type": "NONE"},
     }
+    installed_runtime = destination / "offline/video-runtime/Olivia-video-runtime-private.zip"
+    assert installed_runtime.read_bytes() == runtime.read_bytes()
+    assert manifest["video_runtime"] == {
+        "path": "video-runtime/Olivia-video-runtime-private.zip",
+        "size_bytes": runtime.stat().st_size,
+        "sha256": hashlib.sha256(runtime.read_bytes()).hexdigest(),
+    }
     input_manifest_path = offline / "offline-core-assets.json"
     input_manifest = json.loads(input_manifest_path.read_text())
-    input_manifest.update(distribution="private", voice_reference=manifest["voice_reference"])
+    input_manifest.update(
+        distribution="private",
+        voice_reference=manifest["voice_reference"],
+        video_runtime=manifest["video_runtime"],
+    )
     input_manifest_path.write_text(json.dumps(input_manifest), encoding="utf-8")
     prebundled = offline / "voice" / "olivia-reference.wav"
     prebundled.parent.mkdir()
     prebundled.write_bytes(reference.read_bytes())
     with pytest.raises(SetupBuildError, match="SETUP_INPUT_VOICE_REFERENCE_FORBIDDEN"):
         prepare_setup_payload(source, offline, tmp_path / "prebundled", validate_schema=False)
-    del input_manifest["distribution"], input_manifest["voice_reference"]
+    del input_manifest["distribution"], input_manifest["voice_reference"], input_manifest["video_runtime"]
     input_manifest_path.write_text(json.dumps(input_manifest), encoding="utf-8")
     with pytest.raises(SetupBuildError, match="SETUP_OFFLINE_ASSET_SET_MISMATCH"):
         prepare_setup_payload(source, offline, tmp_path / "orphan", validate_schema=False)
@@ -186,15 +226,23 @@ def test_prepare_setup_payload_injects_hash_locked_voice_reference(tmp_path: Pat
         prepare_setup_payload(
             source, offline, tmp_path / "public", voice_reference=reference, validate_schema=False
         )
-    with pytest.raises(SetupBuildError, match="SETUP_PRIVATE_VOICE_REFERENCE_REQUIRED"):
+    with pytest.raises(SetupBuildError, match="SETUP_PRIVATE_VIDEO_RUNTIME_REQUIRED"):
         prepare_setup_payload(
-            source, offline, tmp_path / "private", distribution="private", validate_schema=False
+            source, offline, tmp_path / "private", distribution="private",
+            voice_reference=reference, validate_schema=False
+        )
+    with pytest.raises(SetupBuildError, match="SETUP_VIDEO_RUNTIME_PRIVATE_ONLY"):
+        prepare_setup_payload(
+            source, offline, tmp_path / "public-runtime", video_runtime=runtime,
+            validate_schema=False,
         )
 
 
 def test_setup_build_cli_forwards_distributor_voice_reference(tmp_path: Path, monkeypatch) -> None:
     reference = tmp_path / "olivia-reference.wav"
     reference.write_bytes(b"RIFF-voice")
+    runtime = tmp_path / "Olivia-video-runtime-fixture.zip"
+    runtime.write_bytes(b"runtime")
     captured: dict[str, object] = {}
     monkeypatch.setattr(
         "installer.build_windows_setup.build_windows_setup",
@@ -204,11 +252,13 @@ def test_setup_build_cli_forwards_distributor_voice_reference(tmp_path: Path, mo
     result = build_setup_main([
         "--offline", str(tmp_path / "offline"), "--output", str(tmp_path / "output"),
         "--version", "0.1.test", "--distribution", "private", "--voice-reference", str(reference),
+        "--video-runtime", str(runtime),
     ])
 
     assert result == 0
     assert captured["distribution"] == "private"
     assert captured["voice_reference"] == reference
+    assert captured["video_runtime"] == runtime
 
 
 def test_failed_private_setup_compile_removes_partial_final_artifacts(
@@ -304,14 +354,17 @@ def test_windows_setup_docs_separate_public_and_private_voice_artifacts() -> Non
     assert "公开安装器不包含参考音频" in documentation
     assert "--distribution private" in documentation
     assert "--voice-reference" in documentation
+    assert "--video-runtime" in documentation
     assert "dist-private" in documentation
-    assert "文件名仍为 `Olivia-Setup-x64.exe`" in documentation
-    assert "除私有模式显式传入的 WAV 外" in documentation
+    assert "全部 `.bin` 分卷" in documentation
+    assert "除私有模式显式传入的 WAV 与视频运行时 ZIP 外" in documentation
     assert "GitHub Actions 只生成公开安装器 artifact" in documentation
 
 
 def test_prepare_setup_payload_rejects_truncated_voice_reference(tmp_path: Path, monkeypatch) -> None:
     source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "Olivia-video-runtime-fixture.zip"
+    _write_video_runtime(runtime)
     reference.write_bytes(reference.read_bytes()[:-1])
 
     with pytest.raises(SetupBuildError, match="SETUP_VOICE_REFERENCE_TRUNCATED"):
@@ -321,6 +374,73 @@ def test_prepare_setup_payload_rejects_truncated_voice_reference(tmp_path: Path,
             tmp_path / "payload",
             distribution="private",
             voice_reference=reference,
+            video_runtime=runtime,
+            validate_schema=False,
+        )
+
+
+def test_private_inno_payload_uses_disk_spanning_for_large_runtime() -> None:
+    script = (ROOT / "installer/windows_setup.iss").read_text(encoding="utf-8")
+    assert "#ifdef PrivatePayload" in script
+    assert "DiskSpanning=yes" in script
+    assert "DiskSliceSize=2100000000" in script
+    assert "video-runtime\\*" in script and "nocompression" in script
+
+
+def test_private_build_hashes_exe_and_all_disk_spanning_parts(tmp_path: Path, monkeypatch) -> None:
+    output = tmp_path / "output"
+    observed: list[str] = []
+
+    def compile_setup(command: list[str], **_: object) -> SimpleNamespace:
+        observed.extend(command)
+        (output / "Olivia-Setup-x64.exe").write_bytes(b"setup")
+        (output / "Olivia-Setup-x64-1.bin").write_bytes(b"runtime")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("installer.build_windows_setup._find_iscc", lambda _: tmp_path / "ISCC.exe")
+    monkeypatch.setattr("installer.build_windows_setup.prepare_setup_payload", lambda *args, **kwargs: None)
+    monkeypatch.setattr("installer.build_windows_setup.subprocess.run", compile_setup)
+
+    result = build_windows_setup(
+        tmp_path / "source",
+        tmp_path / "offline",
+        output,
+        version="fixture",
+        distribution="private",
+        voice_reference=tmp_path / "voice.wav",
+        video_runtime=tmp_path / "runtime.zip",
+    )
+
+    assert "/DPrivatePayload=1" in observed
+    assert [Path(item["path"]).name for item in result["artifacts"]] == [
+        "Olivia-Setup-x64-1.bin",
+        "Olivia-Setup-x64.exe",
+    ]
+    checksum = (output / "Olivia-Setup-x64.exe.sha256").read_text(encoding="ascii")
+    assert "Olivia-Setup-x64-1.bin" in checksum and "Olivia-Setup-x64.exe" in checksum
+
+
+def test_prepare_setup_payload_rejects_runtime_without_exact_python_set(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "runtime.zip"
+    with zipfile.ZipFile(runtime, "w") as archive:
+        archive.writestr("runtime-manifest.json", json.dumps({
+            "schema_version": "olivia.video-runtime-root.v1",
+            "environment": {},
+            "files": [{"path": "fixture.bin", "size_bytes": 1, "sha256": "0" * 64}],
+        }))
+        archive.writestr("fixture.bin", b"x")
+
+    with pytest.raises(SetupBuildError, match="SETUP_VIDEO_RUNTIME_INVALID"):
+        prepare_setup_payload(
+            source,
+            offline,
+            tmp_path / "payload",
+            distribution="private",
+            voice_reference=reference,
+            video_runtime=runtime,
             validate_schema=False,
         )
 


### PR DESCRIPTION
## Scope
- extend the private Windows setup payload contract with one complete video runtime ZIP
- verify runtime size/hash/manifest metadata before packaging
- keep public setup artifacts free of the private runtime and voice bytes
- enable private Inno disk spanning for the large internal distribution package

## Evidence
- exact pair: 24f26d263305199db84d14459ad364565e24596e...df7e2820da986e699982912a60ef48f49e13a17a
- mechanical range-diff from frozen implementation: both commits exact equals
- focused installer tests: 96 passed
- pycompile and git diff --check: pass
- 7 files, 470 changed lines

## Stack boundary
This is the payload-contract half of a strict two-PR stack. Automatic durable install/import/activation is provided by the dependent PR from codex/private-video-runtime-install and must land immediately after this PR. No private runtime or WAV bytes are committed to Git.