### PR TITLE
fix(installer): persist and activate private video runtime

### DIFF
--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -642,6 +642,124 @@ function Install-ManagedVoiceReference {
     }
 }
 
+function Install-ManagedVideoRuntime {
+    param([AllowNull()][object]$VideoRuntime, [Parameter(Mandatory)][string]$InstallRoot)
+
+    if ($null -eq $VideoRuntime) { return $null }
+    $source = [string]$VideoRuntime.path
+    $expectedHash = [string]$VideoRuntime.sha256
+    $expectedSize = [int64]$VideoRuntime.size_bytes
+    if (-not [IO.File]::Exists($source)) { throw 'VIDEO_RUNTIME_MISSING' }
+    if (
+        $expectedSize -lt 1 -or
+        [IO.FileInfo]::new($source).Length -ne $expectedSize -or
+        (Get-Sha256 -LiteralPath $source) -cne $expectedHash
+    ) {
+        throw 'VIDEO_RUNTIME_HASH_MISMATCH'
+    }
+
+    $downloadRoot = Join-Path $InstallRoot 'downloads'
+    $downloadRootExisted = [IO.Directory]::Exists($downloadRoot)
+    Assert-NoReparsePointsInPath -LiteralPath $downloadRoot -ErrorCode 'VIDEO_RUNTIME_INSTALL_PATH_INVALID'
+    New-Item -ItemType Directory -Force -Path $downloadRoot | Out-Null
+    $target = Join-Path $downloadRoot 'Olivia-video-runtime-private.zip'
+    if ((Test-Path -LiteralPath $target) -and (
+        -not [IO.File]::Exists($target) -or
+        (([IO.File]::GetAttributes($target) -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+    )) {
+        throw 'VIDEO_RUNTIME_INSTALL_PATH_INVALID'
+    }
+    if (
+        [IO.File]::Exists($target) -and
+        [IO.FileInfo]::new($target).Length -eq $expectedSize -and
+        (Get-Sha256 -LiteralPath $target) -ceq $expectedHash
+    ) {
+        return [pscustomobject]@{
+            Target = $target; Backup = ''; Existed = $true
+            Changed = $false; DownloadRootExisted = $true
+        }
+    }
+    $transactionId = [guid]::NewGuid().ToString('N')
+    $staged = Join-Path $downloadRoot ('.Olivia-video-runtime.' + $transactionId + '.tmp')
+    $backup = Join-Path $downloadRoot ('.Olivia-video-runtime.' + $transactionId + '.bak')
+    $existed = [IO.File]::Exists($target)
+    $published = $false
+    try {
+        [IO.File]::Copy($source, $staged, $false)
+        if (
+            [IO.FileInfo]::new($staged).Length -ne $expectedSize -or
+            (Get-Sha256 -LiteralPath $staged) -cne $expectedHash
+        ) {
+            throw 'VIDEO_RUNTIME_HASH_MISMATCH'
+        }
+        if ($existed) {
+            [IO.File]::Replace($staged, $target, $backup)
+        } else {
+            [IO.File]::Move($staged, $target)
+        }
+        $published = $true
+        return [pscustomobject]@{
+            Target = $target; Backup = $backup; Existed = $existed
+            Changed = $true; DownloadRootExisted = $downloadRootExisted
+        }
+    } catch {
+        $failure = [string]$_.Exception.Message
+        if ($published) {
+            try {
+                if ($existed) {
+                    [IO.File]::Delete($target)
+                    [IO.File]::Move($backup, $target)
+                } else {
+                    [IO.File]::Delete($target)
+                }
+            } catch {
+                throw 'VIDEO_RUNTIME_INSTALL_ROLLBACK_FAILED'
+            }
+        }
+        if ($failure -in @('VIDEO_RUNTIME_HASH_MISMATCH', 'VIDEO_RUNTIME_INSTALL_PATH_INVALID')) {
+            throw $failure
+        }
+        throw 'VIDEO_RUNTIME_INSTALL_FAILED'
+    } finally {
+        try { [IO.File]::Delete($staged) } catch {}
+    }
+}
+
+function Restore-ManagedVideoRuntimeTransaction {
+    param([AllowNull()][object]$Transaction)
+
+    if ($null -eq $Transaction -or -not [bool]$Transaction.Changed) { return }
+    try {
+        if ([bool]$Transaction.Existed) {
+            if (-not [IO.File]::Exists([string]$Transaction.Backup)) {
+                throw 'VIDEO_RUNTIME_INSTALL_ROLLBACK_FAILED'
+            }
+            [IO.File]::Delete([string]$Transaction.Target)
+            [IO.File]::Move([string]$Transaction.Backup, [string]$Transaction.Target)
+        } else {
+            [IO.File]::Delete([string]$Transaction.Target)
+        }
+        $downloadRoot = Split-Path -Parent ([string]$Transaction.Target)
+        if (
+            -not [bool]$Transaction.DownloadRootExisted -and
+            [IO.Directory]::Exists($downloadRoot) -and
+            [IO.Directory]::GetFileSystemEntries($downloadRoot).Length -eq 0
+        ) {
+            [IO.Directory]::Delete($downloadRoot)
+        }
+    } catch {
+        throw 'VIDEO_RUNTIME_INSTALL_ROLLBACK_FAILED'
+    }
+}
+
+function Complete-ManagedVideoRuntimeTransaction {
+    param([AllowNull()][object]$Transaction)
+
+    if ($null -ne $Transaction -and [bool]$Transaction.Changed -and [string]$Transaction.Backup) {
+        try { [IO.File]::Delete([string]$Transaction.Backup) } catch {}
+    }
+}
+
 function Get-ManagedInstallTransactionNames {
     return @('local_backend', 'launcher', 'START.cmd', 'START.vbs', 'CONFIGURE.cmd', 'UNINSTALL.cmd', '.olivia-full-patch.json')
 }
@@ -814,7 +932,19 @@ function Get-OfflineCoreAssets {
         if ($manifest.video_runtime.path -cne 'video-runtime/Olivia-video-runtime-private.zip') {
             throw 'OFFLINE_CORE_MANIFEST_INVALID'
         }
-        $videoRuntime = Resolve-OfflineAsset -Root $Root -Asset $manifest.video_runtime
+        try {
+            $videoRuntimePath = Resolve-OfflineAsset -Root $Root -Asset $manifest.video_runtime
+        } catch {
+            if ($_.Exception.Message -eq 'OFFLINE_CORE_ASSET_MISSING') {
+                throw 'VIDEO_RUNTIME_MISSING'
+            }
+            if ($_.Exception.Message -in @('OFFLINE_CORE_ASSET_SIZE_MISMATCH', 'OFFLINE_CORE_ASSET_HASH_MISMATCH')) {
+                throw 'VIDEO_RUNTIME_HASH_MISMATCH'
+            }
+            throw 'VIDEO_RUNTIME_INVALID'
+        }
+        $videoRuntime = $manifest.video_runtime
+        $videoRuntime.path = $videoRuntimePath
     }
     $expectedWheelAssets = Get-ExpectedOfflineWheels
     $wheelPaths = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
@@ -1080,17 +1210,30 @@ if ($installExitCode -ne 0) {
     exit $installExitCode
 }
 try {
+    $videoRuntimeTransaction = Install-ManagedVideoRuntime -VideoRuntime $coreAssets.VideoRuntime -InstallRoot $Destination
     Install-ManagedVoiceReference -VoiceReference $coreAssets.VoiceReference -InstallRoot $Destination
 } catch {
-    $voiceFailure = [string]$_.Exception.Message
+    $assetFailure = [string]$_.Exception.Message
+    $rollbackFailed = $false
+    try {
+        Restore-ManagedVideoRuntimeTransaction -Transaction $videoRuntimeTransaction
+    } catch {
+        $rollbackFailed = $true
+    }
     try {
         Repair-ManagedInstallTransaction -ProductRoot $productRoot -InstallRoot $Destination -RuntimeRoot $runtimeRoot
-    } catch { throw 'VOICE_REFERENCE_INSTALL_ROLLBACK_FAILED' }
-    throw $voiceFailure
+    } catch {
+        $rollbackFailed = $true
+    }
+    if ($rollbackFailed) {
+        throw 'PRIVATE_ASSET_INSTALL_ROLLBACK_FAILED'
+    }
+    throw $assetFailure
 }
 
 try { [IO.File]::Move("$installTransaction.active", "$installTransaction.cleanup"); Repair-ManagedInstallTransaction -ProductRoot $productRoot -InstallRoot $Destination -RuntimeRoot $runtimeRoot }
 catch { throw 'VOICE_REFERENCE_INSTALL_CLEANUP_FAILED' }
+Complete-ManagedVideoRuntimeTransaction -Transaction $videoRuntimeTransaction
 if (-not $SetupResultPath) { $installOutput | Write-Output }
 
 $LASTEXITCODE = 0

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -642,6 +642,78 @@ function Install-ManagedVoiceReference {
     }
 }
 
+function Copy-FileWithSha256 {
+    param(
+        [Parameter(Mandatory)][string]$Source,
+        [Parameter(Mandatory)][string]$Destination
+    )
+
+    $sourceStream, $destinationStream, $hasher = $null, $null, $null
+    try {
+        $sourceStream = [IO.File]::Open($Source, [IO.FileMode]::Open, [IO.FileAccess]::Read, [IO.FileShare]::Read)
+        $destinationStream = [IO.File]::Open($Destination, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+        $hasher = [Security.Cryptography.SHA256]::Create()
+        $buffer = New-Object byte[] (4 * 1024 * 1024)
+        $empty = New-Object byte[] 0
+        [int64]$size = 0
+        while (($read = $sourceStream.Read($buffer, 0, $buffer.Length)) -gt 0) {
+            [void]$hasher.TransformBlock($buffer, 0, $read, $buffer, 0)
+            $destinationStream.Write($buffer, 0, $read)
+            $size += $read
+        }
+        [void]$hasher.TransformFinalBlock($empty, 0, 0)
+        $destinationStream.Flush($true)
+        return [pscustomobject]@{
+            SizeBytes = $size
+            Sha256 = ([BitConverter]::ToString($hasher.Hash)).Replace('-', '').ToLowerInvariant()
+        }
+    } finally {
+        if ($null -ne $hasher) { $hasher.Dispose() }
+        if ($null -ne $destinationStream) { $destinationStream.Dispose() }
+        if ($null -ne $sourceStream) { $sourceStream.Dispose() }
+    }
+}
+
+function Remove-ManagedVideoRuntimeArtifact {
+    param([Parameter(Mandatory)][string]$LiteralPath)
+
+    if (-not (Test-Path -LiteralPath $LiteralPath)) { return }
+    for ($attempt = 0; $attempt -lt 3; $attempt++) {
+        try {
+            if ([IO.File]::Exists($LiteralPath)) {
+                [IO.File]::Delete($LiteralPath)
+            } elseif (Test-Path -LiteralPath $LiteralPath) {
+                throw 'VIDEO_RUNTIME_INSTALL_CLEANUP_FAILED'
+            }
+            if (-not (Test-Path -LiteralPath $LiteralPath)) { return }
+        } catch {
+            # Retry briefly for antivirus/indexer handles; never recurse into an unexpected leaf.
+        }
+        if ($attempt -lt 2) { Start-Sleep -Milliseconds 100 }
+    }
+    throw 'VIDEO_RUNTIME_INSTALL_CLEANUP_FAILED'
+}
+
+function Remove-StaleManagedVideoRuntimeArtifacts {
+    param(
+        [Parameter(Mandatory)][string]$DownloadRoot,
+        [Parameter(Mandatory)][string[]]$Extensions
+    )
+
+    foreach ($entry in [IO.Directory]::EnumerateFileSystemEntries($DownloadRoot)) {
+        $leaf = [IO.Path]::GetFileName($entry)
+        $match = [regex]::Match($leaf, '^\.Olivia-video-runtime\.[0-9a-f]{32}\.(tmp|bak)$')
+        if (-not $match.Success -or $Extensions -cnotcontains $match.Groups[1].Value) { continue }
+        if (
+            -not [IO.File]::Exists($entry) -or
+            (([IO.File]::GetAttributes($entry) -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+        ) {
+            throw 'VIDEO_RUNTIME_INSTALL_CLEANUP_FAILED'
+        }
+        Remove-ManagedVideoRuntimeArtifact -LiteralPath $entry
+    }
+}
+
 function Install-ManagedVideoRuntime {
     param([AllowNull()][object]$VideoRuntime, [Parameter(Mandatory)][string]$InstallRoot)
 
@@ -649,13 +721,14 @@ function Install-ManagedVideoRuntime {
     $source = [string]$VideoRuntime.path
     $expectedHash = [string]$VideoRuntime.sha256
     $expectedSize = [int64]$VideoRuntime.size_bytes
-    if (-not [IO.File]::Exists($source)) { throw 'VIDEO_RUNTIME_MISSING' }
     if (
+        $VideoRuntime.PSObject.Properties.Name -cnotcontains 'verified' -or
+        $VideoRuntime.verified -isnot [bool] -or
+        -not [bool]$VideoRuntime.verified -or
         $expectedSize -lt 1 -or
-        [IO.FileInfo]::new($source).Length -ne $expectedSize -or
-        (Get-Sha256 -LiteralPath $source) -cne $expectedHash
+        $expectedHash -cnotmatch '^[0-9a-f]{64}$'
     ) {
-        throw 'VIDEO_RUNTIME_HASH_MISMATCH'
+        throw 'VIDEO_RUNTIME_INVALID'
     }
 
     $downloadRoot = Join-Path $InstallRoot 'downloads'
@@ -669,15 +742,21 @@ function Install-ManagedVideoRuntime {
     )) {
         throw 'VIDEO_RUNTIME_INSTALL_PATH_INVALID'
     }
+    Remove-StaleManagedVideoRuntimeArtifacts -DownloadRoot $downloadRoot -Extensions @('tmp')
     if (
         [IO.File]::Exists($target) -and
         [IO.FileInfo]::new($target).Length -eq $expectedSize -and
         (Get-Sha256 -LiteralPath $target) -ceq $expectedHash
     ) {
+        Remove-StaleManagedVideoRuntimeArtifacts -DownloadRoot $downloadRoot -Extensions @('bak')
         return [pscustomobject]@{
             Target = $target; Backup = ''; Existed = $true
             Changed = $false; DownloadRootExisted = $true
         }
+    }
+    if (-not [IO.File]::Exists($source)) { throw 'VIDEO_RUNTIME_MISSING' }
+    if ([IO.FileInfo]::new($source).Length -ne $expectedSize) {
+        throw 'VIDEO_RUNTIME_HASH_MISMATCH'
     }
     $transactionId = [guid]::NewGuid().ToString('N')
     $staged = Join-Path $downloadRoot ('.Olivia-video-runtime.' + $transactionId + '.tmp')
@@ -685,10 +764,10 @@ function Install-ManagedVideoRuntime {
     $existed = [IO.File]::Exists($target)
     $published = $false
     try {
-        [IO.File]::Copy($source, $staged, $false)
+        $copied = Copy-FileWithSha256 -Source $source -Destination $staged
         if (
-            [IO.FileInfo]::new($staged).Length -ne $expectedSize -or
-            (Get-Sha256 -LiteralPath $staged) -cne $expectedHash
+            [int64]$copied.SizeBytes -ne $expectedSize -or
+            [string]$copied.Sha256 -cne $expectedHash
         ) {
             throw 'VIDEO_RUNTIME_HASH_MISMATCH'
         }
@@ -721,7 +800,7 @@ function Install-ManagedVideoRuntime {
         }
         throw 'VIDEO_RUNTIME_INSTALL_FAILED'
     } finally {
-        try { [IO.File]::Delete($staged) } catch {}
+        Remove-ManagedVideoRuntimeArtifact -LiteralPath $staged
     }
 }
 
@@ -756,7 +835,7 @@ function Complete-ManagedVideoRuntimeTransaction {
     param([AllowNull()][object]$Transaction)
 
     if ($null -ne $Transaction -and [bool]$Transaction.Changed -and [string]$Transaction.Backup) {
-        try { [IO.File]::Delete([string]$Transaction.Backup) } catch {}
+        Remove-ManagedVideoRuntimeArtifact -LiteralPath ([string]$Transaction.Backup)
     }
 }
 
@@ -943,8 +1022,12 @@ function Get-OfflineCoreAssets {
             }
             throw 'VIDEO_RUNTIME_INVALID'
         }
-        $videoRuntime = $manifest.video_runtime
-        $videoRuntime.path = $videoRuntimePath
+        $videoRuntime = [pscustomobject]@{
+            path = $videoRuntimePath
+            size_bytes = [int64]$manifest.video_runtime.size_bytes
+            sha256 = [string]$manifest.video_runtime.sha256
+            verified = [bool]$true
+        }
     }
     $expectedWheelAssets = Get-ExpectedOfflineWheels
     $wheelPaths = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
@@ -1233,7 +1316,8 @@ try {
 
 try { [IO.File]::Move("$installTransaction.active", "$installTransaction.cleanup"); Repair-ManagedInstallTransaction -ProductRoot $productRoot -InstallRoot $Destination -RuntimeRoot $runtimeRoot }
 catch { throw 'VOICE_REFERENCE_INSTALL_CLEANUP_FAILED' }
-Complete-ManagedVideoRuntimeTransaction -Transaction $videoRuntimeTransaction
+try { Complete-ManagedVideoRuntimeTransaction -Transaction $videoRuntimeTransaction }
+catch { Write-Warning 'VIDEO_RUNTIME_INSTALL_CLEANUP_DEFERRED' }
 if (-not $SetupResultPath) { $installOutput | Write-Output }
 
 $LASTEXITCODE = 0

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -764,8 +764,7 @@ def _configured_video_capability_installer(
                     install_root / "downloads",
                     install_root.parent / "downloads",
                 ):
-                    if candidate.is_dir():
-                        runtime_search_roots.append(candidate.resolve())
+                    runtime_search_roots.append(candidate.resolve())
         explicit_runtime = str(
             environ.get("OLIVIA_VIDEO_RUNTIME_ARCHIVE", "")
         ).strip()
@@ -787,6 +786,7 @@ def _configured_video_capability_installer(
             readiness_probe=readiness,
             artifact_roots=artifact_roots,
             runtime_archives=tuple(dict.fromkeys(runtime_archives)),
+            runtime_archive_roots=tuple(dict.fromkeys(runtime_search_roots)),
             runtime_environment_applier=os.environ.update,
         )
     except (OSError, RuntimeError, TypeError, ValueError):

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -37,6 +37,10 @@ def _wave_metadata(**changes: object) -> dict[str, object]:
     return value
 
 
+def _managed_video_runtime(product: Path) -> Path:
+    return product / "install/downloads/Olivia-video-runtime-private.zip"
+
+
 def test_first_install_consumes_only_bundled_core_assets() -> None:
     script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
 
@@ -54,6 +58,7 @@ def test_first_install_consumes_only_bundled_core_assets() -> None:
     assert "provision_mem0_embedding.py" not in script
     assert "BAAI/bge-small-zh-v1.5" not in script
     assert "VOICE_REFERENCE_PRIVATE_MANIFEST_REQUIRED" in script
+    assert "Install-ManagedVideoRuntime -VideoRuntime $coreAssets.VideoRuntime" in script
 
 
 def test_installer_accepts_only_complete_private_video_runtime_manifest() -> None:
@@ -102,6 +107,12 @@ def test_public_schema_accepts_only_complete_hash_locked_private_assets() -> Non
     missing_marker = deepcopy(example)
     del missing_marker["distribution"]
     assert list(validator.iter_errors(missing_marker))
+    wrong_path = deepcopy(example)
+    wrong_path["voice_reference"]["path"] = "voice/arbitrary.wav"
+    assert list(validator.iter_errors(wrong_path))
+    extra_field = deepcopy(example)
+    extra_field["voice_reference"]["license"] = "caller-asserted"
+    assert list(validator.iter_errors(extra_field))
 
 
 def test_public_schema_rejects_nonfixed_runtime_and_incomplete_wheel_closure() -> None:
@@ -216,6 +227,8 @@ def _run_runtime_publish_fixture(
     bootstrap_exit_code: int, bootstrap_replaces_managed_app: bool = False,
     voice_reference: bytes | None = None, voice_reference_sha256: str | None = None,
     voice_reference_wave: dict[str, object] | None = None, voice_reference_missing: bool = False,
+    video_runtime: bytes | None = None, video_runtime_sha256: str | None = None,
+    video_runtime_missing: bool = False,
     block_voice_sidecar: bool = False, cleanup_obstruction: str | None = None,
     product_root: Path | None = None, existing_voice_pair: bool = False,
     interrupt_voice_staging: bool = False, interrupt_after_bootstrap: bool = False, existing_runtime: bool = True, seed_existing_install: bool = True,
@@ -279,9 +292,10 @@ def _run_runtime_publish_fixture(
     script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
     original = "$coreAssets = Get-OfflineCoreAssets -Root $offlineRoot -ManifestPath $offlineManifestPath -RequirementsPath $requirements"
     replacement = (
-        "$voiceManifest = if ($env:BSIDE_TEST_VOICE_MANIFEST) { [IO.File]::ReadAllText($env:BSIDE_TEST_VOICE_MANIFEST) | ConvertFrom-Json } else { $null }\n"
+        "$voiceManifest = if ($env:BSIDE_TEST_PRIVATE_MANIFEST) { [IO.File]::ReadAllText($env:BSIDE_TEST_PRIVATE_MANIFEST) | ConvertFrom-Json } else { $null }\n"
         "$voiceReference = if ($voiceManifest) { $voiceManifest.voice_reference.path = $env:BSIDE_TEST_VOICE_REFERENCE; $voiceManifest.voice_reference } else { $null }\n"
-        "$coreAssets = @{ Runtime = $env:BSIDE_TEST_RUNTIME_ZIP; PipBootstrap = ''; Wheelhouse = ''; VoiceReference = $voiceReference }"
+        "$videoRuntime = if ($voiceManifest) { $voiceManifest.video_runtime.path = $env:BSIDE_TEST_VIDEO_RUNTIME; $voiceManifest.video_runtime } else { $null }\n"
+        "$coreAssets = @{ Runtime = $env:BSIDE_TEST_RUNTIME_ZIP; PipBootstrap = ''; Wheelhouse = ''; VoiceReference = $voiceReference; VideoRuntime = $videoRuntime }"
     )
     assert script.count(original) == 1
     script = script.replace(original, replacement)
@@ -316,6 +330,9 @@ def _run_runtime_publish_fixture(
         old_backend = product / "install" / "local_backend"
         old_backend.mkdir(parents=True)
         (old_backend / "old-backend.txt").write_text("preserve", encoding="utf-8")
+        old_video_runtime = _managed_video_runtime(product)
+        old_video_runtime.parent.mkdir(parents=True)
+        old_video_runtime.write_bytes(b"old-video-runtime")
     if block_voice_sidecar:
         installed = _managed_reference(product)
         installed.parent.mkdir(parents=True)
@@ -329,16 +346,25 @@ def _run_runtime_publish_fixture(
     environment = os.environ.copy()
     environment["BSIDE_TEST_RUNTIME_ZIP"] = str(runtime_zip)
     if voice_reference is not None:
+        if video_runtime is None:
+            video_runtime = b"video-runtime-fixture"
         reference = tmp_path / "distributor-reference.wav"
         if not voice_reference_missing:
             reference.write_bytes(voice_reference)
+        runtime_archive = tmp_path / "Olivia-video-runtime-private.zip"
+        if not video_runtime_missing:
+            runtime_archive.write_bytes(video_runtime)
         manifest = {"voice_reference": {"path": "voice/olivia-reference.wav", "size_bytes": len(voice_reference),
-            "sha256": voice_reference_sha256 or hashlib.sha256(voice_reference).hexdigest(),
-            "wave": voice_reference_wave if voice_reference_wave is not None else _wave_metadata()}}
+                    "sha256": voice_reference_sha256 or hashlib.sha256(voice_reference).hexdigest(),
+                    "wave": voice_reference_wave if voice_reference_wave is not None else _wave_metadata()},
+                    "video_runtime": {"path": "video-runtime/Olivia-video-runtime-private.zip",
+                                       "size_bytes": len(video_runtime),
+                                       "sha256": video_runtime_sha256 or hashlib.sha256(video_runtime).hexdigest()}}
         manifest_path = tmp_path / "offline-core-assets.json"
         manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
         environment["BSIDE_TEST_VOICE_REFERENCE"] = str(reference)
-        environment["BSIDE_TEST_VOICE_MANIFEST"] = str(manifest_path)
+        environment["BSIDE_TEST_VIDEO_RUNTIME"] = str(runtime_archive)
+        environment["BSIDE_TEST_PRIVATE_MANIFEST"] = str(manifest_path)
     result = subprocess.run(
         [
             "powershell",
@@ -378,6 +404,7 @@ def test_first_install_publishes_voice_reference_to_preserved_data_path(tmp_path
     installed = _managed_reference(product)
     assert result.returncode == 0, result.stderr or result.stdout
     assert installed.read_bytes() == _voice_reference_bytes()
+    assert _managed_video_runtime(product).read_bytes() == b"video-runtime-fixture"
     integrity = json.loads(installed.with_suffix(".json").read_text(encoding="utf-8"))
     assert integrity == {"schema_version": "olivia.managed-voice-reference.v1", "path": "linli-reference.wav",
         "size_bytes": installed.stat().st_size, "sha256": hashlib.sha256(installed.read_bytes()).hexdigest(),
@@ -396,6 +423,7 @@ def test_voice_publish_failure_restores_managed_app_runtime_and_voice(tmp_path: 
     assert (backend / "old-backend.txt").read_text() == "preserve" and not (backend / "new-backend.txt").exists()
     assert (runtime / "old-runtime.txt").read_text() == "preserve" and not (runtime / "python.exe").exists()
     assert installed.read_bytes() == b"old-reference" and installed.with_suffix(".json").is_dir()
+    assert _managed_video_runtime(product).read_bytes() == b"old-video-runtime"
     assert not list(product.glob(".install.rollback.*")) and not list((product / "runtime").glob("*.backup.*"))
 
 
@@ -465,6 +493,19 @@ def test_interrupted_voice_staging_has_marker_and_is_recovered(tmp_path: Path) -
     assert rejected.returncode != 0 and "VOICE_REFERENCE_INVALID" in rejected.stdout + rejected.stderr
     assert installed.read_bytes() == b"old-reference" and installed.with_suffix(".json").read_bytes() == b"old-sidecar"
     assert not list(installed.parent.glob(".linli-reference.*"))
+
+
+def test_first_install_rejects_bad_video_runtime_before_publish(tmp_path: Path) -> None:
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=0,
+        voice_reference=_voice_reference_bytes(),
+        video_runtime_sha256="0" * 64,
+    )
+
+    assert result.returncode != 0
+    assert "VIDEO_RUNTIME_HASH_MISMATCH" in result.stdout + result.stderr
+    assert not _managed_video_runtime(product).exists()
 
 
 def test_patch_failure_restores_existing_runtime_and_cleans_transaction_paths(

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -69,7 +69,8 @@ def test_installer_accepts_only_complete_private_video_runtime_manifest() -> Non
     assert "$manifestNames += @('distribution', 'voice_reference', 'video_runtime')" in script
     assert "Assert-OfflineObjectShape -Value $manifest.video_runtime -Names @('path', 'size_bytes', 'sha256')" in script
     assert "$manifest.video_runtime.path -cne 'video-runtime/Olivia-video-runtime-private.zip'" in script
-    assert "$videoRuntime = Resolve-OfflineAsset -Root $Root -Asset $manifest.video_runtime" in script
+    assert "$videoRuntimePath = Resolve-OfflineAsset -Root $Root -Asset $manifest.video_runtime" in script
+    assert "verified = [bool]$true" in script
     assert "VideoRuntime = $videoRuntime" in script
 
 
@@ -229,6 +230,9 @@ def _run_runtime_publish_fixture(
     voice_reference_wave: dict[str, object] | None = None, voice_reference_missing: bool = False,
     video_runtime: bytes | None = None, video_runtime_sha256: str | None = None,
     video_runtime_missing: bool = False,
+    video_runtime_verified: bool = True, preinstalled_video_runtime: bytes | None = None,
+    stale_video_backup: bytes | None = None, reject_video_source_rehash: bool = False,
+    block_video_cleanup: bool = False,
     block_voice_sidecar: bool = False, cleanup_obstruction: str | None = None,
     product_root: Path | None = None, existing_voice_pair: bool = False,
     interrupt_voice_staging: bool = False, interrupt_after_bootstrap: bool = False, existing_runtime: bool = True, seed_existing_install: bool = True,
@@ -297,6 +301,14 @@ def _run_runtime_publish_fixture(
         "$videoRuntime = if ($voiceManifest) { $voiceManifest.video_runtime.path = $env:BSIDE_TEST_VIDEO_RUNTIME; $voiceManifest.video_runtime } else { $null }\n"
         "$coreAssets = @{ Runtime = $env:BSIDE_TEST_RUNTIME_ZIP; PipBootstrap = ''; Wheelhouse = ''; VoiceReference = $voiceReference; VideoRuntime = $videoRuntime }"
     )
+    if reject_video_source_rehash:
+        replacement = (
+            "$script:OriginalGetSha256 = ${function:Get-Sha256}\n"
+            "function Get-Sha256 { param([Parameter(Mandatory)][string]$LiteralPath) "
+            "if ($LiteralPath -ceq $env:BSIDE_TEST_VIDEO_RUNTIME) { throw 'VIDEO_RUNTIME_SOURCE_REHASHED' }; "
+            "& $script:OriginalGetSha256 -LiteralPath $LiteralPath }\n"
+            + replacement
+        )
     assert script.count(original) == 1
     script = script.replace(original, replacement)
     dependency_probe = "if (-not (Test-ManagedServerDependencies -PythonExe $candidateExe)) {"
@@ -319,6 +331,16 @@ def _run_runtime_publish_fixture(
         marker = "$installExitCode = $LASTEXITCODE"
         assert script.count(marker) == 1
         script = script.replace(marker, "[Environment]::FailFast('SYNTHETIC_BOOTSTRAP_INTERRUPTION')\n" + marker)
+    if block_video_cleanup:
+        marker = "Complete-ManagedVideoRuntimeTransaction -Transaction $videoRuntimeTransaction"
+        obstruction = (
+            "if ($videoRuntimeTransaction.Backup) { "
+            "[IO.File]::Delete([string]$videoRuntimeTransaction.Backup); "
+            "[IO.Directory]::CreateDirectory([string]$videoRuntimeTransaction.Backup) | Out-Null }\n"
+            + marker
+        )
+        assert script.count(marker) == 1
+        script = script.replace(marker, obstruction)
     test_script = tmp_path / "Install.ps1"
     test_script.write_text(script, encoding="utf-8-sig")
     product = product_root or tmp_path / "product"
@@ -326,6 +348,14 @@ def _run_runtime_publish_fixture(
     if existing_runtime and not old_runtime.exists():
         old_runtime.mkdir(parents=True)
         (old_runtime / "old-runtime.txt").write_text("preserve", encoding="utf-8")
+    if preinstalled_video_runtime is not None:
+        installed_video_runtime = _managed_video_runtime(product)
+        installed_video_runtime.parent.mkdir(parents=True, exist_ok=True)
+        installed_video_runtime.write_bytes(preinstalled_video_runtime)
+        if stale_video_backup is not None:
+            (installed_video_runtime.parent / (".Olivia-video-runtime." + "0" * 32 + ".bak")).write_bytes(
+                stale_video_backup
+            )
     if bootstrap_replaces_managed_app and seed_existing_install and not (product / "install/local_backend").exists():
         old_backend = product / "install" / "local_backend"
         old_backend.mkdir(parents=True)
@@ -359,7 +389,8 @@ def _run_runtime_publish_fixture(
                     "wave": voice_reference_wave if voice_reference_wave is not None else _wave_metadata()},
                     "video_runtime": {"path": "video-runtime/Olivia-video-runtime-private.zip",
                                        "size_bytes": len(video_runtime),
-                                       "sha256": video_runtime_sha256 or hashlib.sha256(video_runtime).hexdigest()}}
+                                       "sha256": video_runtime_sha256 or hashlib.sha256(video_runtime).hexdigest(),
+                                       "verified": video_runtime_verified}}
         manifest_path = tmp_path / "offline-core-assets.json"
         manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
         environment["BSIDE_TEST_VOICE_REFERENCE"] = str(reference)
@@ -506,6 +537,88 @@ def test_first_install_rejects_bad_video_runtime_before_publish(tmp_path: Path) 
     assert result.returncode != 0
     assert "VIDEO_RUNTIME_HASH_MISMATCH" in result.stdout + result.stderr
     assert not _managed_video_runtime(product).exists()
+
+
+def test_matching_video_runtime_skips_a_missing_payload_archive(tmp_path: Path) -> None:
+    runtime = b"video-runtime-fixture"
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=0,
+        voice_reference=_voice_reference_bytes(),
+        video_runtime=runtime,
+        video_runtime_missing=True,
+        preinstalled_video_runtime=runtime,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert _managed_video_runtime(product).read_bytes() == runtime
+
+
+def test_matching_video_runtime_recovers_a_stale_backup_on_retry(tmp_path: Path) -> None:
+    runtime = b"video-runtime-fixture"
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=0,
+        voice_reference=_voice_reference_bytes(),
+        video_runtime=runtime,
+        video_runtime_missing=True,
+        preinstalled_video_runtime=runtime,
+        stale_video_backup=b"old-video-runtime",
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert _managed_video_runtime(product).read_bytes() == runtime
+    assert not list(_managed_video_runtime(product).parent.glob(".Olivia-video-runtime.*.bak"))
+
+
+def test_video_runtime_publish_rejects_an_unverified_test_asset(tmp_path: Path) -> None:
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=0,
+        voice_reference=_voice_reference_bytes(),
+        video_runtime_verified=False,
+    )
+
+    assert result.returncode != 0
+    assert "VIDEO_RUNTIME_INVALID" in result.stdout + result.stderr
+    assert not _managed_video_runtime(product).exists()
+
+
+def test_fresh_video_runtime_does_not_rehash_the_verified_source(tmp_path: Path) -> None:
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=0,
+        voice_reference=_voice_reference_bytes(),
+        reject_video_source_rehash=True,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert _managed_video_runtime(product).read_bytes() == b"video-runtime-fixture"
+
+
+def test_video_runtime_cleanup_failure_is_deferred_without_undoing_publish(
+    tmp_path: Path,
+) -> None:
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=0,
+        bootstrap_replaces_managed_app=True,
+        voice_reference=_voice_reference_bytes(),
+        block_video_cleanup=True,
+    )
+
+    output = result.stdout + result.stderr
+    target = _managed_video_runtime(product)
+    assert result.returncode == 0, output
+    assert "VIDEO_RUNTIME_INSTALL_CLEANUP_DEFERRED" in output
+    assert target.read_bytes() == b"video-runtime-fixture"
+    assert (product / "install/local_backend/new-backend.txt").is_file()
+    assert (product / "runtime/python-3.12.10-embed-amd64/python.exe").is_file()
+    assert not list(product.glob(".install.rollback.*"))
+    assert not list((product / "runtime").glob("python-3.12.10-embed-amd64.backup.*"))
+    blocked = list(target.parent.glob(".Olivia-video-runtime.*.bak"))
+    assert len(blocked) == 1 and blocked[0].is_dir()
+    shutil.rmtree(blocked[0])
 
 
 def test_patch_failure_restores_existing_runtime_and_cleans_transaction_paths(

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -461,18 +461,21 @@ def test_configured_installer_activates_runtime_for_current_server_process(
     )
     monkeypatch.setattr(original_client_server.os, "environ", process_environment)
 
+    install_root = (tmp_path / "install").resolve()
     assert original_client_server._configured_video_capability_installer(
-        {}, (tmp_path / "data").resolve()
+        {"OLIVIA_INSTALL_ROOT": str(install_root)}, (tmp_path / "data").resolve()
     ) is not None
     observed["runtime_environment_applier"]({"OLIVIA_LATENTSYNC_PYTHON": "runtime"})
 
     assert process_environment["OLIVIA_LATENTSYNC_PYTHON"] == "runtime"
+    assert install_root / "downloads" in observed["runtime_archive_roots"]
 
 
-def test_complete_download_automatically_prepares_adjacent_runtime_archive(
+def test_complete_download_automatically_prepares_new_runtime_archive(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    archive = _runtime_archive(tmp_path)
+    archive_root = (tmp_path / "downloads").resolve()
+    archive_root.mkdir()
     data_root = (tmp_path / "data").resolve()
     manifest = _runtime_ready_manifest()
     _prepare_runtime_dependencies(data_root, manifest)
@@ -485,8 +488,11 @@ def test_complete_download_automatically_prepares_adjacent_runtime_archive(
             "ordinary_missing_dependencies": [],
             "music_ready": True,
         },
-        runtime_archives=(archive,),
+        runtime_archive_roots=(archive_root,),
     )
+
+    assert installer.status()["runtime_import"]["state"] == "required"
+    _runtime_archive(archive_root)
 
     deadline = time.monotonic() + 2
     while time.monotonic() < deadline and installer.status()["runtime_import"]["state"] != "ready":

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -502,31 +502,35 @@ def test_complete_download_automatically_prepares_new_runtime_archive(
     assert [item["state"] for item in installer.status()["bundles"]] == ["ready", "ready"]
 
 
-def test_failed_discovered_runtime_recovers_only_after_archive_replacement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    archive = (tmp_path / "downloads" / "Olivia-video-runtime-fixture.zip").resolve()
-    archive.parent.mkdir()
-    with zipfile.ZipFile(archive, "w") as payload:
-        payload.writestr("runtime-manifest.json", "{}")
+def test_failed_discovered_runtimes_retry_only_after_archive_replacement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = (tmp_path / "downloads").resolve()
+    archive_root.mkdir()
     replacement = _runtime_archive(tmp_path / "replacement")
     manifest = _runtime_ready_manifest()
     data_root = (tmp_path / "data").resolve()
     _prepare_runtime_dependencies(data_root, manifest)
     monkeypatch.setattr(video_capability_install, "_runtime_environment_is_portable", lambda *_: True)
     installer = VideoCapabilityInstaller(
-        data_root=data_root, manifest=manifest,
-        readiness_probe=lambda _environment: {"ordinary_missing_dependencies": [], "music_ready": True},
-        runtime_archive_roots=(archive.parent,),
+        data_root=data_root, manifest=manifest, readiness_probe=lambda _environment: {"ordinary_missing_dependencies": [], "music_ready": True}, runtime_archive_roots=(archive_root,),
     )
-
-    def wait_for(state: str) -> str:
-        deadline = time.monotonic() + 2
-        while time.monotonic() < deadline and installer.status()["runtime_import"]["state"] != state:
-            time.sleep(0.01)
-        return str(installer.status()["runtime_import"]["state"])
-
-    assert wait_for("failed") == "failed"
-    replacement.replace(archive)
-    assert wait_for("ready") == "ready"
+    attempts: list[Path] = []
+    import_runtime_archive = installer.import_runtime_archive
+    monkeypatch.setattr(installer, "import_runtime_archive", lambda *, runtime_archive: (attempts.append(runtime_archive), import_runtime_archive(runtime_archive=runtime_archive))[1])
+    archives = tuple((archive_root / f"Olivia-video-runtime-{name}.zip").resolve() for name in ("a", "b"))
+    for archive in archives:
+        with zipfile.ZipFile(archive, "w") as payload:
+            payload.writestr("runtime-manifest.json", "{}")
+    deadline = time.monotonic() + 0.5
+    while time.monotonic() < deadline:
+        installer.status()
+        time.sleep(0.01)
+    assert len(attempts) == 2 and set(attempts) == set(archives)
+    replacement.replace(archives[0])
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline and installer.status()["runtime_import"]["state"] != "ready":
+        time.sleep(0.01)
+    assert installer.status()["runtime_import"]["state"] == "ready"
+    assert len(attempts) == 3 and attempts[-1] == archives[0]
 
 
 def test_complete_download_reports_missing_runtime_archive_instead_of_idle(

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -502,6 +502,33 @@ def test_complete_download_automatically_prepares_new_runtime_archive(
     assert [item["state"] for item in installer.status()["bundles"]] == ["ready", "ready"]
 
 
+def test_failed_discovered_runtime_recovers_only_after_archive_replacement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive = (tmp_path / "downloads" / "Olivia-video-runtime-fixture.zip").resolve()
+    archive.parent.mkdir()
+    with zipfile.ZipFile(archive, "w") as payload:
+        payload.writestr("runtime-manifest.json", "{}")
+    replacement = _runtime_archive(tmp_path / "replacement")
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    monkeypatch.setattr(video_capability_install, "_runtime_environment_is_portable", lambda *_: True)
+    installer = VideoCapabilityInstaller(
+        data_root=data_root, manifest=manifest,
+        readiness_probe=lambda _environment: {"ordinary_missing_dependencies": [], "music_ready": True},
+        runtime_archive_roots=(archive.parent,),
+    )
+
+    def wait_for(state: str) -> str:
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and installer.status()["runtime_import"]["state"] != state:
+            time.sleep(0.01)
+        return str(installer.status()["runtime_import"]["state"])
+
+    assert wait_for("failed") == "failed"
+    replacement.replace(archive)
+    assert wait_for("ready") == "ready"
+
+
 def test_complete_download_reports_missing_runtime_archive_instead_of_idle(
     tmp_path: Path,
 ) -> None:

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -662,7 +662,7 @@ class VideoCapabilityInstaller:
         self._pause = threading.Event()
         self._threads: dict[str, threading.Thread] = {}
         self._runtime_thread: threading.Thread | None = None
-        self._runtime_failed_archive_identity: tuple[str, int, int, int, int] | None = None
+        self._runtime_failed_archive_identities: set[tuple[str, int, int, int, int]] = set()
         self._status: dict[str, VideoBundleStatus] = {}
         self._runtime_import: dict[str, object] = {
             "state": "idle",
@@ -1091,22 +1091,17 @@ class VideoCapabilityInstaller:
                 "reason_code": "VIDEO_RUNTIME_ARCHIVE_REQUIRED",
             }
             return
-        identified = tuple(
-            (archive, identity)
-            for archive in archives
-            if archive.is_file() and not archive.is_symlink()
-            if (identity := _runtime_archive_identity(archive)) is not None
-        )
+        identified = tuple((archive, identity) for archive in archives if archive.is_file() and not archive.is_symlink() if (identity := _runtime_archive_identity(archive)) is not None)
         if not identified:
             return
+        self._runtime_failed_archive_identities.intersection_update(identity for _, identity in identified)
         candidate = next(
-            (item for item in identified if state != "failed" or item[1] != self._runtime_failed_archive_identity),
+            (item for item in identified if state != "failed" or item[1] not in self._runtime_failed_archive_identities),
             None,
         )
         if candidate is None:
             return
         archive, identity = candidate
-        self._runtime_failed_archive_identity = None
         self._runtime_import["state"] = "queued"
         thread = threading.Thread(
             target=self._run_runtime_archive,
@@ -1121,7 +1116,7 @@ class VideoCapabilityInstaller:
         try:
             self.import_runtime_archive(runtime_archive=archive)
         except Exception as exc:
-            self._runtime_failed_archive_identity = identity
+            self._runtime_failed_archive_identities.add(identity)
             self._set_runtime_import_state(
                 "failed", reason_code=self._runtime_import_error_code(exc)
             )

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -623,6 +623,7 @@ class VideoCapabilityInstaller:
         readiness_probe: Callable[[Mapping[str, str]], Mapping[str, object]] | None = None,
         artifact_roots: tuple[Path, ...] = (),
         runtime_archives: tuple[Path, ...] = (),
+        runtime_archive_roots: tuple[Path, ...] = (),
         runtime_environment_applier: Callable[[Mapping[str, str]], object] | None = None,
     ) -> None:
         if not data_root.is_absolute():
@@ -644,6 +645,9 @@ class VideoCapabilityInstaller:
         ):
             raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
         self._runtime_archives = tuple(archive.resolve() for archive in runtime_archives)
+        if any(not root.is_absolute() or (root.exists() and (not root.is_dir() or _is_reparse_point(root))) for root in runtime_archive_roots):
+            raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
+        self._runtime_archive_roots = tuple(root.resolve() for root in runtime_archive_roots)
         self._runtime_environment_applier = runtime_environment_applier
         self._lock = threading.RLock()
         self._commit_lock = _PROMOTION_LOCK
@@ -1048,7 +1052,7 @@ class VideoCapabilityInstaller:
         return True
 
     def _maybe_start_runtime_prepare(self) -> None:
-        if self._runtime_import["state"] != "idle":
+        if self._runtime_import["state"] not in {"idle", "required"}:
             return
         if self._runtime_thread is not None and self._runtime_thread.is_alive():
             return
@@ -1061,7 +1065,12 @@ class VideoCapabilityInstaller:
             for bundle in self.manifest.bundles
         ):
             return
-        if not self._runtime_archives:
+        try:
+            discovered = tuple(candidate.resolve() for root in self._runtime_archive_roots if root.is_dir() and not _is_reparse_point(root) for candidate in root.glob("Olivia-video-runtime-*.zip") if candidate.is_file() and not candidate.is_symlink())
+        except OSError:
+            discovered = ()
+        archives = tuple(dict.fromkeys((*self._runtime_archives, *discovered)))
+        if not archives:
             self._runtime_import = {
                 "state": "required",
                 "checked_bytes": 0,
@@ -1069,7 +1078,7 @@ class VideoCapabilityInstaller:
                 "reason_code": "VIDEO_RUNTIME_ARCHIVE_REQUIRED",
             }
             return
-        archive = next((path for path in self._runtime_archives if path.is_file()), None)
+        archive = next((path for path in archives if path.is_file()), None)
         if archive is None:
             self._runtime_import = {
                 "state": "required",

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -327,6 +327,14 @@ def _sha256_file(
     return total, digest.hexdigest()
 
 
+def _runtime_archive_identity(path: Path) -> tuple[str, int, int, int, int] | None:
+    try:
+        metadata = path.stat()
+    except OSError:
+        return None
+    return (str(path), metadata.st_dev, metadata.st_ino, metadata.st_size, metadata.st_mtime_ns)
+
+
 def _verify(path: Path, spec: VideoFile) -> None:
     size, digest = _sha256_file(path)
     if size != spec.size_bytes or digest != spec.sha256:
@@ -654,6 +662,7 @@ class VideoCapabilityInstaller:
         self._pause = threading.Event()
         self._threads: dict[str, threading.Thread] = {}
         self._runtime_thread: threading.Thread | None = None
+        self._runtime_failed_archive_identity: tuple[str, int, int, int, int] | None = None
         self._status: dict[str, VideoBundleStatus] = {}
         self._runtime_import: dict[str, object] = {
             "state": "idle",
@@ -1052,9 +1061,12 @@ class VideoCapabilityInstaller:
         return True
 
     def _maybe_start_runtime_prepare(self) -> None:
-        if self._runtime_import["state"] not in {"idle", "required"}:
+        state = self._runtime_import["state"]
+        if state not in {"idle", "required", "failed"}:
             return
         if self._runtime_thread is not None and self._runtime_thread.is_alive():
+            return
+        if state == "failed" and not self._runtime_archives and not self._runtime_archive_roots:
             return
         if self._resume_persisted_runtime():
             return
@@ -1070,14 +1082,6 @@ class VideoCapabilityInstaller:
         except OSError:
             discovered = ()
         archives = tuple(dict.fromkeys((*self._runtime_archives, *discovered)))
-        if not archives:
-            self._runtime_import = {
-                "state": "required",
-                "checked_bytes": 0,
-                "total_bytes": 0,
-                "reason_code": "VIDEO_RUNTIME_ARCHIVE_REQUIRED",
-            }
-            return
         archive = next((path for path in archives if path.is_file()), None)
         if archive is None:
             self._runtime_import = {
@@ -1087,20 +1091,37 @@ class VideoCapabilityInstaller:
                 "reason_code": "VIDEO_RUNTIME_ARCHIVE_REQUIRED",
             }
             return
+        identified = tuple(
+            (archive, identity)
+            for archive in archives
+            if archive.is_file() and not archive.is_symlink()
+            if (identity := _runtime_archive_identity(archive)) is not None
+        )
+        if not identified:
+            return
+        candidate = next(
+            (item for item in identified if state != "failed" or item[1] != self._runtime_failed_archive_identity),
+            None,
+        )
+        if candidate is None:
+            return
+        archive, identity = candidate
+        self._runtime_failed_archive_identity = None
         self._runtime_import["state"] = "queued"
         thread = threading.Thread(
             target=self._run_runtime_archive,
-            args=(archive,),
+            args=(archive, identity),
             name="olivia-video-runtime",
             daemon=True,
         )
         self._runtime_thread = thread
         thread.start()
 
-    def _run_runtime_archive(self, archive: Path) -> None:
+    def _run_runtime_archive(self, archive: Path, identity: tuple[str, int, int, int, int]) -> None:
         try:
             self.import_runtime_archive(runtime_archive=archive)
         except Exception as exc:
+            self._runtime_failed_archive_identity = identity
             self._set_runtime_import_state(
                 "failed", reason_code=self._runtime_import_error_code(exc)
             )


### PR DESCRIPTION
## Scope
- atomically persist the verified private runtime ZIP into the stable managed downloads directory
- rediscover stable runtime ZIPs on subsequent prepare/status calls and automatically import, probe, and activate them
- preserve the user-controlled video-reply toggle while making dependencies READY
- treat post-commit backup cleanup failures as deferred cleanup, not a false installation failure

## Evidence
- stacked exact pair: df7e2820da986e699982912a60ef48f49e13a17a...48f31d337b65e930ba2d2d493cec36cee20f83d6
- mechanical range-diff from frozen implementation: both commits exact equals
- focused tests: 44 passed
- pycompile and git diff --check: pass
- 5 files, 434 changed lines
- local focused boundary: P0/P1=0

## Boundary
This PR is intentionally based on codex/private-video-runtime-payload-v2. It does not contain the 26.2 GiB private ZIP itself and does not claim other-machine installation or final READY acceptance.