### PR TITLE
feat: add privacy-safe diagnostic support bundle

### DIFF
--- a/contracts/diagnostic_bundle_manifest.schema.json
+++ b/contracts/diagnostic_bundle_manifest.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "olivia.diagnostic-bundle-manifest.v1",
+  "title": "Privacy-safe diagnostic bundle manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "members"],
+  "properties": {
+    "schema_version": {"const": "olivia.diagnostic-bundle.v1"},
+    "members": {
+      "const": [
+        "manifest.json",
+        "summary.json",
+        "health.json",
+        "install.json",
+        "tasks.json",
+        "launcher-tail.jsonl",
+        "runtime-tail.jsonl"
+      ]
+    }
+  }
+}

--- a/contracts/diagnostic_export_error.schema.json
+++ b/contracts/diagnostic_export_error.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "olivia.diagnostic-export-error.v1",
+  "title": "Diagnostic export error envelope",
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "status", "error_code"],
+      "properties": {
+        "schema_version": {"const": "olivia.diagnostic-export.v1"},
+        "status": {"const": "FAILED"},
+        "error_code": {
+          "enum": ["DIAGNOSTIC_HOST_FORBIDDEN", "DIAGNOSTIC_ORIGIN_FORBIDDEN"]
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "status", "error_code"],
+      "properties": {
+        "schema_version": {"const": "olivia.diagnostic-export.v1"},
+        "status": {"const": "UNAVAILABLE"},
+        "error_code": {"const": "DIAGNOSTIC_EXPORT_UNAVAILABLE"}
+      }
+    }
+  ]
+}

--- a/contracts/http_contract.example.json
+++ b/contracts/http_contract.example.json
@@ -34,6 +34,14 @@
       "read_only": false,
       "error_code": null,
       "evidence": "local-extension"
+    },
+    "/toy/diagnostics/export": {
+      "methods": ["GET"],
+      "capability": "support.diagnostics",
+      "state": "available",
+      "read_only": true,
+      "error_code": null,
+      "evidence": "local-extension"
     }
   },
   "capabilities": {
@@ -68,6 +76,11 @@
       "status": "available",
       "provider": "local-atomic-state",
       "probe": "startup"
+    },
+    "support.diagnostics": {
+      "status": "available",
+      "provider": "local-allowlisted-zip",
+      "probe": "user-triggered"
     }
   },
   "profiles": {

--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -72,6 +72,9 @@
 | 503 | `MEMORY_ADMIN_CLEAR_FAILED` | UNAVAILABLE | 是 | 精确删除或复读失败 |
 | 503 | `MEMORY_ADMIN_AUDIT_UNAVAILABLE` | UNAVAILABLE | 是 | 审计不可用 |
 | 503 | `MEMORY_MUTATION_RESULT_INVALID` | UNAVAILABLE | 是 | backend mutation 返回无效 |
+| 403 | `DIAGNOSTIC_HOST_FORBIDDEN` | FAILED | 否 | 诊断导出请求不是 loopback Host |
+| 403 | `DIAGNOSTIC_ORIGIN_FORBIDDEN` | FAILED | 否 | 诊断导出 Origin 未授权 |
+| 503 | `DIAGNOSTIC_EXPORT_UNAVAILABLE` | UNAVAILABLE | 是 | 诊断采集、投影或归档不可用 |
 
 源实现和机器可读映射在 `http_contract.py`；原版客户端 companion mutation 的映射在
 `original_client_companion_mutation_api.py` 并由

--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -47,6 +47,9 @@
 | 200 detail media | `TTS_CONTENT_GATE_REJECTED` | FAILED | 否 | 三条时长有效的普通说话候选均未通过内容门；不自动重试 |
 | 200 detail media | `TTS_CONTENT_GATE_UNAVAILABLE` | UNAVAILABLE | 是 | 显式配置的离线 ASR 运行时、checkpoint 或临时质量门不可用；可在修复依赖后恢复 |
 | 200 detail media | `MEDIA_PROVIDER_UNAVAILABLE` | UNAVAILABLE | 是 | 未登记的媒体异常或本地媒体依赖不可用；公开 detail 不回显内部异常、provider 文本或本机路径 |
+| 403 | `DIAGNOSTIC_HOST_FORBIDDEN` | FAILED | 否 | 诊断导出请求不是 loopback Host |
+| 403 | `DIAGNOSTIC_ORIGIN_FORBIDDEN` | FAILED | 否 | 诊断导出 Origin 未授权 |
+| 503 | `DIAGNOSTIC_EXPORT_UNAVAILABLE` | UNAVAILABLE | 是 | 诊断采集、投影或归档不可用 |
 
 ## P03 clear mutation registry
 
@@ -72,9 +75,6 @@
 | 503 | `MEMORY_ADMIN_CLEAR_FAILED` | UNAVAILABLE | 是 | 精确删除或复读失败 |
 | 503 | `MEMORY_ADMIN_AUDIT_UNAVAILABLE` | UNAVAILABLE | 是 | 审计不可用 |
 | 503 | `MEMORY_MUTATION_RESULT_INVALID` | UNAVAILABLE | 是 | backend mutation 返回无效 |
-| 403 | `DIAGNOSTIC_HOST_FORBIDDEN` | FAILED | 否 | 诊断导出请求不是 loopback Host |
-| 403 | `DIAGNOSTIC_ORIGIN_FORBIDDEN` | FAILED | 否 | 诊断导出 Origin 未授权 |
-| 503 | `DIAGNOSTIC_EXPORT_UNAVAILABLE` | UNAVAILABLE | 是 | 诊断采集、投影或归档不可用 |
 
 源实现和机器可读映射在 `http_contract.py`；原版客户端 companion mutation 的映射在
 `original_client_companion_mutation_api.py` 并由

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -41,6 +41,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 | legacy import | `/toy/letter/legacy/import` | available | SQLite 本地扩展；仅接受 `mode=read_only`，以单事务原子导入旧信并按内容哈希去重；导入后旧信域只读且不与新聊天合并 |
 | 官方文字信件导入 | `/toy/letter/legacy/official-import` | available/degraded | 用户在设置页明确确认后，先要求 Mem0 与 PrivateWorld 可用；首次初始化关系状态时还要求大模型已配置。随后临时读取官方客户端登录日志并从官方接口导入原信与文字回信；严格按时间写入 Mem0、初始化 PrivateWorld，最后才原子发布到信箱；忽略视频，不保存或回显凭证 |
 | 长期记忆重试 | `/toy/companion/memory/retry` | available/degraded | 仅接受带确认头的 `POST`；返回 `INITIALIZING`、`AVAILABLE`、`DEGRADED`、`UNAVAILABLE` 或 `DISABLED`，其中显式禁用的 `DISABLED` 不可重试；重试真实 Mem0 factory，并在 delegate 已就绪时重新启动 durable outbox，不要求退出重进 |
+| 诊断包导出 | `/toy/diagnostics/export` | available | 设置页显式触发，只在本机生成并下载严格白名单 ZIP；不上传，不包含密钥、正文、记忆、真实 ID、绝对路径、完整 URL 或原始日志 |
 
 原生 WebSocket、ASR、TTS、Live 没有假 route；`/health` 的 capability registry 明确为 `unavailable`，错误码分别为 `WEBSOCKET_UNAVAILABLE`、`ASR_UNAVAILABLE`、`TTS_UNAVAILABLE`、`LIVE_UNAVAILABLE`。
 

--- a/http_contract.py
+++ b/http_contract.py
@@ -164,6 +164,12 @@ ROUTES: dict[str, dict[str, Any]] = {
     "/toy/settings/video-reply": _route(
         ["GET", "POST"], "settings.video_reply", evidence="local-extension"
     ),
+    "/toy/diagnostics/export": _route(
+        ["GET"],
+        "support.diagnostics",
+        read_only=True,
+        evidence="local-extension",
+    ),
     "/toy/capabilities/video/source": _route(
         ["POST"], "settings.video_reply", evidence="local-extension"
     ),
@@ -378,6 +384,11 @@ CAPABILITIES: dict[str, dict[str, Any]] = {
         "status": "available",
         "provider": "local-atomic-state",
         "probe": "startup",
+    },
+    "support.diagnostics": {
+        "status": "available",
+        "provider": "local-allowlisted-zip",
+        "probe": "user-triggered",
     },
     "profile.preference.write": {
         "status": "unavailable",

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -81,6 +81,7 @@ RELEASE_ROOT_FILES = {
     "original_client_companion_mutation_api.py",
     "original_client_companion_mutation_backend.py",
     "original_client_capability_api.py",
+    "original_client_diagnostics_api.py",
     "original_client_letter_contract.py",
     "original_client_media_http.py",
     "original_client_server.py",

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -47,6 +47,7 @@ PAYLOAD_EXTRA_DIRS = (
     "runtime/reply",
     "runtime/validation",
     "runtime/visual",
+    "runtime/diagnostics",
 )
 PAYLOAD_EXTRA_FILES = (
     "runtime/__init__.py",
@@ -58,6 +59,7 @@ PAYLOAD_ROOT_FILES = {
     "local_server.py",
     "mem0_capability_install.py",
     "original_client_capability_api.py",
+    "original_client_diagnostics_api.py",
     "original_client_video_capability_api.py",
     "original_client_server.py",
     "original_client_setup_api.py",
@@ -82,6 +84,7 @@ PAYLOAD_REQUIRED_ROOT_FILES = {
     "original_client_media_http.py",
     "mem0_capability_install.py",
     "original_client_capability_api.py",
+    "original_client_diagnostics_api.py",
     "original_client_server.py",
     "original_client_setup_api.py",
     "original_client_settings_ui.py",
@@ -127,6 +130,8 @@ PAYLOAD_REQUIRED_RELATIVE_FILES = {
     "runtime/imports/__init__.py",
     "runtime/imports/historical_memory.py",
     "runtime/imports/official_letters.py",
+    "runtime/diagnostics/__init__.py",
+    "runtime/diagnostics/support_bundle.py",
     "runtime/original_client_media_http.py",
     "runtime/video_reply_settings.py",
 }

--- a/local_server.py
+++ b/local_server.py
@@ -6,6 +6,7 @@
 #   letter_adapter.reply(content)  -> 本地 LLM 生成回信
 #   music_adapter.generate(midi)   -> 本地音乐模型生成演奏
 import asyncio
+from collections import deque
 from contextvars import ContextVar
 import json
 import os as _os
@@ -209,9 +210,45 @@ def _wire_reply_mode(value: object) -> str:
     return "text" if exact == ReplyMode.TEXT_LETTER.value else "video"
 
 
+_RUNTIME_DIAGNOSTIC_EVENTS: deque[dict[str, object]] = deque(maxlen=200)
+_RUNTIME_DIAGNOSTIC_EVENT_RE = _re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_RUNTIME_DIAGNOSTIC_CODE_RE = _re.compile(r"^[A-Z][A-Z0-9_]{0,95}$")
+_RUNTIME_DIAGNOSTIC_REPLY_MODES = frozenset(
+    {"text", "video", "text_letter", "normal_video", "music_video", "live"}
+)
+
+
+def _runtime_diagnostic_record(event: object, fields: Mapping[str, object]) -> dict[str, object] | None:
+    """Project one log event into the bounded, path-free export ring."""
+
+    if not isinstance(event, str) or not _RUNTIME_DIAGNOSTIC_EVENT_RE.fullmatch(event):
+        return None
+    record: dict[str, object] = {"event": event}
+    for name in ("status", "error_code"):
+        value = fields.get(name)
+        if isinstance(value, str) and _RUNTIME_DIAGNOSTIC_CODE_RE.fullmatch(value):
+            record[name] = value
+    method = fields.get("method")
+    if method in {"GET", "HEAD", "OPTIONS", "POST"}:
+        record["method"] = method
+    reply_mode = fields.get("reply_mode")
+    if reply_mode in _RUNTIME_DIAGNOSTIC_REPLY_MODES:
+        record["reply_mode"] = reply_mode
+    return record
+
+
+def runtime_diagnostic_event_snapshot() -> tuple[dict[str, object], ...]:
+    """Return a detached, bounded projection for support export only."""
+
+    return tuple(dict(record) for record in _RUNTIME_DIAGNOSTIC_EVENTS)
+
+
 def _safe_log(event: str, **fields) -> None:
     """Emit structured diagnostics without request bodies, URLs or user data."""
     record = {"event": event, **fields}
+    projected = _runtime_diagnostic_record(event, fields)
+    if projected is not None:
+        _RUNTIME_DIAGNOSTIC_EVENTS.append(projected)
     print(json.dumps(record, ensure_ascii=False, sort_keys=True))
 
 

--- a/original_client_diagnostics_api.py
+++ b/original_client_diagnostics_api.py
@@ -1,0 +1,148 @@
+"""Loopback-only download endpoint for the privacy-safe diagnostic bundle."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+import asyncio
+import re
+from urllib.parse import urlsplit
+
+from aiohttp import web
+
+from runtime.diagnostics.support_bundle import DiagnosticBundleError, build_diagnostic_bundle
+
+
+DIAGNOSTIC_EXPORT_PATH = "/toy/diagnostics/export"
+DIAGNOSTIC_EXPORT_SCHEMA = "olivia.diagnostic-export.v1"
+_MOUNTED_KEY = web.AppKey("original_client.diagnostics_mounted", bool)
+_ORIGINS_KEY = web.AppKey("original_client.diagnostics_origins", frozenset)
+_SOURCE_KEY = web.AppKey("original_client.diagnostics_source", object)
+_LOCAL_ORIGIN_RE = re.compile(r"^https?://(?:127\.0\.0\.1|localhost|\[::1\]):[0-9]{1,5}$")
+
+
+class DiagnosticExportAPIError(RuntimeError):
+    def __init__(self, code: str, status: int) -> None:
+        self.code = code
+        self.status = status
+        super().__init__(code)
+
+
+def _trusted_origin(value: object) -> str:
+    if not isinstance(value, str) or len(value) > 240:
+        raise ValueError("trusted diagnostic origin is invalid")
+    try:
+        parsed = urlsplit(value.rstrip("/"))
+    except ValueError as exc:
+        raise ValueError("trusted diagnostic origin is invalid") from exc
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("trusted diagnostic origin is invalid")
+    return f"https://{parsed.netloc}"
+
+
+def _host_is_loopback(request: web.Request) -> bool:
+    try:
+        host = urlsplit(f"//{request.host}").hostname
+    except ValueError:
+        return False
+    return host in {"127.0.0.1", "localhost", "::1"}
+
+
+def _origin_allowed(request: web.Request, origin: str) -> bool:
+    if origin in request.app[_ORIGINS_KEY]:
+        return True
+    if not _LOCAL_ORIGIN_RE.fullmatch(origin):
+        return False
+    try:
+        port = urlsplit(origin).port
+    except ValueError:
+        return False
+    return port is not None and 1 <= port <= 65535
+
+
+def _headers(origin: str | None = None) -> dict[str, str]:
+    result = {"Cache-Control": "no-store", "X-Content-Type-Options": "nosniff"}
+    if origin:
+        result.update({"Access-Control-Allow-Origin": origin, "Vary": "Origin"})
+    return result
+
+
+def _error(code: str, status: int, *, origin: str | None = None) -> web.Response:
+    return web.json_response(
+        {
+            "schema_version": DIAGNOSTIC_EXPORT_SCHEMA,
+            "status": "UNAVAILABLE" if status == 503 else "FAILED",
+            "error_code": code,
+        },
+        status=status,
+        headers=_headers(origin),
+    )
+
+
+def _authorize(request: web.Request) -> str:
+    if not _host_is_loopback(request):
+        raise DiagnosticExportAPIError("DIAGNOSTIC_HOST_FORBIDDEN", 403)
+    origin = request.headers.get("Origin", "")
+    if not _origin_allowed(request, origin):
+        raise DiagnosticExportAPIError("DIAGNOSTIC_ORIGIN_FORBIDDEN", 403)
+    return origin
+
+
+async def _export(request: web.Request) -> web.Response:
+    origin: str | None = None
+    try:
+        origin = _authorize(request)
+        source = request.app[_SOURCE_KEY]
+        if not callable(source):
+            raise DiagnosticExportAPIError("DIAGNOSTIC_EXPORT_UNAVAILABLE", 503)
+        values = await asyncio.to_thread(source)
+        if not isinstance(values, Mapping):
+            raise DiagnosticExportAPIError("DIAGNOSTIC_EXPORT_UNAVAILABLE", 503)
+        bundle = build_diagnostic_bundle(values)
+        return web.Response(
+            body=bundle,
+            content_type="application/zip",
+            headers={
+                **_headers(origin),
+                "Content-Disposition": 'attachment; filename="olivia-diagnostic-bundle.zip"',
+            },
+        )
+    except DiagnosticExportAPIError as exc:
+        return _error(exc.code, exc.status, origin=origin)
+    except (DiagnosticBundleError, OSError, RuntimeError, TypeError, ValueError):
+        return _error("DIAGNOSTIC_EXPORT_UNAVAILABLE", 503, origin=origin)
+
+
+def mount_original_client_diagnostics_api(
+    app: web.Application,
+    source: Callable[[], Mapping[str, object]],
+    *,
+    trusted_origins: Sequence[str] = (),
+) -> None:
+    """Mount the download endpoint once before the legacy catch-all route."""
+
+    if not isinstance(app, web.Application) or not callable(source):
+        raise TypeError("an application and diagnostic source are required")
+    if len(trusted_origins) > 8:
+        raise ValueError("too many trusted diagnostic origins")
+    if app.get(_MOUNTED_KEY, False):
+        raise RuntimeError("DIAGNOSTIC_EXPORT_ALREADY_MOUNTED")
+    app[_ORIGINS_KEY] = frozenset(_trusted_origin(value) for value in trusted_origins)
+    app[_SOURCE_KEY] = source
+    app[_MOUNTED_KEY] = True
+    app.router.add_get(DIAGNOSTIC_EXPORT_PATH, _export)
+
+
+__all__ = [
+    "DIAGNOSTIC_EXPORT_PATH",
+    "DIAGNOSTIC_EXPORT_SCHEMA",
+    "DiagnosticExportAPIError",
+    "mount_original_client_diagnostics_api",
+]

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -12,8 +12,10 @@ from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 import json
 import os
+import platform
 from pathlib import Path
 import sys
+import time
 from types import ModuleType
 from typing import Any
 
@@ -46,6 +48,7 @@ from original_client_companion_mutation_backend import (
     DirectOriginalClientCompanionMutationBackend,
     MemoryAdminMutationService,
 )
+from original_client_diagnostics_api import mount_original_client_diagnostics_api
 from original_client_capability_api import mount_original_client_capability_api
 from original_client_video_capability_api import mount_original_client_video_capability_api
 from video_capability_install import (
@@ -85,6 +88,13 @@ LetterCollection = Callable[[str], Sequence[Mapping[str, object]]]
 _RUNTIME_KEY = web.AppKey("original_client.server_runtime", object)
 _MAILBOX_MOUNTED_KEY = web.AppKey("original_client.mailbox_wire_mounted", bool)
 _MEMORY_ADMIN_FILENAME = "memory_admin_audit.sqlite3"
+_DIAGNOSTIC_TAIL_LIMIT = 200
+_DIAGNOSTIC_LOG_MAX_BYTES = 1 << 20
+_DIAGNOSTIC_PROFILES = ("core", "llm", "memory", "asr")
+_DIAGNOSTIC_CAPABILITIES = {
+    "settings.video_reply": "settings_video_reply",
+    "native.tts": "native_tts",
+}
 
 
 class OriginalClientServerError(RuntimeError):
@@ -334,6 +344,222 @@ class OriginalClientServerRuntime:
         }
 
 
+def _launcher_tail(data_root: Path | None) -> tuple[Mapping[str, object], ...]:
+    """Read only the bounded launcher event tail; raw content is never exported."""
+
+    if data_root is None:
+        return ()
+    path = data_root / "logs" / "launcher.jsonl"
+    if not path.exists():
+        return ()
+    if not path.is_file() or path.stat().st_size > _DIAGNOSTIC_LOG_MAX_BYTES:
+        raise RuntimeError("DIAGNOSTIC_LAUNCHER_TAIL_UNAVAILABLE")
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()[-_DIAGNOSTIC_TAIL_LIMIT:]
+        records = tuple(json.loads(line) for line in lines)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("DIAGNOSTIC_LAUNCHER_TAIL_UNAVAILABLE") from exc
+    if any(not isinstance(record, Mapping) for record in records):
+        raise RuntimeError("DIAGNOSTIC_LAUNCHER_TAIL_UNAVAILABLE")
+    return records
+
+
+def _diagnostic_source(
+    backend: OriginalClientCompanionServiceBackend,
+    *,
+    setup_service: LLMSetupService | None,
+    launcher_tail_provider: Callable[[], Sequence[Mapping[str, object]]] | None,
+    runtime_tail_provider: Callable[[], Sequence[Mapping[str, object]]] | None,
+    health_profile_provider: Callable[[str], Mapping[str, object]] | None = None,
+    task_snapshot_provider: Callable[[], Sequence[Mapping[str, object]]] | None = None,
+) -> Callable[[], Mapping[str, object]]:
+    """Bind only safe, aggregate collectors for a diagnostic export request."""
+
+    def state(value: object) -> str:
+        if not isinstance(value, str):
+            return "unknown"
+        normalized = value.strip().lower()
+        aliases = {
+            "healthy": "available",
+            "ready": "available",
+            "cancelled": "cancelled",
+            "canceled": "cancelled",
+        }
+        normalized = aliases.get(normalized, normalized)
+        if normalized and normalized[0].isalpha() and all(
+            character.islower() or character.isdigit() or character == "_"
+            for character in normalized
+        ):
+            return normalized[:32]
+        return "unknown"
+
+    def code(value: object) -> str | None:
+        if not isinstance(value, str) or not 1 <= len(value) <= 96:
+            return None
+        if not value[0].isalpha() or value != value.upper():
+            return None
+        if any(not (character.isupper() or character.isdigit() or character == "_") for character in value):
+            return None
+        return value
+
+    def project_task(value: Mapping[str, object]) -> dict[str, object]:
+        letter_state = state(value.get("letter_status"))
+        media_state = state(value.get("media_status")) if "media_status" in value else None
+        if media_state in {"pending", "queued", "processing"}:
+            stage = "media_generation"
+        else:
+            stage = {
+                "pending": "waiting",
+                "processing": "reply_generation",
+                "completed": "completed",
+                "failed": "failed",
+                "cancelled": "cancelled",
+            }.get(letter_state, "unknown")
+        created_at = value.get("created_at")
+        elapsed_bucket = "unknown"
+        if type(created_at) in {int, float}:
+            elapsed = max(0.0, time.time() - float(created_at))
+            if elapsed < 60:
+                elapsed_bucket = "under_1m"
+            elif elapsed < 300:
+                elapsed_bucket = "1m_5m"
+            elif elapsed < 900:
+                elapsed_bucket = "5m_15m"
+            elif elapsed < 3_600:
+                elapsed_bucket = "15m_1h"
+            elif elapsed < 21_600:
+                elapsed_bucket = "1h_6h"
+            else:
+                elapsed_bucket = "over_6h"
+        item: dict[str, object] = {
+            "status": letter_state,
+            "stage": stage,
+            "elapsed_bucket": elapsed_bucket,
+        }
+        error_code = code(value.get("error_code"))
+        if error_code is not None:
+            item["error_code"] = error_code
+        if "media_status" in value:
+            item["media_status"] = media_state
+        media_error_code = code(value.get("media_error_code"))
+        if media_error_code is not None:
+            item["media_error_code"] = media_error_code
+        reply_mode = value.get("reply_mode")
+        if reply_mode in {
+            "text",
+            "video",
+            "text_letter",
+            "normal_video",
+            "music_video",
+            "live",
+        }:
+            item["reply_mode"] = reply_mode
+        for name in ("retryable", "media_retryable"):
+            flag = value.get(name)
+            if type(flag) is bool:
+                item[name] = flag
+        return item
+
+    def collect() -> Mapping[str, object]:
+        status = backend.read_status().to_dict()
+        capabilities = status.get("capabilities")
+        if not isinstance(capabilities, Mapping):
+            raise RuntimeError("DIAGNOSTIC_HEALTH_UNAVAILABLE")
+        checks: dict[str, object] = {}
+        for name in ("memory", "private_world", "candidates"):
+            value = capabilities.get(name)
+            if not isinstance(value, Mapping):
+                raise RuntimeError("DIAGNOSTIC_HEALTH_UNAVAILABLE")
+            check: dict[str, object] = {"state": value.get("state")}
+            reason = value.get("reason_code")
+            if reason is not None:
+                check["error_code"] = reason
+            checks[name] = check
+
+        summary: dict[str, object] = {
+            "status": "available",
+            "python_version": platform.python_version(),
+            "os_name": platform.system() or "unknown",
+            "os_release": platform.release() or "unknown",
+            "architecture": platform.machine() or "unknown",
+        }
+        if health_profile_provider is not None:
+            core_data: Mapping[str, object] | None = None
+            for profile_name in _DIAGNOSTIC_PROFILES:
+                envelope = health_profile_provider(profile_name)
+                if not isinstance(envelope, Mapping) or envelope.get("code") != 0:
+                    raise RuntimeError("DIAGNOSTIC_HEALTH_UNAVAILABLE")
+                data = envelope.get("data")
+                if not isinstance(data, Mapping):
+                    raise RuntimeError("DIAGNOSTIC_HEALTH_UNAVAILABLE")
+                profile_state = state(data.get("status"))
+                if profile_state == "failed":
+                    profile_state = "unavailable"
+                checks[f"profile_{profile_name}"] = {
+                    "state": profile_state
+                }
+                if profile_name == "core":
+                    core_data = data
+            if core_data is not None:
+                for name in ("contract_version",):
+                    value = core_data.get(name)
+                    if isinstance(value, str):
+                        summary[name] = value
+                raw_capabilities = core_data.get("capabilities")
+                if not isinstance(raw_capabilities, Mapping):
+                    raise RuntimeError("DIAGNOSTIC_HEALTH_UNAVAILABLE")
+                for public_name, diagnostic_name in _DIAGNOSTIC_CAPABILITIES.items():
+                    value = raw_capabilities.get(public_name)
+                    if not isinstance(value, Mapping):
+                        raise RuntimeError("DIAGNOSTIC_HEALTH_UNAVAILABLE")
+                    entry: dict[str, object] = {"state": state(value.get("status"))}
+                    reason = code(value.get("reason_code"))
+                    if reason is not None:
+                        entry["error_code"] = reason
+                    checks[diagnostic_name] = entry
+
+        install: dict[str, object] = {
+            "status": "available" if setup_service is not None else "disabled"
+        }
+        if setup_service is not None:
+            setup = setup_service.status()
+            llm = setup.get("llm")
+            if not isinstance(llm, Mapping):
+                raise RuntimeError("DIAGNOSTIC_INSTALL_UNAVAILABLE")
+            setup_completed = setup.get("setup_completed")
+            key_configured = llm.get("key_configured")
+            if type(setup_completed) is not bool or type(key_configured) is not bool:
+                raise RuntimeError("DIAGNOSTIC_INSTALL_UNAVAILABLE")
+            install.update(
+                setup_completed=setup_completed,
+                key_configured=key_configured,
+            )
+
+        raw_tasks = tuple(task_snapshot_provider() if task_snapshot_provider else ())
+        if len(raw_tasks) > 20 or any(not isinstance(item, Mapping) for item in raw_tasks):
+            raise RuntimeError("DIAGNOSTIC_TASKS_UNAVAILABLE")
+        task_items = [project_task(item) for item in raw_tasks]
+        pending = sum(
+            item.get("status") in {"pending", "processing"}
+            or item.get("media_status") in {"pending", "queued", "processing"}
+            for item in task_items
+        )
+        return {
+            "summary": summary,
+            "health": {"status": "available", "checks": checks},
+            "install": install,
+            "tasks": {
+                "status": "active" if pending else "idle",
+                "pending": pending,
+                "items": task_items,
+            },
+            "launcher_tail": list(launcher_tail_provider() if launcher_tail_provider else ()),
+            "runtime_tail": list(runtime_tail_provider() if runtime_tail_provider else ()),
+        }
+
+    return collect
+
+
 def create_original_client_server_runtime(
     fallback_handler: FallbackHandler,
     *,
@@ -348,6 +574,10 @@ def create_original_client_server_runtime(
     video_capability_installer: VideoCapabilityInstaller | None = None,
     component_updater: ComponentUpdater | None = None,
     trusted_origins: Sequence[str] = (),
+    launcher_tail_provider: Callable[[], Sequence[Mapping[str, object]]] | None = None,
+    runtime_tail_provider: Callable[[], Sequence[Mapping[str, object]]] | None = None,
+    health_profile_provider: Callable[[str], Mapping[str, object]] | None = None,
+    task_snapshot_provider: Callable[[], Sequence[Mapping[str, object]]] | None = None,
 ) -> OriginalClientServerRuntime:
     """Mount original-client adapters before the toy catch-all."""
 
@@ -422,6 +652,18 @@ def create_original_client_server_runtime(
     mount_original_client_companion_mutation_api(
         app,
         mutation_backend,
+        trusted_origins=origins,
+    )
+    mount_original_client_diagnostics_api(
+        app,
+        _diagnostic_source(
+            backend,
+            setup_service=setup_service,
+            launcher_tail_provider=launcher_tail_provider,
+            runtime_tail_provider=runtime_tail_provider,
+            health_profile_provider=health_profile_provider,
+            task_snapshot_provider=task_snapshot_provider,
+        ),
         trusted_origins=origins,
     )
     if letter_collection is not None:
@@ -707,6 +949,22 @@ def create_configured_original_client_server_runtime(
     capability_installer = _configured_capability_installer(values, data_root)
     video_capability_installer = _configured_video_capability_installer(values, data_root)
     component_updater = _configured_component_updater(values)
+    runtime_tail = getattr(server_module, "runtime_diagnostic_event_snapshot", None)
+    health_profile = getattr(server_module, "_health_result", None)
+
+    def task_snapshot() -> tuple[Mapping[str, object], ...]:
+        store = getattr(server_module, "store", None)
+        letters = getattr(store, "letters", ())
+        if not isinstance(letters, Sequence) or isinstance(
+            letters, (str, bytes, bytearray)
+        ):
+            return ()
+        return tuple(
+            item
+            for item in tuple(letters)[-20:]
+            if isinstance(item, Mapping)
+        )
+
     runtime = create_original_client_server_runtime(
         fallback,
         memory_admin=memory_admin,
@@ -720,6 +978,10 @@ def create_configured_original_client_server_runtime(
         video_capability_installer=video_capability_installer,
         component_updater=component_updater,
         trusted_origins=origins,
+        launcher_tail_provider=lambda: _launcher_tail(data_root),
+        runtime_tail_provider=runtime_tail if callable(runtime_tail) else None,
+        health_profile_provider=health_profile if callable(health_profile) else None,
+        task_snapshot_provider=task_snapshot,
     )
     install_reply_task_lifecycle = getattr(
         server_module,

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -352,10 +352,20 @@ def _launcher_tail(data_root: Path | None) -> tuple[Mapping[str, object], ...]:
     path = data_root / "logs" / "launcher.jsonl"
     if not path.exists():
         return ()
-    if not path.is_file() or path.stat().st_size > _DIAGNOSTIC_LOG_MAX_BYTES:
+    if not path.is_file():
         raise RuntimeError("DIAGNOSTIC_LAUNCHER_TAIL_UNAVAILABLE")
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()[-_DIAGNOSTIC_TAIL_LIMIT:]
+        size = path.stat().st_size
+        start = max(0, size - _DIAGNOSTIC_LOG_MAX_BYTES)
+        with path.open("rb") as stream:
+            stream.seek(start)
+            raw = stream.read(_DIAGNOSTIC_LOG_MAX_BYTES)
+        if start:
+            newline = raw.find(b"\n")
+            if newline < 0:
+                raise RuntimeError("DIAGNOSTIC_LAUNCHER_TAIL_UNAVAILABLE")
+            raw = raw[newline + 1 :]
+        lines = raw.decode("utf-8").splitlines()[-_DIAGNOSTIC_TAIL_LIMIT:]
         records = tuple(json.loads(line) for line in lines)
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         raise RuntimeError("DIAGNOSTIC_LAUNCHER_TAIL_UNAVAILABLE") from exc

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-SETTINGS_UI_VERSION = "p03.original-settings-manage.v13"
+SETTINGS_UI_VERSION = "p03.original-settings-manage.v14"
 
 BOOTSTRAP_JAVASCRIPT = r'''(() => {
   "use strict";
@@ -18,6 +18,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const VIDEO_REPLY_SETTINGS_PATH = "/toy/settings/video-reply";
   const VIDEO_CAPABILITY_PATH = "/toy/capabilities/video";
   const VIDEO_CAPABILITY_ACTION_PATH = "/toy/capabilities/video/action";
+  const DIAGNOSTIC_EXPORT_PATH = "/toy/diagnostics/export";
   const OFFICIAL_LETTER_IMPORT_PATH = "/toy/letter/legacy/official-import";
   const OFFICIAL_IMPORT_CONFIRM_ATTR = "data-olivia-companion-official-import-confirm";
   const MEMORY_CORRECT_PATH = "/toy/companion/memory/correct";
@@ -313,6 +314,43 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         throw error;
       }
       return payload;
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  };
+
+  const requestDiagnosticExport = async () => {
+    const endpoint = new URL(DIAGNOSTIC_EXPORT_PATH, apiBase);
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 15000);
+    try {
+      const response = await fetch(endpoint, {
+        method: "GET",
+        cache: "no-store",
+        credentials: "omit",
+        headers: { "Accept": "application/zip" },
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        let payload = null;
+        try {
+          payload = await response.json();
+        } catch (_error) {
+          payload = null;
+        }
+        const error = new Error("diagnostic-export-unavailable");
+        error.code = payload && typeof payload.error_code === "string"
+          ? payload.error_code
+          : "DIAGNOSTIC_EXPORT_UNAVAILABLE";
+        throw error;
+      }
+      const blob = await response.blob();
+      if (!blob || blob.size < 1) {
+        const error = new Error("diagnostic-export-empty");
+        error.code = "DIAGNOSTIC_EXPORT_UNAVAILABLE";
+        throw error;
+      }
+      return blob;
     } finally {
       window.clearTimeout(timeout);
     }
@@ -1981,6 +2019,44 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     void hydrate();
   };
 
+  const mountDiagnosticExport = (section) => {
+    const row = document.createElement("div");
+    row.className = "flex items-center justify-between px-0 py-3 rounded-3";
+    const copy = document.createElement("div");
+    copy.className = "flex flex-col gap-0 flex-1 min-w-0";
+    const state = text("div", "导出本机脱敏诊断包，文件仅保存到本地。", "text-text-secondary text-caption-m font-regular");
+    copy.append(
+      text("div", "诊断与反馈", "text-text-body text-label-l"),
+      state
+    );
+    const exportButton = button("导出诊断包", async () => {
+      setButtonsBusy([exportButton], true);
+      state.textContent = "正在生成诊断包…";
+      try {
+        const blob = await requestDiagnosticExport();
+        const url = URL.createObjectURL(blob);
+        const download = document.createElement("a");
+        download.href = url;
+        download.download = "olivia-diagnostic-bundle.zip";
+        download.style.display = "none";
+        document.body.append(download);
+        download.click();
+        download.remove();
+        window.setTimeout(() => URL.revokeObjectURL(url), 0);
+        state.textContent = "诊断包已保存到本地下载位置。";
+      } catch (error) {
+        const code = error && typeof error.code === "string"
+          ? error.code
+          : "DIAGNOSTIC_EXPORT_UNAVAILABLE";
+        state.textContent = `导出失败：${code}`;
+      } finally {
+        setButtonsBusy([exportButton], false);
+      }
+    });
+    row.append(copy, exportButton);
+    section.append(text("div", "诊断与反馈", "text-text-body text-title-m"), row);
+  };
+
   const mountOfficialLetterImport = (section) => {
     const importRow = document.createElement("div");
     importRow.className = "flex items-center justify-between px-0 py-3 rounded-3";
@@ -2138,6 +2214,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
 
     row.append(copy, button("打开", () => openDialog(false)));
     section.append(title, row);
+    mountDiagnosticExport(section);
     mountVideoReplySetting(section);
     mountOfficialLetterImport(section);
     container.append(section);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ py-modules = [
     "original_client_companion_backend",
     "original_client_companion_mutation_api",
     "original_client_companion_mutation_backend",
+    "original_client_diagnostics_api",
     "original_client_letter_contract",
     "original_client_media_http",
     "original_client_server",

--- a/runtime/diagnostics/__init__.py
+++ b/runtime/diagnostics/__init__.py
@@ -1,0 +1,13 @@
+"""Bounded, privacy-safe diagnostics exported by the local client only."""
+
+from .support_bundle import (
+    DIAGNOSTIC_BUNDLE_MEMBERS,
+    DiagnosticBundleError,
+    build_diagnostic_bundle,
+)
+
+__all__ = [
+    "DIAGNOSTIC_BUNDLE_MEMBERS",
+    "DiagnosticBundleError",
+    "build_diagnostic_bundle",
+]

--- a/runtime/diagnostics/support_bundle.py
+++ b/runtime/diagnostics/support_bundle.py
@@ -1,0 +1,273 @@
+"""Create a deterministic, allowlisted diagnostic support bundle in memory."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import io
+import json
+import re
+import zipfile
+
+
+DIAGNOSTIC_BUNDLE_SCHEMA = "olivia.diagnostic-bundle.v1"
+DIAGNOSTIC_BUNDLE_MEMBERS = (
+    "manifest.json",
+    "summary.json",
+    "health.json",
+    "install.json",
+    "tasks.json",
+    "launcher-tail.jsonl",
+    "runtime-tail.jsonl",
+)
+MAX_BUNDLE_BYTES = 1 << 20
+MAX_CHECKS = 32
+MAX_TAIL_RECORDS = 200
+_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_STATUS_RE = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
+_CODE_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,95}$")
+_EVENT_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_TOKEN_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z._+-]{0,159}$")
+_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "POST"})
+_REPLY_MODES = frozenset(
+    {"text", "video", "text_letter", "normal_video", "music_video", "live"}
+)
+_TASK_STAGES = frozenset(
+    {
+        "cancelled",
+        "completed",
+        "failed",
+        "media_generation",
+        "reply_generation",
+        "waiting",
+        "unknown",
+    }
+)
+_ELAPSED_BUCKETS = frozenset(
+    {"under_1m", "1m_5m", "5m_15m", "15m_1h", "1h_6h", "over_6h", "unknown"}
+)
+
+
+class DiagnosticBundleError(RuntimeError):
+    """Stable export failure code without any collected diagnostic content."""
+
+
+def _invalid() -> DiagnosticBundleError:
+    return DiagnosticBundleError("DIAGNOSTIC_BUNDLE_INPUT_INVALID")
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise _invalid()
+    return value
+
+
+def _status(value: object) -> str:
+    if not isinstance(value, str) or not _STATUS_RE.fullmatch(value):
+        raise _invalid()
+    return value
+
+
+def _code(value: object) -> str:
+    if not isinstance(value, str) or not _CODE_RE.fullmatch(value):
+        raise _invalid()
+    return value
+
+
+def _project_summary(value: object) -> dict[str, object]:
+    source = _mapping(value)
+    result: dict[str, object] = {"status": _status(source.get("status"))}
+    for name in (
+        "contract_version",
+        "python_version",
+        "os_name",
+        "os_release",
+        "architecture",
+    ):
+        if name not in source:
+            continue
+        item = source[name]
+        if not isinstance(item, str) or not _TOKEN_RE.fullmatch(item):
+            raise _invalid()
+        result[name] = item
+    return result
+
+
+def _project_health(value: object) -> dict[str, object]:
+    source = _mapping(value)
+    checks = _mapping(source.get("checks"))
+    if len(checks) > MAX_CHECKS:
+        raise _invalid()
+    projected: dict[str, object] = {}
+    for name in sorted(checks):
+        if not isinstance(name, str) or not _NAME_RE.fullmatch(name):
+            raise _invalid()
+        check = _mapping(checks[name])
+        entry: dict[str, object] = {"state": _status(check.get("state"))}
+        if "error_code" in check:
+            entry["error_code"] = _code(check["error_code"])
+        projected[name] = entry
+    return {"checks": projected, "status": _status(source.get("status"))}
+
+
+def _project_install(value: object) -> dict[str, object]:
+    source = _mapping(value)
+    result: dict[str, object] = {"status": _status(source.get("status"))}
+    for name in ("setup_completed", "key_configured"):
+        if name in source:
+            item = source[name]
+            if type(item) is not bool:
+                raise _invalid()
+            result[name] = item
+    if "error_code" in source:
+        result["error_code"] = _code(source["error_code"])
+    return result
+
+
+def _project_tasks(value: object) -> dict[str, object]:
+    source = _mapping(value)
+    pending = source.get("pending")
+    if type(pending) is not int or not 0 <= pending <= 100_000:
+        raise _invalid()
+    raw_items = source.get("items", ())
+    if not isinstance(raw_items, Sequence) or isinstance(raw_items, (str, bytes, bytearray)):
+        raise _invalid()
+    if len(raw_items) > 20:
+        raise _invalid()
+    items: list[dict[str, object]] = []
+    for index, value in enumerate(raw_items, start=1):
+        item = _mapping(value)
+        projected: dict[str, object] = {"index": index, "status": _status(item.get("status"))}
+        if "error_code" in item:
+            projected["error_code"] = _code(item["error_code"])
+        if "media_status" in item:
+            projected["media_status"] = _status(item["media_status"])
+        if "media_error_code" in item:
+            projected["media_error_code"] = _code(item["media_error_code"])
+        if "reply_mode" in item:
+            reply_mode = item["reply_mode"]
+            if reply_mode not in _REPLY_MODES:
+                raise _invalid()
+            projected["reply_mode"] = reply_mode
+        stage = item.get("stage")
+        if stage not in _TASK_STAGES:
+            raise _invalid()
+        projected["stage"] = stage
+        elapsed_bucket = item.get("elapsed_bucket")
+        if elapsed_bucket not in _ELAPSED_BUCKETS:
+            raise _invalid()
+        projected["elapsed_bucket"] = elapsed_bucket
+        for name in ("retryable", "media_retryable"):
+            if name in item:
+                flag = item[name]
+                if type(flag) is not bool:
+                    raise _invalid()
+                projected[name] = flag
+        items.append(projected)
+    result: dict[str, object] = {"items": items, "pending": pending, "status": _status(source.get("status"))}
+    if "error_code" in source:
+        result["error_code"] = _code(source["error_code"])
+    return result
+
+
+def _project_tail_record(value: object, *, runtime: bool) -> dict[str, object]:
+    source = _mapping(value)
+    event = source.get("event")
+    if not isinstance(event, str) or not _EVENT_RE.fullmatch(event):
+        raise _invalid()
+    record: dict[str, object] = {"event": event}
+    if "attempt" in source:
+        attempt = source["attempt"]
+        if type(attempt) is not int or not 1 <= attempt <= 10:
+            raise _invalid()
+        record["attempt"] = attempt
+    if "exit_code" in source:
+        exit_code = source["exit_code"]
+        if exit_code is not None:
+            if type(exit_code) is not int or not -(1 << 31) <= exit_code <= 0xFFFFFFFF:
+                raise _invalid()
+            record["exit_code"] = exit_code
+    for name in ("status", "error_code", "health"):
+        if name in source:
+            record[name] = _code(source[name])
+    if runtime:
+        if "reply_mode" in source:
+            reply_mode = source["reply_mode"]
+            if reply_mode not in _REPLY_MODES:
+                raise _invalid()
+            record["reply_mode"] = reply_mode
+        if "method" in source:
+            method = source["method"]
+            if method not in _METHODS:
+                raise _invalid()
+            record["method"] = method
+    return record
+
+
+def _project_tail(value: object, *, runtime: bool) -> bytes:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise _invalid()
+    if len(value) > MAX_TAIL_RECORDS:
+        raise _invalid()
+    records = [_project_tail_record(item, runtime=runtime) for item in value]
+    return b"".join(
+        json.dumps(record, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8") + b"\n"
+        for record in records
+    )
+
+
+def _json_bytes(value: Mapping[str, object]) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _zip_member(archive: zipfile.ZipFile, name: str, payload: bytes) -> None:
+    member = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
+    member.compress_type = zipfile.ZIP_DEFLATED
+    member.external_attr = 0o600 << 16
+    archive.writestr(member, payload)
+
+
+def build_diagnostic_bundle(source: Mapping[str, object]) -> bytes:
+    """Return the complete fixed archive, or fail before returning any bytes."""
+
+    values = _mapping(source)
+    required = {"summary", "health", "install", "tasks", "launcher_tail", "runtime_tail"}
+    if not required.issubset(values):
+        raise _invalid()
+    summary = _project_summary(values["summary"])
+    health = _project_health(values["health"])
+    install = _project_install(values["install"])
+    tasks = _project_tasks(values["tasks"])
+    payloads = {
+        "manifest.json": _json_bytes({
+            "members": list(DIAGNOSTIC_BUNDLE_MEMBERS),
+            "schema_version": DIAGNOSTIC_BUNDLE_SCHEMA,
+        }),
+        "summary.json": _json_bytes(summary),
+        "health.json": _json_bytes(health),
+        "install.json": _json_bytes(install),
+        "tasks.json": _json_bytes(tasks),
+        "launcher-tail.jsonl": _project_tail(values["launcher_tail"], runtime=False),
+        "runtime-tail.jsonl": _project_tail(values["runtime_tail"], runtime=True),
+    }
+    if tuple(payloads) != DIAGNOSTIC_BUNDLE_MEMBERS or sum(map(len, payloads.values())) > MAX_BUNDLE_BYTES:
+        raise DiagnosticBundleError("DIAGNOSTIC_BUNDLE_TOO_LARGE")
+    output = io.BytesIO()
+    try:
+        with zipfile.ZipFile(output, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for name in DIAGNOSTIC_BUNDLE_MEMBERS:
+                _zip_member(archive, name, payloads[name])
+    except (OSError, ValueError, zipfile.BadZipFile) as exc:
+        raise DiagnosticBundleError("DIAGNOSTIC_BUNDLE_UNAVAILABLE") from exc
+    result = output.getvalue()
+    if len(result) > MAX_BUNDLE_BYTES:
+        raise DiagnosticBundleError("DIAGNOSTIC_BUNDLE_TOO_LARGE")
+    return result
+
+
+__all__ = [
+    "DIAGNOSTIC_BUNDLE_MEMBERS",
+    "DIAGNOSTIC_BUNDLE_SCHEMA",
+    "MAX_BUNDLE_BYTES",
+    "DiagnosticBundleError",
+    "build_diagnostic_bundle",
+]

--- a/tests/http/test_diagnostic_support_bundle.py
+++ b/tests/http/test_diagnostic_support_bundle.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+
+import pytest
+
+from runtime.diagnostics.support_bundle import (
+    DiagnosticBundleError,
+    build_diagnostic_bundle,
+)
+
+
+def _source() -> dict[str, object]:
+    return {
+        "summary": {
+            "status": "available",
+            "backend_id": "desktop-local",
+            "contract_version": "2.0",
+            "python_version": "3.12.4",
+            "os_name": "Windows",
+            "os_release": "11",
+            "architecture": "AMD64",
+            "untrusted": "ignore me",
+        },
+        "health": {
+            "status": "available",
+            "checks": {"memory": {"state": "available", "real_id": "user-123"}},
+        },
+        "install": {
+            "status": "available",
+            "setup_completed": True,
+            "key_configured": True,
+            "absolute_path": r"C:\\Users\\pc",
+        },
+        "tasks": {
+            "status": "active",
+            "pending": 1,
+            "items": [
+                {
+                    "status": "failed",
+                    "error_code": "LLM_TIMEOUT",
+                    "media_status": "not_requested",
+                    "reply_mode": "text_letter",
+                    "retryable": True,
+                    "stage": "failed",
+                    "elapsed_bucket": "5m_15m",
+                    "real_id": "task-77",
+                    "body": "private reply",
+                }
+            ],
+        },
+        "launcher_tail": [
+            {
+                "event": "backend_ready",
+                "attempt": 1,
+                "path": r"C:\\Users\\pc\\secret",
+                "url": "https://private.example/token",
+            }
+        ],
+        "runtime_tail": [
+            {
+                "event": "letter_completed",
+                "reply_mode": "text",
+                "path": "/toy/letter/private-real-id",
+                "body": "never include this",
+            }
+        ],
+    }
+
+
+def _contents(bundle: bytes) -> dict[str, bytes]:
+    with zipfile.ZipFile(io.BytesIO(bundle)) as archive:
+        return {name: archive.read(name) for name in archive.namelist()}
+
+
+def test_bundle_has_only_fixed_deterministic_members_and_safe_projection() -> None:
+    first = build_diagnostic_bundle(_source())
+    assert first == build_diagnostic_bundle(_source())
+
+    contents = _contents(first)
+    assert list(contents) == [
+        "manifest.json",
+        "summary.json",
+        "health.json",
+        "install.json",
+        "tasks.json",
+        "launcher-tail.jsonl",
+        "runtime-tail.jsonl",
+    ]
+    joined = b"\n".join(contents.values()).decode("utf-8")
+    for forbidden in (
+        "real_id",
+        "user-123",
+        "C:\\Users\\pc",
+        "private reply",
+        "private.example",
+        "never include this",
+        "private-real-id",
+    ):
+        assert forbidden not in joined
+    assert json.loads(contents["summary.json"]) == {
+        "architecture": "AMD64",
+        "contract_version": "2.0",
+        "os_name": "Windows",
+        "os_release": "11",
+        "python_version": "3.12.4",
+        "status": "available",
+    }
+    assert json.loads(contents["install.json"]) == {
+        "key_configured": True,
+        "setup_completed": True,
+        "status": "available",
+    }
+    assert json.loads(contents["tasks.json"]) == {
+        "items": [
+            {
+                "error_code": "LLM_TIMEOUT",
+                "index": 1,
+                "media_status": "not_requested",
+                "reply_mode": "text_letter",
+                "retryable": True,
+                "stage": "failed",
+                "elapsed_bucket": "5m_15m",
+                "status": "failed",
+            }
+        ],
+        "pending": 1,
+        "status": "active",
+    }
+    assert contents["launcher-tail.jsonl"] == b'{"attempt":1,"event":"backend_ready"}\n'
+    assert contents["runtime-tail.jsonl"] == b'{"event":"letter_completed","reply_mode":"text"}\n'
+
+
+def test_bundle_accepts_normal_windows_launcher_exit_codes_and_missing_code() -> None:
+    source = _source()
+    source["launcher_tail"] = [
+        {"event": "backend_unavailable", "exit_code": None},
+        {"event": "client_exit", "exit_code": 0x0E000003},
+        {"event": "client_exit", "exit_code": 0xC0000005},
+        {"event": "client_exit", "exit_code": -1073741819},
+    ]
+
+    contents = _contents(build_diagnostic_bundle(source))
+    assert contents["launcher-tail.jsonl"] == (
+        b'{"event":"backend_unavailable"}\n'
+        b'{"event":"client_exit","exit_code":234881027}\n'
+        b'{"event":"client_exit","exit_code":3221225477}\n'
+        b'{"event":"client_exit","exit_code":-1073741819}\n'
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        {},
+        {"summary": {"status": "available"}},
+        {
+            **_source(),
+            "health": {
+                "status": "available",
+                "checks": {"memory": {"state": "https://bad"}},
+            },
+        },
+        {**_source(), "launcher_tail": [{"event": "private reply"}]},
+        {**_source(), "runtime_tail": [{"event": "private reply"}]},
+    ),
+)
+def test_bundle_rejects_invalid_input_without_emitting_partial_archive(
+    source: dict[str, object],
+) -> None:
+    with pytest.raises(DiagnosticBundleError, match="DIAGNOSTIC_BUNDLE_INPUT_INVALID"):
+        build_diagnostic_bundle(source)

--- a/tests/http/test_original_client_diagnostics_api.py
+++ b/tests/http/test_original_client_diagnostics_api.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import asyncio
+import io
+import json
 from pathlib import Path
+import zipfile
 
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from jsonschema import Draft202012Validator
 
 from original_client_diagnostics_api import mount_original_client_diagnostics_api
 from original_client_server import (
     _diagnostic_source,
+    _launcher_tail,
     create_original_client_server_runtime,
 )
 from original_client_companion_api import CompanionCapability, CompanionReadStatus
@@ -46,22 +51,91 @@ def test_diagnostics_export_is_loopback_safe_and_downloadable() -> None:
             assert response.headers["Cache-Control"] == "no-store"
             assert response.headers["X-Content-Type-Options"] == "nosniff"
             assert response.headers["Content-Disposition"] == 'attachment; filename="olivia-diagnostic-bundle.zip"'
-            assert await response.read()
+            bundle = await response.read()
+            with zipfile.ZipFile(io.BytesIO(bundle)) as archive:
+                manifest = json.loads(archive.read("manifest.json"))
+            manifest_schema = json.loads(
+                Path("contracts/diagnostic_bundle_manifest.schema.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            Draft202012Validator(manifest_schema).validate(manifest)
 
             forbidden = await client.get(
                 "/toy/diagnostics/export",
                 headers={"Host": "evil.example", "Origin": "https://evil.example"},
             )
             assert forbidden.status == 403
-            assert await forbidden.json() == {
+            forbidden_payload = await forbidden.json()
+            assert forbidden_payload == {
                 "schema_version": "olivia.diagnostic-export.v1",
                 "status": "FAILED",
                 "error_code": "DIAGNOSTIC_HOST_FORBIDDEN",
             }
+            error_schema = json.loads(
+                Path("contracts/diagnostic_export_error.schema.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            Draft202012Validator(error_schema).validate(forbidden_payload)
         finally:
             await client.close()
 
     asyncio.run(scenario())
+
+
+def test_launcher_tail_reads_recent_events_from_large_append_only_log(
+    tmp_path: Path,
+) -> None:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    path = log_dir / "launcher.jsonl"
+    lines = [
+        json.dumps(
+            {
+                "event": "backend_ready",
+                "attempt": 1,
+                "padding": "x" * 160,
+            },
+            separators=(",", ":"),
+        )
+        for _ in range(6_000)
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    assert path.stat().st_size > 1 << 20
+
+    records = _launcher_tail(tmp_path)
+
+    assert len(records) == 200
+    assert all(record["event"] == "backend_ready" for record in records)
+
+
+def test_diagnostic_export_is_registered_in_the_machine_contract_and_docs() -> None:
+    from http_contract import contract_document, route_spec
+
+    assert route_spec("/toy/diagnostics/export") == {
+        "methods": ["GET"],
+        "capability": "support.diagnostics",
+        "state": "available",
+        "read_only": True,
+        "error_code": None,
+        "evidence": "local-extension",
+    }
+    assert contract_document()["capabilities"]["support.diagnostics"] == {
+        "status": "available",
+        "provider": "local-allowlisted-zip",
+        "probe": "user-triggered",
+    }
+    assert "/toy/diagnostics/export" in Path("docs/B02_HTTP_CONTRACT.md").read_text(
+        encoding="utf-8"
+    )
+    error_docs = Path("docs/B02_ERROR_CODES.md").read_text(encoding="utf-8")
+    for code in (
+        "DIAGNOSTIC_HOST_FORBIDDEN",
+        "DIAGNOSTIC_ORIGIN_FORBIDDEN",
+        "DIAGNOSTIC_EXPORT_UNAVAILABLE",
+    ):
+        assert code in error_docs
 
 
 def test_original_server_mounts_diagnostics_before_legacy_catch_all() -> None:

--- a/tests/http/test_original_client_diagnostics_api.py
+++ b/tests/http/test_original_client_diagnostics_api.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from original_client_diagnostics_api import mount_original_client_diagnostics_api
+from original_client_server import (
+    _diagnostic_source,
+    create_original_client_server_runtime,
+)
+from original_client_companion_api import CompanionCapability, CompanionReadStatus
+
+
+async def _client(app: web.Application) -> TestClient:
+    client = TestClient(TestServer(app), cookie_jar=None)
+    await client.start_server()
+    return client
+
+
+def _source() -> dict[str, object]:
+    return {
+        "summary": {"status": "available"},
+        "health": {"status": "available", "checks": {}},
+        "install": {"status": "available"},
+        "tasks": {"status": "idle", "pending": 0, "items": []},
+        "launcher_tail": [],
+        "runtime_tail": [],
+    }
+
+
+def test_diagnostics_export_is_loopback_safe_and_downloadable() -> None:
+    async def scenario() -> None:
+        app = web.Application()
+        mount_original_client_diagnostics_api(app, lambda: _source())
+        client = await _client(app)
+        try:
+            response = await client.get(
+                "/toy/diagnostics/export",
+                headers={"Host": "localhost", "Origin": "http://localhost:3000"},
+            )
+            assert response.status == 200
+            assert response.headers["Content-Type"] == "application/zip"
+            assert response.headers["Cache-Control"] == "no-store"
+            assert response.headers["X-Content-Type-Options"] == "nosniff"
+            assert response.headers["Content-Disposition"] == 'attachment; filename="olivia-diagnostic-bundle.zip"'
+            assert await response.read()
+
+            forbidden = await client.get(
+                "/toy/diagnostics/export",
+                headers={"Host": "evil.example", "Origin": "https://evil.example"},
+            )
+            assert forbidden.status == 403
+            assert await forbidden.json() == {
+                "schema_version": "olivia.diagnostic-export.v1",
+                "status": "FAILED",
+                "error_code": "DIAGNOSTIC_HOST_FORBIDDEN",
+            }
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_original_server_mounts_diagnostics_before_legacy_catch_all() -> None:
+    async def fallback(_request: web.Request) -> web.Response:
+        return web.Response(text="legacy-catch-all")
+
+    async def scenario() -> None:
+        runtime = create_original_client_server_runtime(fallback)
+        client = await _client(runtime.app)
+        try:
+            response = await client.get(
+                "/toy/diagnostics/export",
+                headers={"Host": "localhost", "Origin": "http://localhost:3000"},
+            )
+            assert response.status == 200
+            assert response.headers["Content-Type"] == "application/zip"
+            assert await response.read() != b"legacy-catch-all"
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_safe_log_runtime_ring_is_bounded_and_drops_unknown_fields() -> None:
+    import local_server
+
+    for index in range(205):
+        local_server._safe_log(
+            "diagnostic_test",
+            method="GET",
+            path="/toy/diagnostics/export",
+            error_code="DIAGNOSTIC_TEST",
+            body=f"private-{index}",
+            real_id=f"id-{index}",
+        )
+
+    records = local_server.runtime_diagnostic_event_snapshot()
+    assert len(records) == 200
+    assert records[-1] == {
+        "event": "diagnostic_test",
+        "method": "GET",
+        "error_code": "DIAGNOSTIC_TEST",
+    }
+    assert all(
+        "body" not in record and "real_id" not in record and "path" not in record
+        for record in records
+    )
+
+
+def test_diagnostic_source_projects_profiles_setup_and_recent_task_states() -> None:
+    class Backend:
+        @staticmethod
+        def read_status() -> CompanionReadStatus:
+            return CompanionReadStatus(
+                memory=CompanionCapability("available"),
+                private_world=CompanionCapability("degraded", "PRIVATE_WORLD_DEGRADED"),
+                candidates=CompanionCapability("available"),
+            )
+
+    class Setup:
+        @staticmethod
+        def status() -> dict[str, object]:
+            return {
+                "status": "READY",
+                "setup_completed": True,
+                "llm": {
+                    "key_configured": True,
+                    "base_url": "https://must-not-leak.example/v1",
+                    "model": "must-not-leak",
+                },
+                "session_token": "must-not-leak",
+            }
+
+    def health(profile: str) -> dict[str, object]:
+        state = "DEGRADED" if profile == "llm" else "HEALTHY"
+        return {
+            "code": 0,
+            "data": {
+                "status": state,
+                "backend_id": "desktop-local",
+                "contract_version": "2.0",
+                "required_checks": {"example": "available"},
+                "capabilities": {
+                    "settings.video_reply": {"status": "available"},
+                    "native.tts": {"status": "unavailable"},
+                },
+            },
+        }
+
+    collect = _diagnostic_source(
+        Backend(),  # type: ignore[arg-type]
+        setup_service=Setup(),  # type: ignore[arg-type]
+        launcher_tail_provider=None,
+        runtime_tail_provider=None,
+        health_profile_provider=health,
+        task_snapshot_provider=lambda: (
+            {
+                "letter_status": "FAILED",
+                "error_code": "LLM_TIMEOUT",
+                "media_status": "NOT_REQUESTED",
+                "reply_mode": "text_letter",
+                "retryable": True,
+                "created_at": 0,
+                "letter_id": "must-not-leak",
+                "content": "must-not-leak",
+            },
+        ),
+    )
+
+    source = collect()
+    assert "backend_id" not in source["summary"]  # type: ignore[operator]
+    assert source["summary"]["contract_version"] == "2.0"  # type: ignore[index]
+    assert source["health"]["checks"] == {  # type: ignore[index]
+        "candidates": {"state": "available"},
+        "memory": {"state": "available"},
+        "native_tts": {"state": "unavailable"},
+        "private_world": {
+            "state": "degraded",
+            "error_code": "PRIVATE_WORLD_DEGRADED",
+        },
+        "profile_asr": {"state": "available"},
+        "profile_core": {"state": "available"},
+        "profile_llm": {"state": "degraded"},
+        "profile_memory": {"state": "available"},
+        "settings_video_reply": {"state": "available"},
+    }
+    assert source["install"] == {  # type: ignore[index]
+        "status": "available",
+        "setup_completed": True,
+        "key_configured": True,
+    }
+    assert source["tasks"] == {  # type: ignore[index]
+        "status": "idle",
+        "pending": 0,
+        "items": [
+            {
+                "status": "failed",
+                "error_code": "LLM_TIMEOUT",
+                "media_status": "not_requested",
+                "reply_mode": "text_letter",
+                "retryable": True,
+                "stage": "failed",
+                "elapsed_bucket": "over_6h",
+            }
+        ],
+    }
+
+
+def test_settings_ui_exposes_download_only_diagnostics_action() -> None:
+    script = Path("original_client_settings_ui.py").read_text(encoding="utf-8")
+
+    assert 'const DIAGNOSTIC_EXPORT_PATH = "/toy/diagnostics/export";' in script
+    assert "response.blob()" in script
+    assert 'download = "olivia-diagnostic-bundle.zip"' in script
+    assert "诊断与反馈" in script
+    assert "requestMutation(DIAGNOSTIC_EXPORT_PATH" not in script
+
+
+def test_diagnostics_modules_are_in_both_formal_packaging_allowlists() -> None:
+    from installer.build_windows_setup import _is_release_file
+    from installer.full_patch import PAYLOAD_REQUIRED_RELATIVE_FILES, PAYLOAD_REQUIRED_ROOT_FILES
+
+    assert "original_client_diagnostics_api.py" in PAYLOAD_REQUIRED_ROOT_FILES
+    assert "runtime/diagnostics/__init__.py" in PAYLOAD_REQUIRED_RELATIVE_FILES
+    assert "runtime/diagnostics/support_bundle.py" in PAYLOAD_REQUIRED_RELATIVE_FILES
+    assert _is_release_file("original_client_diagnostics_api.py")
+    assert _is_release_file("runtime/diagnostics/support_bundle.py")
+    assert '"original_client_diagnostics_api"' in Path("pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_full_patch_copies_diagnostics_when_the_release_files_are_tracked(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from installer import full_patch
+
+    root = Path(__file__).parents[2]
+    tracked = full_patch._git_tracked_payload_files(root)
+    monkeypatch.setattr(
+        full_patch,
+        "_git_tracked_payload_files",
+        lambda _root: tracked
+        | {
+            "original_client_diagnostics_api.py",
+            "runtime/diagnostics/__init__.py",
+            "runtime/diagnostics/support_bundle.py",
+        },
+    )
+
+    destination = tmp_path / "local_backend"
+    full_patch.copy_project_payload(root, destination)
+
+    assert (destination / "original_client_diagnostics_api.py").is_file()
+    assert (destination / "runtime" / "diagnostics" / "support_bundle.py").is_file()
+
+
+def test_diagnostics_export_fails_closed_when_collection_raises() -> None:
+    def broken() -> dict[str, object]:
+        raise OSError("C:/private/log")
+
+    async def scenario() -> None:
+        app = web.Application()
+        mount_original_client_diagnostics_api(app, broken)
+        client = await _client(app)
+        try:
+            response = await client.get(
+                "/toy/diagnostics/export",
+                headers={"Host": "127.0.0.1", "Origin": "http://127.0.0.1:3000"},
+            )
+            assert response.status == 503
+            assert await response.json() == {
+                "schema_version": "olivia.diagnostic-export.v1",
+                "status": "UNAVAILABLE",
+                "error_code": "DIAGNOSTIC_EXPORT_UNAVAILABLE",
+            }
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -152,7 +152,7 @@ const run = async () => { const [id, fn] = timers.entries().next().value; timers
 
 # The shipped CEF surface needs explicit no-drag/pointer and display-state guards.
 def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
-    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v13"
+    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v14"
     for declaration in (
             'const STATUS_PATH = "/toy/companion/status";',
             'const MEMORY_PATH = "/toy/companion/memory";',
@@ -166,7 +166,7 @@ def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
         'const CONFIRM_VALUE = "confirmed";',
     ):
         assert BOOTSTRAP_JAVASCRIPT.count(declaration) == 1
-    assert BOOTSTRAP_JAVASCRIPT.count('method: "GET"') == 1
+    assert BOOTSTRAP_JAVASCRIPT.count('method: "GET"') == 2
     assert BOOTSTRAP_JAVASCRIPT.count('method: "POST"') == 2
     assert "limit: 50" in BOOTSTRAP_JAVASCRIPT
     assert "input.maxLength = 500" in BOOTSTRAP_JAVASCRIPT

--- a/tests/installer/test_original_settings_javascript.py
+++ b/tests/installer/test_original_settings_javascript.py
@@ -29,7 +29,7 @@ def test_original_settings_bootstrap_has_valid_javascript(tmp_path: Path) -> Non
 def test_original_settings_actions_remain_bounded_and_in_client() -> None:
     source = BOOTSTRAP_JAVASCRIPT
     assert source.count('method: "POST"') == 2
-    assert source.count('method: "GET"') == 1
+    assert source.count('method: "GET"') == 2
     assert '"Content-Type": "application/json"' in source
     assert 'const CONFIRM_VALUE = "confirmed"' in source
     assert "window.confirm" not in source

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1857,7 +1857,7 @@ def test_install_isolated_copy_activates_original_client_surfaces(
         main = archive.read("assets/main-917d29fc.js").decode("utf-8")
     assert "assets/olivia-companion-settings.js" in names
     assert "data-olivia-companion-settings" in index
-    assert "data-ui-version=\"p03.original-settings-manage.v13\"" in index
+    assert "data-ui-version=\"p03.original-settings-manage.v14\"" in index
     assert (installed / "local_backend" / "original_client_setup_api.py").is_file()
     assert (installed / "local_backend" / "original_client_capability_api.py").is_file()
     assert (installed / "local_backend" / "original_client_update_api.py").is_file()


### PR DESCRIPTION
Adds a Settings-page diagnostic export that builds a bounded ZIP locally without uploading it. The bundle uses strict allowlist projection for health, installation, recent task stage/error, and sanitized launcher/runtime events; it excludes keys, letter/reply/memory content, prompts, media, original assets, real IDs, absolute paths, full URLs, and raw logs/state. Focused validation after merging latest main: 78 related HTTP/UI tests passed, 6 packaging tests passed, py_compile and diff checks passed. Review gate: new Sol high Standards + Spec review on the exact PR base/head; merge only after terminal CI and PASS.