### PR TITLE
fix(persona): fit the release persona inside its prompt budget

### DIFF
--- a/contracts/llm_config.example.json
+++ b/contracts/llm_config.example.json
@@ -8,7 +8,7 @@
   "max_retries": 2,
   "retry_backoff_seconds": 0.25,
   "stream": false,
-  "max_input_chars": 10000,
+  "max_input_chars": 22000,
   "max_output_chars": 10000,
   "fallback_provider": "none",
   "persona_config": "linli_character/persona_config.json",

--- a/docs/B03_LLM_GATEWAY.md
+++ b/docs/B03_LLM_GATEWAY.md
@@ -44,7 +44,7 @@ rtk python tools/healthcheck.py --profile llm
 | `timeout_seconds` / `max_retries` / `retry_backoff_seconds` | 单次请求超时、429/5xx/网络失败重试预算 |
 | `reasoning_timeout_seconds` | 文本信件使用 `deepseek-v4-flash` max thinking 时的单阶段超时；默认 600 秒，范围 0.05-1800 秒 |
 | `stream` | 内部事件编排是否消费 provider 流；HTTP `/toy` 仍是非 SSE 响应 |
-| `max_input_chars` / `max_output_chars` | 输入消息总长度和输出长度上限 |
+| `max_input_chars` / `max_output_chars` | 输入消息总长度和输出长度上限；模板的输入默认值为 22,000，与 `GatewayConfig` 和 `ReplyRequest` 的公共默认一致 |
 | `fallback_provider` | 显式降级登记；默认 `none`，不会无提示生成占位回信 |
 | persona_v2_file / persona_v2_enabled | 默认 Persona 2.0 release 文件与开关；关闭该开关才进入 legacy 路径 |
 | persona_file / feature_enabled | 可选 legacy DRAFT 文件和总开关；默认配置不再引用该文件 |

--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -97,7 +97,7 @@ class GatewayConfig:
     max_retries: int = 2
     retry_backoff_seconds: float = 0.0
     stream: bool = False
-    max_input_chars: int = 10000
+    max_input_chars: int = 22000
     max_output_chars: int = 10000
     fallback_provider: str = "none"
     persona_file: str = ""
@@ -160,7 +160,7 @@ class GatewayConfig:
                 data.get("retry_backoff_seconds", 0.0), 0.0, 0.0, 30.0
             ),
             stream=_as_bool(data.get("stream", False)),
-            max_input_chars=_bounded_int(data.get("max_input_chars", 10000), 10000, 1, 100000),
+            max_input_chars=_bounded_int(data.get("max_input_chars", 22000), 22000, 1, 100000),
             max_output_chars=_bounded_int(data.get("max_output_chars", 10000), 10000, 1, 100000),
             fallback_provider=str(data.get("fallback_provider", "none") or "none").strip().lower(),
             persona_file=str(data.get("persona_file", "") or ""),

--- a/runtime/reply/prompt_budget.py
+++ b/runtime/reply/prompt_budget.py
@@ -49,8 +49,8 @@ _REQUIRED = frozenset(
 _DROP_ORDER = (
     PromptSection.EVIDENCE_SUMMARY,
     PromptSection.INFERRED_TRAIT,
-    PromptSection.SOFT_CANON,
     PromptSection.HISTORY,
+    PromptSection.SOFT_CANON,
     PromptSection.STYLE_EXAMPLE,
     PromptSection.PRIVATE_BEHAVIOR,
     PromptSection.WORLD_FACT,

--- a/runtime/reply/reply_orchestrator.py
+++ b/runtime/reply/reply_orchestrator.py
@@ -52,7 +52,7 @@ class ReplyRequest:
     messages: Sequence[Mapping[str, Any]] | None = None
     request_id: str = field(default_factory=lambda: uuid.uuid4().hex)
     idempotency_key: str | None = None
-    max_input_chars: int = 10000
+    max_input_chars: int = 22000
     gateway_scope: GatewayRequestScope | None = None
 
     def normalized_messages(self) -> tuple[dict[str, str], ...]:

--- a/tests/llm/test_orchestrator.py
+++ b/tests/llm/test_orchestrator.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import asyncio
 
-from llm_gateway import Gateway, GatewayDelta, GatewayError, GatewayResponse
+from llm_gateway import (
+    Gateway,
+    GatewayConfig,
+    GatewayDelta,
+    GatewayError,
+    GatewayResponse,
+)
 from reply_orchestrator import (
     ReplyEventType,
     ReplyOrchestrator,
@@ -13,6 +19,10 @@ from reply_orchestrator import (
 
 def run(coro):
     return asyncio.run(coro)
+
+
+def test_reply_request_uses_the_public_gateway_input_budget() -> None:
+    assert ReplyRequest(content="synthetic").max_input_chars == GatewayConfig().max_input_chars
 
 
 class StreamGateway(Gateway):

--- a/tests/media/test_song_content_pipeline.py
+++ b/tests/media/test_song_content_pipeline.py
@@ -117,7 +117,10 @@ def test_plan_song_content_switches_production_to_semantic_plan_and_fixed_captio
     assert "Traditional East Asian" not in system
     assert '"mode":"musical_video"' in system
     assert "Persona status is DRAFT" not in system
-    assert sum(len(message["content"]) for message in messages) <= 10_000
+    assert (
+        sum(len(message["content"]) for message in messages)
+        <= GatewayConfig().max_input_chars
+    )
 
     user = json.loads(messages[1]["content"])
     assert user == {
@@ -175,7 +178,10 @@ def test_invalid_lyric_count_is_repaired_once_by_the_planner() -> None:
     repair_messages = gateway.calls[1][0]
     assert repair_messages[-1]["role"] == "user"
     assert "SONG_SEMANTIC_PLAN_LYRICS_LINE_COUNT_INVALID" in repair_messages[-1]["content"]
-    assert sum(len(message["content"]) for message in repair_messages) <= 10_000
+    assert (
+        sum(len(message["content"]) for message in repair_messages)
+        <= GatewayConfig().max_input_chars
+    )
 
 
 def test_song_planner_legacy_persona_requires_explicit_opt_in() -> None:

--- a/tests/persona/test_persona_budget_fit.py
+++ b/tests/persona/test_persona_budget_fit.py
@@ -1,0 +1,103 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from llm_gateway import GatewayConfig
+from runtime.persona.persona_assembly import UntrustedFragment, assemble_persona
+from runtime.persona.persona_loader import load_persona
+from runtime.reply.reply_context import ReplyContext, ReplyMode, TrustedTime
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_PERSONA = ROOT / "linli_character" / "persona_release_v2.json"
+NOW = TrustedTime(datetime(2026, 8, 30, tzinfo=timezone.utc))
+
+
+def test_release_persona_fits_default_budget() -> None:
+    loaded = load_persona(RELEASE_PERSONA)
+    context = ReplyContext.create(ReplyMode.TEXT_LETTER, trusted_time=NOW)
+    config = GatewayConfig.from_mapping({})
+
+    assembled = assemble_persona(
+        loaded.snapshot,
+        context,
+        user_input="今天下雨了。",
+        max_units=config.max_input_chars,
+    )
+
+    assert loaded.snapshot.status == "READY"
+    assert GatewayConfig().max_input_chars == 22_000
+    assert config.max_input_chars == 22_000
+    invalid = GatewayConfig.from_mapping({"max_input_chars": "invalid"})
+    assert invalid.max_input_chars == 22_000
+    assert assembled.budget_report.dropped_ids == ()
+
+
+def test_release_persona_fits_with_full_history() -> None:
+    loaded = load_persona(RELEASE_PERSONA)
+    context = ReplyContext.create(ReplyMode.TEXT_LETTER, trusted_time=NOW)
+    history = (UntrustedFragment("history.full", "历" * 3_600),)
+
+    assembled = assemble_persona(
+        loaded.snapshot,
+        context,
+        user_input="来" * 2_000,
+        history=history,
+        max_units=GatewayConfig().max_input_chars,
+    )
+
+    assert assembled.budget_report.dropped_ids == ()
+
+
+def test_soft_canon_outlives_history_under_pressure() -> None:
+    loaded = load_persona(RELEASE_PERSONA)
+    context = ReplyContext.create(ReplyMode.TEXT_LETTER, trusted_time=NOW)
+    history = (
+        UntrustedFragment("older", "甲" * 1_800),
+        UntrustedFragment("recent", "乙" * 1_800),
+    )
+    full = assemble_persona(
+        loaded.snapshot,
+        context,
+        user_input="今天下雨了。",
+        history=history,
+        max_units=100_000,
+    )
+
+    pressured = assemble_persona(
+        loaded.snapshot,
+        context,
+        user_input="今天下雨了。",
+        history=history,
+        max_units=full.budget_report.used_units - 4_000,
+    )
+
+    dropped = pressured.budget_report.dropped_ids
+    history_positions = [i for i, item_id in enumerate(dropped) if item_id.startswith("history.")]
+    soft_ids = {
+        f"declaration.{item.declaration_id}"
+        for item in loaded.snapshot.declarations
+        if item.tier == "COMMUNITY_SOFT_CANON"
+    }
+    soft_positions = [i for i, item_id in enumerate(dropped) if item_id in soft_ids]
+
+    assert history_positions
+    assert not soft_positions or min(history_positions) < min(soft_positions)
+
+
+@pytest.mark.parametrize(
+    "mode", (ReplyMode.SPOKEN_VIDEO, ReplyMode.MUSICAL_VIDEO)
+)
+def test_release_persona_fits_video_mode_budget(mode: ReplyMode) -> None:
+    loaded = load_persona(RELEASE_PERSONA)
+    context = ReplyContext.create(mode, trusted_time=NOW)
+
+    assembled = assemble_persona(
+        loaded.snapshot,
+        context,
+        user_input="今天下雨了。",
+        max_units=GatewayConfig().max_input_chars,
+    )
+
+    assert assembled.budget_report.dropped_ids == ()

--- a/tests/persona/test_persona_budget_fit.py
+++ b/tests/persona/test_persona_budget_fit.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -32,6 +33,15 @@ def test_release_persona_fits_default_budget() -> None:
     invalid = GatewayConfig.from_mapping({"max_input_chars": "invalid"})
     assert invalid.max_input_chars == 22_000
     assert assembled.budget_report.dropped_ids == ()
+
+
+def test_shipped_llm_config_uses_the_public_input_budget() -> None:
+    payload = json.loads(
+        (ROOT / "contracts" / "llm_config.example.json").read_text(encoding="utf-8")
+    )
+
+    configured = GatewayConfig.from_mapping(payload)
+    assert configured.max_input_chars == GatewayConfig().max_input_chars
 
 
 def test_release_persona_fits_with_full_history() -> None:

--- a/tests/persona/test_prompt_budget.py
+++ b/tests/persona/test_prompt_budget.py
@@ -43,13 +43,13 @@ def test_optional_blocks_are_dropped_whole_in_the_fixed_priority_order() -> None
     plan = plan_prompt_budget(items, max_units=130)
 
     assert plan.report.used_units == 125
-    assert plan.report.dropped_ids == ("evidence", "inferred", "soft")
+    assert plan.report.dropped_ids == ("evidence", "inferred", "history")
     assert tuple(item.item_id for item in plan.items) == (
         "constitution",
         "forbidden",
         "mode",
         "user",
-        "history",
+        "soft",
         "behavior",
         "world",
         "canon",


### PR DESCRIPTION
## Work order

Implements PR-1 (budget and delivery mechanics) from `WORKORDER-persona-quality.md`.

Frozen review pair:

- base: `acc9c88e951931cf428428f458eb178f94157aff`
- head: `0a27a0068f1cf4aeeef6164cc30964d57cceb3fe`
- diff hash: `911fdc75ecb9c524e2ad3f433bc04eed7af49902`
- review: `STANDARDS: PASS`; `SPEC: PASS`

## Runtime load path confirmed

The production default is `GatewayConfig.persona_v2_file = "linli_character/persona_release_v2.json"`. `LetterAdapter` resolves that configured path and the reply pipeline calls `load_persona()` on it. `runtime/persona/persona_provider.py` does not choose the Persona v2 release asset; it remains the legacy/candidate provider path. The work-order baseline therefore targets the asset actually loaded by the default Persona v2 runtime.

## Changes

- Raise the public input-budget default and mapping fallback from 10,000 to 22,000 characters.
- Keep `ReplyRequest.max_input_chars` aligned with the same public default.
- Drop reconstructable HISTORY before COMMUNITY_SOFT_CANON under pressure; no other drop priority changes.
- Add real-release-asset regression coverage for the default text mode, 3,600-character history plus 2,000-character input, spoken video, musical video, and HISTORY/SOFT_CANON pressure order.
- Align the shipped config template and B03 documentation with the 22,000 public default.

## Cost and policy trade-off

Raising `max_input_chars` does not itself consume tokens; it changes a limit, not a fill target. Actual token use follows the assembled prompt. This PR sends the currently authored release persona instead of silently dropping nine soft-canon declarations. The later PR-3 content addition is the source of the projected prompt-size increase (about 14%), not this limit change.

Pending maintainer decision, intentionally not implemented here: whether `STYLE_EXAMPLE` should move after `PRIVATE_BEHAVIOR` in the drop order. This PR changes only HISTORY versus SOFT_CANON.

## Work-order conflict adjudications

Two contradictions were discovered by RED/full-suite evidence and explicitly adjudicated before implementation:

1. The music-planner tests hard-coded `<= 10_000`, producing RED totals of 13,467 and 13,672 after the required public default became 22,000. Only those two assertions now bind to `GatewayConfig().max_input_chars`; no media implementation, sample, or behavior changed.
2. `ReplyRequest` retained an independent 10,000 default, causing direct/non-HTTP calls to diverge from production and drop HISTORY after the new order. Its default now equals `GatewayConfig`, with a public-contract regression. The existing memory semantic assertions in `test_reply_model_quality.py` and `test_reply_pipeline.py` were not modified.

The existing `_DROP_ORDER` assertion in `tests/persona/test_prompt_budget.py` changed directly from dropping/keeping SOFT_CANON/HISTORY to dropping/keeping HISTORY/SOFT_CANON, as expressly allowed by PR-1.

## Non-goals self-check

- [x] No existing declaration statement text changed.
- [x] No CONSTITUTION declaration or required prompt section changed or weakened.
- [x] No source-document prose copied into a release asset.
- [x] No change to the non-droppable `PromptSection` set.
- [x] No reply quality gate, reviewer, intimacy model, media implementation, Live, or installer change.
- [x] No third-party dependency added.

## Verification

- `python -m pytest -q tests/persona tests/llm/test_gateway.py tests/llm/test_orchestrator.py tests/media/test_song_content_pipeline.py` — `348 passed`
- `python -m pytest -q` — `1751 passed, 1 skipped, 1 deselected` (exit 0; seven existing aiohttp key warnings)
- `python baseline_hardening_scan.py --mode all` — `status=PASS`, exit 0
- `git diff --check community/main...HEAD` — PASS

No external LLM/model call, GPU run, media run, or human acceptance was needed or claimed for this deterministic budget change.

## Rollback

Revert the two commits in this PR. No data migration or persistent-state change is involved.
