### PR TITLE
fix(media): manage MiniMax process tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ flowchart LR
 
 LatentSync 单次任务（FFmpeg 准备与口型渲染合计）默认最多等待 1800 秒，可用 `OLIVIA_LATENTSYNC_TIMEOUT_SECONDS` 调整，最高 3600 秒；任一阶段超时都会终止整棵工作进程并在本机媒体日志记录脱敏原因。
 
+后台媒体 worker 在 Windows 归入 Job Object，在 POSIX 归入独立进程组；调用结束前会在剩余清理预算内等待整棵进程树归零。确认归零后的额外清理错误只产生脱敏 warning（已有异常只追加脱敏 note），不会改写原 completed 结果或异常；若预算耗尽仍无法确认归零，completed 路径以稳定脱敏错误 fail-closed，已有 timeout 或 worker 异常则保留原类型并追加 cleanup note。
+
 ## Persona、记忆与 PrivateWorld
 
 Persona 不是一段无限增长的 system prompt。公开人格文件带有来源与版本信息，并通过预算器、上下文合同和质量门装配到单次回信中。

--- a/runtime/media/managed_subprocess.py
+++ b/runtime/media/managed_subprocess.py
@@ -7,6 +7,7 @@ import signal
 import subprocess
 import sys
 import time
+import warnings
 from pathlib import Path
 from typing import Mapping, Sequence
 
@@ -47,16 +48,36 @@ def _create_windows_job():
             ("peak_process_memory", ctypes.c_size_t), ("peak_job_memory", ctypes.c_size_t),
         ]
 
+    class BasicAccounting(ctypes.Structure):
+        _fields_ = [
+            (name, ctypes.c_longlong)
+            for name in (
+                "total_user_time", "total_kernel_time",
+                "period_user_time", "period_kernel_time",
+            )
+        ] + [
+            (name, wintypes.DWORD)
+            for name in (
+                "page_faults", "total_processes", "active_processes",
+                "terminated_processes",
+            )
+        ]
+
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
     kernel32.CreateJobObjectW.restype = wintypes.HANDLE
     kernel32.SetInformationJobObject.argtypes = (
         wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD,
     )
+    kernel32.QueryInformationJobObject.argtypes = (
+        wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+    )
     kernel32.AssignProcessToJobObject.argtypes = (wintypes.HANDLE, wintypes.HANDLE)
     kernel32.TerminateJobObject.argtypes = (wintypes.HANDLE, wintypes.UINT)
     kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
     for function in (
-        kernel32.SetInformationJobObject, kernel32.AssignProcessToJobObject,
+        kernel32.SetInformationJobObject, kernel32.QueryInformationJobObject,
+        kernel32.AssignProcessToJobObject,
         kernel32.TerminateJobObject, kernel32.CloseHandle,
     ):
         function.restype = wintypes.BOOL
@@ -95,6 +116,15 @@ def _create_windows_job():
             if not kernel32.TerminateJobObject(self.handle, 1):
                 raise ctypes.WinError(ctypes.get_last_error())
 
+        def active_processes(self) -> int:
+            accounting = BasicAccounting()
+            if not kernel32.QueryInformationJobObject(
+                self.handle, 1, ctypes.byref(accounting),
+                ctypes.sizeof(accounting), None,
+            ):
+                raise ctypes.WinError(ctypes.get_last_error())
+            return int(accounting.active_processes)
+
         def close(self) -> None:
             if self.handle and not kernel32.CloseHandle(self.handle):
                 raise ctypes.WinError(ctypes.get_last_error())
@@ -106,6 +136,7 @@ def _create_windows_job():
 def _report_cleanup_failures(
     active_error: BaseException | None,
     failures: list[tuple[str, BaseException]],
+    tree_exited: bool,
 ) -> None:
     if not failures:
         return
@@ -115,7 +146,17 @@ def _report_cleanup_failures(
     if active_error is not None:
         active_error.add_note(message)
         return
-    raise OSError(message) from failures[0][1]
+    if not tree_exited:
+        raise OSError(message) from None
+    warnings.warn(message, RuntimeWarning, stacklevel=2)
+
+
+def _wait_for_tree_exit(is_empty, cleanup_deadline: float) -> None:
+    while not is_empty():
+        remaining = cleanup_deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("PROCESS_TREE_CLEANUP_TIMEOUT")
+        time.sleep(min(0.05, remaining))
 
 
 def run_managed_process(
@@ -193,7 +234,13 @@ def run_managed_process(
         )
     finally:
         active_error = sys.exc_info()[1]
+        cleanup_deadline = time.monotonic() + wait_budget(
+            _TREE_SHUTDOWN_TIMEOUT_SECONDS
+        )
+        def cleanup_budget() -> float:
+            return max(0.0, cleanup_deadline - time.monotonic())
         if job is not None:
+            tree_exited = False
             if assigned and process is not None:
                 try:
                     job.terminate()
@@ -201,20 +248,28 @@ def run_managed_process(
                     failures.append(("terminate", exc))
                 try:
                     reaped_stdout, reaped_stderr = process.communicate(
-                        timeout=wait_budget(_TREE_SHUTDOWN_TIMEOUT_SECONDS)
+                        timeout=cleanup_budget()
                     )
                     if isinstance(active_error, subprocess.TimeoutExpired):
                         active_error.output = reaped_stdout or active_error.output
                         active_error.stderr = reaped_stderr or active_error.stderr
                 except (OSError, subprocess.TimeoutExpired) as exc:
                     failures.append(("reap", exc))
+                try:
+                    _wait_for_tree_exit(
+                        lambda: job.active_processes() == 0, cleanup_deadline
+                    )
+                    tree_exited = True
+                except (OSError, TimeoutError) as exc:
+                    failures.append(("quiesce", exc))
             try:
                 job.close()
             except OSError as exc:
                 failures.append(("close", exc))
-            _report_cleanup_failures(active_error, failures)
+            _report_cleanup_failures(active_error, failures, tree_exited)
         elif process is not None:
             failures = []
+            tree_exited = False
             try:
                 os.killpg(process.pid, signal.SIGKILL)
             except ProcessLookupError:
@@ -223,14 +278,25 @@ def run_managed_process(
                 failures.append(("killpg", exc))
             try:
                 reaped_stdout, reaped_stderr = process.communicate(
-                    timeout=wait_budget(_TREE_SHUTDOWN_TIMEOUT_SECONDS)
+                    timeout=cleanup_budget()
                 )
                 if isinstance(active_error, subprocess.TimeoutExpired):
                     active_error.output = reaped_stdout or active_error.output
                     active_error.stderr = reaped_stderr or active_error.stderr
             except (OSError, subprocess.TimeoutExpired) as exc:
                 failures.append(("reap", exc))
-            _report_cleanup_failures(active_error, failures)
+            def process_group_is_empty() -> bool:
+                try:
+                    os.killpg(process.pid, 0)
+                except ProcessLookupError:
+                    return True
+                return False
+            try:
+                _wait_for_tree_exit(process_group_is_empty, cleanup_deadline)
+                tree_exited = True
+            except (OSError, TimeoutError) as exc:
+                failures.append(("quiesce", exc))
+            _report_cleanup_failures(active_error, failures, tree_exited)
 
 
 __all__ = ["run_managed_process"]

--- a/runtime/media/music_reply.py
+++ b/runtime/media/music_reply.py
@@ -25,6 +25,7 @@ from runtime.media.latentsync_reply import (
     resolve_ffmpeg_executable,
 )
 from runtime.media.media_paths import configured_media_path
+from runtime.media.managed_subprocess import run_managed_process
 from runtime.media.music_duration import MUSIC_DURATION_OPTIONS, normalize_music_duration as _normalize_music_duration
 from runtime.reply.reply_media import (
     ReplyMediaError,
@@ -782,13 +783,7 @@ def _run(
     cleanup_path: Path | None = None,
 ) -> None:
     try:
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            check=False,
-            timeout=timeout,
-            env=env,
-        )
+        result = run_managed_process(command, timeout_seconds=timeout, env=env)
     except (OSError, subprocess.TimeoutExpired) as exc:
         failure_category = "TimeoutExpired" if isinstance(exc, subprocess.TimeoutExpired) else getattr(exc, "stderr", None) or type(exc).__name__
         diagnostic = _provider_failure_diagnostic(returncode="unavailable", stderr=failure_category)

--- a/tests/media/test_managed_subprocess.py
+++ b/tests/media/test_managed_subprocess.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 import subprocess
 import sys
-import time
 from types import SimpleNamespace
 
 import pytest
@@ -14,6 +13,7 @@ from runtime.media import managed_subprocess
 
 def test_windows_success_terminates_assigned_job_before_close(monkeypatch) -> None:
     events: list[str] = []
+    active_processes = iter((2, 0))
 
     class Process:
         pid, returncode = 4242, 0
@@ -26,6 +26,9 @@ def test_windows_success_terminates_assigned_job_before_close(monkeypatch) -> No
         assign=lambda _process: events.append("assign"),
         resume=lambda _process: events.append("resume"),
         terminate=lambda: events.append("terminate"),
+        active_processes=lambda: (
+            events.append("active") or next(active_processes)
+        ),
         close=lambda: events.append("close"),
     )
     monkeypatch.setattr(managed_subprocess.os, "name", "nt")
@@ -36,7 +39,8 @@ def test_windows_success_terminates_assigned_job_before_close(monkeypatch) -> No
 
     assert result.stdout == b"out"
     assert events == [
-        "assign", "resume", "reap:12", "terminate", "reap:15.0", "close",
+        "assign", "resume", "reap:12", "terminate", "reap:15.0",
+        "active", "active", "close",
     ]
 
 
@@ -56,6 +60,7 @@ def test_windows_timeout_owns_and_terminates_suspended_worker(monkeypatch) -> No
         def assign(self, process): observed["assigned"] = process.pid
         def resume(self, process): observed["resumed"] = process.pid
         def terminate(self): observed["terminated"] = True
+        def active_processes(self): return 0
         def close(self): observed["closed"] = True
 
     def popen(_command, **kwargs):
@@ -91,6 +96,7 @@ def test_absolute_deadline_includes_start_timeout_and_cleanup(monkeypatch) -> No
         def assign(self, _process): spend(1)
         def resume(self, _process): spend(1)
         def terminate(self): spend(1)
+        def active_processes(self): return 0
         def close(self): pass
     monkeypatch.setattr(managed_subprocess.os, "name", "nt")
     monkeypatch.setattr(managed_subprocess, "_TREE_SHUTDOWN_TIMEOUT_SECONDS", 2.0)
@@ -159,6 +165,7 @@ def test_windows_resume_failure_terminates_assigned_job_once(monkeypatch) -> Non
         assign=lambda _process: observed.append("assign"),
         resume=lambda _process: (_ for _ in ()).throw(OSError("resume")),
         terminate=lambda: observed.append("terminate"),
+        active_processes=lambda: 0,
         close=lambda: observed.append("close"),
     )
     monkeypatch.setattr(managed_subprocess.os, "name", "nt")
@@ -181,6 +188,7 @@ def test_windows_cleanup_failures_do_not_swallow_resume_error(monkeypatch) -> No
         assign=lambda _process: None,
         resume=lambda _process: (_ for _ in ()).throw(OSError("resume")),
         terminate=lambda: (_ for _ in ()).throw(OSError("terminate")),
+        active_processes=lambda: 0,
         close=lambda: (_ for _ in ()).throw(OSError("close")),
     )
     monkeypatch.setattr(managed_subprocess.os, "name", "nt")
@@ -195,11 +203,12 @@ def test_windows_cleanup_failures_do_not_swallow_resume_error(monkeypatch) -> No
     ]
 
 
-def test_windows_job_close_failure_is_reported(monkeypatch) -> None:
+def test_windows_job_close_failure_warns_after_tree_exit(monkeypatch) -> None:
     observed: list[str] = []
     job = SimpleNamespace(
         assign=lambda _process: None, resume=lambda _process: None,
         terminate=lambda: observed.append("terminate"),
+        active_processes=lambda: 0,
         close=lambda: (_ for _ in ()).throw(OSError("close")),
     )
     process = SimpleNamespace(
@@ -209,12 +218,15 @@ def test_windows_job_close_failure_is_reported(monkeypatch) -> None:
     monkeypatch.setattr(managed_subprocess.os, "name", "nt")
     monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
     monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
-    with pytest.raises(OSError, match="PROCESS_TREE_CLEANUP_FAILED: close"):
-        managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
+    with pytest.warns(RuntimeWarning, match="PROCESS_TREE_CLEANUP_FAILED: close"):
+        result = managed_subprocess.run_managed_process(
+            ["worker"], timeout_seconds=1,
+        )
+    assert result.returncode == 0
     assert observed == ["reap:1", "terminate", "reap:15.0"]
 
 
-def test_windows_terminate_failure_still_closes_and_is_explicit(monkeypatch) -> None:
+def test_windows_terminate_failure_warns_after_tree_exit(monkeypatch) -> None:
     observed: list[str] = []
     process = SimpleNamespace(
         returncode=0, communicate=lambda timeout: (b"", b""),
@@ -222,20 +234,85 @@ def test_windows_terminate_failure_still_closes_and_is_explicit(monkeypatch) -> 
     job = SimpleNamespace(
         assign=lambda _process: None, resume=lambda _process: None,
         terminate=lambda: (_ for _ in ()).throw(OSError("terminate")),
+        active_processes=lambda: 0,
         close=lambda: observed.append("close"),
     )
     monkeypatch.setattr(managed_subprocess.os, "name", "nt")
     monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
     monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
 
-    with pytest.raises(OSError, match="PROCESS_TREE_CLEANUP_FAILED: terminate"):
+    with pytest.warns(RuntimeWarning, match="PROCESS_TREE_CLEANUP_FAILED: terminate"):
+        result = managed_subprocess.run_managed_process(
+            ["worker"], timeout_seconds=1,
+        )
+
+    assert result.returncode == 0
+    assert observed == ["close"]
+
+
+@pytest.mark.parametrize("returncode", (0, 7))
+def test_cleanup_timeout_fails_closed_for_completed_result(monkeypatch, returncode) -> None:
+    clock = [0.0]
+    process = SimpleNamespace(
+        returncode=returncode, communicate=lambda timeout: (b"out", b"err"),
+    )
+    job = SimpleNamespace(
+        assign=lambda _process: None, resume=lambda _process: None,
+        terminate=lambda: None, active_processes=lambda: 1, close=lambda: None,
+    )
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess, "_TREE_SHUTDOWN_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(managed_subprocess.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(
+        managed_subprocess.time, "sleep",
+        lambda seconds: clock.__setitem__(0, clock[0] + seconds),
+    )
+    monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
+
+    with pytest.raises(
+        OSError, match="^PROCESS_TREE_CLEANUP_FAILED: quiesce$",
+    ) as caught:
+        managed_subprocess.run_managed_process(
+            ["worker"], timeout_seconds=1,
+        )
+
+    assert caught.value.__cause__ is None
+
+
+def test_cleanup_timeout_preserves_process_timeout(monkeypatch) -> None:
+    clock, calls = [0.0], [0]
+    original = subprocess.TimeoutExpired(["worker"], 1, stderr=b"busy")
+    def communicate(timeout):
+        calls[0] += 1
+        if calls[0] == 1:
+            raise original
+        return b"", b"stopped"
+    process = SimpleNamespace(returncode=None, communicate=communicate)
+    job = SimpleNamespace(
+        assign=lambda _process: None, resume=lambda _process: None,
+        terminate=lambda: None, active_processes=lambda: 1, close=lambda: None,
+    )
+    monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(managed_subprocess, "_TREE_SHUTDOWN_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(managed_subprocess.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(
+        managed_subprocess.time, "sleep",
+        lambda seconds: clock.__setitem__(0, clock[0] + seconds),
+    )
+    monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
+
+    with pytest.raises(subprocess.TimeoutExpired) as caught:
         managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
 
-    assert observed == ["close"]
+    assert caught.value is original
+    assert caught.value.__notes__ == ["PROCESS_TREE_CLEANUP_FAILED: quiesce"]
 
 
 def test_posix_success_terminates_process_group_and_reaps(monkeypatch) -> None:
     observed: list[str] = []
+    group_exists = iter((True, False))
 
     class Process:
         pid, returncode = 4242, 0
@@ -248,10 +325,14 @@ def test_posix_success_terminates_process_group_and_reaps(monkeypatch) -> None:
         assert kwargs["start_new_session"] is True
         return Process()
 
+    def killpg(pid, sig):
+        observed.append(f"kill:{pid}:{sig}")
+        if sig == 0 and not next(group_exists):
+            raise ProcessLookupError
+
     monkeypatch.setattr(managed_subprocess.os, "name", "posix")
     monkeypatch.setattr(
-        managed_subprocess.os, "killpg",
-        lambda pid, sig: observed.append(f"kill:{pid}:{sig}"), raising=False,
+        managed_subprocess.os, "killpg", killpg, raising=False,
     )
     monkeypatch.setattr(managed_subprocess.signal, "SIGKILL", 9, raising=False)
     monkeypatch.setattr(managed_subprocess.subprocess, "Popen", popen)
@@ -261,7 +342,49 @@ def test_posix_success_terminates_process_group_and_reaps(monkeypatch) -> None:
     assert result.stdout == b"out"
     assert observed == [
         "reap:12", f"kill:4242:{managed_subprocess.signal.SIGKILL}", "reap:15.0",
+        "kill:4242:0", "kill:4242:0",
     ]
+
+
+def test_posix_kill_failure_warns_after_group_exit(monkeypatch) -> None:
+    process = SimpleNamespace(
+        pid=4242, returncode=7, communicate=lambda timeout: (b"out", b"err"),
+    )
+    def killpg(_pid, sig):
+        if sig == 0:
+            raise ProcessLookupError
+        raise OSError("killpg")
+    monkeypatch.setattr(managed_subprocess.os, "name", "posix")
+    monkeypatch.setattr(managed_subprocess.os, "killpg", killpg, raising=False)
+    monkeypatch.setattr(managed_subprocess.signal, "SIGKILL", 9, raising=False)
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
+
+    with pytest.warns(RuntimeWarning, match="PROCESS_TREE_CLEANUP_FAILED: killpg"):
+        result = managed_subprocess.run_managed_process(
+            ["worker"], timeout_seconds=1,
+        )
+
+    assert (result.returncode, result.stdout, result.stderr) == (7, b"out", b"err")
+
+
+def test_posix_cleanup_timeout_fails_closed(monkeypatch) -> None:
+    clock = [0.0]
+    process = SimpleNamespace(
+        pid=4242, returncode=0, communicate=lambda timeout: (b"out", b"err"),
+    )
+    monkeypatch.setattr(managed_subprocess.os, "name", "posix")
+    monkeypatch.setattr(managed_subprocess.os, "killpg", lambda *_args: None, raising=False)
+    monkeypatch.setattr(managed_subprocess.signal, "SIGKILL", 9, raising=False)
+    monkeypatch.setattr(managed_subprocess, "_TREE_SHUTDOWN_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(managed_subprocess.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(
+        managed_subprocess.time, "sleep",
+        lambda seconds: clock.__setitem__(0, clock[0] + seconds),
+    )
+    monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: process)
+
+    with pytest.raises(OSError, match="^PROCESS_TREE_CLEANUP_FAILED: quiesce$"):
+        managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
 
 
 def test_posix_cleanup_failures_do_not_swallow_timeout(monkeypatch) -> None:
@@ -283,13 +406,13 @@ def test_posix_cleanup_failures_do_not_swallow_timeout(monkeypatch) -> None:
         managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
 
     assert caught.value.__notes__ == [
-        "PROCESS_TREE_CLEANUP_FAILED: killpg, reap",
+        "PROCESS_TREE_CLEANUP_FAILED: killpg, reap, quiesce",
     ]
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows Job Object contract")
 @pytest.mark.parametrize(("parent_sleep", "times_out"), [(30, True), (0, False)])
-def test_real_windows_terminates_worker_tree(
+def test_real_windows_returns_after_worker_tree_exits(
     tmp_path: Path, parent_sleep: int, times_out: bool,
 ) -> None:
     pid_file = tmp_path / "worker-pids.txt"
@@ -302,19 +425,39 @@ def test_real_windows_terminates_worker_tree(
     )
     command = [sys.executable, "-c", script, str(pid_file), str(parent_sleep)]
     if times_out:
-        with pytest.raises(subprocess.TimeoutExpired):
+        with pytest.raises(subprocess.TimeoutExpired) as caught:
             managed_subprocess.run_managed_process(command, timeout_seconds=2)
+        assert not getattr(caught.value, "__notes__", ())
     else:
         assert managed_subprocess.run_managed_process(command, timeout_seconds=2).returncode == 0
     for pid in (int(value) for value in pid_file.read_text().split(",")):
-        deadline = time.monotonic() + 5
-        while True:
-            result = subprocess.run(
-                ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
-                capture_output=True, text=True, timeout=5, check=False,
-            )
-            assert result.returncode == 0
-            if str(pid) not in result.stdout or time.monotonic() >= deadline:
-                break
-            time.sleep(0.1)
+        result = subprocess.run(
+            ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+        assert result.returncode == 0
         assert str(pid) not in result.stdout
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group contract")
+@pytest.mark.parametrize(("parent_sleep", "times_out"), [(30, True), (0, False)])
+def test_real_posix_returns_after_worker_group_exits(
+    tmp_path: Path, parent_sleep: int, times_out: bool,
+) -> None:
+    pid_file = tmp_path / "worker-pgid.txt"
+    script = (
+        "import os,pathlib,subprocess,sys,time;"
+        "subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)'],"
+        "stdin=subprocess.DEVNULL,stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL);"
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid()));"
+        "time.sleep(float(sys.argv[2]))"
+    )
+    command = [sys.executable, "-c", script, str(pid_file), str(parent_sleep)]
+    if times_out:
+        with pytest.raises(subprocess.TimeoutExpired) as caught:
+            managed_subprocess.run_managed_process(command, timeout_seconds=2)
+        assert not getattr(caught.value, "__notes__", ())
+    else:
+        assert managed_subprocess.run_managed_process(command, timeout_seconds=2).returncode == 0
+    with pytest.raises(ProcessLookupError):
+        os.killpg(int(pid_file.read_text()), 0)

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -325,7 +325,7 @@ def test_provider_failures_are_stable_private_safe_and_unchained(tmp_path: Path,
         stderr = f"CUDA out of memory {tmp_path / 'voice.wav'}; {private}; secret-token; unlisted-private-fragment".encode()
         _write(Path(command[-1]), b"partial"); return subprocess.CompletedProcess(command, 23, stdout=b"", stderr=stderr)
     adapter = music_reply.MiniMaxMusic3Worker(python_path=python, worker_path=worker, comfy_root=comfy)
-    monkeypatch.setattr(music_reply.subprocess, "run", failed)
+    monkeypatch.setattr(music_reply, "run_managed_process", failed)
     with pytest.raises(music_reply.MusicReplyError) as captured: adapter.generate(private, private, song, duration_seconds=40, lyrics=private, caption=private)
     diagnostic = captured.value.diagnostic
     assert str(captured.value) == "MINIMAX_MUSIC3_FAILED" and "returncode=23" in diagnostic and "CUDA out of memory" in diagnostic and not song.exists()
@@ -333,7 +333,7 @@ def test_provider_failures_are_stable_private_safe_and_unchained(tmp_path: Path,
     assert "MINIMAX_MUSIC3_FAILED" in persisted and "returncode=23" in persisted and len(diagnostic) <= 512
     assert all(value not in diagnostic and value not in persisted for value in sensitive)
     def stable(error, code, detail="returncode=unavailable; stderr=process timeout"): assert (str(error), error.diagnostic, error.__cause__, error.__context__) == (code, detail, None, None)
-    monkeypatch.setattr(music_reply.subprocess, "run", lambda command, **_kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired(command, 1, stderr=private.encode())))
+    monkeypatch.setattr(music_reply, "run_managed_process", lambda command, **_kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired(command, 1, stderr=private.encode())))
     with pytest.raises(music_reply.MusicReplyError) as caught: adapter.generate(private, private, tmp_path / "song.flac", duration_seconds=40)
     stable(caught.value, "MINIMAX_MUSIC3_FAILED")
     def latentsync_timeout(*_args, **_kwargs):
@@ -353,6 +353,42 @@ def test_provider_failures_are_stable_private_safe_and_unchained(tmp_path: Path,
     ace_error(lambda request, **_kwargs: response(next(responses)) if isinstance(request, music_reply.Request) else (_ for _ in ()).throw(TimeoutError(private)), "ACESTEP_AUDIO_UNAVAILABLE")
     responses = iter(({"code": 200, "data": {"task_id": "id"}}, {"code": 200, "data": [{"status": 1, "result": private}]}))
     ace_error(lambda *_args, **_kwargs: response(next(responses)), "ACESTEP_RESULT_INVALID", "returncode=unavailable; stderr=provider stderr redacted")
+
+
+def test_minimax_timeout_uses_managed_process_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    python = _write(tmp_path / "runtime" / "python.exe")
+    worker = _write(tmp_path / "runtime" / "worker.py")
+    comfy_root = tmp_path / "comfy"
+    _write(comfy_root / "main.py")
+    observed: dict[str, object] = {}
+
+    def timeout(command, *, timeout_seconds, env=None, **_kwargs):
+        observed.update(command=list(command), timeout=timeout_seconds, env=env)
+        raise subprocess.TimeoutExpired(command, timeout_seconds, stderr=b"busy")
+
+    monkeypatch.setattr(music_reply, "run_managed_process", timeout, raising=False)
+    monkeypatch.setattr(
+        music_reply.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("MiniMax must not launch an unmanaged process")
+        ),
+    )
+    adapter = music_reply.MiniMaxMusic3Worker(
+        python_path=python,
+        worker_path=worker,
+        comfy_root=comfy_root,
+        timeout_seconds=2.0,
+    )
+
+    with pytest.raises(music_reply.MusicReplyError, match="MINIMAX_MUSIC3_FAILED"):
+        adapter.generate("letter", "reply", tmp_path / "song.flac", duration_seconds=60)
+
+    assert observed["timeout"] == 2.0
+    assert observed["command"][:2] == [str(python), str(worker)]
 
 
 def test_truncated_video_is_not_recorded_as_completed_stage(tmp_path: Path) -> None:


### PR DESCRIPTION
## Scope

Route MiniMax Music 3, music-pipeline FFmpeg, and RoFormer subprocesses through the managed process-tree runner so timeout cleanup is bounded and descendant processes do not keep GPU resources indefinitely. Preserve active timeout/provider failures and fail closed when process-tree exit cannot be confirmed.

## Frozen evidence

Base 1d5c7eb09aa7df1dbabd7d07d195c6720ab2bfc0; head 087dabbacb238f2dddcf4394aa4b71a97c21a384. Range-diff from reviewed 24f26d2...f251f1c is exact equals. Focused tests: 36 passed, 2 platform-conditional skipped; py_compile and diff-check passed. Scope: 5 files, 280 additions and 38 deletions, 318 changed lines.

## Review and round-cap record

Final review is Standards BLOCK / Spec BLOCK with P0=0 and residual P1 findings after the user-authorized two-repair-round cap: warnings.warn can be promoted to an exception under warnings-as-errors after confirmed cleanup; and a Windows Job close failure before Popen may override the intended timeout. README also overstates runner coverage for some probes/validation calls. Per the user's explicit rule, no third repair head is created; these residuals are recorded before merge.

## Boundary

No full suite or real MiniMax render was run for this candidate. Final private-installer and natural 60-second media acceptance remain separate release gates.