### PR TITLE
feat(media): resolve managed voice reference

### DIFF
--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -25,6 +25,11 @@ from video_capability_install import (
     VideoCapabilityError,
     load_video_runtime_environment,
 )
+from runtime.media.managed_voice_reference import (
+    MANAGED_VOICE_REFERENCE_SHA256,
+    ManagedVoiceReferenceError,
+    resolve_managed_voice_reference,
+)
 
 
 def _load_dpapi_key(path: Path) -> str:
@@ -60,7 +65,10 @@ _LLM_MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
 
 
 def _load_video_environment(
-    environment: dict[str, str], data_root: Path
+    environment: dict[str, str],
+    data_root: Path,
+    *,
+    expected_voice_reference_sha256: str = MANAGED_VOICE_REFERENCE_SHA256,
 ) -> dict[str, str]:
     """Load only verified paths persisted by the video bundle assembler."""
 
@@ -68,9 +76,23 @@ def _load_video_environment(
     try:
         persisted = load_video_runtime_environment(data_root.resolve())
     except (OSError, TypeError, ValueError, VideoCapabilityError):
+        persisted = None
+    if persisted is not None:
+        for key, value in persisted.items():
+            values.setdefault(key, value)
+    if not str(environment.get("OLIVIA_REPLY_VOICE_REFERENCE", "")).strip():
+        values.pop("OLIVIA_REPLY_VOICE_REFERENCE", None)
+        try:
+            reference = resolve_managed_voice_reference(
+                data_root,
+                expected_sha256=expected_voice_reference_sha256,
+            )
+        except ManagedVoiceReferenceError:
+            pass
+        else:
+            values["OLIVIA_REPLY_VOICE_REFERENCE"] = str(reference)
+    if persisted is None:
         return values
-    for key, value in persisted.items():
-        values.setdefault(key, value)
     backend_tools = Path(__file__).resolve().parents[1] / "tools"
     minimax_worker = backend_tools / "minimax_music3_worker.py"
     minimax_profile = backend_tools / "minimax_profile.py"

--- a/runtime/media/managed_voice_reference.py
+++ b/runtime/media/managed_voice_reference.py
@@ -1,0 +1,120 @@
+"""Resolve the private voice reference installed beside the local runtime."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import wave
+
+
+MANAGED_VOICE_REFERENCE_RELATIVE_PATH = Path(
+    "capabilities/video/shared/linli-reference.wav"
+)
+MANAGED_VOICE_REFERENCE_SHA256 = (
+    "7bd846a55265d5ceb4dcf0ef164dc954066b8b056ac1e40d554b1e41d844a5bf"
+)
+MANAGED_VOICE_REFERENCE_WAVE = {
+    "channels": 1,
+    "sample_width_bytes": 2,
+    "sample_rate_hz": 16_000,
+    "frame_count": 77_600,
+    "compression_type": "NONE",
+}
+_METADATA_SCHEMA = "olivia.managed-voice-reference.v1"
+
+
+class ManagedVoiceReferenceError(RuntimeError):
+    """Stable failure raised when an installed reference is not trustworthy."""
+
+
+def _is_reparse_point(path: Path) -> bool:
+    try:
+        attributes = getattr(path.lstat(), "st_file_attributes", 0)
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise ManagedVoiceReferenceError("VOICE_REFERENCE_INVALID") from exc
+    return path.is_symlink() or bool(attributes & 0x0400)
+
+
+def _reject_reparse_points(root: Path, reference: Path) -> None:
+    candidate = root
+    for part in MANAGED_VOICE_REFERENCE_RELATIVE_PATH.parts[:-1]:
+        if _is_reparse_point(candidate):
+            raise ManagedVoiceReferenceError("VOICE_REFERENCE_INVALID")
+        candidate /= part
+    if any(
+        _is_reparse_point(path)
+        for path in (candidate, reference, reference.with_suffix(".json"))
+    ):
+        raise ManagedVoiceReferenceError("VOICE_REFERENCE_INVALID")
+
+
+def _wave_facts(path: Path) -> dict[str, int | str]:
+    try:
+        with wave.open(str(path), "rb") as source:
+            facts: dict[str, int | str] = {
+                "channels": source.getnchannels(),
+                "sample_width_bytes": source.getsampwidth(),
+                "sample_rate_hz": source.getframerate(),
+                "frame_count": source.getnframes(),
+                "compression_type": source.getcomptype(),
+            }
+            frames = source.readframes(int(facts["frame_count"]))
+    except (EOFError, OSError, wave.Error) as exc:
+        raise ManagedVoiceReferenceError("VOICE_REFERENCE_INVALID") from exc
+    if any(facts[key] != value for key, value in MANAGED_VOICE_REFERENCE_WAVE.items() if key != "frame_count"):
+        raise ManagedVoiceReferenceError("VOICE_REFERENCE_INVALID")
+    expected_bytes = (
+        int(facts["frame_count"])
+        * int(facts["channels"])
+        * int(facts["sample_width_bytes"])
+    )
+    if expected_bytes <= 0 or len(frames) != expected_bytes:
+        raise ManagedVoiceReferenceError("VOICE_REFERENCE_INVALID")
+    return facts
+
+
+def resolve_managed_voice_reference(
+    data_root: Path,
+    *,
+    expected_sha256: str = MANAGED_VOICE_REFERENCE_SHA256,
+) -> Path:
+    """Return the installed WAV only when its sidecar and bytes agree."""
+
+    root = Path(data_root).absolute()
+    reference = root / MANAGED_VOICE_REFERENCE_RELATIVE_PATH
+    _reject_reparse_points(root, reference)
+    try:
+        metadata = json.loads(reference.with_suffix(".json").read_text(encoding="utf-8"))
+        payload = reference.read_bytes()
+        facts = _wave_facts(reference)
+    except FileNotFoundError as exc:
+        raise ManagedVoiceReferenceError("VOICE_REFERENCE_UNAVAILABLE") from exc
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ManagedVoiceReferenceError("VOICE_REFERENCE_INVALID") from exc
+    digest = hashlib.sha256(payload).hexdigest()
+    if (
+        not isinstance(metadata, dict)
+        or set(metadata) != {"schema_version", "path", "size_bytes", "sha256", "wave"}
+        or metadata.get("schema_version") != _METADATA_SCHEMA
+        or metadata.get("path") != reference.name
+        or metadata.get("size_bytes") != len(payload)
+        or metadata.get("sha256") != digest
+        or metadata.get("wave") != facts
+        or digest != expected_sha256
+    ):
+        raise ManagedVoiceReferenceError("VOICE_REFERENCE_INVALID")
+    if expected_sha256 == MANAGED_VOICE_REFERENCE_SHA256 and facts != MANAGED_VOICE_REFERENCE_WAVE:
+        raise ManagedVoiceReferenceError("VOICE_REFERENCE_INVALID")
+    return reference
+
+
+__all__ = [
+    "MANAGED_VOICE_REFERENCE_RELATIVE_PATH",
+    "MANAGED_VOICE_REFERENCE_SHA256",
+    "MANAGED_VOICE_REFERENCE_WAVE",
+    "ManagedVoiceReferenceError",
+    "resolve_managed_voice_reference",
+]

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -6,6 +6,7 @@ import json
 import os
 from pathlib import Path
 from urllib.error import HTTPError, URLError
+import wave
 import zipfile
 
 import pytest
@@ -256,6 +257,46 @@ def test_launcher_loads_persisted_video_runtime_environment(tmp_path: Path) -> N
     )
     assert explicit["OLIVIA_LATENTSYNC_ROOT"] == "D:/managed/latentsync"
     assert explicit["OLIVIA_MINIMAX_WORKER"] == "D:/managed/minimax-worker.py"
+
+
+def test_launcher_auto_uses_private_voice_but_keeps_public_absence_valid(
+    tmp_path: Path,
+) -> None:
+    data_root = tmp_path / "private"
+    reference = data_root / "capabilities/video/shared/linli-reference.wav"
+    reference.parent.mkdir(parents=True)
+    with wave.open(str(reference), "wb") as target:
+        target.setparams((1, 2, 16_000, 0, "NONE", "not compressed"))
+        target.writeframes(b"\0\0" * 1_600)
+    digest = hashlib.sha256(reference.read_bytes()).hexdigest()
+    reference.with_suffix(".json").write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.managed-voice-reference.v1",
+                "path": reference.name,
+                "size_bytes": reference.stat().st_size,
+                "sha256": digest,
+                "wave": {
+                    "channels": 1,
+                    "sample_width_bytes": 2,
+                    "sample_rate_hz": 16_000,
+                    "frame_count": 1_600,
+                    "compression_type": "NONE",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    private = start_local._load_video_environment(
+        {}, data_root, expected_voice_reference_sha256=digest
+    )
+    public_root = tmp_path / "public"
+    public_root.mkdir()
+    public = start_local._load_video_environment({}, public_root)
+
+    assert private["OLIVIA_REPLY_VOICE_REFERENCE"] == str(reference.absolute())
+    assert "OLIVIA_REPLY_VOICE_REFERENCE" not in public
 
 
 def test_launcher_uses_fixed_scene_assets_from_the_installed_client(tmp_path: Path) -> None:

--- a/tests/media/test_managed_voice_reference.py
+++ b/tests/media/test_managed_voice_reference.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import wave
+
+import pytest
+
+from runtime.media.managed_voice_reference import (
+    ManagedVoiceReferenceError,
+    resolve_managed_voice_reference,
+)
+
+
+def _managed_reference(root: Path, *, frames: int = 1_600) -> tuple[Path, str]:
+    reference = root / "capabilities/video/shared/linli-reference.wav"
+    reference.parent.mkdir(parents=True)
+    with wave.open(str(reference), "wb") as target:
+        target.setparams((1, 2, 16_000, 0, "NONE", "not compressed"))
+        target.writeframes(b"\0\0" * frames)
+    digest = hashlib.sha256(reference.read_bytes()).hexdigest()
+    reference.with_suffix(".json").write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.managed-voice-reference.v1",
+                "path": reference.name,
+                "size_bytes": reference.stat().st_size,
+                "sha256": digest,
+                "wave": {
+                    "channels": 1,
+                    "sample_width_bytes": 2,
+                    "sample_rate_hz": 16_000,
+                    "frame_count": frames,
+                    "compression_type": "NONE",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return reference, digest
+
+
+def test_resolver_accepts_a_complete_managed_reference(tmp_path: Path) -> None:
+    reference, digest = _managed_reference(tmp_path)
+
+    assert resolve_managed_voice_reference(
+        tmp_path, expected_sha256=digest
+    ) == reference.absolute()
+
+
+def test_resolver_rejects_a_junction_inside_the_managed_path(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    _reference, digest = _managed_reference(outside)
+    shared = tmp_path / "data/capabilities/video/shared"
+    shared.parent.mkdir(parents=True)
+    completed = subprocess.run(
+        [
+            "cmd.exe",
+            "/d",
+            "/c",
+            "mklink",
+            "/J",
+            str(shared),
+            str(outside / "capabilities/video/shared"),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        pytest.skip("Windows junctions are unavailable")
+
+    with pytest.raises(ManagedVoiceReferenceError, match="VOICE_REFERENCE_INVALID"):
+        resolve_managed_voice_reference(tmp_path / "data", expected_sha256=digest)
+
+
+def test_resolver_rejects_a_truncated_wave_payload(tmp_path: Path) -> None:
+    reference, _digest = _managed_reference(tmp_path)
+    reference.write_bytes(reference.read_bytes()[:46])
+    digest = hashlib.sha256(reference.read_bytes()).hexdigest()
+    sidecar = reference.with_suffix(".json")
+    metadata = json.loads(sidecar.read_text(encoding="utf-8"))
+    metadata.update(size_bytes=reference.stat().st_size, sha256=digest)
+    sidecar.write_text(json.dumps(metadata), encoding="utf-8")
+
+    with pytest.raises(ManagedVoiceReferenceError, match="VOICE_REFERENCE_INVALID"):
+        resolve_managed_voice_reference(tmp_path, expected_sha256=digest)


### PR DESCRIPTION
## Scope

Add the private-installer managed Lin Li voice-reference contract and launcher resolution. The launcher only injects the installed WAV after the private sidecar, SHA-256, path, and PCM facts validate; an explicit OLIVIA_REPLY_VOICE_REFERENCE override remains authoritative. No voice WAV is committed.

## Frozen evidence

Base 35820835941c8313acdd7f56cbfa73bab756ef76; head b62ae5478080950ef4abe6c43117959c5077f2df. Range-diff from reviewed 24f26d2...072c797 is exact equals. Independent Standards PASS and Spec PASS, P0/P1/P2=0. Focused tests: 55 passed; py_compile and diff-check passed. Scope: 4 files, 275 additions and 3 deletions, 278 changed lines. Git diff contains no WAV or private payload bytes.

## Boundary

The real private WAV remains outside Git and will be supplied only to the final private setup builder. A real fresh install and audio/video render are separate final acceptance gates.