### PR TITLE
fix(installer): deploy MiniMax worker profile

### DIFF
--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -6,6 +6,7 @@ import hashlib
 from pathlib import Path
 import shutil
 import stat
+import subprocess
 import sys
 import threading
 import time
@@ -338,6 +339,102 @@ def test_runtime_archive_is_extracted_verified_and_activated(
     assert restarted_without_archive.status()["runtime_import"]["state"] == "ready"
 
 
+def test_restart_repairs_legacy_managed_worker_pair_before_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    monkeypatch.setattr(
+        video_capability_install, "_runtime_environment_is_portable", lambda *_: True
+    )
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: {
+            "ordinary_missing_dependencies": [],
+            "music_ready": True,
+        },
+    )
+    assert installer.import_runtime_archive(runtime_archive=archive) == "APPLIED"
+    worker = Path(load_video_runtime_environment(data_root)["OLIVIA_MINIMAX_WORKER"])
+    profile = worker.with_name("minimax_profile.py")
+    profile.unlink()
+    observed: list[dict[str, str]] = []
+
+    restarted = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: pytest.fail(
+            "installed runtime must not reprobe"
+        ),
+        runtime_environment_applier=lambda environment: observed.append(
+            dict(environment)
+        ),
+    )
+
+    source_directory = Path(video_capability_install.__file__).resolve().parent / "tools"
+    assert restarted.status()["runtime_import"]["state"] == "ready"
+    assert profile.read_bytes() == (source_directory / profile.name).read_bytes()
+    assert worker.read_bytes() == (source_directory / worker.name).read_bytes()
+    assert len(observed) == 1
+
+
+def test_restart_fails_closed_when_legacy_managed_worker_pair_cannot_be_repaired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    monkeypatch.setattr(
+        video_capability_install, "_runtime_environment_is_portable", lambda *_: True
+    )
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: {
+            "ordinary_missing_dependencies": [],
+            "music_ready": True,
+        },
+    )
+    assert installer.import_runtime_archive(runtime_archive=archive) == "APPLIED"
+    worker = Path(load_video_runtime_environment(data_root)["OLIVIA_MINIMAX_WORKER"])
+    profile = worker.with_name("minimax_profile.py")
+    profile.unlink()
+    real_copy = video_capability_install.shutil.copy2
+
+    def copy(source: object, target: object) -> object:
+        if Path(source).name == "minimax_profile.py":
+            raise PermissionError("profile unavailable")
+        return real_copy(source, target)
+
+    monkeypatch.setattr(video_capability_install.shutil, "copy2", copy)
+    observed: list[dict[str, str]] = []
+
+    restarted = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: pytest.fail(
+            "failed legacy repair must not reprobe"
+        ),
+        runtime_environment_applier=lambda environment: observed.append(
+            dict(environment)
+        ),
+    )
+
+    assert restarted.status()["runtime_import"] == {
+        "state": "failed",
+        "checked_bytes": 0,
+        "total_bytes": 0,
+        "reason_code": "VIDEO_RUNTIME_WORKER_UNAVAILABLE",
+    }
+    assert observed == []
+    assert not profile.exists()
+    assert worker.is_file()
+
+
 def test_runtime_archive_rejects_managed_component_and_voice_overrides(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -419,7 +516,189 @@ def test_production_manifest_persists_managed_worker_and_finishes_ready(
     assert installer.import_runtime_archive(runtime_archive=_runtime_archive(tmp_path)) == "APPLIED"
     worker = Path(load_video_runtime_environment(data_root)["OLIVIA_MINIMAX_WORKER"])
     assert worker.is_file() and worker.is_relative_to(install_root)
+    profile = worker.with_name("minimax_profile.py")
+    assert profile.is_file() and profile.is_relative_to(install_root)
+    isolated = subprocess.run(
+        [sys.executable, "-I", "-B", str(worker), "--help"],
+        cwd=tmp_path,
+        env={},
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert isolated.returncode == 0, isolated.stderr
     assert installer.status()["status"] == "READY"
+
+
+def _managed_worker_import_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[VideoCapabilityInstaller, Path, str, Path]:
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    runtime_root = (tmp_path / "runtime-source").resolve()
+    _runtime_archive(tmp_path)
+    manifest_sha256 = hashlib.sha256(
+        (runtime_root / "runtime-manifest.json").read_bytes()
+    ).hexdigest()
+    monkeypatch.setattr(
+        video_capability_install, "_runtime_environment_is_portable", lambda *_: True
+    )
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: {
+            "ordinary_missing_dependencies": [],
+            "music_ready": True,
+        },
+    )
+    worker_directory = (
+        data_root
+        / "capabilities"
+        / "video"
+        / "music_video"
+        / "minimax"
+        / "runtime"
+        / "tools"
+    )
+    return installer, runtime_root, manifest_sha256, worker_directory
+
+
+def test_runtime_import_reports_stable_worker_error_when_worker_directory_cannot_be_prepared(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    installer, runtime_root, manifest_sha256, worker_directory = (
+        _managed_worker_import_fixture(tmp_path, monkeypatch)
+    )
+    worker_directory = worker_directory.resolve()
+    real_mkdir = Path.mkdir
+
+    def mkdir(path: Path, *args: object, **kwargs: object) -> None:
+        if path.resolve() == worker_directory:
+            raise PermissionError("worker directory unavailable")
+        real_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", mkdir)
+
+    with pytest.raises(
+        VideoCapabilityError, match="^VIDEO_RUNTIME_WORKER_UNAVAILABLE$"
+    ):
+        installer.import_runtime_root(
+            runtime_root=runtime_root, manifest_sha256=manifest_sha256
+        )
+
+    assert installer.status()["runtime_import"]["reason_code"] == (
+        "VIDEO_RUNTIME_WORKER_UNAVAILABLE"
+    )
+
+
+def test_runtime_import_restores_both_managed_worker_files_after_publish_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    installer, runtime_root, manifest_sha256, worker_directory = (
+        _managed_worker_import_fixture(tmp_path, monkeypatch)
+    )
+    worker_directory.mkdir(parents=True)
+    profile = worker_directory / "minimax_profile.py"
+    worker = worker_directory / "minimax_music3_worker.py"
+    profile.write_bytes(b"old-profile")
+    worker.write_bytes(b"old-worker")
+    real_replace = video_capability_install.os.replace
+
+    def replace(source: object, target: object) -> None:
+        if Path(target) == worker and Path(source).suffix == ".tmp":
+            raise PermissionError("worker publication failed")
+        real_replace(source, target)
+
+    real_unlink = Path.unlink
+    denied_profile_delete = False
+
+    def unlink(path: Path, *args: object, **kwargs: object) -> None:
+        nonlocal denied_profile_delete
+        if path == profile and not denied_profile_delete:
+            denied_profile_delete = True
+            raise PermissionError("profile still open")
+        real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(video_capability_install.os, "replace", replace)
+    monkeypatch.setattr(Path, "unlink", unlink)
+
+    with pytest.raises(
+        VideoCapabilityError, match="^VIDEO_RUNTIME_WORKER_UNAVAILABLE$"
+    ):
+        installer.import_runtime_root(
+            runtime_root=runtime_root, manifest_sha256=manifest_sha256
+        )
+
+    assert profile.read_bytes() == b"old-profile"
+    assert worker.read_bytes() == b"old-worker"
+    assert not tuple(worker_directory.glob("*.tmp"))
+    assert not tuple(worker_directory.glob("*.bak"))
+
+
+def test_first_runtime_import_removes_partial_managed_worker_after_publish_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    installer, runtime_root, manifest_sha256, worker_directory = (
+        _managed_worker_import_fixture(tmp_path, monkeypatch)
+    )
+    profile = worker_directory / "minimax_profile.py"
+    worker = worker_directory / "minimax_music3_worker.py"
+    real_replace = video_capability_install.os.replace
+
+    def replace(source: object, target: object) -> None:
+        if Path(target) == worker and Path(source).suffix == ".tmp":
+            raise PermissionError("worker publication failed")
+        real_replace(source, target)
+
+    real_unlink = Path.unlink
+    denied_profile_delete = False
+
+    def unlink(path: Path, *args: object, **kwargs: object) -> None:
+        nonlocal denied_profile_delete
+        if path == profile and not denied_profile_delete:
+            denied_profile_delete = True
+            raise PermissionError("profile still open")
+        real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(video_capability_install.os, "replace", replace)
+    monkeypatch.setattr(Path, "unlink", unlink)
+
+    with pytest.raises(
+        VideoCapabilityError, match="^VIDEO_RUNTIME_WORKER_UNAVAILABLE$"
+    ):
+        installer.import_runtime_root(
+            runtime_root=runtime_root, manifest_sha256=manifest_sha256
+        )
+
+    assert not profile.exists()
+    assert not worker.exists()
+    assert not tuple(worker_directory.glob("*.tmp"))
+    assert not tuple(worker_directory.glob("*.bak"))
+
+
+def test_repeated_runtime_import_keeps_managed_worker_pair_complete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    installer, runtime_root, manifest_sha256, worker_directory = (
+        _managed_worker_import_fixture(tmp_path, monkeypatch)
+    )
+
+    assert installer.import_runtime_root(
+        runtime_root=runtime_root, manifest_sha256=manifest_sha256
+    ) == "APPLIED"
+    assert installer.import_runtime_root(
+        runtime_root=runtime_root, manifest_sha256=manifest_sha256
+    ) == "APPLIED"
+
+    source_directory = Path(video_capability_install.__file__).resolve().parent / "tools"
+    for name in ("minimax_profile.py", "minimax_music3_worker.py"):
+        assert (worker_directory / name).read_bytes() == (
+            source_directory / name
+        ).read_bytes()
+    assert not tuple(worker_directory.glob("*.tmp"))
+    assert not tuple(worker_directory.glob("*.bak"))
 
 
 def test_runtime_archive_failure_keeps_the_specific_step_reason(tmp_path: Path) -> None:

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -1050,6 +1050,13 @@ class VideoCapabilityInstaller:
         except (OSError, UnicodeError, json.JSONDecodeError, VideoCapabilityError):
             return False
         try:
+            self._install_managed_minimax_worker()
+        except VideoCapabilityError:
+            self._set_runtime_import_state(
+                "failed", reason_code="VIDEO_RUNTIME_WORKER_UNAVAILABLE"
+            )
+            return True
+        try:
             if self._runtime_environment_applier is not None:
                 self._runtime_environment_applier(environment)
         except Exception:
@@ -1139,7 +1146,22 @@ class VideoCapabilityInstaller:
         }
 
     def _install_managed_minimax_worker(self) -> None:
-        source = Path(__file__).resolve().parent / "tools" / "minimax_music3_worker.py"
+        try:
+            self._install_managed_minimax_worker_transaction()
+        except Exception as exc:
+            if (
+                isinstance(exc, VideoCapabilityError)
+                and str(exc) == "VIDEO_RUNTIME_WORKER_UNAVAILABLE"
+            ):
+                raise
+            raise VideoCapabilityError("VIDEO_RUNTIME_WORKER_UNAVAILABLE") from exc
+
+    def _install_managed_minimax_worker_transaction(self) -> None:
+        source_root = Path(__file__).resolve().parent / "tools"
+        sources = (
+            source_root / "minimax_profile.py",
+            source_root / "minimax_music3_worker.py",
+        )
         bundle = self._bundle("music_video")
         music = self._final_root(bundle)
         relative = (bundle.runtime_environment or {}).get(
@@ -1149,21 +1171,94 @@ class VideoCapabilityInstaller:
             if "minimax_music3" in bundle.dependencies:
                 raise VideoCapabilityError("VIDEO_RUNTIME_WORKER_UNAVAILABLE")
             return
-        if not source.is_file() or _is_reparse_point(source):
+        if any(
+            not source.is_file() or _is_reparse_point(source) for source in sources
+        ):
             raise VideoCapabilityError("VIDEO_RUNTIME_WORKER_UNAVAILABLE")
         _reject_reparse_tree(music)
-        target = _inside(music, music / relative)
-        target.parent.mkdir(parents=True, exist_ok=True)
-        if _is_reparse_point(target.parent) or (target.exists() and _is_reparse_point(target)):
+        worker_target = _inside(music, music / relative)
+        targets = (
+            _inside(music, worker_target.with_name("minimax_profile.py")),
+            worker_target,
+        )
+        worker_target.parent.mkdir(parents=True, exist_ok=True)
+        if _is_reparse_point(worker_target.parent) or any(
+            target.exists() and _is_reparse_point(target) for target in targets
+        ):
             raise VideoCapabilityError("VIDEO_RUNTIME_WORKER_UNAVAILABLE")
-        temporary = target.with_name(f"{target.name}.{uuid.uuid4().hex}.tmp")
+        transaction = uuid.uuid4().hex
+        staged = tuple(
+            target.with_name(f"{target.name}.{transaction}.tmp") for target in targets
+        )
+        backups: dict[Path, Path] = {}
+        originals: dict[Path, tuple[int, str] | None] = {}
+        published: list[Path] = []
+        succeeded = False
         try:
-            shutil.copy2(source, temporary)
-            os.replace(temporary, target)
-        except OSError as exc:
-            raise VideoCapabilityError("VIDEO_RUNTIME_WORKER_UNAVAILABLE") from exc
+            for source, temporary in zip(sources, staged, strict=True):
+                shutil.copy2(source, temporary)
+            for target, temporary in zip(targets, staged, strict=True):
+                if target.exists():
+                    originals[target] = _sha256_file(target)
+                    backup = target.with_name(f"{target.name}.{transaction}.bak")
+                    os.replace(target, backup)
+                    backups[target] = backup
+                else:
+                    originals[target] = None
+                os.replace(temporary, target)
+                published.append(target)
+            succeeded = True
+        except Exception as exc:
+            rollback_error: Exception | None = None
+            for target in reversed(targets):
+                try:
+                    if target in published:
+                        target.unlink(missing_ok=True)
+                except Exception as cleanup_exc:
+                    rollback_error = rollback_error or cleanup_exc
+                backup = backups.get(target)
+                if backup is not None:
+                    try:
+                        if backup.exists():
+                            os.replace(backup, target)
+                    except Exception as restore_exc:
+                        rollback_error = rollback_error or restore_exc
+            for target, expected in originals.items():
+                backup = backups.get(target)
+                try:
+                    if expected is None:
+                        target.unlink(missing_ok=True)
+                    elif backup is not None and backup.exists():
+                        os.replace(backup, target)
+                except Exception as reconcile_exc:
+                    rollback_error = rollback_error or reconcile_exc
+            for target, expected in originals.items():
+                try:
+                    restored = (
+                        not target.exists()
+                        if expected is None
+                        else target.is_file() and _sha256_file(target) == expected
+                    )
+                except Exception as verify_exc:
+                    restored = False
+                    rollback_error = rollback_error or verify_exc
+                if not restored and rollback_error is None:
+                    rollback_error = RuntimeError("managed worker rollback incomplete")
+            raise VideoCapabilityError("VIDEO_RUNTIME_WORKER_UNAVAILABLE") from (
+                rollback_error or exc
+            )
         finally:
-            temporary.unlink(missing_ok=True)
+            for temporary in staged:
+                try:
+                    temporary.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            if succeeded:
+                for backup in backups.values():
+                    try:
+                        backup.unlink(missing_ok=True)
+                    except OSError:
+                        pass
 
     def _import_runtime_root(
         self,


### PR DESCRIPTION
## 范围

- 将 minimax_profile.py 与 minimax_music3_worker.py 作为同一受管安装事务部署到目标 MiniMax runtime/tools
- 新安装、重复导入和旧 persisted runtime 恢复均在应用环境/READY 前补齐双文件
- profile 先发布、worker 最后激活；失败恢复旧文件或清除首装半成品
- 不触碰 portable builder、音色、媒体管线或 Live

## 冻结证据

- exact base: 3421df6902c48292a7b16c544bbc2646acea4e1d
- exact head: 7750eb558b2cbad8a005176ddcf1808b7a1af1ac
- focused: 162 passed
- py_compile: PASS
- git diff --check: PASS
- diff: 2 files, +385/-11

## TDD / 审查

RED 依次证明：隔离 worker 缺 profile；准备错误泄漏；回滚可留半安装；旧 persisted runtime 升级不补 profile。GREEN 覆盖双文件原子发布、稳定错误、byte-exact 回滚、首装清理、幂等及旧升级补装。

最终 Spec PASS（P0/P1/P2=0）。最终 Standards BLOCK（P0=0/P1=1/P2=0）：双文件事务未复用现有 _commit_lock，极端自动线程/手动导入并发时可能互相回滚。此 finding 出现在超过两轮修复后的最终冻结；按用户规则记录后不再修改并继续合并。