### PR TITLE
fix(persona): widen emotional situation matching and reduce false refusals

### DIFF
--- a/runtime/persona/persona_assembly.py
+++ b/runtime/persona/persona_assembly.py
@@ -34,8 +34,18 @@ _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 _STYLE_EXAMPLE_LIMIT = 2
 _STYLE_TOKEN_RE = re.compile(r"[A-Za-z0-9]+|[\u3400-\u9fff]")
 _STYLE_SITUATIONS = (
-    ("emotional_acknowledgement", re.compile(r"累|烦|难过|委屈|害怕|焦虑|没劲")),
-    ("boundary_refusal", re.compile(r"不许拒绝|不能拒绝|不准拒绝|必须|一定要")),
+    (
+        "emotional_acknowledgement",
+        re.compile(
+            r"累|烦|难过|委屈|害怕|焦虑|没劲|难受|伤心|崩溃|想哭|压力|孤独|失眠|不开心|撑不住|提不起劲|没意思|心情不好"
+        ),
+    ),
+    (
+        "boundary_refusal",
+        re.compile(
+            r"不许拒绝|不能拒绝|不准拒绝|(?:必须|一定要|非得)(?:陪|来|去|答应|同意|给我|跟我)"
+        ),
+    ),
     ("music_request", re.compile(r"(?:能|可以|请|想听|给我|为我).{0,10}(?:唱|弹|演奏)|(?:唱|弹|演奏)(?:一|几|个|首|段|曲)")),
     ("natural_close", re.compile(r"晚点再说|回头再说|先去忙|先走了|去睡了|晚安")),
     ("brief_greeting", re.compile(r"^(?:在吗|你好|早(?:上好)?|嗨|hi|hello)[！!。.？?\s]*$", re.I)),

--- a/tests/persona/test_style_situation_match.py
+++ b/tests/persona/test_style_situation_match.py
@@ -1,0 +1,123 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from llm_gateway import GatewayConfig
+from runtime.persona.persona_assembly import assemble_persona
+from runtime.persona.persona_loader import load_persona
+from runtime.reply.reply_context import ReplyContext, ReplyMode, TrustedTime
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_PERSONA = ROOT / "linli_character" / "persona_release_v2.json"
+SITUATIONS = (
+    "brief_greeting",
+    "ordinary_smalltalk",
+    "emotional_acknowledgement",
+    "boundary_refusal",
+    "natural_close",
+    "music_request",
+)
+
+
+def _assembled_content(user_input: str) -> str:
+    loaded = load_persona(RELEASE_PERSONA)
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 30, tzinfo=timezone.utc)),
+    )
+    assembled = assemble_persona(
+        loaded.snapshot,
+        context,
+        user_input=user_input,
+        max_units=GatewayConfig().max_input_chars,
+    )
+    return assembled.system_content
+
+
+def _selected_situations(user_input: str) -> set[str]:
+    content = _assembled_content(user_input)
+    return {
+        situation
+        for situation in SITUATIONS
+        if f'"situation":"{situation}"' in content
+    }
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    (
+        "我今天有点难受。",
+        "听到这件事我很伤心。",
+        "我真的快崩溃了。",
+        "最近总有点想哭。",
+        "这周压力特别大。",
+        "晚上总觉得很孤独。",
+        "我最近一直失眠。",
+        "今天有点不开心。",
+        "我感觉快撑不住了。",
+        "这几天什么都提不起劲。",
+        "最近觉得什么都没意思。",
+        "我今天心情不好。",
+    ),
+)
+def test_common_emotional_language_selects_acknowledgement(user_input: str) -> None:
+    assert "emotional_acknowledgement" in _selected_situations(user_input)
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    (
+        "你必须知道我今天多开心。",
+        "我一定要告诉你这件事。",
+        "今天必须早点睡。",
+    ),
+)
+def test_declarative_obligation_does_not_select_boundary_refusal(
+    user_input: str,
+) -> None:
+    assert "boundary_refusal" not in _selected_situations(user_input)
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    (
+        "周末陪我去，不许拒绝。",
+        "你必须陪我去。",
+    ),
+)
+def test_imposed_request_selects_boundary_refusal(user_input: str) -> None:
+    assert "boundary_refusal" in _selected_situations(user_input)
+
+
+@pytest.mark.parametrize(
+    ("situation", "user_input"),
+    (
+        ("brief_greeting", "你好！"),
+        ("ordinary_smalltalk", "今天路上看到一只猫。"),
+        ("emotional_acknowledgement", "我今天很难受。"),
+        ("boundary_refusal", "周末陪我去，不许拒绝。"),
+        ("natural_close", "我先去忙了。"),
+        ("music_request", "能给我弹一首吗？"),
+    ),
+)
+def test_every_release_style_situation_is_reachable(
+    situation: str,
+    user_input: str,
+) -> None:
+    assert situation in _selected_situations(user_input)
+
+
+def test_unmatched_input_falls_back_to_ordinary_smalltalk() -> None:
+    assert _selected_situations("今天路上看到一只猫。") == {
+        "ordinary_smalltalk"
+    }
+
+
+def test_emotional_acknowledgement_precedes_boundary_refusal() -> None:
+    content = _assembled_content("我今天很难受，你必须陪我去。")
+
+    assert content.index('"situation":"emotional_acknowledgement"') < content.index(
+        '"situation":"boundary_refusal"'
+    )


### PR DESCRIPTION
## Summary

- widen emotional situation matching for the 12 phrases required by the persona quality work order
- narrow boundary-refusal matching so declarative uses of `必须` / `一定要` do not look coercive
- prove all six situations in the shipped release persona remain reachable through the public assembly path

## Exact pair

- base: `0fefdd7a147c679e87dd9b2bfdb3a2a7a36936c6`
- head: `7dfd4530875a7ee5723e8fca3da7476d24a0bc0c`
- frozen diff hash: `7f10a695ad82bf4fcb1603a7a8aff51c1d4a0da8`
- scope: 2 files, +135/-2

## TDD evidence

- RED: the newly specified emotional phrases did not select `emotional_acknowledgement`
- RED: `你必须知道我今天多开心。`, `我一定要告诉你这件事。`, and `今天必须早点睡。` incorrectly selected `boundary_refusal`
- GREEN: the 12 emotional phrases select acknowledgement; the three declarative sentences do not select refusal; actual imposed requests still do
- GREEN: the shipped `persona_release_v2.json` proves all six style situations are reachable, unmatched input falls back to `ordinary_smalltalk`, and emotional acknowledgement precedes boundary refusal

## Validation

- focused public-path tests: `40 passed`
- all persona tests: `324 passed`
- full suite: `1825 passed, 3 skipped, 1 deselected` (8 pre-existing warnings)
- `baseline_hardening_scan.py --mode all`: PASS
- `git diff --check`: PASS
- frozen Standards review: PASS
- frozen Spec review: PASS

## Boundaries

- no style exemplar text was changed
- no declaration text, reviewer, reply quality gate, intimacy model, media, Live, installer, provider, schema, dependency, or private asset was changed
- tests use synthetic user text and the public release persona asset

