### PR TITLE
fix(installer): accept real video runtime compression

### DIFF
--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -59,6 +59,7 @@ VIDEO_RUNTIME_MAX_ENTRIES = 250_000
 VIDEO_RUNTIME_MAX_MANIFEST_BYTES = 64 * 1024 * 1024
 VIDEO_RUNTIME_MAX_EXPANDED_BYTES = 64 * 1024 * 1024 * 1024
 VIDEO_RUNTIME_MAX_COMPRESSION_RATIO = 200
+VIDEO_RUNTIME_MAX_ENTRY_COMPRESSION_RATIO = 512
 VIDEO_RUNTIME_MODEL_DIRECTORIES = {"checkpoint", "checkpoints", "downloads", "ffmpeg", "model", "models", "pretrained_models", "source", "sources", "weight", "weights"}
 VIDEO_RUNTIME_MODEL_SUFFIXES = {".ckpt", ".engine", ".gguf", ".h5", ".hdf5", ".onnx", ".pb", ".pt", ".safetensors", ".tflite", ".weights"}
 VIDEO_RUNTIME_MEDIA_SUFFIXES = {".3g2", ".3gp", ".aac", ".aif", ".aiff", ".alac", ".amr", ".asf", ".avi", ".caf", ".flac", ".flv", ".m2ts", ".m2v", ".m4a", ".m4v", ".mka", ".mkv", ".mov", ".mp3", ".mp4", ".mpeg", ".mpg", ".mts", ".mxf", ".ogg", ".ogv", ".opus", ".vob", ".wav", ".webm", ".wma", ".wmv"}
@@ -431,7 +432,7 @@ def _video_runtime_metadata(path: Path) -> dict[str, object]:
         with zipfile.ZipFile(path) as archive:
             entries = archive.infolist()
             expanded = sum(entry.file_size for entry in entries)
-            excessive_ratio = any(entry.file_size / max(1, entry.compress_size) > VIDEO_RUNTIME_MAX_COMPRESSION_RATIO for entry in entries)
+            excessive_ratio = any(entry.file_size / max(1, entry.compress_size) > VIDEO_RUNTIME_MAX_ENTRY_COMPRESSION_RATIO for entry in entries)
             if len(entries) > VIDEO_RUNTIME_MAX_ENTRIES or any(entry.flag_bits & 1 for entry in entries) or expanded > VIDEO_RUNTIME_MAX_EXPANDED_BYTES or excessive_ratio or expanded / physical_size > VIDEO_RUNTIME_MAX_COMPRESSION_RATIO:
                 raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
             archive_files: dict[str, tuple[str, zipfile.ZipInfo]] = {}

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+import random
 import subprocess
 import sys
 from types import SimpleNamespace
@@ -491,6 +492,59 @@ def test_prepare_setup_payload_applies_v2_zip_bounds_before_expansion(
     runtime = tmp_path / "Olivia-video-runtime-v2.zip"
     _write_video_runtime_v2(runtime)
     monkeypatch.setattr(f"installer.build_windows_setup.{limit_name}", limit)
+
+    with pytest.raises(SetupBuildError, match="SETUP_VIDEO_RUNTIME_INVALID"):
+        _prepare_private_runtime(source, offline, reference, runtime, tmp_path / "payload")
+
+
+def test_prepare_setup_payload_accepts_realistic_high_ratio_v2_entry(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "Olivia-video-runtime-v2.zip"
+    payload_size = 1024 * 1024
+    compressed_payload = (
+        b"0" * (payload_size - 1950) + random.Random(17).randbytes(1950)
+    )
+    ballast = random.Random(23).randbytes(64 * 1024)
+    _write_video_runtime_v2(
+        runtime,
+        cosyvoice_extra={
+            "zz-large-data.txt": compressed_payload,
+            "zz-ballast.txt": ballast,
+        },
+    )
+
+    with zipfile.ZipFile(runtime) as archive:
+        entry = archive.getinfo("cosyvoice/runtime/zz-large-data.txt")
+        ratio = entry.file_size / entry.compress_size
+        overall_ratio = sum(item.file_size for item in archive.infolist()) / runtime.stat().st_size
+    assert 320 < ratio < 322
+    assert overall_ratio < 200
+
+    _prepare_private_runtime(source, offline, reference, runtime, tmp_path / "payload")
+
+
+def test_prepare_setup_payload_rejects_v2_entry_above_ratio_limit(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "Olivia-video-runtime-v2.zip"
+    ballast = random.Random(23).randbytes(64 * 1024)
+    _write_video_runtime_v2(
+        runtime,
+        cosyvoice_extra={
+            "zz-large-data.txt": b"0" * (1024 * 1024),
+            "zz-ballast.txt": ballast,
+        },
+    )
+
+    with zipfile.ZipFile(runtime) as archive:
+        entry = archive.getinfo("cosyvoice/runtime/zz-large-data.txt")
+        ratio = entry.file_size / entry.compress_size
+        overall_ratio = sum(item.file_size for item in archive.infolist()) / runtime.stat().st_size
+    assert ratio > 512
+    assert overall_ratio < 200
 
     with pytest.raises(SetupBuildError, match="SETUP_VIDEO_RUNTIME_INVALID"):
         _prepare_private_runtime(source, offline, reference, runtime, tmp_path / "payload")


### PR DESCRIPTION
## Scope
- raise only the per-entry video-runtime ZIP compression-ratio ceiling from 200 to 512
- preserve the independent aggregate ratio ceiling of 200 and every other ZIP bound
- cover the real legal ratio class around 321 and rejection above 512 with focused synthetic archives

## Evidence
- exact pair: 681a2318ace3996c7f32b21ed140f00931047f16...d248b12800932cfdafbbcd604a1cf78d4e410fbe
- diff hash: 7d9518b5338e185aff341a005d4dbfa765e28105
- real archive central-directory maximum: 320.9969 for packaged test data
- focused setup tests: 97 passed
- pycompile and git diff --check: pass
- Standards: PASS, P0/P1/P2=0
- Spec: PASS, P0/P1/P2=0

This does not include or publish the private runtime ZIP, model weights, voice reference, letters or Live components.