### PR TITLE
fix: bound reply memory readiness wait

### DIFF
--- a/contracts/http_contract.example.json
+++ b/contracts/http_contract.example.json
@@ -96,6 +96,7 @@
   "letter_detail_generation": {
     "fields": ["letter_status", "error_code", "retryable"],
     "error_codes": {
+      "MEMORY_UNAVAILABLE": {"status": "FAILED", "retryable": true},
       "LLM_UNAVAILABLE": {"status": "FAILED", "retryable": true},
       "LLM_TIMEOUT": {"status": "FAILED", "retryable": true},
       "LLM_INTERRUPTED": {"status": "FAILED", "retryable": true},

--- a/contracts/http_contract.schema.json
+++ b/contracts/http_contract.schema.json
@@ -55,8 +55,9 @@
         "error_codes": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["LLM_UNAVAILABLE", "LLM_TIMEOUT", "LLM_INTERRUPTED", "LLM_PROVIDER_REJECTED", "LLM_PROTOCOL_ERROR", "LLM_REPLY_LENGTH_INVALID", "REPLY_QUALITY_BLOCKED", "PERSONA_NOT_READY"],
+          "required": ["MEMORY_UNAVAILABLE", "LLM_UNAVAILABLE", "LLM_TIMEOUT", "LLM_INTERRUPTED", "LLM_PROVIDER_REJECTED", "LLM_PROTOCOL_ERROR", "LLM_REPLY_LENGTH_INVALID", "REPLY_QUALITY_BLOCKED", "PERSONA_NOT_READY"],
           "properties": {
+            "MEMORY_UNAVAILABLE": {"$ref": "#/$defs/generation_error"},
             "LLM_UNAVAILABLE": {"$ref": "#/$defs/generation_error"},
             "LLM_TIMEOUT": {"$ref": "#/$defs/generation_error"},
             "LLM_INTERRUPTED": {"$ref": "#/$defs/generation_error"},

--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -24,7 +24,7 @@
 | 200 detail | `LLM_TIMEOUT` / `LLM_UNAVAILABLE` | FAILED | 是 | 发信先确认 PENDING；provider 超时/不可用后 detail 显示 FAILED |
 | 200 detail | `LLM_INTERRUPTED` | FAILED | 是 | 进程在 provider 调用终态落盘前中断；不自动重复生成 |
 | 503 | `STORE_STATE_UNAVAILABLE` | FAILED | 否 | 当前信箱状态损坏或原子持久化不可用；拒绝 current 读写且不回显正文、本机路径或底层异常 |
-| 503 | `MEMORY_UNAVAILABLE` | UNAVAILABLE | 是 | legacy import 的 SQLite 存储不可用；不回显正文、路径或密钥 |
+| 503 / detail | `MEMORY_UNAVAILABLE` | UNAVAILABLE / FAILED | 是 | legacy import 的 SQLite 存储不可用，或回信等待启用的 Mem0/outbox 就绪超过总 deadline；不回显正文、路径或密钥 |
 | 503 | `OFFICIAL_LETTER_IMPORT_UNAVAILABLE` | UNAVAILABLE | 是 | 官方登录日志或文字信件接口暂不可用；不回显凭证、正文或本机路径 |
 | 503 | `OFFICIAL_HISTORY_MEMORY_UNAVAILABLE` | UNAVAILABLE | 是 | Mem0 未安装、未启用或状态不可用；在采集官方历史前拒绝导入 |
 | 503 | `OFFICIAL_HISTORY_LLM_UNAVAILABLE` | UNAVAILABLE | 是 | 预检无法在采集前识别 corpus；大模型未配置时保守拒绝读取或写入官方历史 |

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -17,7 +17,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 - 错误响应：`{"code":<HTTP 状态>,"message":"<error_code>","data":{"status":"FAILED","error_code":"<error_code>"}}`
 - 真正未实现能力：HTTP `501`，`data.status=NOT_IMPLEMENTED`。
 - 已知但不可用的可选能力：HTTP `501`，`data.status=UNAVAILABLE`，并带 `capability`；不会返回 200 假成功。
-- HTTP 发信先返回 `200`/`PENDING`；启用的 Mem0 或 durable outbox 尚未就绪时信件保持 `PENDING`，运行时恢复后只派发一次，不会降级为无记忆生成。LLM 超时或不可用随后写入信件 `FAILED` 终态，detail 返回稳定 `error_code` 与 `retryable`。重启只恢复尚未派发的 `PENDING`；不确定是否已到达 provider 的 `PROCESSING` 会 fail closed 为 `LLM_INTERRUPTED`，不自动重复生成。
+- HTTP 发信先返回 `200`/`PENDING`；启用的 Mem0 或 durable outbox 尚未就绪时信件在自收信起最长 120 秒的总 deadline 内保持 `PENDING`，运行时恢复后只派发一次，不会降级为无记忆生成；重启不会重置该 deadline。deadline 到期会在调用 LLM、PrivateWorld、memory 或 media 前写入可重试的 `FAILED/MEMORY_UNAVAILABLE`，释放“一次一封”的 active gate；进程关闭导致的任务取消仍保持 `PENDING`。LLM 超时或不可用随后写入信件 `FAILED` 终态，detail 返回稳定 `error_code` 与 `retryable`。重启只恢复尚未派发的 `PENDING`；不确定是否已到达 provider 的 `PROCESSING` 会 fail closed 为 `LLM_INTERRUPTED`，不自动重复生成。
 - 视频回信的 detail 额外公开 `media_status`、`media_error_code` 与布尔值 `media_retryable`。路由选中视频后、正文仍在生成时为 `PENDING`；若正文生成、质量检查或重启恢复在媒体启动前失败，则为 `NOT_REQUESTED` 且没有媒体错误；只有正文成功后才进入实际媒体任务。`TTS_CONTENT_GATE_UNAVAILABLE` 为可重试的 `UNAVAILABLE`；三条有效候选均被内容门拒绝时，`TTS_CONTENT_GATE_REJECTED` 为不可重试的 `FAILED`。
 
 机器可读定义：

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -17,7 +17,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 - 错误响应：`{"code":<HTTP 状态>,"message":"<error_code>","data":{"status":"FAILED","error_code":"<error_code>"}}`
 - 真正未实现能力：HTTP `501`，`data.status=NOT_IMPLEMENTED`。
 - 已知但不可用的可选能力：HTTP `501`，`data.status=UNAVAILABLE`，并带 `capability`；不会返回 200 假成功。
-- HTTP 发信先返回 `200`/`PENDING`；启用的 Mem0 或 durable outbox 尚未就绪时信件在自收信起最长 120 秒的总 deadline 内保持 `PENDING`，运行时恢复后只派发一次，不会降级为无记忆生成；重启不会重置该 deadline。deadline 到期会在调用 LLM、PrivateWorld、memory 或 media 前写入可重试的 `FAILED/MEMORY_UNAVAILABLE`，释放“一次一封”的 active gate；进程关闭导致的任务取消仍保持 `PENDING`。LLM 超时或不可用随后写入信件 `FAILED` 终态，detail 返回稳定 `error_code` 与 `retryable`。重启只恢复尚未派发的 `PENDING`；不确定是否已到达 provider 的 `PROCESSING` 会 fail closed 为 `LLM_INTERRUPTED`，不自动重复生成。
+- HTTP 发信先返回 `200`/`PENDING`；启用的 Mem0 或 durable outbox 尚未就绪时信件在自收信起最长 120 秒的总 deadline 内保持 `PENDING`，运行时恢复后只派发一次，不会降级为无记忆生成；重启不会重置该 deadline。deadline 到期会在调用 LLM、PrivateWorld、memory 或 media 前写入可重试的 `FAILED/MEMORY_UNAVAILABLE`，释放“一次一封”的 active gate；进程关闭导致的任务取消仍保持 `PENDING`。用户明确选择的 `MEMORY_ADMIN_PAUSED` 是隔离态而非故障：回信继续使用 Archive，不检索或写入 Mem0，canonical letter 与 PrivateWorld 仍按既有合同提交，outbox 将该次 Mem0 delivery terminal-skip。LLM 超时或不可用随后写入信件 `FAILED` 终态，detail 返回稳定 `error_code` 与 `retryable`。重启只恢复尚未派发的 `PENDING`；不确定是否已到达 provider 的 `PROCESSING` 会 fail closed 为 `LLM_INTERRUPTED`，不自动重复生成。
 - 视频回信的 detail 额外公开 `media_status`、`media_error_code` 与布尔值 `media_retryable`。路由选中视频后、正文仍在生成时为 `PENDING`；若正文生成、质量检查或重启恢复在媒体启动前失败，则为 `NOT_REQUESTED` 且没有媒体错误；只有正文成功后才进入实际媒体任务。`TTS_CONTENT_GATE_UNAVAILABLE` 为可重试的 `UNAVAILABLE`；三条有效候选均被内容门拒绝时，`TTS_CONTENT_GATE_REJECTED` 为不可重试的 `FAILED`。
 
 机器可读定义：

--- a/docs/P03_03_LONG_TERM_MEMORY_MEM0.md
+++ b/docs/P03_03_LONG_TERM_MEMORY_MEM0.md
@@ -61,7 +61,7 @@ PersonaAssembly
 - 不把 PrivateWorld hidden score、control-only fact 或管理命令写入 Mem0；
 - 不在本仓库实现新的事实提取、冲突合并、时间推理或向量数据库；
 - 不要求 Mem0 Cloud；
-- 不让记忆失败无限占用回信队列；启用的 Mem0/outbox 超过 B02 总 deadline 仍未就绪时转为可重试失败，不降级为无记忆生成；
+- 不让记忆失败无限占用回信队列；启用的 Mem0/outbox 超过 B02 总 deadline 仍未就绪时转为可重试失败，不降级为无记忆生成；用户主动的 `MEMORY_ADMIN_PAUSED` 继续既有 Archive-only canonical/PrivateWorld 路径，并由 outbox terminal-skip Mem0 delivery；
 - 不用记忆摘要覆盖原始档案；
 - 不要求用户运行 CLI 管理记忆。
 

--- a/docs/P03_03_LONG_TERM_MEMORY_MEM0.md
+++ b/docs/P03_03_LONG_TERM_MEMORY_MEM0.md
@@ -61,7 +61,7 @@ PersonaAssembly
 - 不把 PrivateWorld hidden score、control-only fact 或管理命令写入 Mem0；
 - 不在本仓库实现新的事实提取、冲突合并、时间推理或向量数据库；
 - 不要求 Mem0 Cloud；
-- 不因记忆失败阻断回信；
+- 不让记忆失败无限占用回信队列；启用的 Mem0/outbox 超过 B02 总 deadline 仍未就绪时转为可重试失败，不降级为无记忆生成；
 - 不用记忆摘要覆盖原始档案；
 - 不要求用户运行 CLI 管理记忆。
 

--- a/http_contract.py
+++ b/http_contract.py
@@ -118,6 +118,7 @@ LETTER_DETAIL_GENERATION_ERROR_CODES: dict[str, dict[str, Any]] = {
         "retryable": ERROR_CODES[code]["retryable"],
     }
     for code in (
+        "MEMORY_UNAVAILABLE",
         "LLM_UNAVAILABLE",
         "LLM_TIMEOUT",
         "LLM_INTERRUPTED",

--- a/local_server.py
+++ b/local_server.py
@@ -145,6 +145,7 @@ from runtime.reply.reply_reviewer import NullReviewer
 PORT = int(_os.environ.get("OLIVIA_PORT", "8899"))
 LLM_TIMEOUT_SECONDS = 30
 LETTER_RETRY_DEDUP_SECONDS = 60
+MEMORY_READY_REPLY_TIMEOUT_SECONDS = 120.0
 
 _official_import_progress_lock = threading.Lock()
 _official_import_progress: dict[str, object] = {
@@ -2253,6 +2254,8 @@ def _public_llm_error(code: str | None) -> tuple[str, bool]:
         return "LLM_TIMEOUT", True
     if code == "LLM_INTERRUPTED":
         return "LLM_INTERRUPTED", True
+    if code == "MEMORY_UNAVAILABLE":
+        return "MEMORY_UNAVAILABLE", True
     if code in {"LLM_PROVIDER_REJECTED", "PROVIDER_REJECTED"}:
         return "LLM_PROVIDER_REJECTED", False
     if code in {"LLM_PROTOCOL_ERROR", "PROVIDER_PROTOCOL"}:
@@ -3293,9 +3296,51 @@ async def _run_reply_job(
         return False
 
 
-async def _run_reply_when_memory_ready(letter_id: str, content: str, *, idempotency_key: str | None) -> bool:
-    while not _conversation_memory_ready_for_reply():
-        await asyncio.sleep(0.25)
+def _fail_pending_reply_for_memory_timeout(letter_id: str) -> None:
+    letter = next(
+        (item for item in store.letters if item["letter_id"] == letter_id),
+        None,
+    )
+    if letter is None or letter.get("letter_status") != "PENDING":
+        return
+    letter["letter_status"] = "FAILED"
+    letter["error_code"] = "MEMORY_UNAVAILABLE"
+    _mark_media_not_requested(letter)
+    _persist_store_state()
+    _safe_log("letter_failed", error_code="MEMORY_UNAVAILABLE")
+
+
+async def _run_reply_when_memory_ready(
+    letter_id: str,
+    content: str,
+    *,
+    idempotency_key: str | None,
+    ready_timeout_seconds: float | None = None,
+) -> bool:
+    timeout_seconds = (
+        MEMORY_READY_REPLY_TIMEOUT_SECONDS
+        if ready_timeout_seconds is None
+        else max(0.0, float(ready_timeout_seconds))
+    )
+    if ready_timeout_seconds is None:
+        letter = next(
+            (item for item in store.letters if item["letter_id"] == letter_id),
+            None,
+        )
+        created_at = None if letter is None else letter.get("created_at")
+        if isinstance(created_at, (int, float)) and not isinstance(created_at, bool):
+            elapsed = max(0.0, time.time() - float(created_at))
+            timeout_seconds = max(0.0, timeout_seconds - elapsed)
+    if timeout_seconds <= 0.0:
+        _fail_pending_reply_for_memory_timeout(letter_id)
+        return False
+    try:
+        async with asyncio.timeout(timeout_seconds):
+            while not _conversation_memory_ready_for_reply():
+                await asyncio.sleep(0.25)
+    except TimeoutError:
+        _fail_pending_reply_for_memory_timeout(letter_id)
+        return False
     return await _run_reply_job(letter_id, content, idempotency_key=idempotency_key)
 
 

--- a/local_server.py
+++ b/local_server.py
@@ -87,6 +87,7 @@ from runtime.video_reply_settings import (
 )
 from conversation_memory_port import ConversationMemoryPort
 from conversation_memory_runtime import (
+    conversation_memory_reply_readiness_status,
     conversation_memory_runtime_status,
     ensure_conversation_memory_runtime,
     stop_conversation_memory_runtime,
@@ -1122,14 +1123,30 @@ def _official_history_memory_available() -> bool:
 
 
 def _conversation_memory_ready_for_reply() -> bool:
-    try:
-        status = conversation_memory_adapter.status().status
-        runtime = conversation_memory_runtime_status()
-        return status == "disabled" or (
-            status == "available" and runtime.status == "available"
-        )
-    except Exception:
+    bootstrap = getattr(
+        letters_adapter.memory_prompt_builder,
+        "conversation_runtime_status",
+        None,
+    )
+    if not isinstance(bootstrap, Mapping):
         return False
+    if bootstrap.get("status") == "disabled":
+        return bootstrap.get("provider") == "none"
+    if bootstrap.get("status") not in {"available", "degraded"}:
+        return False
+    runtime = conversation_memory_reply_readiness_status()
+    if (
+        runtime.enabled is True
+        and runtime.worker_running is True
+        and runtime.status == "degraded"
+        and runtime.reason_code == "MEMORY_ADMIN_PAUSED"
+    ):
+        return True
+    return (
+        runtime.enabled is True
+        and runtime.worker_running is True
+        and runtime.status == "available"
+    )
 
 
 def _official_history_private_world_available() -> bool:

--- a/runtime/memory/conversation_memory_runtime.py
+++ b/runtime/memory/conversation_memory_runtime.py
@@ -91,6 +91,14 @@ class ConversationMemoryRuntime:
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
         self._thread_lock = threading.Lock()
+        self._reply_status_lock = threading.Lock()
+        self._reply_status = ConversationMemoryRuntimeStatus(
+            "unavailable",
+            True,
+            "mem0-outbox",
+            False,
+            reason_code="MEMORY_OUTBOX_INITIALIZING",
+        )
 
     def start(self) -> bool:
         with self._thread_lock:
@@ -138,7 +146,7 @@ class ConversationMemoryRuntime:
             except Exception:
                 status = "unavailable"
                 reason_code = "MEMORY_ADMIN_AUDIT_UNAVAILABLE"
-        return ConversationMemoryRuntimeStatus(
+        resolved = ConversationMemoryRuntimeStatus(
             status=status,
             enabled=True,
             provider="mem0-outbox",
@@ -148,14 +156,44 @@ class ConversationMemoryRuntime:
             pending_count=_count(health.get("pending_count")),
             attempt_count=_count(health.get("attempt_count")),
         )
+        with self._reply_status_lock:
+            self._reply_status = resolved
+        return resolved
+
+    def reply_readiness_status(self) -> ConversationMemoryRuntimeStatus:
+        """Return the worker's last status without provider or storage I/O."""
+
+        with self._reply_status_lock:
+            cached = self._reply_status
+        with self._thread_lock:
+            worker_running = bool(self._thread and self._thread.is_alive())
+        if not worker_running:
+            return ConversationMemoryRuntimeStatus(
+                "degraded",
+                True,
+                "mem0-outbox",
+                False,
+                reason_code="MEMORY_OUTBOX_WORKER_NOT_RUNNING",
+                terminal_count=cached.terminal_count,
+                pending_count=cached.pending_count,
+                attempt_count=cached.attempt_count,
+            )
+        return cached
 
     def _run(self) -> None:
         while not self._stop_event.is_set():
             try:
                 asyncio.run(self.outbox.scan_once())
+                self.status()
             except Exception:
-                # Optional memory delivery never terminates the letter runtime.
-                pass
+                with self._reply_status_lock:
+                    self._reply_status = ConversationMemoryRuntimeStatus(
+                        "unavailable",
+                        True,
+                        "mem0-outbox",
+                        True,
+                        reason_code="MEMORY_OUTBOX_RUNTIME_UNAVAILABLE",
+                    )
             if self._stop_event.wait(self.interval_seconds):
                 break
 
@@ -303,6 +341,21 @@ def conversation_memory_runtime_status() -> ConversationMemoryRuntimeStatus:
     return runtime.status()
 
 
+def conversation_memory_reply_readiness_status() -> ConversationMemoryRuntimeStatus:
+    """Read the in-process reply gate snapshot without provider or SQLite I/O."""
+
+    with _RUNTIME_LOCK:
+        runtime = _RUNTIME
+    if runtime is None:
+        return ConversationMemoryRuntimeStatus(
+            "disabled",
+            False,
+            "none",
+            False,
+        )
+    return runtime.reply_readiness_status()
+
+
 def stop_conversation_memory_runtime() -> None:
     global _RUNTIME, _RUNTIME_KEY
     with _RUNTIME_LOCK:
@@ -447,6 +500,7 @@ def _count(value: object) -> int:
 __all__ = [
     "ConversationMemoryRuntime",
     "ConversationMemoryRuntimeStatus",
+    "conversation_memory_reply_readiness_status",
     "conversation_memory_runtime_status",
     "ensure_conversation_memory_runtime",
     "stop_conversation_memory_runtime",

--- a/runtime/memory/conversation_memory_runtime.py
+++ b/runtime/memory/conversation_memory_runtime.py
@@ -342,7 +342,7 @@ def conversation_memory_runtime_status() -> ConversationMemoryRuntimeStatus:
 
 
 def conversation_memory_reply_readiness_status() -> ConversationMemoryRuntimeStatus:
-    """Read the in-process reply gate snapshot without provider or SQLite I/O."""
+    """Read the in-process reply gate state without provider or SQLite I/O."""
 
     with _RUNTIME_LOCK:
         runtime = _RUNTIME

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -149,7 +149,14 @@ def test_http_startup_exposes_core_health_while_mem0_initializes(
         "ensure_conversation_memory_runtime",
         runtime_status,
     )
-    monkeypatch.setattr(local_server, "conversation_memory_runtime_status", lambda: ConversationMemoryRuntimeStatus(runtime_state[0], True, "mem0-outbox", runtime_state[0] == "available"))
+    def current_runtime_status() -> ConversationMemoryRuntimeStatus:
+        state = runtime_state[0]
+        return ConversationMemoryRuntimeStatus(
+            state, True, "mem0-outbox", state == "available"
+        )
+
+    monkeypatch.setattr(local_server, "conversation_memory_runtime_status", current_runtime_status)
+    monkeypatch.setattr(local_server, "conversation_memory_reply_readiness_status", current_runtime_status)
     history_calls: list[str] = []
     monkeypatch.setattr(local_server, "collect_default_official_text_replies", lambda: history_calls.append("collector"))
     monkeypatch.setattr(local_server, "_legacy_import_adapter", lambda: history_calls.append("archive"))
@@ -299,6 +306,67 @@ def test_memory_readiness_deadline_fails_pending_letter_before_generation(
     assert second["data"]["letter_id"] != letter["letter_id"]
 
 
+@pytest.mark.parametrize(
+    ("bootstrap", "runtime_state", "expected"),
+    [
+        (("disabled", "none"), ("disabled", False, False, None), True),
+        (("disabled", "mem0-outbox"), ("disabled", False, False, None), False),
+        (("unavailable", "mem0-outbox"), ("disabled", False, False, None), False),
+        (("available", "mem0-outbox"), ("available", True, True, None), True),
+        (("available", "mem0-outbox"), ("available", True, False, None), False),
+        (("available", "mem0-outbox"), ("degraded", True, True, "MEMORY_ADMIN_PAUSED"), True),
+        (("available", "mem0-outbox"), ("degraded", True, True, "MEMORY_OUTBOX_DELIVERY_FAILED"), False),
+        (("available", "mem0-outbox"), ("unavailable", True, True, "MEMORY_OUTBOX_STORAGE_UNAVAILABLE"), False),
+    ],
+)
+def test_memory_readiness_uses_provider_free_runtime_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    bootstrap: tuple[str, str],
+    runtime_state: tuple[str, bool, bool, str | None],
+    expected: bool,
+) -> None:
+    import local_server
+    from conversation_memory_runtime import ConversationMemoryRuntimeStatus
+
+    bootstrap_status, bootstrap_provider = bootstrap
+    runtime_status, runtime_enabled, runtime_worker, runtime_reason = runtime_state
+
+    class ProviderStatusMustNotRun:
+        def status(self):
+            raise AssertionError("reply readiness must not call the memory provider")
+
+    runtime = ConversationMemoryRuntimeStatus(
+        runtime_status,
+        runtime_worker,
+        "mem0-outbox" if runtime_enabled else "none",
+        runtime_enabled,
+        reason_code=runtime_reason,
+    )
+    monkeypatch.setattr(
+        local_server.letters_adapter.memory_prompt_builder,
+        "conversation_runtime_status",
+        {
+            "status": bootstrap_status,
+            "enabled": bootstrap_status != "disabled",
+            "provider": bootstrap_provider,
+            "worker_running": runtime_worker,
+        },
+    )
+    monkeypatch.setattr(
+        local_server,
+        "conversation_memory_adapter",
+        ProviderStatusMustNotRun(),
+    )
+    monkeypatch.setattr(
+        local_server,
+        "conversation_memory_reply_readiness_status",
+        lambda: runtime,
+        raising=False,
+    )
+
+    assert local_server._conversation_memory_ready_for_reply() is expected
+
+
 def test_memory_readiness_deadline_does_not_reset_after_restart(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -315,10 +383,16 @@ def test_memory_readiness_deadline_does_not_reset_after_restart(
     local_server.store.letters[:] = [letter]
     generated: list[str] = []
     persisted: list[str] = []
+    readiness_checks: list[str] = []
+
+    def memory_ready() -> bool:
+        readiness_checks.append("called")
+        return True
+
     monkeypatch.setattr(
         local_server,
         "_conversation_memory_ready_for_reply",
-        lambda: True,
+        memory_ready,
     )
 
     async def record_generation(*_args, **_kwargs) -> bool:
@@ -347,6 +421,7 @@ def test_memory_readiness_deadline_does_not_reset_after_restart(
     assert letter["error_code"] == "MEMORY_UNAVAILABLE"
     assert generated == []
     assert persisted == ["FAILED"]
+    assert readiness_checks == []
 
 
 def test_memory_readiness_recovery_dispatches_pending_letter_once(
@@ -377,6 +452,12 @@ def test_memory_readiness_recovery_dispatches_pending_letter_once(
         memory_ready,
     )
     monkeypatch.setattr(local_server, "_run_reply_job", record_generation)
+    original_sleep = asyncio.sleep
+
+    async def yield_once(_delay: float) -> None:
+        await original_sleep(0)
+
+    monkeypatch.setattr(local_server.asyncio, "sleep", yield_once)
 
     completed = asyncio.run(
         local_server._run_reply_when_memory_ready(

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import sys
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -221,6 +222,239 @@ def test_http_startup_exposes_core_health_while_mem0_initializes(
         assert factory_calls == ["old", "latest"]
     finally:
         release.set()
+
+
+def test_memory_readiness_deadline_fails_pending_letter_before_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    letter = {
+        "letter_id": "memory-deadline-letter",
+        "content": "synthetic memory deadline input",
+        "reply_text": "",
+        "reply_mode": "text_letter",
+        "letter_status": "PENDING",
+    }
+    local_server.store.letters[:] = [letter]
+    generated: list[str] = []
+    persisted: list[tuple[str, str | None]] = []
+
+    monkeypatch.setattr(
+        local_server,
+        "_conversation_memory_ready_for_reply",
+        lambda: False,
+    )
+
+    async def record_generation(*_args, **_kwargs) -> bool:
+        generated.append("called")
+        return True
+
+    monkeypatch.setattr(local_server, "_run_reply_job", record_generation)
+    monkeypatch.setattr(
+        local_server,
+        "_persist_store_state",
+        lambda: persisted.append(
+            (letter["letter_status"], letter.get("error_code"))
+        ),
+    )
+
+    completed = asyncio.run(
+        local_server._run_reply_when_memory_ready(
+            letter["letter_id"],
+            letter["content"],
+            idempotency_key="memory-deadline-key",
+            ready_timeout_seconds=0.01,
+        )
+    )
+
+    assert completed is False
+    assert generated == []
+    assert persisted == [("FAILED", "MEMORY_UNAVAILABLE")]
+    assert letter["letter_status"] == "FAILED"
+    assert letter["error_code"] == "MEMORY_UNAVAILABLE"
+    assert letter["reply_text"] == ""
+    assert local_server._active_undelivered_letter() is None
+    assert local_server._send_result_for_letter(letter) == {
+        "code": 503,
+        "message": "MEMORY_UNAVAILABLE",
+        "data": {
+            "letter_id": "memory-deadline-letter",
+            "status": "FAILED",
+            "error_code": "MEMORY_UNAVAILABLE",
+            "retryable": True,
+        },
+    }
+
+    second = asyncio.run(
+        local_server.route(
+            "POST",
+            "/toy/letter/send",
+            {"content": "synthetic next letter"},
+            {},
+            defer_reply=True,
+        )
+    )
+    assert second["code"] == 0
+    assert second["data"]["letter_id"] != letter["letter_id"]
+
+
+def test_memory_readiness_deadline_does_not_reset_after_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    letter = {
+        "letter_id": "memory-restart-deadline-letter",
+        "content": "synthetic old pending memory input",
+        "reply_text": "",
+        "reply_mode": "text_letter",
+        "letter_status": "PENDING",
+        "created_at": int(time.time()) - 121,
+    }
+    local_server.store.letters[:] = [letter]
+    generated: list[str] = []
+    persisted: list[str] = []
+    monkeypatch.setattr(
+        local_server,
+        "_conversation_memory_ready_for_reply",
+        lambda: True,
+    )
+
+    async def record_generation(*_args, **_kwargs) -> bool:
+        generated.append("called")
+        return True
+
+    monkeypatch.setattr(local_server, "_run_reply_job", record_generation)
+    monkeypatch.setattr(
+        local_server,
+        "_persist_store_state",
+        lambda: persisted.append(letter["letter_status"]),
+    )
+
+    async def exercise() -> bool:
+        return await asyncio.wait_for(
+            local_server._run_reply_when_memory_ready(
+                letter["letter_id"],
+                letter["content"],
+                idempotency_key=None,
+            ),
+            timeout=0.05,
+        )
+
+    assert asyncio.run(exercise()) is False
+    assert letter["letter_status"] == "FAILED"
+    assert letter["error_code"] == "MEMORY_UNAVAILABLE"
+    assert generated == []
+    assert persisted == ["FAILED"]
+
+
+def test_memory_readiness_recovery_dispatches_pending_letter_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    checks = 0
+    generated: list[tuple[str, str, str | None]] = []
+
+    def memory_ready() -> bool:
+        nonlocal checks
+        checks += 1
+        return checks >= 2
+
+    async def record_generation(
+        letter_id: str,
+        content: str,
+        *,
+        idempotency_key: str | None,
+    ) -> bool:
+        generated.append((letter_id, content, idempotency_key))
+        return True
+
+    monkeypatch.setattr(
+        local_server,
+        "_conversation_memory_ready_for_reply",
+        memory_ready,
+    )
+    monkeypatch.setattr(local_server, "_run_reply_job", record_generation)
+
+    completed = asyncio.run(
+        local_server._run_reply_when_memory_ready(
+            "memory-recovered-letter",
+            "synthetic recovered memory input",
+            idempotency_key="memory-recovered-key",
+            ready_timeout_seconds=0.5,
+        )
+    )
+
+    assert completed is True
+    assert generated == [
+        (
+            "memory-recovered-letter",
+            "synthetic recovered memory input",
+            "memory-recovered-key",
+        )
+    ]
+
+
+def test_memory_readiness_waiter_cancellation_keeps_letter_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    letter = {
+        "letter_id": "memory-cancelled-letter",
+        "content": "synthetic cancelled memory wait",
+        "reply_text": "",
+        "reply_mode": "text_letter",
+        "letter_status": "PENDING",
+    }
+    local_server.store.letters[:] = [letter]
+    checks: list[bool] = []
+    generated: list[str] = []
+    persisted: list[str] = []
+
+    def memory_ready() -> bool:
+        checks.append(False)
+        return False
+
+    async def record_generation(*_args, **_kwargs) -> bool:
+        generated.append("called")
+        return True
+
+    monkeypatch.setattr(
+        local_server,
+        "_conversation_memory_ready_for_reply",
+        memory_ready,
+    )
+    monkeypatch.setattr(local_server, "_run_reply_job", record_generation)
+    monkeypatch.setattr(
+        local_server,
+        "_persist_store_state",
+        lambda: persisted.append("called"),
+    )
+
+    async def exercise() -> None:
+        task = asyncio.create_task(
+            local_server._run_reply_when_memory_ready(
+                letter["letter_id"],
+                letter["content"],
+                idempotency_key=None,
+                ready_timeout_seconds=10,
+            )
+        )
+        while not checks:
+            await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+
+    assert letter["letter_status"] == "PENDING"
+    assert "error_code" not in letter
+    assert generated == []
+    assert persisted == []
 
 
 @pytest.mark.parametrize(
@@ -856,7 +1090,7 @@ def test_persisted_pending_reply_resumes_when_http_runtime_starts(
         "letter_status": "PENDING",
         "audit_status": 2,
         "is_read": 1,
-        "created_at": 100,
+        "created_at": int(time.time()),
         "reply_text": "",
         "reply_mode": "text_letter",
         "triage": {"status": "pending"},
@@ -1856,6 +2090,7 @@ def test_contract_and_fixture_artifacts_are_versioned_and_sanitized() -> None:
     generation_contract = {
         "fields": ["letter_status", "error_code", "retryable"],
         "error_codes": {
+            "MEMORY_UNAVAILABLE": {"status": "FAILED", "retryable": True},
             "LLM_UNAVAILABLE": {"status": "FAILED", "retryable": True},
             "LLM_TIMEOUT": {"status": "FAILED", "retryable": True},
             "LLM_INTERRUPTED": {"status": "FAILED", "retryable": True},

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -315,6 +315,7 @@ def test_memory_readiness_deadline_fails_pending_letter_before_generation(
         (("available", "mem0-outbox"), ("available", True, True, None), True),
         (("available", "mem0-outbox"), ("available", True, False, None), False),
         (("available", "mem0-outbox"), ("degraded", True, True, "MEMORY_ADMIN_PAUSED"), True),
+        (("available", "mem0-outbox"), ("degraded", True, False, "MEMORY_ADMIN_PAUSED"), False),
         (("available", "mem0-outbox"), ("degraded", True, True, "MEMORY_OUTBOX_DELIVERY_FAILED"), False),
         (("available", "mem0-outbox"), ("unavailable", True, True, "MEMORY_OUTBOX_STORAGE_UNAVAILABLE"), False),
     ],
@@ -336,12 +337,14 @@ def test_memory_readiness_uses_provider_free_runtime_snapshot(
             raise AssertionError("reply readiness must not call the memory provider")
 
     runtime = ConversationMemoryRuntimeStatus(
-        runtime_status,
-        runtime_worker,
-        "mem0-outbox" if runtime_enabled else "none",
-        runtime_enabled,
+        status=runtime_status,
+        enabled=runtime_enabled,
+        provider="mem0-outbox" if runtime_enabled else "none",
+        worker_running=runtime_worker,
         reason_code=runtime_reason,
     )
+    assert runtime.enabled is runtime_enabled
+    assert runtime.worker_running is runtime_worker
     monkeypatch.setattr(
         local_server.letters_adapter.memory_prompt_builder,
         "conversation_runtime_status",

--- a/tests/memory/test_conversation_memory_runtime.py
+++ b/tests/memory/test_conversation_memory_runtime.py
@@ -300,7 +300,10 @@ def test_adapter_runtime_configuration_wins_over_host_outbox_environment(
 
 def test_available_ledger_without_worker_reports_degraded_runtime(
     tmp_path: Path,
+    monkeypatch,
 ) -> None:
+    import conversation_memory_runtime as runtime_module
+
     root = tmp_path / "configured-state-root"
     _write_state(root)
 
@@ -314,6 +317,14 @@ def test_available_ledger_without_worker_reports_degraded_runtime(
     assert status.status == "degraded"
     assert status.worker_running is False
     assert status.reason_code == "MEMORY_OUTBOX_WORKER_NOT_RUNNING"
+    runtime = runtime_module._RUNTIME
+    assert runtime is not None
+
+    def unexpected_health_probe():
+        raise AssertionError("reply readiness must use the in-process snapshot")
+
+    monkeypatch.setattr(runtime.outbox, "health", unexpected_health_probe)
+    assert runtime_module.conversation_memory_reply_readiness_status() == status
 
 
 def test_memory_prompt_builder_configures_runtime_but_keeps_prompt_available(


### PR DESCRIPTION
## Summary

- Bound enabled Mem0/outbox reply readiness to one 120-second total deadline that survives restart accounting.
- Persist retryable FAILED/MEMORY_UNAVAILABLE before provider, PrivateWorld, memory, or media work when readiness expires, releasing the active-letter gate.
- Use an in-process provider-free readiness state; preserve the intentional Archive-only MEMORY_ADMIN_PAUSED path only while the worker is running.
- Fix the ConversationMemoryRuntimeStatus test matrix and cover paused plus worker-not-running.

## Focused verification

- 87 passed, 1 deselected: HTTP contract, conversation memory runtime, B04 memory integration, and four pause lifecycle tests.
- Mechanical rebase range-diff: all three original commits unchanged.
- baseline_hardening_scan.py --mode all: PASS on the current head.
- py_compile and git diff --check: PASS.
- 10 files, 468 insertions, 19 deletions, 487 total changed lines.

## CI repair trace

Initial reviewed head f2a6aaf6a5f903bc7e09a1f7722c9a0553fd5a61 passed the full CI pytest step with 1926 passed, 2 skipped, 1 deselected, but hardening run 33350544225 failed only at runtime/memory/conversation_memory_runtime.py:345 with historical_snapshot_word.

Authorized one-line repair af41a16a49cec2c8818872e18d0e6ed1d90dedb6 changed the internal docstring word snapshot to state. Local RED reproduced the single finding; GREEN reduced all hardening matches to zero. No executable behavior changed.

## Current frozen review evidence

- Base: c891b78f88fd26792db10ee3ef9ce6f0b4dfd49e
- Head: af41a16a49cec2c8818872e18d0e6ed1d90dedb6
- Mechanical: PASS
- Standards: PASS, P0=0 P1=0 P2=0
- Spec: PASS, P0=0 P1=0 P2=0

The pair and merge-base were rechecked at the start and end of both fresh read-only reviews.

## Scope and evidence boundary

Fixtures are synthetic and sanitized. The diff contains no private letter text, API keys, provider payloads, or private absolute paths. It does not change Live, media implementations, installers, voice, or persona semantics.

No real provider generation, real client, long-running restart campaign, or human acceptance was run. Current-head CI remains required before merge.