### PR TITLE
fix: run video runtime imports in background

### DIFF
--- a/original_client_video_capability_api.py
+++ b/original_client_video_capability_api.py
@@ -44,6 +44,7 @@ class VideoCapabilityAPIInstaller(Protocol):
     def import_offline(self, *, bundle_id: str, offline_root: Path, source_mode: str = "official", accept_licenses: bool = False) -> str: ...
     def import_runtime_root(self, *, runtime_root: Path, manifest_sha256: str) -> str: ...
     def import_runtime_archive(self, *, runtime_archive: Path) -> str: ...
+    def start_runtime_archive_import(self, *, runtime_archive: Path) -> str: ...
 
 
 def _runtime_root_path(value: object) -> Path:
@@ -334,7 +335,7 @@ def mount_original_client_video_capability_api(
         elif action_name == "import_runtime_archive":
             if set(payload) != {"action", "runtime_archive"}:
                 raise VideoCapabilityAPIError("VIDEO_CAPABILITY_FIELDS_INVALID", status=400)
-            call = installer.import_runtime_archive
+            call = installer.start_runtime_archive_import
             kwargs = {
                 "runtime_archive": _offline_archive_path(payload.get("runtime_archive")),
             }
@@ -352,7 +353,7 @@ def mount_original_client_video_capability_api(
                 async with control_lock:
                     if _is_runtime_archive(archive):
                         result = await asyncio.to_thread(
-                            installer.import_runtime_archive,
+                            installer.start_runtime_archive_import,
                             runtime_archive=archive,
                         )
                         if result not in {"APPLIED", "NOOP", "REJECTED"}:

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -705,10 +705,13 @@ def test_runtime_archive_failure_keeps_the_specific_step_reason(tmp_path: Path) 
     archive = (tmp_path / "Olivia-video-runtime-broken.zip").resolve()
     with zipfile.ZipFile(archive, "w") as payload:
         payload.writestr("runtime-manifest.json", "{}")
+    configured_downloads = (tmp_path / "downloads").resolve()
+    configured_downloads.mkdir()
     installer = VideoCapabilityInstaller(
         data_root=(tmp_path / "data").resolve(),
         manifest=VideoManifest("1.0", ()),
         readiness_probe=lambda _environment: {},
+        runtime_archive_roots=(configured_downloads,),
     )
 
     with pytest.raises(VideoCapabilityError, match="VIDEO_RUNTIME_ROOT_INVALID"):

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -722,6 +722,67 @@ def test_runtime_archive_failure_keeps_the_specific_step_reason(tmp_path: Path) 
     }
 
 
+def test_runtime_archive_background_start_returns_before_extraction_and_deduplicates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = (tmp_path / "Olivia-video-runtime-slow.zip").resolve()
+    with zipfile.ZipFile(archive, "w") as payload:
+        payload.writestr("runtime-manifest.json", "{}")
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_extract(
+        _archive: Path,
+        staging: Path,
+        *,
+        progress,
+    ) -> None:
+        staging.mkdir(parents=True)
+        progress(1, 2)
+        started.set()
+        assert release.wait(2)
+        (staging / "runtime-manifest.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(
+        video_capability_install,
+        "_extract_runtime_zip_safely",
+        slow_extract,
+    )
+    installer = VideoCapabilityInstaller(
+        data_root=(tmp_path / "data").resolve(),
+        manifest=VideoManifest("1.0", ()),
+        readiness_probe=lambda _environment: {},
+    )
+
+    try:
+        assert (
+            installer.start_runtime_archive_import(runtime_archive=archive)
+            == "APPLIED"
+        )
+        assert started.wait(1)
+        assert installer.status()["runtime_import"] == {
+            "state": "extracting",
+            "checked_bytes": 1,
+            "total_bytes": 2,
+        }
+        assert (
+            installer.start_runtime_archive_import(runtime_archive=archive) == "NOOP"
+        )
+    finally:
+        release.set()
+
+    deadline = time.monotonic() + 2
+    while (
+        time.monotonic() < deadline
+        and installer.status()["runtime_import"]["state"] != "failed"
+    ):
+        time.sleep(0.01)
+    failed = installer.status()["runtime_import"]
+    assert failed["state"] == "failed"
+    assert failed["reason_code"] == "VIDEO_RUNTIME_ROOT_INVALID"
+
+
 def test_configured_installer_activates_runtime_for_current_server_process(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1942,9 +2003,12 @@ def test_video_capability_api_selects_and_imports_runtime_archive(tmp_path: Path
         def status(self):
             return {"schema_version": "olivia.video-capability-status.v2", "status": "UNAVAILABLE", "capability": "video", "install_locations": [], "bundles": []}
 
-        def import_runtime_archive(self, *, runtime_archive: Path):
+        def start_runtime_archive_import(self, *, runtime_archive: Path):
             observed.append(runtime_archive)
             return "APPLIED"
+
+        def import_runtime_archive(self, *, runtime_archive: Path):
+            pytest.fail("the HTTP request must not run the archive import inline")
 
     async def call():
         app = web.Application()
@@ -2007,9 +2071,12 @@ def test_video_capability_api_single_offline_import_detects_runtime_archive(
                 "bundles": [],
             }
 
-        def import_runtime_archive(self, *, runtime_archive: Path):
+        def start_runtime_archive_import(self, *, runtime_archive: Path):
             observed.append(runtime_archive)
             return "APPLIED"
+
+        def import_runtime_archive(self, *, runtime_archive: Path):
+            pytest.fail("the HTTP request must not run the archive import inline")
 
         def import_offline(self, **_kwargs):
             raise AssertionError("runtime archives must not be treated as component ZIPs")

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -1147,6 +1147,8 @@ class VideoCapabilityInstaller:
         archives = tuple(dict.fromkeys((*self._runtime_archives, *discovered)))
         archive = next((path for path in archives if path.is_file()), None)
         if archive is None:
+            if state == "failed":
+                return
             self._runtime_import = {
                 "state": "required",
                 "checked_bytes": 0,

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -680,6 +680,7 @@ class VideoCapabilityInstaller:
         self._pause = threading.Event()
         self._threads: dict[str, threading.Thread] = {}
         self._runtime_thread: threading.Thread | None = None
+        self._runtime_archive_identity: tuple[str, int, int, int, int] | None = None
         self._runtime_failed_archive_identities: set[tuple[str, int, int, int, int]] = set()
         self._status: dict[str, VideoBundleStatus] = {}
         self._runtime_import: dict[str, object] = {
@@ -1047,6 +1048,43 @@ class VideoCapabilityInstaller:
             if staging.exists():
                 shutil.rmtree(staging, ignore_errors=True)
 
+    def start_runtime_archive_import(self, *, runtime_archive: Path) -> str:
+        try:
+            archive = runtime_archive.resolve(strict=True)
+        except OSError as exc:
+            raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID") from exc
+        identity = _runtime_archive_identity(archive)
+        if (
+            identity is None
+            or not archive.is_file()
+            or archive.is_symlink()
+            or archive.suffix.casefold() != ".zip"
+        ):
+            raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
+        with self._lock:
+            if self._runtime_thread is not None and self._runtime_thread.is_alive():
+                return "NOOP"
+            if (
+                self._runtime_import["state"] == "ready"
+                and self._runtime_archive_identity == identity
+            ):
+                return "NOOP"
+            self._runtime_import = {
+                "state": "queued",
+                "checked_bytes": 0,
+                "total_bytes": 0,
+            }
+            self._runtime_archive_identity = identity
+            thread = threading.Thread(
+                target=self._run_runtime_archive,
+                args=(archive, identity),
+                name="olivia-video-runtime",
+                daemon=True,
+            )
+            self._runtime_thread = thread
+            thread.start()
+        return "APPLIED"
+
     def _update_runtime_extract_progress(
         self, checked_bytes: int, total_bytes: int
     ) -> None:
@@ -1128,6 +1166,7 @@ class VideoCapabilityInstaller:
             return
         archive, identity = candidate
         self._runtime_import["state"] = "queued"
+        self._runtime_archive_identity = identity
         thread = threading.Thread(
             target=self._run_runtime_archive,
             args=(archive, identity),


### PR DESCRIPTION
## Problem
A real 12.5 GB runtime archive kept the capability POST open until the client hit its exact 1800-second timeout, while the import continued in the background. The UI therefore looked stuck or failed.

## Change
- queue explicit runtime-archive imports on the existing managed background worker
- route the UI offline-import runtime-ZIP path through the same worker
- deduplicate active and already-ready archives
- preserve extracting/checking/testing/ready/failed progress and the exact terminal reason code
- keep strict archive verification and missing-bundle behavior unchanged

## Frozen evidence
- base: 00aebc706c61bb3d3e2e0fd781fc2655c4e0bb04
- head: c92de61ca0e30016b7e5443fa653c056a0ee496b
- Standards: PASS, P0/P1/P2 = 0/0/0
- Spec: PASS, P0/P1/P2 = 0/0/0
- focused: 14 passed, 57 deselected
- py_compile and git diff --check: PASS

## Boundary
No installer, media rendering, Live, persona, provider, or bundle-readiness semantics are changed. Real large-archive evidence proves the timeout and final status behavior; final private installer acceptance remains separate.