### PR TITLE
test(media): tolerate shrinking cleanup budgets

### DIFF
--- a/tests/media/test_managed_subprocess.py
+++ b/tests/media/test_managed_subprocess.py
@@ -14,6 +14,7 @@ from runtime.media import managed_subprocess
 def test_windows_success_terminates_assigned_job_before_close(monkeypatch) -> None:
     events: list[str] = []
     active_processes = iter((2, 0))
+    monotonic_times = iter((100.0, 100.000003, 100.000004))
 
     class Process:
         pid, returncode = 4242, 0
@@ -32,20 +33,24 @@ def test_windows_success_terminates_assigned_job_before_close(monkeypatch) -> No
         close=lambda: events.append("close"),
     )
     monkeypatch.setattr(managed_subprocess.os, "name", "nt")
+    monkeypatch.setattr(
+        managed_subprocess.time, "monotonic", lambda: next(monotonic_times)
+    )
     monkeypatch.setattr(managed_subprocess, "_create_windows_job", lambda: job)
     monkeypatch.setattr(managed_subprocess.subprocess, "Popen", lambda *_a, **_k: Process())
 
     result = managed_subprocess.run_managed_process(["worker"], timeout_seconds=12)
 
     assert result.stdout == b"out"
-    assert events == [
-        "assign", "resume", "reap:12", "terminate", "reap:15.0",
-        "active", "active", "close",
-    ]
+    assert events[:4] == ["assign", "resume", "reap:12", "terminate"]
+    assert events[4].startswith("reap:")
+    assert float(events[4].removeprefix("reap:")) == pytest.approx(15.0)
+    assert events[5:] == ["active", "active", "close"]
 
 
 def test_windows_timeout_owns_and_terminates_suspended_worker(monkeypatch) -> None:
     observed: dict[str, object] = {"timeouts": []}
+    monotonic_times = iter((100.0, 100.000003))
 
     class Process:
         pid, returncode = 4242, None
@@ -70,6 +75,9 @@ def test_windows_timeout_owns_and_terminates_suspended_worker(monkeypatch) -> No
     monkeypatch.setattr(managed_subprocess.os, "name", "nt")
     monkeypatch.setattr(managed_subprocess, "_create_windows_job", Job)
     monkeypatch.setattr(managed_subprocess.subprocess, "Popen", popen)
+    monkeypatch.setattr(
+        managed_subprocess.time, "monotonic", lambda: next(monotonic_times)
+    )
     with pytest.raises(subprocess.TimeoutExpired):
         managed_subprocess.run_managed_process(["worker"], timeout_seconds=12)
     flags = observed["kwargs"]["creationflags"]
@@ -77,7 +85,10 @@ def test_windows_timeout_owns_and_terminates_suspended_worker(monkeypatch) -> No
     assert flags & getattr(subprocess, "CREATE_SUSPENDED", 4)
     assert (observed["assigned"], observed["resumed"]) == (4242, 4242)
     assert observed["terminated"] is True and observed["closed"] is True
-    assert observed["timeouts"] == [12, 15.0]
+    timeouts = observed["timeouts"]
+    assert isinstance(timeouts, list)
+    assert timeouts[0] == 12
+    assert timeouts[1] == pytest.approx(15.0)
 
 
 def test_absolute_deadline_includes_start_timeout_and_cleanup(monkeypatch) -> None:


### PR DESCRIPTION
Test-only fix for two Windows managed-subprocess assertions that compared a monotonic-clock-derived cleanup budget with the exact float 15.0. Both tests now pin the clock for deterministic coverage and use pytest.approx only for the derived cleanup budget; event ordering, initial timeout, termination, and close semantics remain strict. No production code changed. Exact pair: 00aebc706c61bb3d3e2e0fd781fc2655c4e0bb04...ec1c803f3359d9a4d49673a5ff6e1b62d3d71764. RED: derived cleanup timeout 14.999996999999993 failed exact equality in both named tests. GREEN: 2 target tests passed; managed-subprocess file 18 passed, 2 skipped; full suite 1925 passed, 3 skipped, 1 deselected; hardening scan, compileall, and diff check passed. Fresh exact-pair reviews: Standards PASS; Spec PASS.