### PR TITLE
feat(installer): add private video sidecar activator

### DIFF
--- a/installer/activate_private_video.py
+++ b/installer/activate_private_video.py
@@ -33,6 +33,14 @@ class PrivateVideoActivationError(RuntimeError):
     """Stable private-video activation failure code."""
 
 
+class _ManifestSnapshot:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def read_text(self, *, encoding: str) -> str:
+        return self._payload.decode(encoding)
+
+
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as stream:
@@ -55,9 +63,9 @@ def _absolute_path(path: Path, *, code: str) -> Path:
     try:
         candidate = Path(os.path.abspath(candidate))
         for current in reversed((candidate, *candidate.parents)):
-            if current.exists() and _is_reparse_point(current):
+            if (current.is_symlink() or current.exists()) and _is_reparse_point(current):
                 raise PrivateVideoActivationError(code)
-        return candidate.resolve(strict=True)
+        return candidate
     except PrivateVideoActivationError:
         raise
     except (OSError, RuntimeError) as exc:
@@ -70,14 +78,18 @@ def _verify_manifest(
     if re.fullmatch(r"[0-9a-f]{64}", expected_sha256) is None:
         raise PrivateVideoActivationError("VIDEO_PRIVATE_MANIFEST_INVALID")
     manifest_path = _absolute_path(path, code="VIDEO_PRIVATE_MANIFEST_INVALID")
-    if (
-        not manifest_path.is_file()
-        or _is_reparse_point(manifest_path)
-        or _sha256(manifest_path) != expected_sha256
-    ):
+    try:
+        if not manifest_path.is_file() or _is_reparse_point(manifest_path):
+            raise PrivateVideoActivationError("VIDEO_PRIVATE_MANIFEST_INVALID")
+        payload = manifest_path.read_bytes()
+    except PrivateVideoActivationError:
+        raise
+    except OSError as exc:
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_MANIFEST_INVALID") from exc
+    if hashlib.sha256(payload).hexdigest() != expected_sha256:
         raise PrivateVideoActivationError("VIDEO_PRIVATE_MANIFEST_INVALID")
     try:
-        manifest = load_video_manifest(manifest_path)
+        manifest = load_video_manifest(_ManifestSnapshot(payload))  # type: ignore[arg-type]
     except VideoCapabilityError as exc:
         raise PrivateVideoActivationError("VIDEO_PRIVATE_MANIFEST_INVALID") from exc
     if manifest.version != expected_version:
@@ -161,7 +173,7 @@ def _verify_offline_root(
 def _create_installer(
     *, install_root: Path, manifest: VideoManifest
 ) -> VideoCapabilityInstaller:
-    data_root = (install_root / "data").resolve()
+    data_root = install_root / "data"
     environment = _load_fixed_video_assets_environment(
         {
             **os.environ,
@@ -244,6 +256,7 @@ def activate_private_video(
     root = _absolute_path(install_root, code="VIDEO_PRIVATE_INSTALL_ROOT_INVALID")
     if not root.is_dir() or _is_reparse_point(root):
         raise PrivateVideoActivationError("VIDEO_PRIVATE_INSTALL_ROOT_INVALID")
+    _absolute_path(root / "data", code="VIDEO_PRIVATE_INSTALL_ROOT_INVALID")
     manifest = _verify_manifest(
         manifest_path,
         expected_version=expected_manifest_version,

--- a/installer/activate_private_video.py
+++ b/installer/activate_private_video.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import time
+from collections.abc import Callable, Mapping
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from installer.component_update import ComponentUpdateError, _validate_relative_path
+from installer.start_local import _load_fixed_video_assets_environment
+from music_reply import video_reply_dependency_status
+from runtime.media.media_paths import configured_media_path
+from video_capability_install import (
+    VideoCapabilityError,
+    VideoCapabilityInstaller,
+    VideoManifest,
+    load_video_manifest,
+)
+
+
+OFFLINE_ROOT_NAME = "Olivia-video-offline-private"
+RUNTIME_ARCHIVE_NAME = "Olivia-video-runtime-private.zip"
+_ASSEMBLED_STATES = {"ready", "prerequisites_required"}
+_ACTIVE_STATES = {"missing", "queued", "downloading", "verifying"}
+
+
+class PrivateVideoActivationError(RuntimeError):
+    """Stable private-video activation failure code."""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _is_reparse_point(path: Path) -> bool:
+    attributes = getattr(path.stat(follow_symlinks=False), "st_file_attributes", 0)
+    return path.is_symlink() or bool(
+        attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    )
+
+
+def _absolute_path(path: Path, *, code: str) -> Path:
+    candidate = path.expanduser()
+    if not candidate.is_absolute():
+        raise PrivateVideoActivationError(code)
+    try:
+        candidate = Path(os.path.abspath(candidate))
+        for current in reversed((candidate, *candidate.parents)):
+            if current.exists() and _is_reparse_point(current):
+                raise PrivateVideoActivationError(code)
+        return candidate.resolve(strict=True)
+    except PrivateVideoActivationError:
+        raise
+    except (OSError, RuntimeError) as exc:
+        raise PrivateVideoActivationError(code) from exc
+
+
+def _verify_manifest(
+    path: Path, *, expected_version: str, expected_sha256: str
+) -> VideoManifest:
+    if re.fullmatch(r"[0-9a-f]{64}", expected_sha256) is None:
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_MANIFEST_INVALID")
+    manifest_path = _absolute_path(path, code="VIDEO_PRIVATE_MANIFEST_INVALID")
+    if (
+        not manifest_path.is_file()
+        or _is_reparse_point(manifest_path)
+        or _sha256(manifest_path) != expected_sha256
+    ):
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_MANIFEST_INVALID")
+    try:
+        manifest = load_video_manifest(manifest_path)
+    except VideoCapabilityError as exc:
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_MANIFEST_INVALID") from exc
+    if manifest.version != expected_version:
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_MANIFEST_INVALID")
+    return manifest
+
+
+def _verify_offline_root(
+    root: Path,
+    manifest: VideoManifest,
+    *,
+    expected_file_count: int,
+    expected_size_bytes: int,
+) -> Path:
+    candidate = _absolute_path(root, code="VIDEO_PRIVATE_OFFLINE_INVALID")
+    if candidate.name != OFFLINE_ROOT_NAME or not candidate.is_dir() or _is_reparse_point(candidate):
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID")
+    expected: dict[str, tuple[str, int, str]] = {}
+    for bundle in manifest.bundles:
+        for item in bundle.files:
+            try:
+                relative = _validate_relative_path(item.relative_path)
+            except ComponentUpdateError as exc:
+                raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID") from exc
+            path = f"{bundle.identifier}/{relative}"
+            folded = path.casefold()
+            if folded in expected:
+                raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID")
+            expected[folded] = (path, item.size_bytes, item.sha256)
+    if (
+        expected_file_count < 1
+        or expected_size_bytes < 1
+        or len(expected) != expected_file_count
+        or sum(size for _, size, _ in expected.values()) != expected_size_bytes
+    ):
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID")
+
+    actual: dict[str, Path] = {}
+    actual_directories: set[str] = set()
+    try:
+        for current, directories, filenames in os.walk(candidate, followlinks=False):
+            current_path = Path(current)
+            if _is_reparse_point(current_path):
+                raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID")
+            for name in directories:
+                directory = current_path / name
+                if _is_reparse_point(directory):
+                    raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID")
+                actual_directories.add(
+                    directory.relative_to(candidate).as_posix().casefold()
+                )
+            for name in filenames:
+                path = current_path / name
+                if not path.is_file() or _is_reparse_point(path):
+                    raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID")
+                relative = path.relative_to(candidate).as_posix()
+                folded = relative.casefold()
+                if folded in actual:
+                    raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID")
+                actual[folded] = path
+    except OSError as exc:
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID") from exc
+    expected_directories = {
+        parent.as_posix().casefold()
+        for relative, _, _ in expected.values()
+        for parent in PurePosixPath(relative).parents
+        if parent.as_posix() != "."
+    }
+    if set(actual) != set(expected) or actual_directories - expected_directories:
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID")
+    for folded, (_, size, digest) in expected.items():
+        path = actual[folded]
+        try:
+            if path.stat().st_size != size or _sha256(path) != digest:
+                raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID")
+        except OSError as exc:
+            raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID") from exc
+    return candidate
+
+
+def _create_installer(
+    *, install_root: Path, manifest: VideoManifest
+) -> VideoCapabilityInstaller:
+    data_root = (install_root / "data").resolve()
+    environment = _load_fixed_video_assets_environment(
+        {
+            **os.environ,
+            "OLIVIA_INSTALL_ROOT": str(install_root),
+            "OLIVIA_PROJECT_ROOT": str(install_root / "app"),
+            "OLIVIA_LOCAL_DATA_ROOT": str(data_root),
+            "OLIVIA_PROVIDER_CACHE_ROOT": str(data_root / "provider-cache"),
+        },
+        install_root,
+    )
+    os.environ.update(environment)
+
+    def readiness(runtime_environment: Mapping[str, str]) -> Mapping[str, object]:
+        values = dict(environment)
+        values.update(runtime_environment)
+        return video_reply_dependency_status(
+            values,
+            performance_video_path=configured_media_path(
+                values, "OLIVIA_MUSIC_PERFORMANCE_BASE"
+            ),
+        )
+
+    return VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=readiness,
+        runtime_environment_applier=os.environ.update,
+    )
+
+
+def _bundle_state(status: Mapping[str, object], bundle_id: str) -> Mapping[str, object]:
+    bundles = status.get("bundles")
+    if not isinstance(bundles, list):
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_ACTIVATION_FAILED")
+    for item in bundles:
+        if isinstance(item, Mapping) and item.get("id") == bundle_id:
+            return item
+    raise PrivateVideoActivationError("VIDEO_PRIVATE_ACTIVATION_FAILED")
+
+
+def _wait_for_bundle(
+    installer: Any,
+    bundle_id: str,
+    *,
+    deadline: float,
+    clock: Callable[[], float],
+    sleep: Callable[[float], object],
+) -> None:
+    while True:
+        item = _bundle_state(installer.status(), bundle_id)
+        state = item.get("state")
+        if state in _ASSEMBLED_STATES:
+            return
+        if state not in _ACTIVE_STATES:
+            reason = item.get("reason_code")
+            code = reason if isinstance(reason, str) and re.fullmatch(r"[A-Z][A-Z0-9_]{3,95}", reason) else "VIDEO_BUNDLE_INSTALL_FAILED"
+            raise PrivateVideoActivationError(code)
+        if clock() >= deadline:
+            raise PrivateVideoActivationError("VIDEO_PRIVATE_ACTIVATION_TIMEOUT")
+        sleep(0.1)
+
+
+def activate_private_video(
+    *,
+    install_root: Path,
+    offline_root: Path,
+    runtime_archive: Path,
+    manifest_path: Path,
+    expected_manifest_version: str,
+    expected_manifest_sha256: str,
+    expected_file_count: int,
+    expected_size_bytes: int,
+    timeout_seconds: float = 14_400,
+    installer_factory: Callable[..., Any] = _create_installer,
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], object] = time.sleep,
+) -> dict[str, object]:
+    if timeout_seconds <= 0:
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_ACTIVATION_TIMEOUT")
+    root = _absolute_path(install_root, code="VIDEO_PRIVATE_INSTALL_ROOT_INVALID")
+    if not root.is_dir() or _is_reparse_point(root):
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_INSTALL_ROOT_INVALID")
+    manifest = _verify_manifest(
+        manifest_path,
+        expected_version=expected_manifest_version,
+        expected_sha256=expected_manifest_sha256,
+    )
+    offline = _verify_offline_root(
+        offline_root,
+        manifest,
+        expected_file_count=expected_file_count,
+        expected_size_bytes=expected_size_bytes,
+    )
+    runtime = _absolute_path(
+        runtime_archive, code="VIDEO_RUNTIME_ARCHIVE_INVALID"
+    )
+    if (
+        runtime.name != RUNTIME_ARCHIVE_NAME
+        or not runtime.is_file()
+        or _is_reparse_point(runtime)
+    ):
+        raise PrivateVideoActivationError("VIDEO_RUNTIME_ARCHIVE_INVALID")
+    try:
+        installer = installer_factory(install_root=root, manifest=manifest)
+        deadline = clock() + timeout_seconds
+        for bundle_id in ("ordinary_video", "music_video"):
+            current = _bundle_state(installer.status(), bundle_id)
+            if current.get("state") not in _ASSEMBLED_STATES:
+                installer.import_offline(
+                    bundle_id=bundle_id,
+                    offline_root=offline / bundle_id,
+                    source_mode="official",
+                    accept_licenses=True,
+                )
+                _wait_for_bundle(
+                    installer,
+                    bundle_id,
+                    deadline=deadline,
+                    clock=clock,
+                    sleep=sleep,
+                )
+        installer.import_runtime_archive(runtime_archive=runtime)
+        final = installer.status()
+    except PrivateVideoActivationError:
+        raise
+    except VideoCapabilityError as exc:
+        code = str(exc)
+        if re.fullmatch(r"[A-Z][A-Z0-9_]{3,95}", code):
+            raise PrivateVideoActivationError(code) from exc
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_ACTIVATION_FAILED") from exc
+    except Exception as exc:
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_ACTIVATION_FAILED") from exc
+    if (
+        final.get("status") != "READY"
+        or any(
+            _bundle_state(final, bundle_id).get("state") != "ready"
+            for bundle_id in ("ordinary_video", "music_video")
+        )
+        or not isinstance(final.get("runtime_import"), Mapping)
+        or final["runtime_import"].get("state") != "ready"
+    ):
+        raise PrivateVideoActivationError("VIDEO_PRIVATE_NOT_READY")
+    return dict(final)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="activate-private-video")
+    parser.add_argument("--install-root", type=Path, required=True)
+    parser.add_argument("--offline-root", type=Path, required=True)
+    parser.add_argument("--runtime-archive", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--manifest-version", required=True)
+    parser.add_argument("--manifest-sha256", required=True)
+    parser.add_argument("--expected-file-count", type=int, required=True)
+    parser.add_argument("--expected-size-bytes", type=int, required=True)
+    parser.add_argument("--timeout-seconds", type=float, default=14_400)
+    args = parser.parse_args(argv)
+    try:
+        result = activate_private_video(
+            install_root=args.install_root,
+            offline_root=args.offline_root,
+            runtime_archive=args.runtime_archive,
+            manifest_path=args.manifest,
+            expected_manifest_version=args.manifest_version,
+            expected_manifest_sha256=args.manifest_sha256,
+            expected_file_count=args.expected_file_count,
+            expected_size_bytes=args.expected_size_bytes,
+            timeout_seconds=args.timeout_seconds,
+        )
+        print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+        return 0
+    except PrivateVideoActivationError as exc:
+        print(json.dumps({"status": "ERROR", "code": str(exc)}, sort_keys=True))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/installer/test_private_video_activation.py
+++ b/tests/installer/test_private_video_activation.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -9,6 +11,7 @@ import pytest
 from installer.activate_private_video import (
     PrivateVideoActivationError,
     activate_private_video,
+    main as activate_private_video_main,
 )
 
 
@@ -136,6 +139,162 @@ def test_private_activation_uses_existing_installer_in_strict_ready_order(
     assert result["status"] == "READY"
     assert result["runtime_import"]["state"] == "ready"
     assert [item["state"] for item in result["bundles"]] == ["ready", "ready"]
+
+
+def test_private_activation_parses_the_exact_manifest_bytes_that_were_hashed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest, offline, manifest_sha256 = _manifest_fixture(tmp_path)
+    runtime = tmp_path / "Olivia-video-runtime-private.zip"
+    runtime.write_bytes(b"runtime")
+    original_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    replacement_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    for bundle in replacement_payload["bundles"]:
+        bundle["label"] = "replacement"
+    replacement_bytes = json.dumps(replacement_payload).encode("utf-8")
+    original_open = Path.open
+    replaced = False
+
+    class _ReplaceAfterRead:
+        def __init__(self, stream: object) -> None:
+            self._stream = stream
+
+        def __enter__(self) -> object:
+            return self._stream.__enter__()
+
+        def __exit__(self, *args: object) -> object:
+            result = self._stream.__exit__(*args)
+            with original_open(manifest, "wb") as replacement:
+                replacement.write(replacement_bytes)
+            return result
+
+    def racing_open(path: Path, *args: object, **kwargs: object) -> object:
+        nonlocal replaced
+        stream = original_open(path, *args, **kwargs)
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if path == manifest and "r" in str(mode) and not replaced:
+            replaced = True
+            return _ReplaceAfterRead(stream)
+        return stream
+
+    monkeypatch.setattr(Path, "open", racing_open)
+    calls: list[tuple[str, str]] = []
+    installer = _FakeInstaller(calls)
+    observed_labels: list[str] = []
+
+    def installer_factory(**kwargs: object) -> _FakeInstaller:
+        observed_labels.extend(
+            bundle.label for bundle in kwargs["manifest"].bundles
+        )
+        return installer
+
+    activate_private_video(
+        install_root=tmp_path / "install",
+        offline_root=offline,
+        runtime_archive=runtime,
+        manifest_path=manifest,
+        expected_manifest_version="fixture-video",
+        expected_manifest_sha256=manifest_sha256,
+        expected_file_count=2,
+        expected_size_bytes=len(b"ordinary") + len(b"music"),
+        installer_factory=installer_factory,
+        timeout_seconds=1,
+    )
+
+    assert replaced is True
+    assert observed_labels == [
+        bundle["label"] for bundle in original_payload["bundles"]
+    ]
+
+
+def test_private_activation_cli_normalizes_manifest_io_failure_without_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    manifest, offline, manifest_sha256 = _manifest_fixture(tmp_path)
+    runtime = tmp_path / "Olivia-video-runtime-private.zip"
+    runtime.write_bytes(b"runtime")
+    original_open = Path.open
+
+    def failing_open(path: Path, *args: object, **kwargs: object) -> object:
+        if path == manifest:
+            raise OSError(f"cannot read private manifest at {manifest}")
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", failing_open)
+
+    exit_code = activate_private_video_main(
+        [
+            "--install-root",
+            str(tmp_path / "install"),
+            "--offline-root",
+            str(offline),
+            "--runtime-archive",
+            str(runtime),
+            "--manifest",
+            str(manifest),
+            "--manifest-version",
+            "fixture-video",
+            "--manifest-sha256",
+            manifest_sha256,
+            "--expected-file-count",
+            "2",
+            "--expected-size-bytes",
+            str(len(b"ordinary") + len(b"music")),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert json.loads(captured.out) == {
+        "status": "ERROR",
+        "code": "VIDEO_PRIVATE_MANIFEST_INVALID",
+    }
+    assert captured.err == ""
+    assert str(manifest) not in captured.out
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows junction contract")
+def test_private_activation_rejects_a_reparse_data_root_before_installer_creation(
+    tmp_path: Path,
+) -> None:
+    manifest, offline, manifest_sha256 = _manifest_fixture(tmp_path)
+    runtime = tmp_path / "Olivia-video-runtime-private.zip"
+    runtime.write_bytes(b"runtime")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    data_root = tmp_path / "install" / "data"
+    linked = subprocess.run(
+        ["cmd.exe", "/d", "/c", "mklink", "/J", str(data_root), str(outside)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if linked.returncode != 0:
+        pytest.skip("Windows junction creation unavailable")
+
+    with pytest.raises(
+        PrivateVideoActivationError,
+        match="^VIDEO_PRIVATE_INSTALL_ROOT_INVALID$",
+    ):
+        activate_private_video(
+            install_root=tmp_path / "install",
+            offline_root=offline,
+            runtime_archive=runtime,
+            manifest_path=manifest,
+            expected_manifest_version="fixture-video",
+            expected_manifest_sha256=manifest_sha256,
+            expected_file_count=2,
+            expected_size_bytes=len(b"ordinary") + len(b"music"),
+            installer_factory=lambda **_kwargs: pytest.fail(
+                "reparse data root must fail before installer creation"
+            ),
+            timeout_seconds=1,
+        )
+
+    assert list(outside.iterdir()) == []
 
 
 def test_private_activation_rejects_tampered_or_extra_offline_files_before_import(

--- a/tests/installer/test_private_video_activation.py
+++ b/tests/installer/test_private_video_activation.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from installer.activate_private_video import (
+    PrivateVideoActivationError,
+    activate_private_video,
+)
+
+
+def _manifest_fixture(root: Path) -> tuple[Path, Path, str]:
+    (root / "install").mkdir()
+    offline = root / "Olivia-video-offline-private"
+    bundles = []
+    for bundle_id, relative, content in (
+        ("ordinary_video", "ordinary.bin", b"ordinary"),
+        ("music_video", "music.bin", b"music"),
+    ):
+        target = offline / bundle_id / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+        bundles.append(
+            {
+                "id": bundle_id,
+                "label": bundle_id,
+                "status": "FIXED",
+                "requires_gpu": True,
+                "dependencies": [],
+                "files": [
+                    {
+                        "id": f"{bundle_id}-fixture",
+                        "path": relative,
+                        "size_bytes": len(content),
+                        "sha256": hashlib.sha256(content).hexdigest(),
+                        "license": "MIT",
+                        "sources": {
+                            "official": f"https://example.com/{relative}"
+                        },
+                    }
+                ],
+            }
+        )
+    manifest = root / "video-capability-manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.video-capability-bom.v1",
+                "version": "fixture-video",
+                "bundles": bundles,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest, offline, hashlib.sha256(manifest.read_bytes()).hexdigest()
+
+
+class _FakeInstaller:
+    def __init__(self, calls: list[tuple[str, str]], *, fail_bundle: str = "") -> None:
+        self.calls = calls
+        self.fail_bundle = fail_bundle
+        self.states = {"ordinary_video": "missing", "music_video": "missing"}
+        self.runtime_state = "idle"
+
+    def status(self) -> dict[str, object]:
+        bundles = [
+            {"id": bundle_id, "state": state}
+            for bundle_id, state in self.states.items()
+        ]
+        return {
+            "status": (
+                "READY"
+                if all(state == "ready" for state in self.states.values())
+                and self.runtime_state == "ready"
+                else "UNAVAILABLE"
+            ),
+            "bundles": bundles,
+            "runtime_import": {"state": self.runtime_state},
+        }
+
+    def import_offline(
+        self,
+        *,
+        bundle_id: str,
+        offline_root: Path,
+        source_mode: str,
+        accept_licenses: bool,
+    ) -> str:
+        assert offline_root.name == bundle_id
+        assert source_mode == "official"
+        assert accept_licenses is True
+        self.calls.append(("offline", bundle_id))
+        self.states[bundle_id] = (
+            "failed" if bundle_id == self.fail_bundle else "prerequisites_required"
+        )
+        return "APPLIED"
+
+    def import_runtime_archive(self, *, runtime_archive: Path) -> str:
+        assert runtime_archive.name == "Olivia-video-runtime-private.zip"
+        self.calls.append(("runtime", runtime_archive.name))
+        self.runtime_state = "ready"
+        self.states = {bundle_id: "ready" for bundle_id in self.states}
+        return "APPLIED"
+
+
+def test_private_activation_uses_existing_installer_in_strict_ready_order(
+    tmp_path: Path,
+) -> None:
+    manifest, offline, manifest_sha256 = _manifest_fixture(tmp_path)
+    runtime = tmp_path / "Olivia-video-runtime-private.zip"
+    runtime.write_bytes(b"runtime")
+    calls: list[tuple[str, str]] = []
+    installer = _FakeInstaller(calls)
+
+    result = activate_private_video(
+        install_root=tmp_path / "install",
+        offline_root=offline,
+        runtime_archive=runtime,
+        manifest_path=manifest,
+        expected_manifest_version="fixture-video",
+        expected_manifest_sha256=manifest_sha256,
+        expected_file_count=2,
+        expected_size_bytes=len(b"ordinary") + len(b"music"),
+        installer_factory=lambda **_kwargs: installer,
+        timeout_seconds=1,
+    )
+
+    assert calls == [
+        ("offline", "ordinary_video"),
+        ("offline", "music_video"),
+        ("runtime", "Olivia-video-runtime-private.zip"),
+    ]
+    assert result["status"] == "READY"
+    assert result["runtime_import"]["state"] == "ready"
+    assert [item["state"] for item in result["bundles"]] == ["ready", "ready"]
+
+
+def test_private_activation_rejects_tampered_or_extra_offline_files_before_import(
+    tmp_path: Path,
+) -> None:
+    manifest, offline, manifest_sha256 = _manifest_fixture(tmp_path)
+    runtime = tmp_path / "Olivia-video-runtime-private.zip"
+    runtime.write_bytes(b"runtime")
+    (offline / "ordinary_video/extra.bin").write_bytes(b"extra")
+
+    with pytest.raises(
+        PrivateVideoActivationError, match="VIDEO_PRIVATE_OFFLINE_INVALID"
+    ):
+        activate_private_video(
+            install_root=tmp_path / "install",
+            offline_root=offline,
+            runtime_archive=runtime,
+            manifest_path=manifest,
+            expected_manifest_version="fixture-video",
+            expected_manifest_sha256=manifest_sha256,
+            expected_file_count=2,
+            expected_size_bytes=len(b"ordinary") + len(b"music"),
+            installer_factory=lambda **_kwargs: pytest.fail(
+                "invalid sidecar must fail before installer creation"
+            ),
+            timeout_seconds=1,
+        )
+
+
+def test_private_activation_stops_before_runtime_when_bundle_fails(
+    tmp_path: Path,
+) -> None:
+    manifest, offline, manifest_sha256 = _manifest_fixture(tmp_path)
+    runtime = tmp_path / "Olivia-video-runtime-private.zip"
+    runtime.write_bytes(b"runtime")
+    calls: list[tuple[str, str]] = []
+    installer = _FakeInstaller(calls, fail_bundle="music_video")
+
+    with pytest.raises(
+        PrivateVideoActivationError, match="VIDEO_BUNDLE_INSTALL_FAILED"
+    ):
+        activate_private_video(
+            install_root=tmp_path / "install",
+            offline_root=offline,
+            runtime_archive=runtime,
+            manifest_path=manifest,
+            expected_manifest_version="fixture-video",
+            expected_manifest_sha256=manifest_sha256,
+            expected_file_count=2,
+            expected_size_bytes=len(b"ordinary") + len(b"music"),
+            installer_factory=lambda **_kwargs: installer,
+            timeout_seconds=1,
+        )
+
+    assert calls == [
+        ("offline", "ordinary_video"),
+        ("offline", "music_video"),
+    ]


### PR DESCRIPTION
## Summary

- Add a dormant private-video activation helper and focused synthetic contract tests.
- Reuse VideoCapabilityInstaller, the canonical manifest parser, and existing readiness probes.
- Validate a single manifest byte snapshot, exact offline BOM, runtime archive identity, and reparse-point boundaries before activation.
- Enforce ordinary video, then music video, then runtime activation, and require final READY state.
- This PR does not connect the helper to Setup or Install.ps1; that production lifecycle is the follow-up PR-B.

## Atomic scope rationale

This PR is 710 inserted lines across exactly two new files. The helper and its direct synthetic contract tests are one independently reversible, dormant seam. Splitting the tests from the helper would land untested release code, while including installer wiring here would exceed the review hard cap. Existing production callers and behavior remain unchanged.

## Frozen review evidence

- Base: 9e33288404c4429cc19e909dcf07c1bcdac923cf
- Head: 9cd480711ffb93787531c336bdbba4d105666dbf
- Standards: PASS after closing the three first-round P1 findings.
- Spec: BLOCK, accepted under the explicit user policy to stop after two P1 repair rounds and merge.
- Accepted residual P1 boundary: a raw path argument of ~ is expanded before the absolute-path check, so that relative spelling can proceed as an absolute home path. This is not represented as a dual PASS and is not fixed in this PR.

## Focused verification

- python -m pytest tests/installer/test_private_video_activation.py -q: 6 passed
- python -m py_compile installer/activate_private_video.py: PASS
- git diff --check 9e33288404c4429cc19e909dcf07c1bcdac923cf...9cd480711ffb93787531c336bdbba4d105666dbf: PASS
- Worktree was clean at freeze and push.

## Verification boundary

No real private Setup build or installation was run. No 12.5 GB runtime archive or 28.1 GB offline root was activated. GPU readiness, first-launch readiness, and human acceptance remain unverified. Because this helper is dormant in PR-A, those checks belong to PR-B and the final private-artifact acceptance run.

## Rollback

Revert the squashed PR-A commit to remove the dormant helper and tests. No installed state or user data is changed by this PR.