### PR TITLE
fix(installer): activate private video sidecars transactionally

### DIFF
--- a/contracts/offline_core_assets.schema.json
+++ b/contracts/offline_core_assets.schema.json
@@ -6,9 +6,10 @@
   "additionalProperties": false,
   "required": ["schema_version", "python_runtime", "pip_bootstrap", "requirements_sha256", "wheels"],
   "dependentRequired": {
-    "distribution": ["voice_reference", "video_runtime"],
-    "voice_reference": ["distribution", "video_runtime"],
-    "video_runtime": ["distribution", "voice_reference"]
+    "distribution": ["voice_reference", "video_runtime", "video_offline"],
+    "voice_reference": ["distribution", "video_runtime", "video_offline"],
+    "video_runtime": ["distribution", "voice_reference", "video_offline"],
+    "video_offline": ["distribution", "voice_reference", "video_runtime"]
   },
   "$defs": {
     "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
@@ -77,9 +78,21 @@
       "additionalProperties": false,
       "required": ["path", "size_bytes", "sha256"],
       "properties": {
-        "path": {"const": "video-runtime/Olivia-video-runtime-private.zip"},
+        "path": {"const": "Olivia-video-runtime-private.zip"},
         "size_bytes": {"type": "integer", "minimum": 1},
         "sha256": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "video_offline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "manifest_version", "manifest_sha256", "file_count", "size_bytes"],
+      "properties": {
+        "path": {"const": "Olivia-video-offline-private"},
+        "manifest_version": {"type": "string", "minLength": 1, "maxLength": 64},
+        "manifest_sha256": {"$ref": "#/$defs/digest"},
+        "file_count": {"type": "integer", "minimum": 1},
+        "size_bytes": {"type": "integer", "minimum": 1}
       }
     },
     "wheels": {

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -1,10 +1,10 @@
 # Windows 完整版补丁（隔离安装）
 
-公开补丁只复制并修改用户自己的正版 Steam 文件副本，不写入正版目录，也不分发原版游戏、可选模型或媒体；经授权单独构建的私有安装包会额外内嵌下文指定的林离参考 WAV 和视频运行时。`Olivia-Setup-x64.exe` 内含固定版本的核心 Python 运行时和依赖，使首次安装不依赖 Python.org、PyPI 或 Hugging Face。安装目标默认是 `%LOCALAPPDATA%\BSideOliviaLocal\install`，用户数据和未来外部缓存保留在同一产品目录的 `data` / `third-party` 下。
+公开补丁只复制并修改用户自己的正版 Steam 文件副本，不写入正版目录，也不分发原版游戏、可选模型或媒体；经授权单独构建的私有安装包会额外交付下文指定的林离参考 WAV、视频 Python 运行时和 ordinary/music 两套完整离线 BOM 资产。大体积内容作为与 EXE 同目录的受校验 sidecar，不进入 Inno 临时目录。`Olivia-Setup-x64.exe` 内含固定版本的核心 Python 运行时和依赖，使首次安装不依赖 Python.org、PyPI 或 Hugging Face。安装目标默认是 `%LOCALAPPDATA%\BSideOliviaLocal\install`，用户数据和未来外部缓存保留在同一产品目录的 `data` / `third-party` 下。
 
 ## 使用
 
-1. 公开包：下载 EXE 和 `.sha256`。私有视频包：下载完整 ZIP，解压后把 EXE、全部 `.bin` 分卷和 `.sha256` 保持在同一目录。运行前先核对 SHA-256。
+1. 公开包：下载 EXE 和 `.sha256`。私有视频包：下载完整 ZIP并完整解压，保持 `Olivia-Setup-x64.exe`、`Olivia-video-runtime-private.zip`、`Olivia-video-offline-private/`、`Olivia-Setup-x64.receipt.json` 和 `.sha256` 的同目录结构。运行前按 `.sha256` 逐项核对 EXE、runtime ZIP、receipt 和 offline root 内每个文件。
 2. 双击 EXE，选择产品目录和正版 Steam 游戏目录。安装器按当前用户运行，不要求管理员权限；它在产品目录内分别创建 `install` 与 `runtime`，从 EXE 内置的离线资产安装受管 Python 3.12 runtime 和固定 wheel，不联网下载。正版目录可留空并按 Steam AppID `4532590` 自动发现。
 3. 安装成功后可从开始菜单的“Olivia 本地版”快捷方式启动；安装时勾选“创建桌面快捷方式”后也可从桌面启动。两个快捷方式都由 `%WINDIR%\System32\wscript.exe //B //Nologo "<安装目录>\START.vbs"` 隐藏启动，不会显示可被误关的命令行窗口；工作目录固定为安装目录。点击后会立即显示“Olivia 正在启动，请稍候”的短暂提示，实际启动同时开始，不会等待提示关闭。只有隐藏启动器最终返回非零退出码时才显示中文失败对话框；正常关闭返回 `0` 时不会弹出错误。`START.cmd` 仍保留为兼容入口。它只启动一个监听 `127.0.0.1` 的本机服务，再直接启动隔离副本的 `0.0.9.627\Olivia.exe`，并使用安装目录下的独立 profile。
 4. 首次登录后在原版客户端内完成 LLM key 与按需能力设置；后续在 Settings 的“本地陪伴”中管理。公开安装器不包含参考音频或视频运行时；私有视频包已包含，无需用户再选离线包。
@@ -36,7 +36,7 @@ python installer/build_windows_setup.py `
   --iscc 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
 ```
 
-上面的默认构建是公开产物：不得传入参考音频或视频运行时，内嵌 offline manifest 也不含 `distribution`、`voice_reference` 或 `video_runtime`。需要经授权在私有渠道交付完整视频回信能力时，维护者必须使用隔离输出目录并同时显式提供私有分发、音色和运行时：
+上面的默认构建是公开产物：不得传入参考音频、视频运行时或视频离线根目录，内嵌 offline manifest 也不含 `distribution`、`voice_reference`、`video_runtime` 或 `video_offline`。需要经授权在私有渠道交付完整视频回信能力时，维护者必须使用隔离输出目录并同时显式提供私有分发、音色、运行时和与生产视频 BOM 完全匹配的离线根目录：
 
 ```powershell
 python installer/build_windows_setup.py `
@@ -46,14 +46,15 @@ python installer/build_windows_setup.py `
   --distribution private `
   --voice-reference '<私有 WAV 的本机路径>' `
   --video-runtime '<Olivia-video-runtime-*.zip 的本机路径>' `
+  --video-offline-root '<含 ordinary_video 与 music_video 的离线根目录>' `
   --iscc 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
 ```
 
-私有构建器只接受显式 WAV 和完整视频运行时 ZIP：它核对 PCM 帧、视频运行时根 manifest 与四个独立 Python 入口，随后把两项资产的大小和 SHA-256 写入内嵌 `offline/offline-core-assets.json`，其中 `distribution` 固定为 `private`。输入的 `offline` 目录不得预先夹带私有字段或资产；公开模式传入任一私有资产、私有模式缺少任一资产都会拒绝构建。
+私有构建器只接受三项显式输入：WAV、完整视频运行时 ZIP、完整视频离线根目录。它核对 PCM 帧、视频运行时根 manifest 与四个独立 Python 入口；再以 `installer/video-capability-manifest.json` 为唯一 BOM，要求离线根目录同时包含 `ordinary_video` 与 `music_video`，逐文件核对路径、大小和 SHA-256，并拒绝缺失、多余、重解析点或被修改的文件。随后把三项资产的固定名称和摘要写入内嵌 `offline/offline-core-assets.json`，其中 `distribution` 固定为 `private`。输入的 `offline` 目录不得预先夹带私有字段或资产；公开模式传入任一私有资产、私有模式缺少任一资产都会拒绝构建。
 
-公开构建仍是单个 `Olivia-Setup-x64.exe`。私有视频运行时超过单个安装程序容量上限，因此私有产物是一个完整目录：`Olivia-Setup-x64.exe`、同名前缀的全部 `.bin` 分卷和 `.sha256`。交付时必须把整个目录压成一个 ZIP，用户完整解压后再运行 EXE；缺少任一分卷都不能安装。私有产物只保存在专用 `dist-private`，不得与公开 `dist` artifact 共置、替换或上传到公开 Release。
+公开构建仍是单个 `Olivia-Setup-x64.exe`。私有产物是自包含目录：`Olivia-Setup-x64.exe`、`Olivia-video-runtime-private.zip`、`Olivia-video-offline-private/`、`Olivia-Setup-x64.receipt.json` 和 `Olivia-Setup-x64.exe.sha256`。交付时必须把整个目录压成一个 ZIP，用户完整解压后再运行 EXE；Inno 只把小型核心 payload 解到 `{tmp}`，并把 `{src}` 下固定名称的 runtime ZIP 与 offline root 传给 `Install.ps1`。runtime 由既有事务原子复制到受管 `install/downloads`，ordinary/music 资产由既有视频能力导入链校验、组装与激活；两类大文件都不会进入 Inno `{tmp}`。缺少、改名或篡改任一 sidecar 都会在发布安装结果前失败。私有产物只保存在专用 `dist-private`，不得与公开 `dist` artifact 共置、替换或上传到公开 Release。
 
-除私有模式显式传入的 WAV 与视频运行时 ZIP 外，构建器只复制 Git 已跟踪且相对 `HEAD` 未修改的发布文件，排除 `.github`、`docs`、测试和构建/CI 元数据，并在编译前复验离线 manifest、requirements 哈希、每个资产的大小与 SHA-256，以及实际资产集合。私有构建使用约 2.1 GB 的安装分卷；`.sha256` 会逐项记录 EXE 与全部分卷。
+除私有模式显式传入的 WAV、视频运行时 ZIP 与视频离线根目录外，构建器只复制 Git 已跟踪且相对 `HEAD` 未修改的发布文件，排除 `.github`、`docs`、测试和构建/CI 元数据，并在编译前复验离线 manifest、requirements 哈希、每个资产的大小与 SHA-256，以及实际资产集合。构建器先把两类大 sidecar 原子发布到输出目录并以这些最终字节生成内嵌 BOM；Inno 编译完成后再次复验，防止编译期间的替换进入交付。私有 receipt 记录 EXE、runtime ZIP 与 offline root 内每个文件的相对路径、大小和 SHA-256；`.sha256` 再覆盖这些文件及 receipt 本身，因而没有自引用。公开构建流程与原有输出保持不变，只校验并记录 EXE。
 
 GitHub Actions 只生成公开安装器 artifact；它会在 PR 和 `main` 更新时执行默认公开构建，不接受私有 WAV 或视频运行时，也不会生成私有安装器。私有安装包只能由维护者在隔离环境手工构建。当前产物未做商业代码签名；正式面向普通用户发布前应增加受信任的 Authenticode 签名，但签名不替代随包 SHA-256 校验。
 

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -4,6 +4,8 @@ param(
     [string]$Destination = (Join-Path $env:LOCALAPPDATA 'BSideOliviaLocal'),
     [string]$OfficialRoot = '',
     [string]$OfflineAssetsRoot = '',
+    [string]$VideoRuntimePath = '',
+    [string]$VideoOfflineRoot = '',
     [string]$SetupResultPath = '',
     [switch]$NonInteractive,
     [switch]$SkipShortcut,
@@ -523,6 +525,77 @@ function Resolve-OfflineAsset {
     return $path
 }
 
+function Resolve-VideoRuntimeSidecar {
+    param(
+        [Parameter(Mandatory)]
+        [string]$LiteralPath,
+        [Parameter(Mandatory)]
+        [object]$Asset
+    )
+
+    if (-not $LiteralPath) { throw 'VIDEO_RUNTIME_MISSING' }
+    try {
+        if (-not [IO.Path]::IsPathRooted($LiteralPath)) {
+            throw 'VIDEO_RUNTIME_INVALID'
+        }
+        $path = [IO.Path]::GetFullPath($LiteralPath)
+        if ([IO.Path]::GetFileName($path) -cne [string]$Asset.path) {
+            throw 'VIDEO_RUNTIME_INVALID'
+        }
+        $parent = [IO.Path]::GetDirectoryName($path)
+        if (-not $parent) { throw 'VIDEO_RUNTIME_INVALID' }
+        Assert-NoReparsePointsInPath -LiteralPath $parent -ErrorCode 'VIDEO_RUNTIME_INVALID'
+        if ((Test-Path -LiteralPath $path) -and -not [IO.File]::Exists($path)) {
+            throw 'VIDEO_RUNTIME_INVALID'
+        }
+        if ([IO.File]::Exists($path) -and ([IO.File]::GetAttributes($path) -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw 'VIDEO_RUNTIME_INVALID'
+        }
+        return $path
+    } catch {
+        $code = [string]$_.Exception.Message
+        if ($code -in @('VIDEO_RUNTIME_MISSING', 'VIDEO_RUNTIME_HASH_MISMATCH')) {
+            throw $code
+        }
+        throw 'VIDEO_RUNTIME_INVALID'
+    }
+}
+
+function Resolve-VideoOfflineSidecar {
+    param(
+        [string]$LiteralPath = '',
+        [Parameter(Mandatory)]
+        [object]$Asset
+    )
+
+    if (-not $LiteralPath) { throw 'VIDEO_PRIVATE_OFFLINE_MISSING' }
+    try {
+        if (-not [IO.Path]::IsPathRooted($LiteralPath)) {
+            throw 'VIDEO_PRIVATE_OFFLINE_INVALID'
+        }
+        $path = [IO.Path]::GetFullPath($LiteralPath)
+        if ([IO.Path]::GetFileName($path) -cne [string]$Asset.path) {
+            throw 'VIDEO_PRIVATE_OFFLINE_INVALID'
+        }
+        $parent = [IO.Path]::GetDirectoryName($path)
+        if (-not $parent) { throw 'VIDEO_PRIVATE_OFFLINE_INVALID' }
+        Assert-NoReparsePointsInPath -LiteralPath $parent -ErrorCode 'VIDEO_PRIVATE_OFFLINE_INVALID'
+        if (-not [IO.Directory]::Exists($path)) {
+            throw 'VIDEO_PRIVATE_OFFLINE_MISSING'
+        }
+        if (([IO.File]::GetAttributes($path) -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw 'VIDEO_PRIVATE_OFFLINE_INVALID'
+        }
+        return $path
+    } catch {
+        $code = [string]$_.Exception.Message
+        if ($code -in @('VIDEO_PRIVATE_OFFLINE_MISSING', 'VIDEO_PRIVATE_OFFLINE_INVALID')) {
+            throw $code
+        }
+        throw 'VIDEO_PRIVATE_OFFLINE_INVALID'
+    }
+}
+
 function Get-PcmWaveMetadata {
     param([Parameter(Mandatory)][string]$Path)
     try {
@@ -839,6 +912,255 @@ function Complete-ManagedVideoRuntimeTransaction {
     }
 }
 
+function Get-ManagedPrivateVideoTransactionPaths {
+    param(
+        [Parameter(Mandatory)][string]$InstallRoot,
+        [Parameter(Mandatory)][string]$TransactionId
+    )
+
+    if ($TransactionId -cnotmatch '^[0-9a-f]{32}$') {
+        throw 'VIDEO_PRIVATE_TRANSACTION_FAILED'
+    }
+    $capabilityRoot = Join-Path $InstallRoot 'data\capabilities'
+    $downloadRoot = Join-Path $InstallRoot 'downloads'
+    return [pscustomobject]@{
+        CapabilityRoot = $capabilityRoot
+        VideoRoot = Join-Path $capabilityRoot 'video'
+        Backup = Join-Path $capabilityRoot ('.video.private-backup.' + $TransactionId)
+        Discard = Join-Path $capabilityRoot ('.video.private-discard.' + $TransactionId)
+        DownloadRoot = $downloadRoot
+        RuntimeTarget = Join-Path $downloadRoot 'Olivia-video-runtime-private.zip'
+        RuntimeBackup = Join-Path $downloadRoot ('.Olivia-private-runtime-backup.' + $TransactionId + '.zip')
+        RuntimeDiscard = Join-Path $downloadRoot ('.Olivia-private-runtime-discard.' + $TransactionId + '.zip')
+    }
+}
+
+function Start-ManagedPrivateVideoTransaction {
+    param(
+        [Parameter(Mandatory)][string]$InstallRoot,
+        [Parameter(Mandatory)][string]$TransactionId,
+        [Parameter(Mandatory)][string]$PendingMarker,
+        [Parameter(Mandatory)][object]$VideoRuntime
+    )
+
+    $paths = Get-ManagedPrivateVideoTransactionPaths -InstallRoot $InstallRoot -TransactionId $TransactionId
+    try {
+        Assert-NoReparsePointsInPath -LiteralPath $paths.CapabilityRoot -ErrorCode 'VIDEO_PRIVATE_TRANSACTION_FAILED'
+        Assert-NoReparsePointsInPath -LiteralPath $paths.DownloadRoot -ErrorCode 'VIDEO_PRIVATE_TRANSACTION_FAILED'
+        New-Item -ItemType Directory -Force -Path $paths.CapabilityRoot | Out-Null
+        New-Item -ItemType Directory -Force -Path $paths.DownloadRoot | Out-Null
+        if (
+            (Test-Path -LiteralPath $paths.Backup) -or
+            (Test-Path -LiteralPath $paths.Discard) -or
+            (Test-Path -LiteralPath $paths.RuntimeBackup) -or
+            (Test-Path -LiteralPath $paths.RuntimeDiscard)
+        ) {
+            throw 'VIDEO_PRIVATE_TRANSACTION_FAILED'
+        }
+        $existed = [IO.Directory]::Exists($paths.VideoRoot)
+        $runtimeExisted = [IO.File]::Exists($paths.RuntimeTarget)
+        if (
+            ((Test-Path -LiteralPath $paths.VideoRoot) -and -not $existed) -or
+            ($existed -and -not (Test-NoReparsePointsInTree -LiteralPath $paths.VideoRoot)) -or
+            ((Test-Path -LiteralPath $paths.RuntimeTarget) -and -not $runtimeExisted) -or
+            ($runtimeExisted -and (([IO.File]::GetAttributes($paths.RuntimeTarget) -band [IO.FileAttributes]::ReparsePoint) -ne 0))
+        ) {
+            throw 'VIDEO_PRIVATE_TRANSACTION_FAILED'
+        }
+        $runtimeMode = 0
+        if ($runtimeExisted) {
+            $runtimeMode = if (
+                [IO.FileInfo]::new($paths.RuntimeTarget).Length -eq [int64]$VideoRuntime.size_bytes -and
+                (Get-Sha256 -LiteralPath $paths.RuntimeTarget) -ceq [string]$VideoRuntime.sha256
+            ) { 2 } else { 1 }
+        }
+        if ($runtimeMode -eq 2) {
+            Remove-StaleManagedVideoRuntimeArtifacts -DownloadRoot $paths.DownloadRoot -Extensions @('tmp', 'bak')
+        }
+        Set-DurableTransactionState -Path $PendingMarker -State "$TransactionId|$([int]$existed)|$runtimeMode"
+        if ($existed) {
+            [IO.Directory]::Move($paths.VideoRoot, $paths.Backup)
+        }
+        if ($runtimeMode -eq 1) {
+            [IO.File]::Move($paths.RuntimeTarget, $paths.RuntimeBackup)
+        }
+        return [pscustomobject]@{ RuntimeMode = $runtimeMode }
+    } catch {
+        throw 'VIDEO_PRIVATE_TRANSACTION_FAILED'
+    }
+}
+
+function Restore-ManagedPrivateVideoTransaction {
+    param(
+        [Parameter(Mandatory)][string]$InstallRoot,
+        [Parameter(Mandatory)][string]$TransactionId,
+        [Parameter(Mandatory)][bool]$VideoRootExisted
+    )
+
+    $paths = Get-ManagedPrivateVideoTransactionPaths -InstallRoot $InstallRoot -TransactionId $TransactionId
+    try {
+        $videoPresent = Test-Path -LiteralPath $paths.VideoRoot
+        $backupPresent = Test-Path -LiteralPath $paths.Backup
+        $discardPresent = Test-Path -LiteralPath $paths.Discard
+        foreach ($entry in @($paths.VideoRoot, $paths.Backup, $paths.Discard)) {
+            if ((Test-Path -LiteralPath $entry) -and (
+                -not [IO.Directory]::Exists($entry) -or
+                -not (Test-NoReparsePointsInTree -LiteralPath $entry)
+            )) {
+                throw 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+            }
+        }
+        if ($VideoRootExisted) {
+            if ($backupPresent) {
+                if ($videoPresent) {
+                    if ($discardPresent) {
+                        throw 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+                    }
+                    [IO.Directory]::Move($paths.VideoRoot, $paths.Discard)
+                    $discardPresent = $true
+                }
+                [IO.Directory]::Move($paths.Backup, $paths.VideoRoot)
+            } elseif (-not $videoPresent) {
+                throw 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+            }
+        } else {
+            if ($backupPresent) {
+                throw 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+            }
+            if ($videoPresent) {
+                if ($discardPresent) {
+                    throw 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+                }
+                [IO.Directory]::Move($paths.VideoRoot, $paths.Discard)
+                $discardPresent = $true
+            }
+        }
+        if ($discardPresent) {
+            Remove-Item -LiteralPath $paths.Discard -Recurse -Force
+        }
+    } catch {
+        throw 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+    }
+}
+
+function Complete-ManagedPrivateVideoTransaction {
+    param(
+        [Parameter(Mandatory)][string]$InstallRoot,
+        [Parameter(Mandatory)][string]$TransactionId,
+        [Parameter(Mandatory)][bool]$VideoRootExisted
+    )
+
+    $paths = Get-ManagedPrivateVideoTransactionPaths -InstallRoot $InstallRoot -TransactionId $TransactionId
+    try {
+        if (Test-Path -LiteralPath $paths.Discard) {
+            throw 'VIDEO_PRIVATE_TRANSACTION_CLEANUP_FAILED'
+        }
+        if (-not [IO.Directory]::Exists($paths.VideoRoot) -or
+            -not (Test-NoReparsePointsInTree -LiteralPath $paths.VideoRoot)) {
+            throw 'VIDEO_PRIVATE_TRANSACTION_CLEANUP_FAILED'
+        }
+        if (Test-Path -LiteralPath $paths.Backup) {
+            if (-not $VideoRootExisted -or -not [IO.Directory]::Exists($paths.Backup) -or
+                -not (Test-NoReparsePointsInTree -LiteralPath $paths.Backup)) {
+                throw 'VIDEO_PRIVATE_TRANSACTION_CLEANUP_FAILED'
+            }
+            Remove-Item -LiteralPath $paths.Backup -Recurse -Force
+        }
+    } catch {
+        throw 'VIDEO_PRIVATE_TRANSACTION_CLEANUP_FAILED'
+    }
+}
+
+function Restore-ManagedPrivateRuntimeSidecarTransaction {
+    param(
+        [Parameter(Mandatory)][string]$InstallRoot,
+        [Parameter(Mandatory)][string]$TransactionId,
+        [Parameter(Mandatory)][ValidateSet(0, 1, 2)][int]$RuntimeMode
+    )
+
+    $paths = Get-ManagedPrivateVideoTransactionPaths -InstallRoot $InstallRoot -TransactionId $TransactionId
+    try {
+        Assert-NoReparsePointsInPath -LiteralPath $paths.DownloadRoot -ErrorCode 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+        $targetPresent = Test-Path -LiteralPath $paths.RuntimeTarget
+        $backupPresent = Test-Path -LiteralPath $paths.RuntimeBackup
+        $discardPresent = Test-Path -LiteralPath $paths.RuntimeDiscard
+        foreach ($entry in @($paths.RuntimeTarget, $paths.RuntimeBackup, $paths.RuntimeDiscard)) {
+            if ((Test-Path -LiteralPath $entry) -and (
+                -not [IO.File]::Exists($entry) -or
+                (([IO.File]::GetAttributes($entry) -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+            )) {
+                throw 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+            }
+        }
+        if ($RuntimeMode -eq 2) {
+            if (-not $targetPresent -or $backupPresent -or $discardPresent) {
+                throw 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+            }
+        } elseif ($RuntimeMode -eq 1) {
+            if ($backupPresent) {
+                if ($targetPresent) {
+                    if ($discardPresent) {
+                        throw 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+                    }
+                    [IO.File]::Move($paths.RuntimeTarget, $paths.RuntimeDiscard)
+                    $discardPresent = $true
+                }
+                [IO.File]::Move($paths.RuntimeBackup, $paths.RuntimeTarget)
+            } elseif (-not $targetPresent) {
+                throw 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+            }
+        } else {
+            if ($backupPresent) {
+                throw 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+            }
+            if ($targetPresent) {
+                if ($discardPresent) {
+                    throw 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+                }
+                [IO.File]::Move($paths.RuntimeTarget, $paths.RuntimeDiscard)
+                $discardPresent = $true
+            }
+        }
+        if ($discardPresent) {
+            [IO.File]::Delete($paths.RuntimeDiscard)
+        }
+    } catch {
+        throw 'VIDEO_PRIVATE_TRANSACTION_ROLLBACK_FAILED'
+    }
+}
+
+function Complete-ManagedPrivateRuntimeSidecarTransaction {
+    param(
+        [Parameter(Mandatory)][string]$InstallRoot,
+        [Parameter(Mandatory)][string]$TransactionId,
+        [Parameter(Mandatory)][ValidateSet(0, 1, 2)][int]$RuntimeMode
+    )
+
+    $paths = Get-ManagedPrivateVideoTransactionPaths -InstallRoot $InstallRoot -TransactionId $TransactionId
+    try {
+        Assert-NoReparsePointsInPath -LiteralPath $paths.DownloadRoot -ErrorCode 'VIDEO_PRIVATE_TRANSACTION_CLEANUP_FAILED'
+        if (
+            -not [IO.File]::Exists($paths.RuntimeTarget) -or
+            (([IO.File]::GetAttributes($paths.RuntimeTarget) -band [IO.FileAttributes]::ReparsePoint) -ne 0) -or
+            (Test-Path -LiteralPath $paths.RuntimeDiscard)
+        ) {
+            throw 'VIDEO_PRIVATE_TRANSACTION_CLEANUP_FAILED'
+        }
+        if (Test-Path -LiteralPath $paths.RuntimeBackup) {
+            if (
+                $RuntimeMode -ne 1 -or
+                -not [IO.File]::Exists($paths.RuntimeBackup) -or
+                (([IO.File]::GetAttributes($paths.RuntimeBackup) -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+            ) {
+                throw 'VIDEO_PRIVATE_TRANSACTION_CLEANUP_FAILED'
+            }
+            [IO.File]::Delete($paths.RuntimeBackup)
+        }
+    } catch {
+        throw 'VIDEO_PRIVATE_TRANSACTION_CLEANUP_FAILED'
+    }
+}
+
 function Get-ManagedInstallTransactionNames {
     return @('local_backend', 'launcher', 'START.cmd', 'START.vbs', 'CONFIGURE.cmd', 'UNINSTALL.cmd', '.olivia-full-patch.json')
 }
@@ -896,7 +1218,7 @@ function Remove-ManagedInstallRollbackSnapshot {
 
 function Repair-ManagedInstallTransaction {
     param([Parameter(Mandatory)][string]$ProductRoot, [Parameter(Mandatory)][string]$InstallRoot, [Parameter(Mandatory)][string]$RuntimeRoot); if (-not [IO.Directory]::Exists($ProductRoot)) { return }
-    $journal = Join-Path $ProductRoot '.install.transaction'; $activeMarker = "$journal.active"; $rollbackMarker = "$journal.rollback"; $cleanupMarker = "$journal.cleanup"; try { foreach ($next in @("$journal.next", "$activeMarker.next")) { [IO.File]::Delete($next) } } catch { throw 'VOICE_REFERENCE_INSTALL_CLEANUP_FAILED' }
+    $journal = Join-Path $ProductRoot '.install.transaction'; $activeMarker = "$journal.active"; $rollbackMarker = "$journal.rollback"; $cleanupMarker = "$journal.cleanup"; $privateVideoPending = "$journal.private-video-pending"; try { foreach ($next in @("$journal.next", "$activeMarker.next", "$privateVideoPending.next")) { [IO.File]::Delete($next) } } catch { throw 'VOICE_REFERENCE_INSTALL_CLEANUP_FAILED' }
     if ((@($activeMarker, $rollbackMarker, $cleanupMarker) | Where-Object { [IO.File]::Exists($_) }).Count -gt 1) { throw 'VOICE_REFERENCE_INSTALL_ROLLBACK_FAILED' }
     if (-not [IO.File]::Exists($journal) -and ([IO.File]::Exists($activeMarker) -or [IO.File]::Exists($rollbackMarker) -or [IO.File]::Exists($cleanupMarker))) { throw 'VOICE_REFERENCE_INSTALL_ROLLBACK_FAILED' }
     if (-not [IO.File]::Exists($journal)) { $shared = Join-Path $InstallRoot 'data\capabilities\video\shared'; if ([IO.Directory]::Exists($shared)) { Repair-ManagedVoiceTransaction -SharedRoot $shared }; return }
@@ -905,18 +1227,41 @@ function Repair-ManagedInstallTransaction {
         $state = [IO.File]::ReadAllText($marker)
         if ($state -cnotmatch '^(?<id>[0-9a-f]{32})\|(?<install>[01])\|(?<runtime>[01])$') { throw 'invalid install transaction' }
         $id = $Matches.id; $installExisted = $Matches.install -ceq '1'; $runtimeExisted = $Matches.runtime -ceq '1'
+        $privateVideoState = $null
+        if ([IO.File]::Exists($privateVideoPending)) {
+            $pendingState = [IO.File]::ReadAllText($privateVideoPending)
+            if ($pendingState -cnotmatch '^(?<id>[0-9a-f]{32})\|(?<video>[01])\|(?<runtime>[012])$' -or $Matches.id -cne $id) {
+                throw 'invalid private video transaction'
+            }
+            $privateVideoState = [pscustomobject]@{
+                Id = $id
+                Existed = $Matches.video -ceq '1'
+                RuntimeMode = [int]$Matches.runtime
+            }
+        }
         $snapshot = Join-Path $ProductRoot ".install.rollback.$id"; $staging = "$RuntimeRoot.staging.$id"; $backup = "$RuntimeRoot.backup.$id"; $shared = Join-Path $InstallRoot 'data\capabilities\video\shared'
-        $committed = $phase -ceq 'cleanup' -or [IO.File]::Exists((Join-Path $shared '.linli-reference.transaction.cleanup'))
+        $committed = ($phase -ceq 'cleanup' -or [IO.File]::Exists((Join-Path $shared '.linli-reference.transaction.cleanup'))) -and -not [IO.File]::Exists($privateVideoPending)
         if ($committed -and $phase -eq 'active') { [IO.File]::Move($activeMarker, $cleanupMarker); $marker = $cleanupMarker; $phase = 'cleanup' }
         if ($phase -ceq 'active') {
             if ([IO.Directory]::Exists($shared)) { Repair-ManagedVoiceTransaction -SharedRoot $shared }
             Restore-ManagedInstallRollbackSnapshot -InstallRoot $InstallRoot -InstallRootExisted $installExisted -Snapshot $snapshot
             Restore-ManagedRuntimeTransaction -RuntimeRoot $RuntimeRoot -RuntimeBackup $backup -RuntimeRootExisted $runtimeExisted
+            if ($null -ne $privateVideoState) {
+                Restore-ManagedPrivateVideoTransaction -InstallRoot $InstallRoot -TransactionId $privateVideoState.Id -VideoRootExisted $privateVideoState.Existed
+                Restore-ManagedPrivateRuntimeSidecarTransaction -InstallRoot $InstallRoot -TransactionId $privateVideoState.Id -RuntimeMode $privateVideoState.RuntimeMode
+            }
             [IO.File]::Move($activeMarker, $rollbackMarker); $marker = $rollbackMarker; $phase = 'rollback'
-        } elseif ($phase -ceq 'cleanup' -and [IO.Directory]::Exists($shared)) { Repair-ManagedVoiceTransaction -SharedRoot $shared }
+        } elseif ($phase -ceq 'cleanup') {
+            if ([IO.Directory]::Exists($shared)) { Repair-ManagedVoiceTransaction -SharedRoot $shared }
+            if ($null -ne $privateVideoState) {
+                Complete-ManagedPrivateVideoTransaction -InstallRoot $InstallRoot -TransactionId $privateVideoState.Id -VideoRootExisted $privateVideoState.Existed
+                Complete-ManagedPrivateRuntimeSidecarTransaction -InstallRoot $InstallRoot -TransactionId $privateVideoState.Id -RuntimeMode $privateVideoState.RuntimeMode
+            }
+        }
         foreach ($path in @($staging, $backup)) { if (Test-Path -LiteralPath $path) { Remove-Item -LiteralPath $path -Recurse -Force } }
         Remove-ManagedInstallRollbackSnapshot -Snapshot $snapshot
         if ($marker -cne $journal) { [IO.File]::Delete($marker) }
+        [IO.File]::Delete($privateVideoPending)
         [IO.File]::Delete($journal)
     } catch { if ($phase -ceq 'cleanup' -or $committed) { throw 'VOICE_REFERENCE_INSTALL_CLEANUP_FAILED' }; throw 'VOICE_REFERENCE_INSTALL_ROLLBACK_FAILED' }
 }
@@ -928,7 +1273,9 @@ function Get-OfflineCoreAssets {
         [Parameter(Mandatory)]
         [string]$ManifestPath,
         [Parameter(Mandatory)]
-        [string]$RequirementsPath
+        [string]$RequirementsPath,
+        [string]$VideoRuntimePath = '',
+        [string]$VideoOfflineRoot = ''
     )
 
     if (-not [IO.File]::Exists($ManifestPath)) { throw 'OFFLINE_CORE_ASSETS_MISSING' }
@@ -940,15 +1287,18 @@ function Get-OfflineCoreAssets {
     $manifestNames = @('schema_version', 'python_runtime', 'pip_bootstrap', 'requirements_sha256', 'wheels')
     $hasVoiceReference = $manifest.PSObject.Properties.Name -ccontains 'voice_reference'
     $hasVideoRuntime = $manifest.PSObject.Properties.Name -ccontains 'video_runtime'
+    $hasVideoOffline = $manifest.PSObject.Properties.Name -ccontains 'video_offline'
     $hasDistribution = $manifest.PSObject.Properties.Name -ccontains 'distribution'
     if (
-        $hasVideoRuntime -ne $hasVoiceReference -or
+        $hasVideoRuntime -ne $hasVoiceReference -or $hasVideoOffline -ne $hasVoiceReference -or
         $hasVoiceReference -ne $hasDistribution -or
         ($hasDistribution -and $manifest.distribution -cne 'private')
     ) {
         throw 'VOICE_REFERENCE_PRIVATE_MANIFEST_REQUIRED'
     }
-    if ($hasVoiceReference) { $manifestNames += @('distribution', 'voice_reference', 'video_runtime') }
+    if (-not $hasVideoRuntime -and $VideoRuntimePath) { throw 'VIDEO_RUNTIME_INVALID' }
+    if (-not $hasVideoOffline -and $VideoOfflineRoot) { throw 'VIDEO_PRIVATE_OFFLINE_INVALID' }
+    if ($hasVoiceReference) { $manifestNames += @('distribution', 'voice_reference', 'video_runtime', 'video_offline') }
     Assert-OfflineObjectShape -Value $manifest -Names $manifestNames
     Assert-OfflineObjectShape -Value $manifest.python_runtime -Names @('path', 'size_bytes', 'sha256', 'source_url')
     Assert-OfflineObjectShape -Value $manifest.pip_bootstrap -Names @('path', 'size_bytes', 'sha256', 'package', 'version')
@@ -988,6 +1338,7 @@ function Get-OfflineCoreAssets {
     $pipBootstrap = Resolve-OfflineAsset -Root $Root -Asset $manifest.pip_bootstrap
     $voiceReference = $null
     $videoRuntime = $null
+    $videoOffline = $null
     if ($hasVoiceReference) {
         Assert-OfflineObjectShape -Value $manifest.voice_reference -Names @('path', 'size_bytes', 'sha256', 'wave')
         Assert-OfflineObjectShape -Value $manifest.voice_reference.wave -Names @('channels', 'sample_width_bytes', 'sample_rate_hz', 'frame_count', 'compression_type')
@@ -1008,11 +1359,11 @@ function Get-OfflineCoreAssets {
         $voiceReference = $manifest.voice_reference
         $voiceReference.path = $voiceReferencePath
         Assert-OfflineObjectShape -Value $manifest.video_runtime -Names @('path', 'size_bytes', 'sha256')
-        if ($manifest.video_runtime.path -cne 'video-runtime/Olivia-video-runtime-private.zip') {
+        if ($manifest.video_runtime.path -cne 'Olivia-video-runtime-private.zip') {
             throw 'OFFLINE_CORE_MANIFEST_INVALID'
         }
         try {
-            $videoRuntimePath = Resolve-OfflineAsset -Root $Root -Asset $manifest.video_runtime
+            $videoRuntimePath = Resolve-VideoRuntimeSidecar -LiteralPath $VideoRuntimePath -Asset $manifest.video_runtime
         } catch {
             if ($_.Exception.Message -eq 'OFFLINE_CORE_ASSET_MISSING') {
                 throw 'VIDEO_RUNTIME_MISSING'
@@ -1027,6 +1378,28 @@ function Get-OfflineCoreAssets {
             size_bytes = [int64]$manifest.video_runtime.size_bytes
             sha256 = [string]$manifest.video_runtime.sha256
             verified = [bool]$true
+        }
+        Assert-OfflineObjectShape -Value $manifest.video_offline -Names @('path', 'manifest_version', 'manifest_sha256', 'file_count', 'size_bytes')
+        if (
+            $manifest.video_offline.path -cne 'Olivia-video-offline-private' -or
+            $manifest.video_offline.manifest_version -isnot [string] -or
+            -not [string]$manifest.video_offline.manifest_version -or
+            $manifest.video_offline.manifest_sha256 -isnot [string] -or
+            $manifest.video_offline.manifest_sha256 -cnotmatch '^[0-9a-f]{64}$' -or
+            ($manifest.video_offline.file_count -isnot [int] -and $manifest.video_offline.file_count -isnot [long]) -or
+            [int]$manifest.video_offline.file_count -lt 1 -or
+            ($manifest.video_offline.size_bytes -isnot [int] -and $manifest.video_offline.size_bytes -isnot [long]) -or
+            [int64]$manifest.video_offline.size_bytes -lt 1
+        ) {
+            throw 'OFFLINE_CORE_MANIFEST_INVALID'
+        }
+        $videoOfflinePath = Resolve-VideoOfflineSidecar -LiteralPath $VideoOfflineRoot -Asset $manifest.video_offline
+        $videoOffline = [pscustomobject]@{
+            path = $videoOfflinePath
+            manifest_version = [string]$manifest.video_offline.manifest_version
+            manifest_sha256 = [string]$manifest.video_offline.manifest_sha256
+            file_count = [int]$manifest.video_offline.file_count
+            size_bytes = [int64]$manifest.video_offline.size_bytes
         }
     }
     $expectedWheelAssets = Get-ExpectedOfflineWheels
@@ -1068,6 +1441,7 @@ function Get-OfflineCoreAssets {
         Wheelhouse = (Join-Path $Root 'wheelhouse')
         VoiceReference = $voiceReference
         VideoRuntime = $videoRuntime
+        VideoOffline = $videoOffline
     }
 }
 
@@ -1190,6 +1564,7 @@ function Test-ManagedServerDependencies {
 }
 
 Assert-ManagedRuntimeParent -ProductRoot $productRoot -RuntimePath $runtimeRoot
+Repair-ManagedInstallTransaction -ProductRoot $productRoot -InstallRoot $Destination -RuntimeRoot $runtimeRoot
 $selectedOfficial = $OfficialRoot
 if (-not $selectedOfficial -and -not $NonInteractive) {
     $selectedOfficial = Read-Host 'Steam 游戏目录（留空则按 AppID 自动发现）'
@@ -1205,8 +1580,7 @@ if (Test-PathsOverlap -Left $productRoot -Right $selectedOfficial) {
 $script:OfficialSourceDiagnostic = New-OfficialSourceDiagnostic -Selection $officialSelection -ManifestPath $manifestPath
 Write-SetupDiagnosticResult -Diagnostic $script:OfficialSourceDiagnostic
 Assert-OfficialSource -SourceRoot $selectedOfficial -ManifestPath $manifestPath
-$coreAssets = Get-OfflineCoreAssets -Root $offlineRoot -ManifestPath $offlineManifestPath -RequirementsPath $requirements
-Repair-ManagedInstallTransaction -ProductRoot $productRoot -InstallRoot $Destination -RuntimeRoot $runtimeRoot
+$coreAssets = Get-OfflineCoreAssets -Root $offlineRoot -ManifestPath $offlineManifestPath -RequirementsPath $requirements -VideoRuntimePath $VideoRuntimePath -VideoOfflineRoot $VideoOfflineRoot
 New-Item -ItemType Directory -Force -Path $productRoot | Out-Null
 $installRootExisted = [IO.Directory]::Exists($Destination); $runtimeRootExisted = Test-Path -LiteralPath $runtimeRoot
 $installTransactionId = [guid]::NewGuid().ToString('N')
@@ -1293,8 +1667,58 @@ if ($installExitCode -ne 0) {
     exit $installExitCode
 }
 try {
-    $videoRuntimeTransaction = Install-ManagedVideoRuntime -VideoRuntime $coreAssets.VideoRuntime -InstallRoot $Destination
+    $privateVideoPending = "$installTransaction.private-video-pending"
+    $privateVideoTransaction = $null
+    if ($null -ne $coreAssets.VideoOffline) {
+        $privateVideoTransaction = Start-ManagedPrivateVideoTransaction -InstallRoot $Destination -TransactionId $installTransactionId -PendingMarker $privateVideoPending -VideoRuntime $coreAssets.VideoRuntime
+    }
+    $videoRuntimeTransaction = if (
+        $null -ne $privateVideoTransaction -and
+        [int]$privateVideoTransaction.RuntimeMode -eq 2
+    ) { $null } else {
+        Install-ManagedVideoRuntime -VideoRuntime $coreAssets.VideoRuntime -InstallRoot $Destination
+    }
     Install-ManagedVoiceReference -VoiceReference $coreAssets.VoiceReference -InstallRoot $Destination
+    if ($null -ne $coreAssets.VideoOffline) {
+        $privateVideoActivator = Join-Path $PayloadRoot 'installer\activate_private_video.py'
+        if (-not [IO.File]::Exists($privateVideoActivator)) {
+            throw 'VIDEO_PRIVATE_ACTIVATION_FAILED'
+        }
+        $managedVideoRuntime = Join-Path $Destination 'downloads\Olivia-video-runtime-private.zip'
+        $videoManifest = Join-Path $PayloadRoot 'installer\video-capability-manifest.json'
+        $privateVideoArguments = @(
+            '--install-root', $Destination,
+            '--offline-root', [string]$coreAssets.VideoOffline.path,
+            '--runtime-archive', $managedVideoRuntime,
+            '--manifest', $videoManifest,
+            '--manifest-version', [string]$coreAssets.VideoOffline.manifest_version,
+            '--manifest-sha256', [string]$coreAssets.VideoOffline.manifest_sha256,
+            '--expected-file-count', [string]$coreAssets.VideoOffline.file_count,
+            '--expected-size-bytes', [string]$coreAssets.VideoOffline.size_bytes,
+            '--timeout-seconds', '14400'
+        )
+        $privateVideoOutput = @(& $runner.File @($runner.Args + @($privateVideoActivator) + $privateVideoArguments))
+        $privateVideoExitCode = $LASTEXITCODE
+        $privateVideoReady = $false
+        $privateVideoFailure = 'VIDEO_PRIVATE_ACTIVATION_FAILED'
+        foreach ($line in $privateVideoOutput) {
+            try {
+                $record = $line | ConvertFrom-Json
+                if ($record.status -eq 'READY') { $privateVideoReady = $true }
+                if (
+                    $record.status -eq 'ERROR' -and
+                    $record.code -is [string] -and
+                    $record.code -cmatch '^[A-Z][A-Z0-9_]{3,95}$'
+                ) {
+                    $privateVideoFailure = $record.code
+                }
+            } catch {
+                # Ignore non-contract child output; setup logs must not expose paths.
+            }
+        }
+        if ($privateVideoExitCode -ne 0) { throw $privateVideoFailure }
+        if (-not $privateVideoReady) { throw 'VIDEO_PRIVATE_NOT_READY' }
+    }
 } catch {
     $assetFailure = [string]$_.Exception.Message
     $rollbackFailed = $false

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -222,18 +222,33 @@ def _sha256(path: Path) -> str:
 
 def _directory_file_records(root: Path, *, prefix: str) -> list[dict[str, object]]:
     records: list[dict[str, object]] = []
-    for path in sorted(root.rglob("*"), key=lambda item: item.as_posix().casefold()):
-        if not path.is_file():
-            continue
-        relative = path.relative_to(root).as_posix()
-        records.append(
-            {
-                "path": f"{prefix}/{relative}",
-                "size_bytes": path.stat().st_size,
-                "sha256": _sha256(path),
-            }
-        )
-    return records
+    try:
+        if not root.is_dir() or _is_reparse_point(root):
+            raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+        for current, directories, filenames in os.walk(root, followlinks=False):
+            current_path = Path(current)
+            if _is_reparse_point(current_path):
+                raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+            for name in directories:
+                if _is_reparse_point(current_path / name):
+                    raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+            for name in filenames:
+                path = current_path / name
+                if not path.is_file() or _is_reparse_point(path):
+                    raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+                relative = path.relative_to(root).as_posix()
+                records.append(
+                    {
+                        "path": f"{prefix}/{relative}",
+                        "size_bytes": path.stat().st_size,
+                        "sha256": _sha256(path),
+                    }
+                )
+        return sorted(records, key=lambda record: str(record["path"]).casefold())
+    except SetupBuildError:
+        raise
+    except OSError as exc:
+        raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID") from exc
 
 
 def _tree_sha256(records: list[dict[str, object]]) -> str:
@@ -650,7 +665,12 @@ def _copytree_without_reparse(source: Path, destination: Path) -> None:
         raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID") from exc
 
 
-def _video_offline_metadata(manifest_path: Path, root: Path) -> dict[str, object]:
+def _video_offline_metadata(
+    manifest_path: Path,
+    root: Path,
+    *,
+    file_records: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
     try:
         manifest_bytes = manifest_path.read_bytes()
         payload = json.loads(manifest_bytes.decode("utf-8"))
@@ -734,11 +754,21 @@ def _video_offline_metadata(manifest_path: Path, root: Path) -> dict[str, object
         if set(actual_files) != set(expected) or actual_directories - expected_directories:
             raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
         total = 0
-        for folded, (_, size, digest) in expected.items():
+        for folded, (relative, size, digest) in expected.items():
             path = actual_files[folded]
             if path.stat().st_size != size or _sha256(path) != digest:
                 raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
             total += size
+            if file_records is not None:
+                file_records.append(
+                    {
+                        "path": f"{VIDEO_OFFLINE_SIDECAR_NAME}/{relative}",
+                        "size_bytes": size,
+                        "sha256": digest,
+                    }
+                )
+        if file_records is not None:
+            file_records.sort(key=lambda record: str(record["path"]).casefold())
         return {
             "manifest_version": payload["version"],
             "manifest_sha256": hashlib.sha256(manifest_bytes).hexdigest(),
@@ -753,7 +783,7 @@ def _video_offline_metadata(manifest_path: Path, root: Path) -> dict[str, object
 
 def _verify_pinned_private_sidecars(
     payload: Path, runtime: Path, video_offline_root: Path
-) -> None:
+) -> tuple[dict[str, object], list[dict[str, object]]]:
     try:
         private_manifest = json.loads(
             (payload / "offline" / MANIFEST_NAME).read_text(encoding="utf-8")
@@ -765,15 +795,24 @@ def _verify_pinned_private_sidecars(
             "size_bytes": runtime.stat().st_size,
             "sha256": _sha256(runtime),
         }
+        offline_file_records: list[dict[str, object]] = []
         actual_offline = {
             "path": VIDEO_OFFLINE_SIDECAR_NAME,
             **_video_offline_metadata(
                 payload / "installer" / "video-capability-manifest.json",
                 video_offline_root,
+                file_records=offline_file_records,
             ),
         }
         if actual_runtime != expected_runtime or actual_offline != expected_offline:
             raise SetupBuildError("SETUP_PRIVATE_SIDECAR_CHANGED")
+        return (
+            {
+                **actual_runtime,
+                "path": os.fspath(runtime),
+            },
+            offline_file_records,
+        )
     except SetupBuildError as exc:
         if str(exc) == "SETUP_PRIVATE_SIDECAR_CHANGED":
             raise
@@ -1156,18 +1195,34 @@ def build_windows_setup(
         )
         if compiled_artifacts != [setup]:
             raise SetupBuildError("SETUP_COMPILE_FAILED")
+        verified_sidecars = None
         if video_runtime is not None and video_offline_root is not None:
-            _verify_pinned_private_sidecars(payload, sidecar, offline_sidecar)
+            verified_sidecars = _verify_pinned_private_sidecars(
+                payload, sidecar, offline_sidecar
+            )
         artifacts = [setup]
-        if video_runtime is not None:
-            artifacts.append(sidecar)
         file_records = [
             {"path": os.fspath(path), "size_bytes": path.stat().st_size, "sha256": _sha256(path)}
             for path in artifacts
         ]
+        if video_runtime is not None:
+            artifacts.append(sidecar)
+            file_records.append(
+                verified_sidecars[0]
+                if verified_sidecars is not None
+                else {
+                    "path": os.fspath(sidecar),
+                    "size_bytes": sidecar.stat().st_size,
+                    "sha256": _sha256(sidecar),
+                }
+            )
         if video_offline_root is not None:
-            offline_file_records = _directory_file_records(
-                offline_sidecar, prefix=VIDEO_OFFLINE_SIDECAR_NAME
+            offline_file_records = (
+                verified_sidecars[1]
+                if verified_sidecars is not None
+                else _directory_file_records(
+                    offline_sidecar, prefix=VIDEO_OFFLINE_SIDECAR_NAME
+                )
             )
             offline_size = sum(int(record["size_bytes"]) for record in offline_file_records)
             file_records.extend(offline_file_records)

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -25,6 +25,9 @@ from installer.component_update import ComponentUpdateError, _validate_relative_
 
 MANIFEST_NAME = "offline-core-assets.json"
 SETUP_NAME = "Olivia-Setup-x64.exe"
+VIDEO_RUNTIME_SIDECAR_NAME = "Olivia-video-runtime-private.zip"
+VIDEO_OFFLINE_SIDECAR_NAME = "Olivia-video-offline-private"
+PRIVATE_RECEIPT_NAME = "Olivia-Setup-x64.receipt.json"
 VOICE_REFERENCE_PATH = "voice/olivia-reference.wav"
 FORBIDDEN_MEDIA_SUFFIXES = {
     ".aac",
@@ -41,7 +44,7 @@ FORBIDDEN_MEDIA_SUFFIXES = {
     ".webm",
     ".wmv",
 }
-VIDEO_RUNTIME_PATH = "video-runtime/Olivia-video-runtime-private.zip"
+VIDEO_RUNTIME_PATH = VIDEO_RUNTIME_SIDECAR_NAME
 VIDEO_RUNTIME_ENVIRONMENT_KEYS = {
     "OLIVIA_COSYVOICE_PYTHON",
     "OLIVIA_LATENTSYNC_PYTHON",
@@ -158,6 +161,7 @@ RELEASE_INSTALLER_FILES = {
     "installer/full_patch.py",
     "installer/full-patch-manifest.json",
     "installer/Install.ps1",
+    "installer/activate_private_video.py",
     "installer/mem0-capability-manifest.json",
     "installer/mem0-runtime-artifacts.json",
     "installer/mem0-runtime-requirements.txt",
@@ -199,6 +203,9 @@ REQUIRED_PAYLOAD_FILES = {
     "installer/Install.ps1",
     "installer/runtime-requirements.txt",
 }
+PRIVATE_REQUIRED_PAYLOAD_FILES = {
+    "installer/activate_private_video.py",
+}
 
 
 class SetupBuildError(RuntimeError):
@@ -211,6 +218,28 @@ def _sha256(path: Path) -> str:
         for block in iter(lambda: stream.read(1 << 20), b""):
             digest.update(block)
     return digest.hexdigest()
+
+
+def _directory_file_records(root: Path, *, prefix: str) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for path in sorted(root.rglob("*"), key=lambda item: item.as_posix().casefold()):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root).as_posix()
+        records.append(
+            {
+                "path": f"{prefix}/{relative}",
+                "size_bytes": path.stat().st_size,
+                "sha256": _sha256(path),
+            }
+        )
+    return records
+
+
+def _tree_sha256(records: list[dict[str, object]]) -> str:
+    return hashlib.sha256(
+        json.dumps(records, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
 
 
 def _voice_reference_metadata(path: Path) -> dict[str, object]:
@@ -570,6 +599,189 @@ def _is_reparse_point(path: Path) -> bool:
     )
 
 
+def _absolute_sidecar_source(
+    path: Path, *, directory: bool, error_code: str
+) -> Path:
+    try:
+        candidate = Path(os.path.abspath(path.expanduser()))
+        for current in reversed((candidate, *candidate.parents)):
+            if os.path.lexists(current) and _is_reparse_point(current):
+                raise SetupBuildError(error_code)
+        valid = candidate.is_dir() if directory else candidate.is_file()
+        if not valid:
+            raise SetupBuildError(error_code)
+        return candidate
+    except SetupBuildError:
+        raise
+    except (OSError, RuntimeError) as exc:
+        raise SetupBuildError(error_code) from exc
+
+
+def _assert_no_reparse_tree(root: Path, *, error_code: str) -> None:
+    try:
+        for current, directories, filenames in os.walk(root, followlinks=False):
+            current_path = Path(current)
+            for name in (*directories, *filenames):
+                if _is_reparse_point(current_path / name):
+                    raise SetupBuildError(error_code)
+    except SetupBuildError:
+        raise
+    except OSError as exc:
+        raise SetupBuildError(error_code) from exc
+
+
+def _copytree_without_reparse(source: Path, destination: Path) -> None:
+    def reject_reparse(directory: str, names: list[str]) -> tuple[str, ...]:
+        current = Path(directory)
+        if any(_is_reparse_point(current / name) for name in names):
+            raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+        return ()
+
+    try:
+        shutil.copytree(
+            source,
+            destination,
+            symlinks=True,
+            ignore=reject_reparse,
+        )
+    except SetupBuildError:
+        raise
+    except OSError as exc:
+        raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID") from exc
+
+
+def _video_offline_metadata(manifest_path: Path, root: Path) -> dict[str, object]:
+    try:
+        manifest_bytes = manifest_path.read_bytes()
+        payload = json.loads(manifest_bytes.decode("utf-8"))
+        physical_root = _absolute_sidecar_source(
+            root, directory=True, error_code="SETUP_VIDEO_OFFLINE_INVALID"
+        )
+        bundles = payload.get("bundles") if isinstance(payload, dict) else None
+        if (
+            not isinstance(payload, dict)
+            or payload.get("schema_version") != "olivia.video-capability-bom.v1"
+            or not isinstance(payload.get("version"), str)
+            or not payload["version"]
+            or not isinstance(bundles, list)
+        ):
+            raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+        expected: dict[str, tuple[str, int, str]] = {}
+        seen_bundles: set[str] = set()
+        for bundle in bundles:
+            if not isinstance(bundle, dict):
+                raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+            bundle_id = bundle.get("id")
+            files = bundle.get("files")
+            if (
+                bundle_id not in {"ordinary_video", "music_video"}
+                or bundle_id in seen_bundles
+                or not isinstance(files, list)
+                or not files
+            ):
+                raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+            seen_bundles.add(bundle_id)
+            for item in files:
+                if not isinstance(item, dict):
+                    raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+                try:
+                    relative = _validate_relative_path(item.get("path"))
+                except ComponentUpdateError as exc:
+                    raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID") from exc
+                size = item.get("size_bytes")
+                digest = item.get("sha256")
+                path = f"{bundle_id}/{relative}"
+                folded = path.casefold()
+                if (
+                    type(size) is not int
+                    or size < 1
+                    or not isinstance(digest, str)
+                    or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+                    or folded in expected
+                ):
+                    raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+                expected[folded] = (path, size, digest)
+        if seen_bundles != {"ordinary_video", "music_video"}:
+            raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+
+        actual_files: dict[str, Path] = {}
+        actual_directories: set[str] = set()
+        for current, directories, filenames in os.walk(physical_root, followlinks=False):
+            current_path = Path(current)
+            if _is_reparse_point(current_path):
+                raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+            for name in directories:
+                directory = current_path / name
+                if _is_reparse_point(directory):
+                    raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+                relative = directory.relative_to(physical_root).as_posix()
+                actual_directories.add(relative.casefold())
+            for name in filenames:
+                path = current_path / name
+                if not path.is_file() or _is_reparse_point(path):
+                    raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+                relative = path.relative_to(physical_root).as_posix()
+                folded = relative.casefold()
+                if folded in actual_files:
+                    raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+                actual_files[folded] = path
+        expected_directories = {
+            parent.as_posix().casefold()
+            for path, _, _ in expected.values()
+            for parent in PurePosixPath(path).parents
+            if parent.as_posix() != "."
+        }
+        if set(actual_files) != set(expected) or actual_directories - expected_directories:
+            raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+        total = 0
+        for folded, (_, size, digest) in expected.items():
+            path = actual_files[folded]
+            if path.stat().st_size != size or _sha256(path) != digest:
+                raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID")
+            total += size
+        return {
+            "manifest_version": payload["version"],
+            "manifest_sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+            "file_count": len(expected),
+            "size_bytes": total,
+        }
+    except SetupBuildError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise SetupBuildError("SETUP_VIDEO_OFFLINE_INVALID") from exc
+
+
+def _verify_pinned_private_sidecars(
+    payload: Path, runtime: Path, video_offline_root: Path
+) -> None:
+    try:
+        private_manifest = json.loads(
+            (payload / "offline" / MANIFEST_NAME).read_text(encoding="utf-8")
+        )
+        expected_runtime = private_manifest["video_runtime"]
+        expected_offline = private_manifest["video_offline"]
+        actual_runtime = {
+            "path": VIDEO_RUNTIME_SIDECAR_NAME,
+            "size_bytes": runtime.stat().st_size,
+            "sha256": _sha256(runtime),
+        }
+        actual_offline = {
+            "path": VIDEO_OFFLINE_SIDECAR_NAME,
+            **_video_offline_metadata(
+                payload / "installer" / "video-capability-manifest.json",
+                video_offline_root,
+            ),
+        }
+        if actual_runtime != expected_runtime or actual_offline != expected_offline:
+            raise SetupBuildError("SETUP_PRIVATE_SIDECAR_CHANGED")
+    except SetupBuildError as exc:
+        if str(exc) == "SETUP_PRIVATE_SIDECAR_CHANGED":
+            raise
+        raise SetupBuildError("SETUP_PRIVATE_SIDECAR_CHANGED") from exc
+    except (KeyError, OSError, UnicodeError, json.JSONDecodeError, TypeError) as exc:
+        raise SetupBuildError("SETUP_PRIVATE_SIDECAR_CHANGED") from exc
+
+
 def _git_tracked_files(source: Path) -> set[str]:
     try:
         result = subprocess.run(
@@ -661,7 +873,10 @@ def _load_and_verify_manifest(
         raise SetupBuildError("SETUP_OFFLINE_MANIFEST_INVALID") from exc
     if not isinstance(manifest, dict):
         raise SetupBuildError("SETUP_OFFLINE_MANIFEST_INVALID")
-    if any(key in manifest for key in ("distribution", "voice_reference", "video_runtime")):
+    if any(
+        key in manifest
+        for key in ("distribution", "voice_reference", "video_runtime", "video_offline")
+    ):
         raise SetupBuildError("SETUP_INPUT_VOICE_REFERENCE_FORBIDDEN")
 
     if validate_schema:
@@ -731,6 +946,7 @@ def prepare_setup_payload(
     distribution: str = "public",
     voice_reference: Path | None = None,
     video_runtime: Path | None = None,
+    video_offline_root: Path | None = None,
     validate_schema: bool = True,
 ) -> None:
     source = source.expanduser().resolve()
@@ -746,11 +962,20 @@ def prepare_setup_payload(
         raise SetupBuildError("SETUP_VIDEO_RUNTIME_PRIVATE_ONLY")
     if distribution == "private" and video_runtime is None:
         raise SetupBuildError("SETUP_PRIVATE_VIDEO_RUNTIME_REQUIRED")
+    if video_offline_root is not None and distribution != "private":
+        raise SetupBuildError("SETUP_VIDEO_OFFLINE_PRIVATE_ONLY")
+    if distribution == "private" and video_offline_root is None:
+        raise SetupBuildError("SETUP_PRIVATE_VIDEO_OFFLINE_REQUIRED")
     if destination.exists():
         raise SetupBuildError("SETUP_PAYLOAD_EXISTS")
     _load_and_verify_manifest(source, offline, validate_schema=validate_schema)
     tracked = _git_tracked_files(source)
     if not REQUIRED_PAYLOAD_FILES.issubset(tracked):
+        raise SetupBuildError("SETUP_REQUIRED_PAYLOAD_MISSING")
+    if (
+        distribution == "private"
+        and not PRIVATE_REQUIRED_PAYLOAD_FILES.issubset(tracked)
+    ):
         raise SetupBuildError("SETUP_REQUIRED_PAYLOAD_MISSING")
     selected = sorted(relative for relative in tracked if _is_release_file(relative))
     if any(
@@ -772,28 +997,33 @@ def prepare_setup_payload(
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source_path, target)
         shutil.copytree(offline, staging / "offline")
-        if voice_reference is not None and video_runtime is not None:
-            reference = voice_reference.expanduser().resolve()
-            if (
-                not reference.is_file()
-                or _is_reparse_point(reference)
-                or reference.stat().st_size < 1
-            ):
+        if (
+            voice_reference is not None
+            and video_runtime is not None
+            and video_offline_root is not None
+        ):
+            reference = _absolute_sidecar_source(
+                voice_reference,
+                directory=False,
+                error_code="SETUP_VOICE_REFERENCE_INVALID",
+            )
+            if reference.stat().st_size < 1:
                 raise SetupBuildError("SETUP_VOICE_REFERENCE_INVALID")
             target = staging / "offline" / Path(*VOICE_REFERENCE_PATH.split("/"))
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(reference, target)
-            runtime_source = video_runtime.expanduser()
-            if (
-                not runtime_source.is_file()
-                or _is_reparse_point(runtime_source)
-                or runtime_source.stat().st_size < 1
-            ):
+            runtime_source = _absolute_sidecar_source(
+                video_runtime,
+                directory=False,
+                error_code="SETUP_VIDEO_RUNTIME_INVALID",
+            )
+            if runtime_source.stat().st_size < 1:
                 raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
-            runtime_target = staging / "offline" / Path(*VIDEO_RUNTIME_PATH.split("/"))
-            runtime_target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(runtime_source.resolve(), runtime_target)
-            runtime_metadata = _video_runtime_metadata(runtime_target)
+            runtime_metadata = _video_runtime_metadata(runtime_source)
+            video_offline_metadata = _video_offline_metadata(
+                staging / "installer" / "video-capability-manifest.json",
+                video_offline_root,
+            )
             manifest_path = staging / "offline" / MANIFEST_NAME
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             manifest["distribution"] = "private"
@@ -806,6 +1036,10 @@ def prepare_setup_payload(
             manifest["video_runtime"] = {
                 "path": VIDEO_RUNTIME_PATH,
                 **runtime_metadata,
+            }
+            manifest["video_offline"] = {
+                "path": VIDEO_OFFLINE_SIDECAR_NAME,
+                **video_offline_metadata,
             }
             manifest_path.write_text(
                 json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True)
@@ -851,25 +1085,58 @@ def build_windows_setup(
     distribution: str = "public",
     voice_reference: Path | None = None,
     video_runtime: Path | None = None,
+    video_offline_root: Path | None = None,
 ) -> dict[str, object]:
     source = source.expanduser().resolve()
     output = output.expanduser().resolve()
     output.mkdir(parents=True, exist_ok=True)
     setup = output / SETUP_NAME
     checksum = output / f"{SETUP_NAME}.sha256"
-    if any(output.glob("Olivia-Setup-x64*")):
+    sidecar = output / VIDEO_RUNTIME_SIDECAR_NAME
+    offline_sidecar = output / VIDEO_OFFLINE_SIDECAR_NAME
+    receipt = output / PRIVATE_RECEIPT_NAME
+    if (
+        any(output.glob("Olivia-Setup-x64*"))
+        or sidecar.exists()
+        or offline_sidecar.exists()
+        or receipt.exists()
+    ):
         raise SetupBuildError("SETUP_OUTPUT_EXISTS")
     payload = output / f".setup-payload-{uuid.uuid4().hex}"
+    sidecar_staging = output / f".{VIDEO_RUNTIME_SIDECAR_NAME}.{uuid.uuid4().hex}.tmp"
+    offline_staging = output / f".{VIDEO_OFFLINE_SIDECAR_NAME}.{uuid.uuid4().hex}.tmp"
     compiler = _find_iscc(iscc)
     completed = False
     try:
+        if video_runtime is not None:
+            runtime_source = _absolute_sidecar_source(
+                video_runtime,
+                directory=False,
+                error_code="SETUP_VIDEO_RUNTIME_INVALID",
+            )
+            shutil.copy2(runtime_source, sidecar_staging)
+            os.replace(sidecar_staging, sidecar)
+        if video_offline_root is not None:
+            offline_source = _absolute_sidecar_source(
+                video_offline_root,
+                directory=True,
+                error_code="SETUP_VIDEO_OFFLINE_INVALID",
+            )
+            _assert_no_reparse_tree(
+                offline_source, error_code="SETUP_VIDEO_OFFLINE_INVALID"
+            )
+            _copytree_without_reparse(offline_source, offline_staging)
+            os.replace(offline_staging, offline_sidecar)
         prepare_setup_payload(
             source,
             offline,
             payload,
             distribution=distribution,
             voice_reference=voice_reference,
-            video_runtime=video_runtime,
+            video_runtime=sidecar if video_runtime is not None else None,
+            video_offline_root=(
+                offline_sidecar if video_offline_root is not None else None
+            ),
         )
         command = [
             os.fspath(compiler),
@@ -883,31 +1150,83 @@ def build_windows_setup(
         result = subprocess.run(command, check=False, timeout=900)
         if result.returncode != 0 or not setup.is_file():
             raise SetupBuildError("SETUP_COMPILE_FAILED")
-        artifacts = sorted(
+        compiled_artifacts = sorted(
             path for path in output.glob("Olivia-Setup-x64*")
             if path.is_file() and path != checksum
         )
+        if compiled_artifacts != [setup]:
+            raise SetupBuildError("SETUP_COMPILE_FAILED")
+        if video_runtime is not None and video_offline_root is not None:
+            _verify_pinned_private_sidecars(payload, sidecar, offline_sidecar)
+        artifacts = [setup]
         if video_runtime is not None:
-            part_numbers: list[int] = []
-            for artifact in artifacts:
-                if artifact == setup:
-                    continue
-                prefix, suffix = "Olivia-Setup-x64-", ".bin"
-                if not artifact.name.startswith(prefix) or not artifact.name.endswith(suffix):
-                    raise SetupBuildError("SETUP_COMPILE_FAILED")
-                number = artifact.name[len(prefix):-len(suffix)]
-                if not number.isdecimal() or str(int(number)) != number:
-                    raise SetupBuildError("SETUP_COMPILE_FAILED")
-                part_numbers.append(int(number))
-            if not part_numbers or sorted(part_numbers) != list(range(1, len(part_numbers) + 1)):
-                raise SetupBuildError("SETUP_COMPILE_FAILED")
-        records = [
+            artifacts.append(sidecar)
+        file_records = [
             {"path": os.fspath(path), "size_bytes": path.stat().st_size, "sha256": _sha256(path)}
             for path in artifacts
         ]
+        if video_offline_root is not None:
+            offline_file_records = _directory_file_records(
+                offline_sidecar, prefix=VIDEO_OFFLINE_SIDECAR_NAME
+            )
+            offline_size = sum(int(record["size_bytes"]) for record in offline_file_records)
+            file_records.extend(offline_file_records)
+            artifacts.append(offline_sidecar)
+            receipt.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "olivia.private-setup-receipt.v1",
+                        "distribution": "private",
+                        "version": version,
+                        "offline_root": VIDEO_OFFLINE_SIDECAR_NAME,
+                        "files": [
+                            {
+                                **record,
+                                "path": (
+                                    Path(str(record["path"])).name
+                                    if Path(str(record["path"])).is_absolute()
+                                    else record["path"]
+                                ),
+                            }
+                            for record in file_records
+                        ],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            file_records.append(
+                {
+                    "path": PRIVATE_RECEIPT_NAME,
+                    "size_bytes": receipt.stat().st_size,
+                    "sha256": _sha256(receipt),
+                }
+            )
+            records = [
+                *(
+                    record
+                    for record in file_records
+                    if Path(str(record["path"])).is_absolute()
+                ),
+                {
+                    "path": os.fspath(offline_sidecar),
+                    "size_bytes": offline_size,
+                    "sha256": _tree_sha256(offline_file_records),
+                },
+            ]
+        else:
+            records = file_records
+        artifacts.sort()
         digest = next(record["sha256"] for record in records if Path(record["path"]) == setup)
         checksum.write_text(
-            "".join(f"{record['sha256']}  {Path(record['path']).name}\n" for record in records),
+            "".join(
+                f"{record['sha256']}  "
+                f"{Path(str(record['path'])).name if Path(str(record['path'])).is_absolute() else record['path']}\n"
+                for record in file_records
+            ),
             encoding="ascii",
         )
         result = {
@@ -925,13 +1244,20 @@ def build_windows_setup(
         raise SetupBuildError("SETUP_BUILD_FAILED") from exc
     finally:
         shutil.rmtree(payload, ignore_errors=True)
+        sidecar_staging.unlink(missing_ok=True)
+        shutil.rmtree(offline_staging, ignore_errors=True)
         if not completed:
             cleanup_failed = False
-            for artifact in output.glob("Olivia-Setup-x64*"):
+            for artifact in (*output.glob("Olivia-Setup-x64*"), sidecar, receipt):
                 try:
                     artifact.unlink(missing_ok=True)
                 except OSError:
                     cleanup_failed = True
+            try:
+                if offline_sidecar.exists():
+                    shutil.rmtree(offline_sidecar)
+            except OSError:
+                cleanup_failed = True
             if cleanup_failed:
                 raise SetupBuildError("SETUP_OUTPUT_CLEANUP_FAILED")
 
@@ -946,6 +1272,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--distribution", choices=("public", "private"), default="public")
     parser.add_argument("--voice-reference", type=Path)
     parser.add_argument("--video-runtime", type=Path)
+    parser.add_argument("--video-offline-root", type=Path)
     args = parser.parse_args(argv)
     try:
         result = build_windows_setup(
@@ -957,6 +1284,7 @@ def main(argv: list[str] | None = None) -> int:
             distribution=args.distribution,
             voice_reference=args.voice_reference,
             video_runtime=args.video_runtime,
+            video_offline_root=args.video_offline_root,
         )
         print(json.dumps(result, ensure_ascii=False, sort_keys=True))
         return 0

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -790,6 +790,8 @@ def _verify_pinned_private_sidecars(
         )
         expected_runtime = private_manifest["video_runtime"]
         expected_offline = private_manifest["video_offline"]
+        if _is_reparse_point(runtime):
+            raise SetupBuildError("SETUP_PRIVATE_SIDECAR_CHANGED")
         actual_runtime = {
             "path": VIDEO_RUNTIME_SIDECAR_NAME,
             "size_bytes": runtime.stat().st_size,

--- a/installer/windows_setup.iss
+++ b/installer/windows_setup.iss
@@ -22,10 +22,6 @@ OutputDir={#OutputDir}
 OutputBaseFilename=Olivia-Setup-x64
 Compression=lzma2/max
 SolidCompression=yes
-#ifdef PrivatePayload
-DiskSpanning=yes
-DiskSliceSize=2100000000
-#endif
 WizardStyle=modern
 LicenseFile={#PayloadRoot}\LICENSE
 SetupIconFile={#PayloadRoot}\installer\assets\olivia.ico
@@ -38,9 +34,6 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
 Source: "{#PayloadRoot}\*"; Excludes: "offline\video-runtime\*"; DestDir: "{tmp}\OliviaPayload"; Flags: recursesubdirs createallsubdirs dontcopy noencryption ignoreversion
-#ifdef PrivatePayload
-Source: "{#PayloadRoot}\offline\video-runtime\*"; DestDir: "{tmp}\OliviaPayload\offline\video-runtime"; Flags: recursesubdirs createallsubdirs dontcopy noencryption ignoreversion nocompression
-#endif
 
 [Tasks]
 Name: "desktopicon"; Description: "创建桌面快捷方式"; GroupDescription: "附加选项："; Flags: unchecked
@@ -188,6 +181,15 @@ begin
     ' -SetupResultPath ' + AddQuotes(SetupResultPath) +
     ' -NonInteractive' +
     ' -SkipShortcut';
+#ifdef PrivatePayload
+  Params := Params +
+    ' -VideoRuntimePath ' + AddQuotes(
+      ExpandConstant('{src}\Olivia-video-runtime-private.zip')
+    ) +
+    ' -VideoOfflineRoot ' + AddQuotes(
+      ExpandConstant('{src}\Olivia-video-offline-private')
+    );
+#endif
   if Trim(OfficialDirPage.Values[0]) <> '' then
     Params := Params + ' -OfficialRoot ' + AddQuotes(OfficialDirPage.Values[0]);
 

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -64,14 +64,37 @@ def test_first_install_consumes_only_bundled_core_assets() -> None:
 def test_installer_accepts_only_complete_private_video_runtime_manifest() -> None:
     script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
 
+    assert "[string]$VideoRuntimePath = ''" in script
+    assert "[string]$VideoOfflineRoot = ''" in script
     assert "$hasVideoRuntime = $manifest.PSObject.Properties.Name -ccontains 'video_runtime'" in script
-    assert "$hasVideoRuntime -ne $hasVoiceReference" in script
-    assert "$manifestNames += @('distribution', 'voice_reference', 'video_runtime')" in script
+    assert "$hasVideoOffline = $manifest.PSObject.Properties.Name -ccontains 'video_offline'" in script
+    assert "$hasVideoRuntime -ne $hasVoiceReference -or $hasVideoOffline -ne $hasVoiceReference" in script
+    assert "$manifestNames += @('distribution', 'voice_reference', 'video_runtime', 'video_offline')" in script
     assert "Assert-OfflineObjectShape -Value $manifest.video_runtime -Names @('path', 'size_bytes', 'sha256')" in script
-    assert "$manifest.video_runtime.path -cne 'video-runtime/Olivia-video-runtime-private.zip'" in script
-    assert "$videoRuntimePath = Resolve-OfflineAsset -Root $Root -Asset $manifest.video_runtime" in script
+    assert "Assert-OfflineObjectShape -Value $manifest.video_offline -Names @('path', 'manifest_version', 'manifest_sha256', 'file_count', 'size_bytes')" in script
+    assert "$manifest.video_runtime.path -cne 'Olivia-video-runtime-private.zip'" in script
+    assert "$manifest.video_offline.path -cne 'Olivia-video-offline-private'" in script
+    assert "$videoRuntimePath = Resolve-VideoRuntimeSidecar -LiteralPath $VideoRuntimePath -Asset $manifest.video_runtime" in script
+    assert "$videoOfflinePath = Resolve-VideoOfflineSidecar -LiteralPath $VideoOfflineRoot -Asset $manifest.video_offline" in script
+    assert "Get-OfflineCoreAssets -Root $offlineRoot -ManifestPath $offlineManifestPath -RequirementsPath $requirements -VideoRuntimePath $VideoRuntimePath -VideoOfflineRoot $VideoOfflineRoot" in script
     assert "verified = [bool]$true" in script
     assert "VideoRuntime = $videoRuntime" in script
+    assert "VideoOffline = $videoOffline" in script
+
+
+def test_private_video_activation_must_finish_before_install_transaction_commit() -> None:
+    script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
+
+    activation = "$privateVideoOutput = @(& $runner.File @($runner.Args + @($privateVideoActivator) + $privateVideoArguments))"
+    assert activation in script
+    assert "--manifest-version" in script
+    assert "--manifest-sha256" in script
+    assert "--expected-file-count" in script
+    assert "--expected-size-bytes" in script
+    assert "VIDEO_PRIVATE_NOT_READY" in script
+    assert script.index(activation) < script.index(
+        '[IO.File]::Move("$installTransaction.active", "$installTransaction.cleanup")'
+    )
 
 
 def test_offline_core_asset_example_matches_its_public_schema() -> None:
@@ -97,20 +120,38 @@ def test_public_schema_accepts_only_complete_hash_locked_private_assets() -> Non
     example["distribution"] = "private"
     example["voice_reference"] = {"path": "voice/olivia-reference.wav", "size_bytes": 155278, "sha256": "7bd846a55265d5ceb4dcf0ef164dc954066b8b056ac1e40d554b1e41d844a5bf", "wave": _wave_metadata(frame_count=77600)}
     example["video_runtime"] = {
-        "path": "video-runtime/Olivia-video-runtime-private.zip",
+        "path": "Olivia-video-runtime-private.zip",
         "size_bytes": 1,
         "sha256": "0" * 64,
+    }
+    example["video_offline"] = {
+        "path": "Olivia-video-offline-private",
+        "manifest_version": "fixture-video",
+        "manifest_sha256": "1" * 64,
+        "file_count": 32,
+        "size_bytes": 28_146_607_024,
     }
     assert not list(validator.iter_errors(example))
     missing_runtime = deepcopy(example)
     del missing_runtime["video_runtime"]
     assert list(validator.iter_errors(missing_runtime))
+    missing_offline = deepcopy(example)
+    del missing_offline["video_offline"]
+    assert list(validator.iter_errors(missing_offline))
     missing_marker = deepcopy(example)
     del missing_marker["distribution"]
     assert list(validator.iter_errors(missing_marker))
     wrong_path = deepcopy(example)
     wrong_path["voice_reference"]["path"] = "voice/arbitrary.wav"
     assert list(validator.iter_errors(wrong_path))
+    embedded_runtime = deepcopy(example)
+    embedded_runtime["video_runtime"]["path"] = (
+        "video-runtime/Olivia-video-runtime-private.zip"
+    )
+    assert list(validator.iter_errors(embedded_runtime))
+    renamed_offline = deepcopy(example)
+    renamed_offline["video_offline"]["path"] = "renamed-video-offline"
+    assert list(validator.iter_errors(renamed_offline))
     extra_field = deepcopy(example)
     extra_field["voice_reference"]["license"] = "caller-asserted"
     assert list(validator.iter_errors(extra_field))
@@ -230,12 +271,17 @@ def _run_runtime_publish_fixture(
     voice_reference_wave: dict[str, object] | None = None, voice_reference_missing: bool = False,
     video_runtime: bytes | None = None, video_runtime_sha256: str | None = None,
     video_runtime_missing: bool = False,
+    video_runtime_name: str = "Olivia-video-runtime-private.zip",
     video_runtime_verified: bool = True, preinstalled_video_runtime: bytes | None = None,
     stale_video_backup: bytes | None = None, reject_video_source_rehash: bool = False,
     block_video_cleanup: bool = False,
     block_voice_sidecar: bool = False, cleanup_obstruction: str | None = None,
     product_root: Path | None = None, existing_voice_pair: bool = False,
     interrupt_voice_staging: bool = False, interrupt_after_bootstrap: bool = False, existing_runtime: bool = True, seed_existing_install: bool = True,
+    private_video_exit_code: int = 0,
+    private_video_mutates_tree: bool = False,
+    interrupt_after_private_video: bool = False,
+    fail_core_asset_preflight: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
     payload = tmp_path / "payload"
     payload_installer = payload / "installer"
@@ -245,6 +291,7 @@ def _run_runtime_publish_fixture(
         "runtime-requirements.txt",
         "mem0-runtime-requirements.txt",
         "verify_mem0_runtime.py",
+        "video-capability-manifest.json",
     ):
         shutil.copy2(ROOT / "installer" / name, payload_installer / name)
     bootstrap_actions = ""
@@ -260,6 +307,32 @@ def _run_runtime_publish_fixture(
         + bootstrap_actions
         + f"print(json.dumps({{'status': '{'OK' if bootstrap_exit_code == 0 else 'ERROR'}', 'code': 'SYNTHETIC_PATCH_FAILED'}}))\n"
         f"raise SystemExit({bootstrap_exit_code})\n",
+        encoding="utf-8",
+    )
+    (payload_installer / "activate_private_video.py").write_text(
+        "import json, pathlib, sys\n"
+        + (
+            "install_root = pathlib.Path(sys.argv[sys.argv.index('--install-root') + 1])\n"
+            "video_root = install_root / 'data/capabilities/video'\n"
+            "(video_root / 'ordinary_video').mkdir(parents=True, exist_ok=True)\n"
+            "(video_root / 'music_video').mkdir(parents=True, exist_ok=True)\n"
+            "(video_root / 'runtime').mkdir(parents=True, exist_ok=True)\n"
+            "(video_root / 'ordinary_video/old.txt').write_text('replaced')\n"
+            "(video_root / 'music_video/partial.txt').write_text('partial')\n"
+            "(video_root / 'runtime/partial.txt').write_text('partial')\n"
+            if private_video_mutates_tree
+            else ""
+        )
+        + (
+            "print(json.dumps({'status': 'READY', 'bundles': "
+            if private_video_exit_code == 0
+            else "print(json.dumps({'status': 'ERROR', 'code': 'VIDEO_PRIVATE_ACTIVATION_FAILED', 'bundles': "
+        )
+        +
+        "[{'id': 'ordinary_video', 'state': 'ready'}, "
+        "{'id': 'music_video', 'state': 'ready'}], "
+        "'runtime_import': {'state': 'ready'}}))\n"
+        f"raise SystemExit({private_video_exit_code})\n",
         encoding="utf-8",
     )
     official = tmp_path / "official"
@@ -294,28 +367,36 @@ def _run_runtime_publish_fixture(
         )
 
     script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
-    original = "$coreAssets = Get-OfflineCoreAssets -Root $offlineRoot -ManifestPath $offlineManifestPath -RequirementsPath $requirements"
+    original = "$coreAssets = Get-OfflineCoreAssets -Root $offlineRoot -ManifestPath $offlineManifestPath -RequirementsPath $requirements -VideoRuntimePath $VideoRuntimePath -VideoOfflineRoot $VideoOfflineRoot"
     replacement = (
         "$voiceManifest = if ($env:BSIDE_TEST_PRIVATE_MANIFEST) { [IO.File]::ReadAllText($env:BSIDE_TEST_PRIVATE_MANIFEST) | ConvertFrom-Json } else { $null }\n"
         "$voiceReference = if ($voiceManifest) { $voiceManifest.voice_reference.path = $env:BSIDE_TEST_VOICE_REFERENCE; $voiceManifest.voice_reference } else { $null }\n"
-        "$videoRuntime = if ($voiceManifest) { $voiceManifest.video_runtime.path = $env:BSIDE_TEST_VIDEO_RUNTIME; $voiceManifest.video_runtime } else { $null }\n"
-        "$coreAssets = @{ Runtime = $env:BSIDE_TEST_RUNTIME_ZIP; PipBootstrap = ''; Wheelhouse = ''; VoiceReference = $voiceReference; VideoRuntime = $videoRuntime }"
+        "$videoRuntime = if ($voiceManifest) { $resolvedVideoRuntime = Resolve-VideoRuntimeSidecar -LiteralPath $VideoRuntimePath -Asset $voiceManifest.video_runtime; $voiceManifest.video_runtime.path = $resolvedVideoRuntime; $voiceManifest.video_runtime } else { $null }\n"
+        "$videoOffline = if ($voiceManifest) { $resolvedVideoOffline = Resolve-VideoOfflineSidecar -LiteralPath $VideoOfflineRoot -Asset $voiceManifest.video_offline; $voiceManifest.video_offline.path = $resolvedVideoOffline; $voiceManifest.video_offline } else { $null }\n"
+        "$coreAssets = @{ Runtime = $env:BSIDE_TEST_RUNTIME_ZIP; PipBootstrap = ''; Wheelhouse = ''; VoiceReference = $voiceReference; VideoRuntime = $videoRuntime; VideoOffline = $videoOffline }"
     )
     if reject_video_source_rehash:
         replacement = (
             "$script:OriginalGetSha256 = ${function:Get-Sha256}\n"
+            "$script:VideoRuntimeSourceHashCalls = 0\n"
             "function Get-Sha256 { param([Parameter(Mandatory)][string]$LiteralPath) "
-            "if ($LiteralPath -ceq $env:BSIDE_TEST_VIDEO_RUNTIME) { throw 'VIDEO_RUNTIME_SOURCE_REHASHED' }; "
+            "if ($LiteralPath -ceq $env:BSIDE_TEST_VIDEO_RUNTIME) { $script:VideoRuntimeSourceHashCalls += 1; "
+            "if ($script:VideoRuntimeSourceHashCalls -gt 1) { throw 'VIDEO_RUNTIME_SOURCE_REHASHED' } }; "
             "& $script:OriginalGetSha256 -LiteralPath $LiteralPath }\n"
             + replacement
         )
+    if fail_core_asset_preflight:
+        replacement = "throw 'VIDEO_RUNTIME_MISSING'\n" + replacement
     assert script.count(original) == 1
     script = script.replace(original, replacement)
     dependency_probe = "if (-not (Test-ManagedServerDependencies -PythonExe $candidateExe)) {"
     assert script.count(dependency_probe) == 2
     script = script.replace(dependency_probe, "if ($false) {", 1)
     if cleanup_obstruction == "voice":
-        marker = "} elseif ($phase -ceq 'cleanup' -and [IO.Directory]::Exists($shared)) { Repair-ManagedVoiceTransaction -SharedRoot $shared }"
+        marker = (
+            "} elseif ($phase -ceq 'cleanup') {\n"
+            "            if ([IO.Directory]::Exists($shared)) { Repair-ManagedVoiceTransaction -SharedRoot $shared }"
+        )
         obstruction = marker.replace("Repair-Managed", "$voiceLock = [IO.File]::Open((Get-ChildItem -LiteralPath $shared -Filter '*.wav.bak' | Select-Object -First 1).FullName, 'Open', 'Read', 'None'); Repair-Managed")
         assert script.count(marker) == 1
         script = script.replace(marker, obstruction)
@@ -331,6 +412,21 @@ def _run_runtime_publish_fixture(
         marker = "$installExitCode = $LASTEXITCODE"
         assert script.count(marker) == 1
         script = script.replace(marker, "[Environment]::FailFast('SYNTHETIC_BOOTSTRAP_INTERRUPTION')\n" + marker)
+    if interrupt_after_private_video:
+        marker = "$privateVideoOutput = @(& $runner.File @($runner.Args + @($privateVideoActivator) + $privateVideoArguments))"
+        assert script.count(marker) == 1
+        script = script.replace(
+            marker,
+            marker + "\n        [Environment]::FailFast('SYNTHETIC_PRIVATE_VIDEO_INTERRUPTION')",
+        )
+    if block_voice_sidecar:
+        marker = "$privateVideoTransaction = Start-ManagedPrivateVideoTransaction -InstallRoot $Destination -TransactionId $installTransactionId -PendingMarker $privateVideoPending -VideoRuntime $coreAssets.VideoRuntime"
+        assert script.count(marker) == 1
+        script = script.replace(
+            marker,
+            marker
+            + "\n        New-Item -ItemType Directory -Force -Path (Join-Path $Destination 'data\\capabilities\\video\\shared\\linli-reference.json') | Out-Null",
+        )
     if block_video_cleanup:
         marker = "Complete-ManagedVideoRuntimeTransaction -Transaction $videoRuntimeTransaction"
         obstruction = (
@@ -381,23 +477,31 @@ def _run_runtime_publish_fixture(
         reference = tmp_path / "distributor-reference.wav"
         if not voice_reference_missing:
             reference.write_bytes(voice_reference)
-        runtime_archive = tmp_path / "Olivia-video-runtime-private.zip"
+        runtime_archive = tmp_path / video_runtime_name
+        video_offline_root = tmp_path / "Olivia-video-offline-private"
+        video_offline_root.mkdir()
         if not video_runtime_missing:
             runtime_archive.write_bytes(video_runtime)
         manifest = {"voice_reference": {"path": "voice/olivia-reference.wav", "size_bytes": len(voice_reference),
                     "sha256": voice_reference_sha256 or hashlib.sha256(voice_reference).hexdigest(),
                     "wave": voice_reference_wave if voice_reference_wave is not None else _wave_metadata()},
-                    "video_runtime": {"path": "video-runtime/Olivia-video-runtime-private.zip",
+                    "video_runtime": {"path": "Olivia-video-runtime-private.zip",
                                        "size_bytes": len(video_runtime),
                                        "sha256": video_runtime_sha256 or hashlib.sha256(video_runtime).hexdigest(),
-                                       "verified": video_runtime_verified}}
+                                       "verified": video_runtime_verified},
+                    "video_offline": {"path": "Olivia-video-offline-private",
+                                      "manifest_version": "2026.08.28",
+                                      "manifest_sha256": hashlib.sha256(
+                                          (payload_installer / "video-capability-manifest.json").read_bytes()
+                                      ).hexdigest(),
+                                      "file_count": 32,
+                                      "size_bytes": 28_146_607_024}}
         manifest_path = tmp_path / "offline-core-assets.json"
         manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
         environment["BSIDE_TEST_VOICE_REFERENCE"] = str(reference)
         environment["BSIDE_TEST_VIDEO_RUNTIME"] = str(runtime_archive)
         environment["BSIDE_TEST_PRIVATE_MANIFEST"] = str(manifest_path)
-    result = subprocess.run(
-        [
+    command = [
             "powershell",
             "-NoProfile",
             "-NonInteractive",
@@ -413,7 +517,18 @@ def _run_runtime_publish_fixture(
             str(official),
             "-NonInteractive",
             "-SkipShortcut",
-        ],
+        ]
+    if voice_reference is not None:
+        command.extend(
+            (
+                "-VideoRuntimePath",
+                str(runtime_archive),
+                "-VideoOfflineRoot",
+                str(video_offline_root),
+            )
+        )
+    result = subprocess.run(
+        command,
         env=environment,
         capture_output=True,
         text=True,
@@ -456,6 +571,99 @@ def test_voice_publish_failure_restores_managed_app_runtime_and_voice(tmp_path: 
     assert installed.read_bytes() == b"old-reference" and installed.with_suffix(".json").is_dir()
     assert _managed_video_runtime(product).read_bytes() == b"old-video-runtime"
     assert not list(product.glob(".install.rollback.*")) and not list((product / "runtime").glob("*.backup.*"))
+
+
+def test_private_video_activation_failure_rolls_back_install_and_runtime_archive(
+    tmp_path: Path,
+) -> None:
+    product = tmp_path / "product"
+    old_video = product / "install/data/capabilities/video"
+    for relative, content in (
+        ("ordinary_video/old.txt", "ordinary-old"),
+        ("music_video/old.txt", "music-old"),
+        ("runtime/old.txt", "runtime-old"),
+        ("runtime-environment.json", "environment-old"),
+        ("shared/old.txt", "shared-old"),
+    ):
+        target = old_video / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        product_root=product,
+        bootstrap_exit_code=0,
+        bootstrap_replaces_managed_app=True,
+        voice_reference=_voice_reference_bytes(),
+        private_video_exit_code=2,
+        private_video_mutates_tree=True,
+    )
+
+    assert result.returncode != 0
+    assert "VIDEO_PRIVATE_ACTIVATION_FAILED" in result.stdout + result.stderr
+    assert (product / "install/local_backend/old-backend.txt").is_file()
+    assert not (product / "install/local_backend/new-backend.txt").exists()
+    assert (product / "runtime/python-3.12.10-embed-amd64/old-runtime.txt").is_file()
+    assert _managed_video_runtime(product).read_bytes() == b"old-video-runtime"
+    assert (old_video / "ordinary_video/old.txt").read_text() == "ordinary-old"
+    assert (old_video / "music_video/old.txt").read_text() == "music-old"
+    assert (old_video / "runtime/old.txt").read_text() == "runtime-old"
+    assert (old_video / "runtime-environment.json").read_text() == "environment-old"
+    assert (old_video / "shared/old.txt").read_text() == "shared-old"
+    assert not (old_video / "music_video/partial.txt").exists()
+    assert not (old_video / "runtime/partial.txt").exists()
+    assert not list(old_video.parent.glob(".video.private-*"))
+
+
+def test_private_video_activation_failure_removes_fresh_partial_tree(
+    tmp_path: Path,
+) -> None:
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=0,
+        voice_reference=_voice_reference_bytes(),
+        private_video_exit_code=2,
+        private_video_mutates_tree=True,
+    )
+
+    assert result.returncode != 0
+    assert not (product / "install/data/capabilities/video").exists()
+
+
+def test_interrupted_private_video_activation_recovers_old_tree_on_next_run(
+    tmp_path: Path,
+) -> None:
+    product = tmp_path / "product"
+    old_video = product / "install/data/capabilities/video"
+    (old_video / "ordinary_video").mkdir(parents=True)
+    (old_video / "ordinary_video/old.txt").write_text("ordinary-old")
+    old_runtime_sidecar = _managed_video_runtime(product)
+    old_runtime_sidecar.parent.mkdir(parents=True)
+    old_runtime_sidecar.write_bytes(b"runtime-old")
+
+    interrupted, _ = _run_runtime_publish_fixture(
+        tmp_path / "first",
+        product_root=product,
+        bootstrap_exit_code=0,
+        voice_reference=_voice_reference_bytes(),
+        private_video_mutates_tree=True,
+        interrupt_after_private_video=True,
+    )
+    assert interrupted.returncode != 0
+
+    recovered, _ = _run_runtime_publish_fixture(
+        tmp_path / "second",
+        product_root=product,
+        bootstrap_exit_code=23,
+        fail_core_asset_preflight=True,
+    )
+
+    assert recovered.returncode != 0
+    assert "VIDEO_RUNTIME_MISSING" in recovered.stdout + recovered.stderr
+    assert (old_video / "ordinary_video/old.txt").read_text() == "ordinary-old"
+    assert old_runtime_sidecar.read_bytes() == b"runtime-old"
+    assert not (old_video / "music_video/partial.txt").exists()
+    assert not list(old_video.parent.glob(".video.private-*"))
+    assert not list(product.glob(".install.transaction*"))
 
 
 @pytest.mark.parametrize("cleanup_obstruction", ["voice", "snapshot"])
@@ -536,6 +744,21 @@ def test_first_install_rejects_bad_video_runtime_before_publish(tmp_path: Path) 
 
     assert result.returncode != 0
     assert "VIDEO_RUNTIME_HASH_MISMATCH" in result.stdout + result.stderr
+    assert not _managed_video_runtime(product).exists()
+
+
+def test_first_install_rejects_renamed_video_runtime_sidecar_before_publish(
+    tmp_path: Path,
+) -> None:
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=0,
+        voice_reference=_voice_reference_bytes(),
+        video_runtime_name="renamed-runtime.zip",
+    )
+
+    assert result.returncode != 0
+    assert "VIDEO_RUNTIME_INVALID" in result.stdout + result.stderr
     assert not _managed_video_runtime(product).exists()
 
 

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -1255,6 +1255,61 @@ def test_private_build_receipt_reuses_post_compile_verified_sidecar_records(
     ] == expected_ordinary_sha256
 
 
+def test_private_build_rejects_runtime_output_reparse_before_final_hash(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "distributor/Olivia-video-runtime-fixture.zip"
+    _write_video_runtime(runtime)
+    video_offline = reference.parent / "Olivia-video-offline-fixture"
+    output = tmp_path / "output"
+    runtime_output = output / "Olivia-video-runtime-private.zip"
+    compiled = False
+
+    def prepare_without_schema(*args: object, **kwargs: object) -> None:
+        kwargs["validate_schema"] = False
+        prepare_setup_payload(*args, **kwargs)
+
+    def compile_setup(_command: list[str], **_: object) -> SimpleNamespace:
+        nonlocal compiled
+        (output / "Olivia-Setup-x64.exe").write_bytes(b"setup")
+        compiled = True
+        return SimpleNamespace(returncode=0)
+
+    original_is_reparse_point = setup_builder._is_reparse_point
+
+    def mark_runtime_output(path: Path) -> bool:
+        return (compiled and Path(path) == runtime_output) or original_is_reparse_point(
+            Path(path)
+        )
+
+    monkeypatch.setattr(
+        "installer.build_windows_setup._find_iscc", lambda _: tmp_path / "ISCC.exe"
+    )
+    monkeypatch.setattr(
+        "installer.build_windows_setup.prepare_setup_payload", prepare_without_schema
+    )
+    monkeypatch.setattr(
+        "installer.build_windows_setup._is_reparse_point", mark_runtime_output
+    )
+    monkeypatch.setattr("installer.build_windows_setup.subprocess.run", compile_setup)
+
+    with pytest.raises(SetupBuildError, match="SETUP_PRIVATE_SIDECAR_CHANGED"):
+        build_windows_setup(
+            source,
+            offline,
+            output,
+            version="fixture",
+            distribution="private",
+            voice_reference=reference,
+            video_runtime=runtime,
+            video_offline_root=video_offline,
+        )
+
+    assert not any(output.iterdir())
+
+
 @pytest.mark.parametrize("parts", [(1,), (1, 3)])
 def test_private_build_rejects_unexpected_compiler_disk_parts(
     tmp_path: Path, monkeypatch, parts: tuple[int, ...]

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -12,6 +12,7 @@ import zipfile
 
 import pytest
 
+import installer.build_windows_setup as setup_builder
 from installer.build_windows_setup import (
     BUILD_CONTROL_FILES,
     SetupBuildError,
@@ -1017,6 +1018,7 @@ def test_private_build_publishes_hash_locked_video_runtime_sidecar(
     [
         ("runtime", "SETUP_VIDEO_RUNTIME_INVALID"),
         ("offline-file", "SETUP_VIDEO_OFFLINE_INVALID"),
+        ("offline-output", "SETUP_VIDEO_OFFLINE_INVALID"),
     ],
 )
 def test_private_build_rejects_reparse_sidecar_sources_before_copy(
@@ -1035,7 +1037,14 @@ def test_private_build_rejects_reparse_sidecar_sources_before_copy(
     music = video_offline / "music_video/music.bin"
     ordinary.write_bytes(b"ordinary")
     music.write_bytes(b"music")
-    marked = runtime if marked_source == "runtime" else music
+    marked = {
+        "runtime": runtime,
+        "offline-file": music,
+        "offline-output": (
+            output
+            / "Olivia-video-offline-private/music_video/music.bin"
+        ),
+    }[marked_source]
 
     def compile_setup(_command: list[str], **_: object) -> SimpleNamespace:
         (output / "Olivia-Setup-x64.exe").write_bytes(b"setup")
@@ -1157,6 +1166,93 @@ def test_private_build_rejects_runtime_sidecar_changed_after_payload_pin(
         )
 
     assert not any(output.iterdir())
+
+
+def test_private_build_receipt_reuses_post_compile_verified_sidecar_records(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "distributor/Olivia-video-runtime-fixture.zip"
+    _write_video_runtime(runtime)
+    expected_runtime_sha256 = hashlib.sha256(runtime.read_bytes()).hexdigest()
+    video_offline = reference.parent / "Olivia-video-offline-fixture"
+    expected_ordinary_sha256 = hashlib.sha256(b"ordinary").hexdigest()
+    output = tmp_path / "output"
+
+    def prepare_without_schema(*args: object, **kwargs: object) -> None:
+        kwargs["validate_schema"] = False
+        prepare_setup_payload(*args, **kwargs)
+
+    def compile_setup(_command: list[str], **_: object) -> SimpleNamespace:
+        (output / "Olivia-Setup-x64.exe").write_bytes(b"setup")
+        return SimpleNamespace(returncode=0)
+
+    original_verify = setup_builder._verify_pinned_private_sidecars
+
+    def verify_then_replace(
+        payload: Path,
+        runtime_sidecar: Path,
+        offline_sidecar: Path,
+    ) -> object:
+        verified = original_verify(payload, runtime_sidecar, offline_sidecar)
+        runtime_sidecar.write_bytes(b"replacement runtime")
+        (offline_sidecar / "ordinary_video/ordinary.bin").write_bytes(b"replaced")
+        return verified
+
+    monkeypatch.setattr(
+        "installer.build_windows_setup._find_iscc", lambda _: tmp_path / "ISCC.exe"
+    )
+    monkeypatch.setattr(
+        "installer.build_windows_setup.prepare_setup_payload", prepare_without_schema
+    )
+    monkeypatch.setattr(
+        "installer.build_windows_setup._verify_pinned_private_sidecars",
+        verify_then_replace,
+    )
+    monkeypatch.setattr("installer.build_windows_setup.subprocess.run", compile_setup)
+
+    build_windows_setup(
+        source,
+        offline,
+        output,
+        version="fixture",
+        distribution="private",
+        voice_reference=reference,
+        video_runtime=runtime,
+        video_offline_root=video_offline,
+    )
+
+    receipt = json.loads(
+        (output / "Olivia-Setup-x64.receipt.json").read_text(encoding="utf-8")
+    )
+    receipt_records = {record["path"]: record for record in receipt["files"]}
+    checksum_records = {
+        relative: digest
+        for digest, relative in (
+            line.split("  ", 1)
+            for line in (output / "Olivia-Setup-x64.exe.sha256")
+            .read_text(encoding="ascii")
+            .splitlines()
+        )
+    }
+
+    assert (output / "Olivia-video-runtime-private.zip").read_bytes() == b"replacement runtime"
+    assert (
+        output / "Olivia-video-offline-private/ordinary_video/ordinary.bin"
+    ).read_bytes() == b"replaced"
+    assert receipt_records["Olivia-video-runtime-private.zip"]["sha256"] == (
+        expected_runtime_sha256
+    )
+    assert receipt_records[
+        "Olivia-video-offline-private/ordinary_video/ordinary.bin"
+    ]["sha256"] == expected_ordinary_sha256
+    assert checksum_records["Olivia-video-runtime-private.zip"] == (
+        expected_runtime_sha256
+    )
+    assert checksum_records[
+        "Olivia-video-offline-private/ordinary_video/ordinary.bin"
+    ] == expected_ordinary_sha256
 
 
 @pytest.mark.parametrize("parts", [(1,), (1, 3)])

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -210,21 +210,78 @@ def _offline_fixture(root: Path, requirements: bytes) -> None:
     )
 
 
+def _video_offline_fixture(source: Path, root: Path) -> dict[str, bytes]:
+    files = {
+        "ordinary_video/ordinary.bin": b"ordinary",
+        "music_video/music.bin": b"music",
+    }
+    bundles = []
+    for bundle_id, relative in (
+        ("ordinary_video", "ordinary.bin"),
+        ("music_video", "music.bin"),
+    ):
+        content = files[f"{bundle_id}/{relative}"]
+        target = root / bundle_id / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+        bundles.append(
+            {
+                "id": bundle_id,
+                "label": bundle_id,
+                "status": "FIXED",
+                "requires_gpu": True,
+                "dependencies": [],
+                "files": [
+                    {
+                        "id": f"{bundle_id}-fixture",
+                        "path": relative,
+                        "size_bytes": len(content),
+                        "sha256": hashlib.sha256(content).hexdigest(),
+                        "license": "MIT",
+                        "redistributable": True,
+                        "sources": {"official": f"https://example.com/{relative}"},
+                    }
+                ],
+            }
+        )
+    manifest = source / "installer/video-capability-manifest.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.video-capability-bom.v1",
+                "version": "fixture-video",
+                "bundles": bundles,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return files
+
+
 def _voice_setup_fixture(tmp_path: Path, monkeypatch) -> tuple[Path, Path, Path]:
     source, offline = tmp_path / "source", tmp_path / "offline"
     installer = source / "installer"
     installer.mkdir(parents=True)
     (installer / "Install.ps1").write_text("install", encoding="utf-8")
+    (installer / "activate_private_video.py").write_text(
+        "# private video activation entrypoint\n", encoding="utf-8"
+    )
     requirements = b"locked requirements"
     (installer / "runtime-requirements.txt").write_bytes(requirements)
     reference = tmp_path / "distributor" / "olivia-reference.wav"
     _write_voice_reference(reference)
+    _video_offline_fixture(
+        source, tmp_path / "distributor" / "Olivia-video-offline-fixture"
+    )
     _offline_fixture(offline, requirements)
     monkeypatch.setattr(
         "installer.build_windows_setup._git_tracked_files",
         lambda _source: {
             "installer/Install.ps1",
+            "installer/activate_private_video.py",
             "installer/runtime-requirements.txt",
+            "installer/video-capability-manifest.json",
             *BUILD_CONTROL_FILES,
         },
     )
@@ -233,11 +290,18 @@ def _voice_setup_fixture(tmp_path: Path, monkeypatch) -> tuple[Path, Path, Path]
 
 
 def _prepare_private_runtime(
-    source: Path, offline: Path, reference: Path, runtime: Path, destination: Path
+    source: Path,
+    offline: Path,
+    reference: Path,
+    runtime: Path,
+    destination: Path,
 ) -> None:
     prepare_setup_payload(
         source, offline, destination, distribution="private",
-        voice_reference=reference, video_runtime=runtime, validate_schema=False,
+        voice_reference=reference,
+        video_runtime=runtime,
+        video_offline_root=reference.parent / "Olivia-video-offline-fixture",
+        validate_schema=False,
     )
 
 
@@ -318,6 +382,7 @@ def test_prepare_setup_payload_injects_hash_locked_voice_reference(tmp_path: Pat
         distribution="private",
         voice_reference=reference,
         video_runtime=runtime,
+        video_offline_root=reference.parent / "Olivia-video-offline-fixture",
         validate_schema=False,
     )
 
@@ -332,19 +397,22 @@ def test_prepare_setup_payload_injects_hash_locked_voice_reference(tmp_path: Pat
         "wave": {"channels": 1, "sample_width_bytes": 2, "sample_rate_hz": 16000,
                  "frame_count": 160, "compression_type": "NONE"},
     }
-    installed_runtime = destination / "offline/video-runtime/Olivia-video-runtime-private.zip"
-    assert installed_runtime.read_bytes() == runtime.read_bytes()
+    assert not (destination / "offline/video-runtime").exists()
     assert manifest["video_runtime"] == {
-        "path": "video-runtime/Olivia-video-runtime-private.zip",
+        "path": "Olivia-video-runtime-private.zip",
         "size_bytes": runtime.stat().st_size,
         "sha256": hashlib.sha256(runtime.read_bytes()).hexdigest(),
     }
+    assert (
+        destination / "installer/activate_private_video.py"
+    ).read_text(encoding="utf-8") == "# private video activation entrypoint\n"
     input_manifest_path = offline / "offline-core-assets.json"
     input_manifest = json.loads(input_manifest_path.read_text())
     input_manifest.update(
         distribution="private",
         voice_reference=manifest["voice_reference"],
         video_runtime=manifest["video_runtime"],
+        video_offline=manifest["video_offline"],
     )
     input_manifest_path.write_text(json.dumps(input_manifest), encoding="utf-8")
     prebundled = offline / "voice" / "olivia-reference.wav"
@@ -352,7 +420,16 @@ def test_prepare_setup_payload_injects_hash_locked_voice_reference(tmp_path: Pat
     prebundled.write_bytes(reference.read_bytes())
     with pytest.raises(SetupBuildError, match="SETUP_INPUT_VOICE_REFERENCE_FORBIDDEN"):
         prepare_setup_payload(source, offline, tmp_path / "prebundled", validate_schema=False)
-    del input_manifest["distribution"], input_manifest["voice_reference"], input_manifest["video_runtime"]
+    for field in ("distribution", "voice_reference", "video_runtime"):
+        del input_manifest[field]
+    input_manifest_path.write_text(json.dumps(input_manifest), encoding="utf-8")
+    with pytest.raises(SetupBuildError, match="SETUP_INPUT_VOICE_REFERENCE_FORBIDDEN"):
+        prepare_setup_payload(
+            source, offline, tmp_path / "prebundled-video-offline", validate_schema=False
+        )
+    del (
+        input_manifest["video_offline"],
+    )
     input_manifest_path.write_text(json.dumps(input_manifest), encoding="utf-8")
     with pytest.raises(SetupBuildError, match="SETUP_OFFLINE_ASSET_SET_MISMATCH"):
         prepare_setup_payload(source, offline, tmp_path / "orphan", validate_schema=False)
@@ -372,7 +449,90 @@ def test_prepare_setup_payload_injects_hash_locked_voice_reference(tmp_path: Pat
         )
 
 
-def test_prepare_setup_payload_accepts_builder_v2_runtime(
+def test_prepare_private_payload_requires_video_activation_entrypoint(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "distributor/Olivia-video-runtime-fixture.zip"
+    _write_video_runtime(runtime)
+    monkeypatch.setattr(
+        "installer.build_windows_setup._git_tracked_files",
+        lambda _source: {
+            "installer/Install.ps1",
+            "installer/runtime-requirements.txt",
+            "installer/video-capability-manifest.json",
+            *BUILD_CONTROL_FILES,
+        },
+    )
+
+    with pytest.raises(SetupBuildError, match="SETUP_REQUIRED_PAYLOAD_MISSING"):
+        _prepare_private_runtime(
+            source, offline, reference, runtime, tmp_path / "missing-activation"
+        )
+
+
+def test_prepare_private_payload_records_sidecar_without_copying_large_runtime(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "distributor" / "Olivia-video-runtime-v2.zip"
+    _write_video_runtime_v2(runtime)
+    destination = tmp_path / "payload"
+
+    _prepare_private_runtime(source, offline, reference, runtime, destination)
+
+    manifest = json.loads(
+        (destination / "offline/offline-core-assets.json").read_text(encoding="utf-8")
+    )
+    assert manifest["video_runtime"] == {
+        "path": "Olivia-video-runtime-private.zip",
+        "size_bytes": runtime.stat().st_size,
+        "sha256": hashlib.sha256(runtime.read_bytes()).hexdigest(),
+    }
+    assert not (destination / "offline/video-runtime").exists()
+
+
+def test_prepare_private_payload_pins_exact_shared_video_offline_root(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "distributor/Olivia-video-runtime-v2.zip"
+    _write_video_runtime_v2(runtime)
+    video_offline = tmp_path / "distributor/Olivia-video-offline-fixture"
+    destination = tmp_path / "payload"
+
+    _prepare_private_runtime(source, offline, reference, runtime, destination)
+
+    private_manifest = json.loads(
+        (destination / "offline/offline-core-assets.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    video_manifest = source / "installer/video-capability-manifest.json"
+    assert private_manifest["video_offline"] == {
+        "path": "Olivia-video-offline-private",
+        "manifest_version": "fixture-video",
+        "manifest_sha256": hashlib.sha256(video_manifest.read_bytes()).hexdigest(),
+        "file_count": 2,
+        "size_bytes": len(b"ordinary") + len(b"music"),
+    }
+    assert not (destination / "offline/video-offline").exists()
+
+    (video_offline / "ordinary_video/ordinary.bin").write_bytes(b"tampered")
+    with pytest.raises(SetupBuildError, match="SETUP_VIDEO_OFFLINE_INVALID"):
+        prepare_setup_payload(
+            source,
+            offline,
+            tmp_path / "tampered-payload",
+            distribution="private",
+            voice_reference=reference,
+            video_runtime=runtime,
+            video_offline_root=video_offline,
+            validate_schema=False,
+        )
+
+
+def test_prepare_setup_payload_accepts_builder_v2_runtime_metadata(
     tmp_path: Path, monkeypatch
 ) -> None:
     source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
@@ -381,9 +541,14 @@ def test_prepare_setup_payload_accepts_builder_v2_runtime(
 
     _prepare_private_runtime(source, offline, reference, runtime, tmp_path / "payload")
 
-    assert (
-        tmp_path / "payload/offline/video-runtime/Olivia-video-runtime-private.zip"
-    ).read_bytes() == runtime.read_bytes()
+    manifest = json.loads(
+        (tmp_path / "payload/offline/offline-core-assets.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["video_runtime"]["path"] == "Olivia-video-runtime-private.zip"
+    assert manifest["video_runtime"]["size_bytes"] == runtime.stat().st_size
+    assert not (tmp_path / "payload/offline/video-runtime").exists()
 
 
 @pytest.mark.parametrize(
@@ -586,6 +751,7 @@ def test_setup_build_cli_forwards_distributor_voice_reference(tmp_path: Path, mo
     reference.write_bytes(b"RIFF-voice")
     runtime = tmp_path / "Olivia-video-runtime-fixture.zip"
     runtime.write_bytes(b"runtime")
+    video_offline = tmp_path / "Olivia-video-offline-private"
     captured: dict[str, object] = {}
     monkeypatch.setattr(
         "installer.build_windows_setup.build_windows_setup",
@@ -595,13 +761,14 @@ def test_setup_build_cli_forwards_distributor_voice_reference(tmp_path: Path, mo
     result = build_setup_main([
         "--offline", str(tmp_path / "offline"), "--output", str(tmp_path / "output"),
         "--version", "0.1.test", "--distribution", "private", "--voice-reference", str(reference),
-        "--video-runtime", str(runtime),
+        "--video-runtime", str(runtime), "--video-offline-root", str(video_offline),
     ])
 
     assert result == 0
     assert captured["distribution"] == "private"
     assert captured["voice_reference"] == reference
     assert captured["video_runtime"] == runtime
+    assert captured["video_offline_root"] == video_offline
 
 
 def test_failed_private_setup_compile_removes_partial_final_artifacts(
@@ -611,6 +778,7 @@ def test_failed_private_setup_compile_removes_partial_final_artifacts(
     source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
     runtime = tmp_path / "video-runtime.zip"
     _write_video_runtime(runtime)
+    video_offline = reference.parent / "Olivia-video-offline-fixture"
     output = tmp_path / "dist-private"
     compiler = tmp_path / "ISCC.exe"
     compiler.write_bytes(b"compiler")
@@ -640,6 +808,7 @@ def test_failed_private_setup_compile_removes_partial_final_artifacts(
             distribution="private",
             voice_reference=reference,
             video_runtime=runtime,
+            video_offline_root=video_offline,
         )
 
     assert not (output / "Olivia-Setup-x64.exe").exists()
@@ -654,6 +823,7 @@ def test_failed_private_setup_checksum_removes_setup_and_partial_checksum(
     source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
     runtime = tmp_path / "video-runtime.zip"
     _write_video_runtime(runtime)
+    video_offline = reference.parent / "Olivia-video-offline-fixture"
     output = tmp_path / "dist-private"
     compiler = tmp_path / "ISCC.exe"
     compiler.write_bytes(b"compiler")
@@ -668,7 +838,6 @@ def test_failed_private_setup_checksum_removes_setup_and_partial_checksum(
         assert check is False
         assert timeout == 900
         (output / "Olivia-Setup-x64.exe").write_bytes(b"complete private setup")
-        (output / "Olivia-Setup-x64-1.bin").write_bytes(b"complete runtime")
         return type("Result", (), {"returncode": 0})()
 
     original_write_text = Path.write_text
@@ -692,10 +861,13 @@ def test_failed_private_setup_checksum_removes_setup_and_partial_checksum(
             distribution="private",
             voice_reference=reference,
             video_runtime=runtime,
+            video_offline_root=video_offline,
         )
 
     assert not (output / "Olivia-Setup-x64.exe").exists()
-    assert not (output / "Olivia-Setup-x64-1.bin").exists()
+    assert not (output / "Olivia-video-runtime-private.zip").exists()
+    assert not (output / "Olivia-video-offline-private").exists()
+    assert not (output / "Olivia-Setup-x64.receipt.json").exists()
     assert not (output / "Olivia-Setup-x64.exe.sha256").exists()
 
 
@@ -708,10 +880,17 @@ def test_windows_setup_docs_separate_public_and_private_voice_artifacts() -> Non
     assert "--distribution private" in documentation
     assert "--voice-reference" in documentation
     assert "--video-runtime" in documentation
+    assert "--video-offline-root" in documentation
     assert "dist-private" in documentation
-    assert "全部 `.bin` 分卷" in documentation
+    assert "Olivia-video-runtime-private.zip" in documentation
+    assert "Olivia-video-offline-private" in documentation
+    assert "Olivia-Setup-x64.receipt.json" in documentation
+    assert "不会进入 Inno `{tmp}`" in documentation
     assert "私有视频包：下载完整 ZIP" in documentation
-    assert "除私有模式显式传入的 WAV 与视频运行时 ZIP 外" in documentation
+    assert "除私有模式显式传入的 WAV、视频运行时 ZIP 与视频离线根目录外" in documentation
+    assert "ordinary_video" in documentation
+    assert "music_video" in documentation
+    assert "因而没有自引用" in documentation
     assert "GitHub Actions 只生成公开安装器 artifact" in documentation
 
 
@@ -729,30 +908,47 @@ def test_prepare_setup_payload_rejects_truncated_voice_reference(tmp_path: Path,
             distribution="private",
             voice_reference=reference,
             video_runtime=runtime,
+            video_offline_root=reference.parent / "Olivia-video-offline-fixture",
             validate_schema=False,
         )
 
 
-def test_private_inno_payload_uses_disk_spanning_for_large_runtime() -> None:
+def test_private_inno_payload_reads_large_runtime_beside_setup_without_tmp_extract() -> None:
     script = (ROOT / "installer/windows_setup.iss").read_text(encoding="utf-8")
     assert "#ifdef PrivatePayload" in script
-    assert "DiskSpanning=yes" in script
-    assert "DiskSliceSize=2100000000" in script
-    assert "video-runtime\\*" in script and "nocompression" in script
+    assert "DiskSpanning=yes" not in script
+    assert "DiskSliceSize=" not in script
+    assert 'Source: "{#PayloadRoot}\\offline\\video-runtime\\*"' not in script
+    assert "-VideoRuntimePath" in script
+    assert "{src}\\Olivia-video-runtime-private.zip" in script
+    assert "-VideoOfflineRoot" in script
+    assert "{src}\\Olivia-video-offline-private" in script
 
 
-def test_private_build_hashes_exe_and_all_disk_spanning_parts(tmp_path: Path, monkeypatch) -> None:
+def test_private_build_publishes_hash_locked_video_runtime_sidecar(
+    tmp_path: Path, monkeypatch
+) -> None:
     output = tmp_path / "output"
     observed: list[str] = []
+    runtime = tmp_path / "runtime.zip"
+    runtime.write_bytes(b"runtime")
+    video_offline = tmp_path / "video-offline"
+    (video_offline / "ordinary_video").mkdir(parents=True)
+    (video_offline / "music_video").mkdir()
+    (video_offline / "ordinary_video" / "ordinary.bin").write_bytes(b"ordinary")
+    (video_offline / "music_video" / "music.bin").write_bytes(b"music")
 
     def compile_setup(command: list[str], **_: object) -> SimpleNamespace:
         observed.extend(command)
         (output / "Olivia-Setup-x64.exe").write_bytes(b"setup")
-        (output / "Olivia-Setup-x64-1.bin").write_bytes(b"runtime")
         return SimpleNamespace(returncode=0)
 
     monkeypatch.setattr("installer.build_windows_setup._find_iscc", lambda _: tmp_path / "ISCC.exe")
     monkeypatch.setattr("installer.build_windows_setup.prepare_setup_payload", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "installer.build_windows_setup._verify_pinned_private_sidecars",
+        lambda *args, **kwargs: None,
+    )
     monkeypatch.setattr("installer.build_windows_setup.subprocess.run", compile_setup)
 
     result = build_windows_setup(
@@ -762,23 +958,216 @@ def test_private_build_hashes_exe_and_all_disk_spanning_parts(tmp_path: Path, mo
         version="fixture",
         distribution="private",
         voice_reference=tmp_path / "voice.wav",
-        video_runtime=tmp_path / "runtime.zip",
+        video_runtime=runtime,
+        video_offline_root=video_offline,
     )
 
     assert "/DPrivatePayload=1" in observed
     assert [Path(item["path"]).name for item in result["artifacts"]] == [
-        "Olivia-Setup-x64-1.bin",
         "Olivia-Setup-x64.exe",
+        "Olivia-video-runtime-private.zip",
+        "Olivia-video-offline-private",
     ]
+    assert (output / "Olivia-video-runtime-private.zip").read_bytes() == b"runtime"
+    assert (
+        output / "Olivia-video-offline-private/ordinary_video/ordinary.bin"
+    ).read_bytes() == b"ordinary"
+    assert (
+        output / "Olivia-video-offline-private/music_video/music.bin"
+    ).read_bytes() == b"music"
+    assert not list(output.glob("Olivia-Setup-x64-*.bin"))
     checksum = (output / "Olivia-Setup-x64.exe.sha256").read_text(encoding="ascii")
-    assert "Olivia-Setup-x64-1.bin" in checksum and "Olivia-Setup-x64.exe" in checksum
+    assert "Olivia-Setup-x64.exe" in checksum
+    assert "Olivia-video-runtime-private.zip" in checksum
+    assert "Olivia-video-offline-private/ordinary_video/ordinary.bin" in checksum
+    assert "Olivia-video-offline-private/music_video/music.bin" in checksum
+    receipt = json.loads(
+        (output / "Olivia-Setup-x64.receipt.json").read_text(encoding="utf-8")
+    )
+    assert receipt["schema_version"] == "olivia.private-setup-receipt.v1"
+    assert receipt["distribution"] == "private"
+    assert receipt["offline_root"] == "Olivia-video-offline-private"
+    receipt_paths = [item["path"] for item in receipt["files"]]
+    assert receipt_paths == [
+        "Olivia-Setup-x64.exe",
+        "Olivia-video-runtime-private.zip",
+        "Olivia-video-offline-private/music_video/music.bin",
+        "Olivia-video-offline-private/ordinary_video/ordinary.bin",
+    ]
+    assert all(not Path(path).is_absolute() for path in receipt_paths)
+    assert set(path.name for path in output.iterdir()) == {
+        "Olivia-Setup-x64.exe",
+        "Olivia-video-runtime-private.zip",
+        "Olivia-video-offline-private",
+        "Olivia-Setup-x64.receipt.json",
+        "Olivia-Setup-x64.exe.sha256",
+    }
+
+    checksum_records = {}
+    for line in checksum.splitlines():
+        digest, relative = line.split("  ", 1)
+        checksum_records[relative] = digest
+    assert set(checksum_records) == {*receipt_paths, "Olivia-Setup-x64.receipt.json"}
+    for relative, digest in checksum_records.items():
+        assert hashlib.sha256((output / relative).read_bytes()).hexdigest() == digest
 
 
-@pytest.mark.parametrize("parts", [(), (1, 3)])
-def test_private_build_requires_contiguous_disk_spanning_parts(
+@pytest.mark.parametrize(
+    ("marked_source", "error_code"),
+    [
+        ("runtime", "SETUP_VIDEO_RUNTIME_INVALID"),
+        ("offline-file", "SETUP_VIDEO_OFFLINE_INVALID"),
+    ],
+)
+def test_private_build_rejects_reparse_sidecar_sources_before_copy(
+    tmp_path: Path,
+    monkeypatch,
+    marked_source: str,
+    error_code: str,
+) -> None:
+    output = tmp_path / "output"
+    runtime = tmp_path / "runtime.zip"
+    runtime.write_bytes(b"runtime")
+    video_offline = tmp_path / "video-offline"
+    (video_offline / "ordinary_video").mkdir(parents=True)
+    (video_offline / "music_video").mkdir()
+    ordinary = video_offline / "ordinary_video/ordinary.bin"
+    music = video_offline / "music_video/music.bin"
+    ordinary.write_bytes(b"ordinary")
+    music.write_bytes(b"music")
+    marked = runtime if marked_source == "runtime" else music
+
+    def compile_setup(_command: list[str], **_: object) -> SimpleNamespace:
+        (output / "Olivia-Setup-x64.exe").write_bytes(b"setup")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(
+        "installer.build_windows_setup._find_iscc", lambda _: tmp_path / "ISCC.exe"
+    )
+    monkeypatch.setattr(
+        "installer.build_windows_setup.prepare_setup_payload", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "installer.build_windows_setup._verify_pinned_private_sidecars",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "installer.build_windows_setup._is_reparse_point",
+        lambda path: Path(path) == marked,
+    )
+    monkeypatch.setattr("installer.build_windows_setup.subprocess.run", compile_setup)
+
+    with pytest.raises(SetupBuildError, match=error_code):
+        build_windows_setup(
+            tmp_path / "source",
+            tmp_path / "offline",
+            output,
+            version="fixture",
+            distribution="private",
+            voice_reference=tmp_path / "voice.wav",
+            video_runtime=runtime,
+            video_offline_root=video_offline,
+        )
+
+
+def test_private_build_rejects_runtime_sidecar_changed_after_payload_pin(
+    tmp_path: Path, monkeypatch
+) -> None:
+    output = tmp_path / "output"
+    runtime = tmp_path / "runtime.zip"
+    runtime.write_bytes(b"runtime")
+    video_offline = tmp_path / "video-offline"
+    (video_offline / "ordinary_video").mkdir(parents=True)
+    (video_offline / "music_video").mkdir()
+    ordinary = video_offline / "ordinary_video/ordinary.bin"
+    music = video_offline / "music_video/music.bin"
+    ordinary.write_bytes(b"ordinary")
+    music.write_bytes(b"music")
+
+    def pin_payload(*args: object, **kwargs: object) -> None:
+        payload = Path(args[2])
+        (payload / "offline").mkdir(parents=True)
+        (payload / "installer").mkdir()
+        runtime_sidecar = Path(kwargs["video_runtime"])
+        offline_sidecar = Path(kwargs["video_offline_root"])
+        video_manifest = {
+            "schema_version": "olivia.video-capability-bom.v1",
+            "version": "fixture-video",
+            "bundles": [
+                {
+                    "id": bundle,
+                    "files": [
+                        {
+                            "path": path.name,
+                            "size_bytes": path.stat().st_size,
+                            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                        }
+                    ],
+                }
+                for bundle, path in (("ordinary_video", ordinary), ("music_video", music))
+            ],
+        }
+        video_manifest_bytes = json.dumps(video_manifest).encode()
+        (payload / "installer/video-capability-manifest.json").write_bytes(
+            video_manifest_bytes
+        )
+        (payload / "offline/offline-core-assets.json").write_text(
+            json.dumps(
+                {
+                    "video_runtime": {
+                        "path": "Olivia-video-runtime-private.zip",
+                        "size_bytes": runtime_sidecar.stat().st_size,
+                        "sha256": hashlib.sha256(runtime_sidecar.read_bytes()).hexdigest(),
+                    },
+                    "video_offline": {
+                        "path": "Olivia-video-offline-private",
+                        "manifest_version": "fixture-video",
+                        "manifest_sha256": hashlib.sha256(video_manifest_bytes).hexdigest(),
+                        "file_count": 2,
+                        "size_bytes": sum(
+                            path.stat().st_size
+                            for path in offline_sidecar.rglob("*")
+                            if path.is_file()
+                        ),
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def compile_setup(_command: list[str], **_: object) -> SimpleNamespace:
+        (output / "Olivia-Setup-x64.exe").write_bytes(b"setup")
+        (output / "Olivia-video-runtime-private.zip").write_bytes(b"changed")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("installer.build_windows_setup._find_iscc", lambda _: tmp_path / "ISCC.exe")
+    monkeypatch.setattr("installer.build_windows_setup.prepare_setup_payload", pin_payload)
+    monkeypatch.setattr("installer.build_windows_setup.subprocess.run", compile_setup)
+
+    with pytest.raises(SetupBuildError, match="SETUP_PRIVATE_SIDECAR_CHANGED"):
+        build_windows_setup(
+            tmp_path / "source",
+            tmp_path / "offline",
+            output,
+            version="fixture",
+            distribution="private",
+            voice_reference=tmp_path / "voice.wav",
+            video_runtime=runtime,
+            video_offline_root=video_offline,
+        )
+
+    assert not any(output.iterdir())
+
+
+@pytest.mark.parametrize("parts", [(1,), (1, 3)])
+def test_private_build_rejects_unexpected_compiler_disk_parts(
     tmp_path: Path, monkeypatch, parts: tuple[int, ...]
 ) -> None:
     output = tmp_path / "output"
+    runtime = tmp_path / "runtime.zip"
+    runtime.write_bytes(b"runtime")
+    video_offline = tmp_path / "video-offline"
+    video_offline.mkdir()
 
     def compile_setup(_command: list[str], **_: object) -> SimpleNamespace:
         (output / "Olivia-Setup-x64.exe").write_bytes(b"setup")
@@ -794,7 +1183,8 @@ def test_private_build_requires_contiguous_disk_spanning_parts(
         build_windows_setup(
             tmp_path / "source", tmp_path / "offline", output, version="fixture",
             distribution="private", voice_reference=tmp_path / "voice.wav",
-            video_runtime=tmp_path / "runtime.zip",
+            video_runtime=runtime,
+            video_offline_root=video_offline,
         )
 
     assert not list(output.glob("Olivia-Setup-x64*"))
@@ -839,7 +1229,9 @@ def test_prepare_setup_payload_rejects_invalid_runtime_zip(
     with pytest.raises(SetupBuildError, match="SETUP_VIDEO_RUNTIME_INVALID"):
         prepare_setup_payload(
             source, offline, tmp_path / "payload", distribution="private",
-            voice_reference=reference, video_runtime=runtime, validate_schema=False,
+            voice_reference=reference, video_runtime=runtime,
+            video_offline_root=reference.parent / "Olivia-video-offline-fixture",
+            validate_schema=False,
         )
 
 
@@ -883,11 +1275,12 @@ def test_setup_rejects_git_selected_audio_and_video_payloads(
     media.write_bytes(b"private media")
     monkeypatch.setattr(
         "installer.build_windows_setup._git_tracked_files",
-        lambda _source: {
-            "installer/Install.ps1",
-            "installer/runtime-requirements.txt",
-            *BUILD_CONTROL_FILES,
-            relative,
+            lambda _source: {
+                "installer/Install.ps1",
+                "installer/activate_private_video.py",
+                "installer/runtime-requirements.txt",
+                *BUILD_CONTROL_FILES,
+                relative,
         },
     )
 
@@ -899,6 +1292,11 @@ def test_setup_rejects_git_selected_audio_and_video_payloads(
             distribution=distribution,
             voice_reference=reference if distribution == "private" else None,
             video_runtime=runtime if distribution == "private" else None,
+            video_offline_root=(
+                reference.parent / "Olivia-video-offline-fixture"
+                if distribution == "private"
+                else None
+            ),
             validate_schema=False,
         )
 
@@ -938,6 +1336,7 @@ def test_setup_payload_uses_positive_runtime_allowlist() -> None:
     assert _is_release_file("original_client_update_api.py")
     assert _is_release_file("control_center/static/index.html")
     assert _is_release_file("installer/full_patch.py")
+    assert _is_release_file("installer/activate_private_video.py")
     assert _is_release_file("installer/component_package.py")
     assert _is_release_file("installer/seed-vc-overlap-frames.patch")
     assert _is_release_file("installer/start_hidden.vbs.txt")


### PR DESCRIPTION
## Scope

Complete the private Windows setup sidecar lifecycle after the dormant activator landed in PR #318:

- package the pinned video runtime ZIP and one shared ordinary/music offline root beside the setup EXE instead of embedding the 12.5 GB runtime under Inno {tmp};
- verify the private BOM, size, SHA-256, and reparse boundaries from {src};
- activate ordinary -> music -> runtime through the existing managed installer;
- journal and recover the entire video capability tree plus the managed runtime archive before activation, then commit only after all three capabilities are READY;
- keep the public setup path unchanged.

Frozen review pair:

- base: b6be10d1bc1659fa0442a8ef4f626fea48dbfdb7
- head: 4b66a19c56bf7c65d7564c1470340ac8f6ae749b
- merge-base: exact base
- worktree: clean

## Atomic-scope rationale

This is 7 files and 1830 changed lines, so it exceeds the 500-line review threshold but remains below the hard 2000-line cap. Builder -> Inno -> Install.ps1 -> dormant activator plus whole-tree/runtime rollback is one private-install lifecycle. Splitting these remaining pieces would publish an intermediate main that either emits sidecars without activating them or activates them without durable rollback. The independently safe dormant helper and its direct tests were already isolated and merged as PR #318.

## TDD and focused verification

- deterministic RED -> GREEN for consuming the same pinned verification records in receipt/checksum/tree output and rejecting offline directory records that become reparse points;
- deterministic RED -> GREEN for rejecting the compiled runtime output leaf as a reparse point before any stat/SHA/record operation;
- tests/installer/test_windows_setup_exe.py + tests/installer/test_private_video_activation.py: 112 passed, 1 expected duplicate-ZIP warning;
- tests/installer/test_offline_core_assets.py: 39 passed;
- py_compile for installer/build_windows_setup.py and installer/activate_private_video.py: PASS;
- git diff --check: PASS.

## Fresh exact-pair review

- Standards: PASS — P0/P1/P2 none.
- Spec: PASS — P0/P1/P2 none.
- Review covered the complete frozen 1830-line diff. The final reparse repair rejects same-content symlink/junction runtime outputs before size/hash/record access; the receipt/checksum/tree digest reuses the same verified record set.

## Verification boundary

No real approximately 40 GB private delivery directory was assembled in this development worktree. The real private EXE + 12.5 GB runtime ZIP + 32-file approximately 28.1 GB offline root was not built or installed here; low-C-drive setup, complete ordinary/music/runtime READY state, first launch, GPU execution, external-provider configuration, and human acceptance remain unverified. This PR therefore proves the focused code/test contract only and does not claim real installation or media readiness.