### PR TITLE
fix(llm): reject truncated nonstream replies

### DIFF
--- a/llm_gateway.py
+++ b/llm_gateway.py
@@ -95,7 +95,7 @@ class GatewayConfig:
     timeout_seconds: float = 30.0
     reasoning_timeout_seconds: float = 600.0
     max_retries: int = 2
-    retry_backoff_seconds: float = 0.0
+    retry_backoff_seconds: float = 0.25
     stream: bool = False
     max_input_chars: int = 22000
     max_output_chars: int = 10000
@@ -157,7 +157,7 @@ class GatewayConfig:
             ),
             max_retries=_bounded_int(data.get("max_retries", 2), 2, 0, 8),
             retry_backoff_seconds=_bounded_float(
-                data.get("retry_backoff_seconds", 0.0), 0.0, 0.0, 30.0
+                data.get("retry_backoff_seconds", 0.25), 0.25, 0.0, 30.0
             ),
             stream=_as_bool(data.get("stream", False)),
             max_input_chars=_bounded_int(data.get("max_input_chars", 22000), 22000, 1, 100000),
@@ -804,6 +804,8 @@ class OpenAICompatibleAdapter(Gateway):
             max_reasoning=max_reasoning,
         )
         data = await self._post_json(body, request, max_reasoning=max_reasoning)
+        if _extract_finish_reason(data) == "length":
+            raise ProviderProtocolError()
         text = _extract_response_text(data)
         if not text:
             raise ProviderProtocolError()

--- a/tests/llm/test_gateway.py
+++ b/tests/llm/test_gateway.py
@@ -79,6 +79,11 @@ def test_reasoning_timeout_is_an_explicit_bounded_public_config() -> None:
     assert configured.public_dict()["reasoning_timeout_seconds"] == 720.0
 
 
+def test_retry_backoff_default_matches_public_template() -> None:
+    assert GatewayConfig().retry_backoff_seconds == 0.25
+    assert GatewayConfig.from_mapping({}).retry_backoff_seconds == 0.25
+
+
 def test_reasoning_timeout_environment_override_is_loaded(tmp_path) -> None:
     config = load_gateway_config(
         tmp_path / "missing.json",
@@ -176,6 +181,37 @@ def test_chat_completion_adapter_uses_local_mock_server_and_env_key(monkeypatch:
     assert seen["request_id"] == "request-1"
     assert seen["body"]["model"] == "synthetic-model"
     assert seen["body"]["messages"] == list(ROOT_MESSAGES)
+
+
+def test_nonstream_length_finish_reason_is_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def exercise() -> ProviderProtocolError:
+        async def handler(_request: web.Request) -> web.Response:
+            return web.json_response(
+                {
+                    "choices": [
+                        {
+                            "message": {"content": "partial private reply"},
+                            "finish_reason": "length",
+                        }
+                    ]
+                }
+            )
+
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", handler)
+        async with TestClient(TestServer(app)) as client:
+            adapter = OpenAICompatibleAdapter(make_config(str(client.make_url("/v1"))))
+            with pytest.raises(ProviderProtocolError) as caught:
+                await adapter.complete(ROOT_MESSAGES)
+        return caught.value
+
+    monkeypatch.setenv("B03_TEST_KEY", "TEST")
+    error = run(exercise())
+
+    assert str(error) == "PROVIDER_PROTOCOL"
+    assert "partial private reply" not in str(error)
 
 
 @pytest.mark.parametrize("endpoint", ["opencode-go", "official-deepseek"])


### PR DESCRIPTION
Two narrow LLM gateway reliability fixes. Missing retry_backoff_seconds now defaults to 0.25 in both GatewayConfig construction paths, matching the public config example. Non-stream chat completions with finish_reason=length now fail closed through the existing sanitized PROVIDER_PROTOCOL path before a GatewayResponse can be returned, preventing partial text from reaching COMPLETED or memory. Retry-After header parsing is intentionally out of scope. No installer or media changes. Exact pair: 50d775421f2a836dfa09a900b83d276054e415f8...e7751eb8c20d2da50751ec32fcf2a9004cbddb6b. TDD RED: default was 0.0; length response did not raise. GREEN: target 2 passed; gateway+orchestrator 42 passed; full suite 1946 passed, 3 skipped, 1 deselected; hardening, compileall, and diff check passed. Fresh reviews: Standards PASS; Spec PASS.