### PR TITLE
fix(media): harden cold runtime probes

### DIFF
--- a/runtime/media/music_reply.py
+++ b/runtime/media/music_reply.py
@@ -44,7 +44,13 @@ from .voice_direction import VoicePerformancePlan
 
 _MINIMAX_WORKER_TIMEOUT_SECONDS = 7500.0
 _MUSIC_STAGE_MANIFEST_VERSION = 3
-_RUNTIME_PROBE_TIMEOUT_SECONDS = 60.0
+_RUNTIME_PROBE_TIMEOUT_SECONDS = 120.0
+_RUNTIME_PROBE_REMOVED_ENVIRONMENT = (
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "VIRTUAL_ENV",
+    "CONDA_PREFIX",
+)
 _PROVIDER_DIAGNOSTIC_LIMIT = 512
 _MEDIA_VALIDATION_TIMEOUT_SECONDS = 180.0
 
@@ -104,18 +110,27 @@ class MusicProviderPathSnapshot:
 
 
 def _run_runtime_probe(command: list[str], *, cwd: Path) -> bool:
-    try:
-        result = subprocess.run(
-            command,
-            cwd=cwd,
-            capture_output=True,
-            check=False,
-            timeout=_RUNTIME_PROBE_TIMEOUT_SECONDS,
-            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    return result.returncode == 0
+    environment = dict(os.environ)
+    for key in _RUNTIME_PROBE_REMOVED_ENVIRONMENT:
+        environment.pop(key, None)
+    for attempt in range(2):
+        try:
+            result = subprocess.run(
+                command,
+                cwd=cwd,
+                capture_output=True,
+                check=False,
+                env=environment,
+                timeout=_RUNTIME_PROBE_TIMEOUT_SECONDS,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            if attempt == 0:
+                continue
+            return False
+        if result.returncode == 0:
+            return True
+    return False
 
 
 def _python_runtime_ready(
@@ -138,7 +153,7 @@ def _python_runtime_ready(
         "assert torch.cuda.is_available(); "
         "torch.ones(1, device='cuda')"
     )
-    return _run_runtime_probe([str(executable), "-B", "-c", script], cwd=cwd)
+    return _run_runtime_probe([str(executable), "-I", "-B", "-c", script], cwd=cwd)
 
 
 def _executable_runtime_ready(executable: Path | None) -> bool:
@@ -307,7 +322,6 @@ def video_reply_dependency_status(
             )
         except ReplyMediaError:
             pass
-
     minimax_root = configured("OLIVIA_MINIMAX_COMFY_ROOT")
     minimax_ready = bool(
         minimax_root is not None

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -429,7 +429,7 @@ def test_python_runtime_probe_checks_version_imports_cuda_and_has_hard_timeout(
         imports=("torch", "provider.module"),
         accepted_torch_versions=("2.9.1+cu128",),
     )
-    assert observed["command"][1] == "-B"
+    assert observed["command"][1:3] == ["-I", "-B"]
     script = observed["command"][-1]
     assert "sys.version_info[:2]" in script
     assert "import_module" in script
@@ -448,6 +448,52 @@ def test_python_runtime_probe_checks_version_imports_cuda_and_has_hard_timeout(
         imports=("torch",),
         accepted_torch_versions=("2.9.1+cu128",),
     )
+
+
+def test_runtime_probe_retries_transient_failures_once_with_sanitized_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    python = _write(tmp_path / "python.exe")
+    monkeypatch.setenv("PYTHONHOME", "sensitive-home")
+    monkeypatch.setenv("PYTHONPATH", "sensitive-path")
+    monkeypatch.setenv("VIRTUAL_ENV", "sensitive-venv")
+    monkeypatch.setenv("CONDA_PREFIX", "sensitive-conda")
+    monkeypatch.setenv("PATH", "system-path")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+
+    for first in (
+        subprocess.TimeoutExpired("python", 1),
+        OSError("private probe failure"),
+        subprocess.CompletedProcess(["python"], 7),
+    ):
+        calls: list[dict[str, object]] = []
+
+        def retry_once(command, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                if isinstance(first, BaseException):
+                    raise first
+                return first
+            return subprocess.CompletedProcess(command, 0)
+
+        monkeypatch.setattr(music_reply.subprocess, "run", retry_once)
+        assert music_reply._run_runtime_probe([str(python), "--help"], cwd=tmp_path)
+        assert len(calls) == 2
+        assert calls[0]["timeout"] == 120.0
+        probe_env = calls[0]["env"]
+        assert probe_env["PATH"] == "system-path"
+        assert probe_env["CUDA_VISIBLE_DEVICES"] == "0"
+        assert all(key not in probe_env for key in ("PYTHONHOME", "PYTHONPATH", "VIRTUAL_ENV", "CONDA_PREFIX"))
+
+    calls = []
+
+    def always_fails(command, **kwargs):
+        calls.append(kwargs)
+        return subprocess.CompletedProcess(command, 7)
+
+    monkeypatch.setattr(music_reply.subprocess, "run", always_fails)
+    assert not music_reply._run_runtime_probe([str(python), "--help"], cwd=tmp_path)
+    assert len(calls) == 2
 
 
 def test_provider_failures_are_stable_private_safe_and_unchained(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Small runtime-probe hardening for private Windows installs.\n\n- use a 120s per-attempt budget\n- launch embedded Python with -I -B and remove parent Python/venv contamination\n- retry one transient timeout, OSError, or nonzero exit once\n- keep the existing public dependency contract unchanged\n\nRED: focused probe cases failed before the implementation.\nGREEN: tests/media/test_music_reply_concat_pipeline.py: 23 passed; focused video settings contract: 3 passed.\n\nFrozen pair: bc229cda8d6e0aeb1b366c6cc9aabce54cfc913e...192fbbbdf0b268959da2e21b3b2b16b8547f9026\nStandards: PASS. Spec: PASS. P0/P1/P2=0.\n\nBoundary: targeted synthetic tests only; final private installer rebuild and real-device acceptance follow after the installer degradation slice merges.