### PR TITLE
fix(installer): preserve verified video runtime on incompatible hosts

### DIFF
--- a/docs/P03_05_INSTALLATION_AND_DEFAULTS.md
+++ b/docs/P03_05_INSTALLATION_AND_DEFAULTS.md
@@ -477,6 +477,8 @@ PrivateWorld
 
 设置页的“一键下载并安装”负责下载公开可分发的语音、音乐、口型和媒体工具，并优先选择国内源。私有完整安装器同时携带只含四套隔离 Python 的 `Olivia-video-runtime-*.zip` 与受管林离音色；组件下载完成后会自动发现、解压、逐文件校验、补齐受管 MiniMax worker、应用到当前服务进程并立即重新检测。状态契约为 `olivia.video-capability-status.v2`；设置页只保留一个手动选择 ZIP 的断网恢复入口。
 
+私有视频运行时的归档、manifest、哈希、路径、reparse point、worker 和配置错误必须硬失败并回滚。归档和逐文件校验已通过、但 portable Python、readiness probe 或 Windows loader 在当前宿主不可用时，安装仍以 exit code 0 完成：`runtime_import.state=ready` 只表示运行时归档已安装，整体状态为 `UNAVAILABLE`，两个视频 bundle 均为 `prerequisites_required`，原因固定为 `VIDEO_RUNTIME_HOST_UNAVAILABLE`。安装器会保存已验证运行时 profile 和不含路径的宿主状态；重启只恢复该状态，不重新解压、重哈希或重新 probe，核心、语音及视频字节仍提交。兼容宿主保持 `READY`。
+
 ## 17. 完成条件
 
 - clean Windows 用户可以完成 Core 安装；

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -1699,12 +1699,18 @@ try {
         )
         $privateVideoOutput = @(& $runner.File @($runner.Args + @($privateVideoActivator) + $privateVideoArguments))
         $privateVideoExitCode = $LASTEXITCODE
-        $privateVideoReady = $false
+        $privateVideoStatus = $null
         $privateVideoFailure = 'VIDEO_PRIVATE_ACTIVATION_FAILED'
         foreach ($line in $privateVideoOutput) {
             try {
                 $record = $line | ConvertFrom-Json
-                if ($record.status -eq 'READY') { $privateVideoReady = $true }
+                if ($record.status -in @('READY', 'UNAVAILABLE')) {
+                    if ($null -ne $privateVideoStatus -and $privateVideoStatus -ne $record.status) {
+                        $privateVideoStatus = $null
+                        break
+                    }
+                    $privateVideoStatus = $record.status
+                }
                 if (
                     $record.status -eq 'ERROR' -and
                     $record.code -is [string] -and
@@ -1717,7 +1723,7 @@ try {
             }
         }
         if ($privateVideoExitCode -ne 0) { throw $privateVideoFailure }
-        if (-not $privateVideoReady) { throw 'VIDEO_PRIVATE_NOT_READY' }
+        if ($privateVideoStatus -notin @('READY', 'UNAVAILABLE')) { throw 'VIDEO_PRIVATE_NOT_READY' }
     }
 } catch {
     $assetFailure = [string]$_.Exception.Message

--- a/installer/activate_private_video.py
+++ b/installer/activate_private_video.py
@@ -311,15 +311,16 @@ def activate_private_video(
         raise PrivateVideoActivationError("VIDEO_PRIVATE_ACTIVATION_FAILED") from exc
     except Exception as exc:
         raise PrivateVideoActivationError("VIDEO_PRIVATE_ACTIVATION_FAILED") from exc
-    if (
-        final.get("status") != "READY"
-        or any(
-            _bundle_state(final, bundle_id).get("state") != "ready"
-            for bundle_id in ("ordinary_video", "music_video")
-        )
-        or not isinstance(final.get("runtime_import"), Mapping)
-        or final["runtime_import"].get("state") != "ready"
-    ):
+    runtime_import = final.get("runtime_import")
+    runtime_ready = isinstance(runtime_import, Mapping) and runtime_import.get("state") == "ready"
+    bundle_items = [_bundle_state(final, bundle_id) for bundle_id in ("ordinary_video", "music_video")]
+    ready = final.get("status") == "READY" and all(item.get("state") == "ready" for item in bundle_items)
+    unavailable = final.get("status") == "UNAVAILABLE" and all(
+        item.get("state") == "prerequisites_required"
+        and item.get("reason_code") == "VIDEO_RUNTIME_HOST_UNAVAILABLE"
+        for item in bundle_items
+    )
+    if not runtime_ready or not (ready or unavailable):
         raise PrivateVideoActivationError("VIDEO_PRIVATE_NOT_READY")
     return dict(final)
 

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -279,6 +279,7 @@ def _run_runtime_publish_fixture(
     product_root: Path | None = None, existing_voice_pair: bool = False,
     interrupt_voice_staging: bool = False, interrupt_after_bootstrap: bool = False, existing_runtime: bool = True, seed_existing_install: bool = True,
     private_video_exit_code: int = 0,
+    private_video_status: str | None = None,
     private_video_mutates_tree: bool = False,
     interrupt_after_private_video: bool = False,
     fail_core_asset_preflight: bool = False,
@@ -309,6 +310,7 @@ def _run_runtime_publish_fixture(
         f"raise SystemExit({bootstrap_exit_code})\n",
         encoding="utf-8",
     )
+    private_status = private_video_status or ("READY" if private_video_exit_code == 0 else "ERROR")
     (payload_installer / "activate_private_video.py").write_text(
         "import json, pathlib, sys\n"
         + (
@@ -324,9 +326,9 @@ def _run_runtime_publish_fixture(
             else ""
         )
         + (
-            "print(json.dumps({'status': 'READY', 'bundles': "
+            f"print(json.dumps({{'status': '{private_status}', 'bundles': "
             if private_video_exit_code == 0
-            else "print(json.dumps({'status': 'ERROR', 'code': 'VIDEO_PRIVATE_ACTIVATION_FAILED', 'bundles': "
+            else f"print(json.dumps({{'status': '{private_status}', 'code': 'VIDEO_PRIVATE_ACTIVATION_FAILED', 'bundles': "
         )
         +
         "[{'id': 'ordinary_video', 'state': 'ready'}, "
@@ -612,6 +614,21 @@ def test_private_video_activation_failure_rolls_back_install_and_runtime_archive
     assert not (old_video / "music_video/partial.txt").exists()
     assert not (old_video / "runtime/partial.txt").exists()
     assert not list(old_video.parent.glob(".video.private-*"))
+
+
+def test_private_video_host_unavailable_commits_verified_assets(
+    tmp_path: Path,
+) -> None:
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=0,
+        voice_reference=_voice_reference_bytes(),
+        private_video_status="UNAVAILABLE",
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert _managed_video_runtime(product).read_bytes() == b"video-runtime-fixture"
+    assert (product / "install/data/capabilities/video").is_dir()
 
 
 def test_private_video_activation_failure_removes_fresh_partial_tree(

--- a/tests/installer/test_private_video_activation.py
+++ b/tests/installer/test_private_video_activation.py
@@ -126,6 +126,22 @@ class _FakeInstaller:
         return "APPLIED"
 
 
+class _UnavailableHostInstaller(_FakeInstaller):
+    def import_runtime_archive(self, *, runtime_archive: Path) -> str:
+        result = super().import_runtime_archive(runtime_archive=runtime_archive)
+        self.states = {bundle_id: "prerequisites_required" for bundle_id in self.states}
+        return result
+
+    def status(self) -> dict[str, object]:
+        result = super().status()
+        result["status"] = "UNAVAILABLE"
+        result["bundles"] = [
+            {**item, "reason_code": "VIDEO_RUNTIME_HOST_UNAVAILABLE"}
+            for item in result["bundles"]
+        ]
+        return result
+
+
 def test_private_activation_uses_existing_installer_in_strict_ready_order(
     tmp_path: Path,
 ) -> None:
@@ -156,6 +172,35 @@ def test_private_activation_uses_existing_installer_in_strict_ready_order(
     assert result["status"] == "READY"
     assert result["runtime_import"]["state"] == "ready"
     assert [item["state"] for item in result["bundles"]] == ["ready", "ready"]
+
+
+def test_private_activation_accepts_verified_runtime_with_unavailable_host(
+    tmp_path: Path,
+) -> None:
+    manifest, offline, manifest_sha256 = _manifest_fixture(tmp_path)
+    runtime = tmp_path / "Olivia-video-runtime-private.zip"
+    runtime.write_bytes(b"runtime")
+    installer = _UnavailableHostInstaller([])
+
+    result = activate_private_video(
+        install_root=tmp_path / "install",
+        offline_root=offline,
+        runtime_archive=runtime,
+        manifest_path=manifest,
+        expected_manifest_version="fixture-video",
+        expected_manifest_sha256=manifest_sha256,
+        expected_file_count=2,
+        expected_size_bytes=len(b"ordinary") + len(b"music"),
+        installer_factory=lambda **_kwargs: installer,
+        timeout_seconds=1,
+    )
+
+    assert result["status"] == "UNAVAILABLE"
+    assert result["runtime_import"]["state"] == "ready"
+    assert [item["state"] for item in result["bundles"]] == [
+        "prerequisites_required",
+        "prerequisites_required",
+    ]
 
 
 def test_private_activation_parses_the_exact_manifest_bytes_that_were_hashed(

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -339,6 +339,186 @@ def test_runtime_archive_is_extracted_verified_and_activated(
     assert restarted_without_archive.status()["runtime_import"]["state"] == "ready"
 
 
+def test_runtime_host_unavailable_keeps_verified_artifact_and_degrades_bundles(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    monkeypatch.setattr(video_capability_install, "_runtime_environment_is_portable", lambda *_: True)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: {
+            "ordinary_missing_dependencies": ["loader"],
+            "music_ready": False,
+            "dependencies": [
+                {"id": "cosyvoice", "state": "missing"},
+                {"id": "minimax_music3", "state": "missing"},
+            ],
+        },
+    )
+
+    assert installer.import_runtime_archive(runtime_archive=archive) == "APPLIED"
+
+    status = installer.status()
+    assert status["status"] == "UNAVAILABLE"
+    assert status["runtime_import"]["state"] == "ready"
+    assert status["runtime_import"]["reason_code"] == "VIDEO_RUNTIME_HOST_UNAVAILABLE"
+    assert [item["state"] for item in status["bundles"]] == [
+        "prerequisites_required",
+        "prerequisites_required",
+    ]
+    assert all(
+        item["reason_code"] == "VIDEO_RUNTIME_HOST_UNAVAILABLE"
+        for item in status["bundles"]
+    )
+    profile = json.loads(
+        (installer.install_root / "runtime-environment.json").read_text(encoding="utf-8")
+    )
+    assert profile["host_status"] == {
+        "status": "UNAVAILABLE",
+        "reason_code": "VIDEO_RUNTIME_HOST_UNAVAILABLE",
+    }
+
+
+def test_runtime_hard_failure_restores_previous_runtime_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    monkeypatch.setattr(video_capability_install, "_runtime_environment_is_portable", lambda *_: True)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: {
+            "ordinary_missing_dependencies": [],
+            "music_ready": True,
+        },
+    )
+    previous = installer.install_root / "runtime"
+    previous.mkdir()
+    (previous / "old.txt").write_text("preserve", encoding="utf-8")
+    monkeypatch.setattr(
+        installer,
+        "_install_managed_minimax_worker",
+        lambda: (_ for _ in ()).throw(
+            VideoCapabilityError("VIDEO_RUNTIME_WORKER_UNAVAILABLE")
+        ),
+    )
+
+    with pytest.raises(VideoCapabilityError, match="VIDEO_RUNTIME_WORKER_UNAVAILABLE"):
+        installer.import_runtime_archive(runtime_archive=archive)
+
+    assert (previous / "old.txt").read_text(encoding="utf-8") == "preserve"
+    assert not list(installer.install_root.glob(".runtime.backup"))
+
+
+def test_successful_runtime_upgrade_removes_directory_backup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    monkeypatch.setattr(video_capability_install, "_runtime_environment_is_portable", lambda *_: True)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: {
+            "ordinary_missing_dependencies": [],
+            "music_ready": True,
+        },
+    )
+    previous = installer.install_root / "runtime"
+    previous.mkdir()
+    (previous / "old.txt").write_text("replace", encoding="utf-8")
+
+    assert installer.import_runtime_archive(runtime_archive=archive) == "APPLIED"
+    assert not (installer.install_root / ".runtime.backup").exists()
+    assert not (installer.install_root / "runtime" / "old.txt").exists()
+    assert (installer.install_root / "runtime" / "runtime-manifest.json").is_file()
+
+
+def test_structurally_nonportable_runtime_hard_fails_and_rolls_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    monkeypatch.setattr(video_capability_install, "_runtime_environment_is_portable", lambda *_: False)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: {
+            "ordinary_missing_dependencies": [],
+            "music_ready": True,
+        },
+    )
+
+    with pytest.raises(VideoCapabilityError, match="VIDEO_RUNTIME_NOT_PORTABLE"):
+        installer.import_runtime_archive(runtime_archive=archive)
+    assert not (installer.install_root / "runtime").exists()
+
+
+@pytest.mark.parametrize("failure", ["timeout", "loader"])
+def test_runtime_host_start_failure_soft_degrades_without_reprobe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+
+    def failed_process(*_args: object, **_kwargs: object) -> object:
+        if failure == "timeout":
+            raise subprocess.TimeoutExpired("portable-python", 20)
+        return subprocess.CompletedProcess([], 0xC0000135)
+
+    monkeypatch.setattr(video_capability_install.subprocess, "run", failed_process)
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: pytest.fail("host failure must not reprobe"),
+    )
+
+    assert installer.import_runtime_archive(runtime_archive=archive) == "APPLIED"
+    status = installer.status()
+    assert status["status"] == "UNAVAILABLE"
+    assert status["runtime_import"]["state"] == "ready"
+    assert status["runtime_import"]["reason_code"] == "VIDEO_RUNTIME_HOST_UNAVAILABLE"
+    assert all(item["reason_code"] == "VIDEO_RUNTIME_HOST_UNAVAILABLE" for item in status["bundles"])
+    schema = json.loads(Path("contracts/video_capability_status.schema.json").read_text(encoding="utf-8"))
+    Draft202012Validator(schema).validate(status)
+
+
+def test_static_dependency_probe_failure_remains_hard_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    monkeypatch.setattr(video_capability_install, "_runtime_environment_is_portable", lambda *_: True)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: {
+            "ordinary_missing_dependencies": ["ffmpeg"],
+            "music_ready": False,
+            "dependencies": [{"id": "ffmpeg", "state": "missing"}],
+        },
+    )
+
+    with pytest.raises(VideoCapabilityError, match="VIDEO_RUNTIME_PROBE_FAILED"):
+        installer.import_runtime_archive(runtime_archive=archive)
+    assert not (installer.install_root / "runtime").exists()
+
+
 def test_restart_repairs_legacy_managed_worker_pair_before_ready(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -58,12 +58,20 @@ _PORTABLE_RUNTIME_ENVIRONMENT_KEYS = frozenset(("OLIVIA_COSYVOICE_PYTHON", "OLIV
 _MAX_ARCHIVE_EXPANDED_BYTES = 4 * 1024 * 1024 * 1024
 _MAX_RUNTIME_ARCHIVE_EXPANDED_BYTES = 64 * 1024 * 1024 * 1024
 _RUNTIME_PORTABILITY_TIMEOUT_SECONDS = 20.0
+_RUNTIME_HOST_UNAVAILABLE = "VIDEO_RUNTIME_HOST_UNAVAILABLE"
+_RUNTIME_HOST_DEPENDENCIES = frozenset(
+    {"cosyvoice", "latentsync", "minimax_music3", "roformer"}
+)
 _SEED_VC_PATCH_SHA256 = "f61ffb5193514ee3e34a439ebcd89c6168cf4bdb6a8d960513ee471d8840f2a6"
 _PROMOTION_LOCK = threading.RLock()
 
 
 class VideoCapabilityError(ValueError):
     """Raised for invalid manifests or unsafe installation inputs."""
+
+
+class _RuntimeHostUnavailable(RuntimeError):
+    """The portable runtime process could not start on this host."""
 
 
 class VideoCapabilityState(StrEnum):
@@ -365,9 +373,12 @@ def _portable_python_runtime(python: Path, runtime_root: Path) -> bool:
             timeout=_RUNTIME_PORTABILITY_TIMEOUT_SECONDS,
             creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         )
-    except (OSError, subprocess.SubprocessError):
-        return False
-    return completed.returncode == 0
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise _RuntimeHostUnavailable from exc
+    returncode = int(completed.returncode)
+    if os.name == "nt" and returncode & 0xFFFFFFFF >= 0xC0000000:
+        raise _RuntimeHostUnavailable
+    return returncode == 0
 
 
 def _runtime_environment_is_portable(
@@ -712,7 +723,9 @@ class VideoCapabilityInstaller:
 
     def _runtime_wiring_ready(self, root: Path, bundle: VideoBundle) -> bool:
         try:
-            persisted = load_video_runtime_environment(self.data_root)
+            persisted = _load_video_runtime_environment(
+                self.data_root, restore_backups=False
+            )
             ready = all(
                 key in persisted and Path(persisted[key]).exists()
                 for key in (bundle.runtime_environment or {})
@@ -801,6 +814,16 @@ class VideoCapabilityInstaller:
                 "manifest_sha256",
             }:
                 return VideoCapabilityState.READY, None
+            if isinstance(profile, dict) and profile.get("host_status") == {
+                "status": "READY",
+                "reason_code": None,
+            }:
+                return VideoCapabilityState.READY, None
+            if isinstance(profile, dict) and profile.get("host_status") == {
+                "status": "UNAVAILABLE",
+                "reason_code": _RUNTIME_HOST_UNAVAILABLE,
+            }:
+                return VideoCapabilityState.PREREQUISITES_REQUIRED, _RUNTIME_HOST_UNAVAILABLE
         except (OSError, UnicodeError, json.JSONDecodeError):
             pass
         return self._runtime_dependency_state(bundle, probe_cache=probe_cache)
@@ -1024,6 +1047,7 @@ class VideoCapabilityInstaller:
             }
         staging = self.install_root / f".runtime-staging-{uuid.uuid4().hex}"
         final = self.install_root / "runtime"
+        backup = self.install_root / ".runtime.backup"
         try:
             _extract_runtime_zip_safely(
                 archive,
@@ -1034,12 +1058,46 @@ class VideoCapabilityInstaller:
             if not manifest_path.is_file() or manifest_path.is_symlink():
                 raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
             manifest_sha256 = _sha256_file(manifest_path)[1]
-            self._promote_directory(staging, final)
-            return self.import_runtime_root(
-                runtime_root=final.resolve(),
-                manifest_sha256=manifest_sha256,
-            )
+            with self._commit_lock:
+                if backup.exists():
+                    _restore_interrupted_promotions(self.install_root)
+                if final.exists():
+                    _reject_reparse_tree(final)
+                    os.replace(final, backup)
+                os.replace(staging, final)
+            try:
+                result = self.import_runtime_root(
+                    runtime_root=final.resolve(),
+                    manifest_sha256=manifest_sha256,
+                )
+                if backup.exists():
+                    shutil.rmtree(backup)
+                return result
+            except Exception as exc:
+                rollback_error: Exception | None = None
+                with self._commit_lock:
+                    try:
+                        if final.exists():
+                            _reject_reparse_tree(final)
+                            shutil.rmtree(final)
+                        if backup.exists():
+                            os.replace(backup, final)
+                    except Exception as restore_exc:
+                        rollback_error = restore_exc
+                if rollback_error is not None:
+                    raise VideoCapabilityError(
+                        "VIDEO_RUNTIME_IMPORT_ROLLBACK_FAILED"
+                    ) from rollback_error
+                raise
         except Exception as exc:
+            if backup.exists() and not final.exists():
+                try:
+                    os.replace(backup, final)
+                except OSError as rollback_exc:
+                    exc = VideoCapabilityError(
+                        "VIDEO_RUNTIME_IMPORT_ROLLBACK_FAILED"
+                    )
+                    exc.__cause__ = rollback_exc
             self._set_runtime_import_state(
                 "failed", reason_code=self._runtime_import_error_code(exc)
             )
@@ -1100,7 +1158,17 @@ class VideoCapabilityInstaller:
             payload = json.loads(
                 (self.install_root / _RUNTIME_ENVIRONMENT_FILE).read_text(encoding="utf-8")
             )
-            if not isinstance(payload, dict) or set(payload.get("external_environment", {})) != _PORTABLE_RUNTIME_ENVIRONMENT_KEYS:
+            if (
+                not isinstance(payload, dict)
+                or set(payload.get("external_environment", {})) != _PORTABLE_RUNTIME_ENVIRONMENT_KEYS
+                or payload.get("host_status") not in (None, {
+                    "status": "READY",
+                    "reason_code": None,
+                }, {
+                    "status": "UNAVAILABLE",
+                    "reason_code": _RUNTIME_HOST_UNAVAILABLE,
+                })
+            ):
                 return False
             environment = load_video_runtime_environment(self.data_root)
         except (OSError, UnicodeError, json.JSONDecodeError, VideoCapabilityError):
@@ -1120,7 +1188,14 @@ class VideoCapabilityInstaller:
                 "failed", reason_code="VIDEO_RUNTIME_ENVIRONMENT_ACTIVATION_FAILED"
             )
             return True
-        self._runtime_import = {"state": "ready", "checked_bytes": 0, "total_bytes": 0}
+        self._runtime_import = {
+            "state": "ready",
+            "checked_bytes": 0,
+            "total_bytes": 0,
+        }
+        host_status = payload.get("host_status")
+        if isinstance(host_status, dict) and host_status.get("status") == "UNAVAILABLE":
+            self._runtime_import["reason_code"] = _RUNTIME_HOST_UNAVAILABLE
         return True
 
     def _maybe_start_runtime_prepare(self) -> None:
@@ -1337,11 +1412,19 @@ class VideoCapabilityInstaller:
             progress=self._update_runtime_import_progress,
         )
         self._set_runtime_import_state("testing")
-        if not _runtime_environment_is_portable(external_environment, root):
+        host_unavailable = False
+        try:
+            portable = _runtime_environment_is_portable(external_environment, root)
+        except _RuntimeHostUnavailable:
+            portable = False
+            host_unavailable = True
+        if not portable and not host_unavailable:
             raise VideoCapabilityError("VIDEO_RUNTIME_NOT_PORTABLE")
         self._install_managed_minimax_worker()
         try:
-            environment = load_video_runtime_environment(self.data_root)
+            environment = _load_video_runtime_environment(
+                self.data_root, restore_backups=False
+            )
         except VideoCapabilityError:
             environment = {}
         for key, value in self._installed_bundle_environment().items():
@@ -1398,23 +1481,45 @@ class VideoCapabilityInstaller:
             finally:
                 generated_temporary.unlink(missing_ok=True)
             environment["OLIVIA_TTS_CONFIG"] = str(generated_config)
-        if self._readiness_probe is None:
-            raise VideoCapabilityError("VIDEO_RUNTIME_PROBE_UNAVAILABLE")
-        probe_environment = dict(os.environ)
-        probe_environment.update(environment)
-        probe_environment["OLIVIA_LOCAL_DATA_ROOT"] = str(self.data_root)
-        try:
-            readiness = self._readiness_probe(probe_environment)
-            ordinary_missing = readiness.get("ordinary_missing_dependencies")
-            ready = (
-                isinstance(ordinary_missing, (list, tuple))
-                and not ordinary_missing
-                and readiness.get("music_ready") is True
-            )
-        except Exception:
-            ready = False
-        if not ready:
-            raise VideoCapabilityError("VIDEO_RUNTIME_PROBE_FAILED")
+        ready = False
+        probe_exception = False
+        if not host_unavailable:
+            if self._readiness_probe is None:
+                raise VideoCapabilityError("VIDEO_RUNTIME_PROBE_UNAVAILABLE")
+            probe_environment = dict(os.environ)
+            probe_environment.update(environment)
+            probe_environment["OLIVIA_LOCAL_DATA_ROOT"] = str(self.data_root)
+            try:
+                readiness = self._readiness_probe(probe_environment)
+                ordinary_missing = readiness.get("ordinary_missing_dependencies")
+                ready = (
+                    isinstance(ordinary_missing, (list, tuple))
+                    and not ordinary_missing
+                    and readiness.get("music_ready") is True
+                )
+            except Exception:
+                probe_exception = True
+                ready = False
+        if not ready and not host_unavailable and not probe_exception:
+            dependencies = readiness.get("dependencies")
+            if not isinstance(dependencies, list):
+                raise VideoCapabilityError("VIDEO_RUNTIME_PROBE_FAILED")
+            missing_ids: set[str] = set()
+            for dependency in dependencies:
+                if (
+                    not isinstance(dependency, Mapping)
+                    or not isinstance(dependency.get("id"), str)
+                    or dependency.get("state") not in {"ready", "missing"}
+                ):
+                    raise VideoCapabilityError("VIDEO_RUNTIME_PROBE_FAILED")
+                if dependency["state"] == "missing":
+                    missing_ids.add(dependency["id"])
+            if not missing_ids or not missing_ids <= _RUNTIME_HOST_DEPENDENCIES:
+                raise VideoCapabilityError("VIDEO_RUNTIME_PROBE_FAILED")
+        host_status = {
+            "status": "READY" if portable and ready else "UNAVAILABLE",
+            "reason_code": None if portable and ready else _RUNTIME_HOST_UNAVAILABLE,
+        }
         self.install_root.mkdir(parents=True, exist_ok=True)
         target = self.install_root / _RUNTIME_ENVIRONMENT_FILE
         temporary = target.with_name(f"{target.name}.{uuid.uuid4().hex}.tmp")
@@ -1434,6 +1539,7 @@ class VideoCapabilityInstaller:
             "external_environment": external_environment,
             "runtime_root": str(root),
             "manifest_sha256": _safe_sha(manifest_sha256),
+            "host_status": host_status,
         }
         backup = target.with_name(f"{target.name}.{uuid.uuid4().hex}.backup")
         previous_environment = {key: os.environ.get(key) for key in environment}
@@ -1476,6 +1582,8 @@ class VideoCapabilityInstaller:
                 except OSError:
                     pass
         with self._lock:
+            if host_status["status"] == "UNAVAILABLE":
+                self._runtime_import["reason_code"] = _RUNTIME_HOST_UNAVAILABLE
             self._load_status()
         return "APPLIED"
 
@@ -1871,11 +1979,14 @@ def _extract_runtime_zip_safely(
         raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID") from exc
 
 
-def _load_video_runtime_environment(data_root: Path) -> dict[str, str]:
+def _load_video_runtime_environment(
+    data_root: Path, *, restore_backups: bool = True
+) -> dict[str, str]:
     if not data_root.is_absolute():
         raise VideoCapabilityError("VIDEO_DATA_ROOT_INVALID")
     install_root = _checked_install_root(data_root.resolve(), create=False)
-    _restore_interrupted_promotions(install_root)
+    if restore_backups:
+        _restore_interrupted_promotions(install_root)
     path = install_root / _RUNTIME_ENVIRONMENT_FILE
     try:
         payload: Any = json.loads(path.read_text(encoding="utf-8"))
@@ -1884,21 +1995,37 @@ def _load_video_runtime_environment(data_root: Path) -> dict[str, str]:
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         raise VideoCapabilityError("VIDEO_RUNTIME_ENVIRONMENT_INVALID") from exc
     managed_fields = {"schema_version", "environment"}
+    managed_fields_with_host = managed_fields | {"host_status"}
     external_fields = managed_fields | {
         "external_environment",
         "runtime_root",
         "manifest_sha256",
     }
+    external_fields_with_host = external_fields | {"host_status"}
     if (
         not isinstance(payload, dict)
-        or set(payload) not in {frozenset(managed_fields), frozenset(external_fields)}
+        or set(payload) not in {
+            frozenset(managed_fields),
+            frozenset(managed_fields_with_host),
+            frozenset(external_fields),
+            frozenset(external_fields_with_host),
+        }
         or payload.get("schema_version") != "olivia.video-runtime-environment.v1"
         or not isinstance(payload.get("environment"), dict)
         or set(payload["environment"]) - _RUNTIME_ENVIRONMENT_KEYS
     ):
         raise VideoCapabilityError("VIDEO_RUNTIME_ENVIRONMENT_INVALID")
+    host_status = payload.get("host_status")
+    if host_status is not None and host_status not in ({
+        "status": "READY",
+        "reason_code": None,
+    }, {
+        "status": "UNAVAILABLE",
+        "reason_code": _RUNTIME_HOST_UNAVAILABLE,
+    }):
+        raise VideoCapabilityError("VIDEO_RUNTIME_ENVIRONMENT_INVALID")
     external_environment: dict[str, str] | None = None
-    if set(payload) == external_fields:
+    if set(payload) in (external_fields, external_fields_with_host):
         raw_root = payload.get("runtime_root")
         declared_external = payload.get("external_environment")
         if (


### PR DESCRIPTION
Scope: keep verified private video assets installed when a target Windows host cannot execute the bundled portable runtimes, while preserving hard failure and rollback for archive, manifest, path, reparse, worker, config, static dependency, and structural portability failures. Successful upgrades remove the runtime backup; restarts restore persisted host state without extraction, hashing, or probing. Public status remains schema v2 and exposes only the existing reason_code. Frozen pair: 9a56512282117fe81da683a2527cc587d339e5ae...f3e7f36c91206c8edc651fc2b5ced965ffc0aad8. Validation: 126 targeted installer tests passed; compileall and git diff --check passed. Standards PASS and Spec PASS; P0/P1/P2=0 on both axes.