### PR TITLE
fix(installer): resume private runtime imports

### DIFF
--- a/docs/P03_05_INSTALLATION_AND_DEFAULTS.md
+++ b/docs/P03_05_INSTALLATION_AND_DEFAULTS.md
@@ -479,6 +479,8 @@ PrivateWorld
 
 私有视频运行时的归档、manifest、哈希、路径、reparse point、worker 和配置错误必须硬失败并回滚。归档和逐文件校验已通过、但 portable Python、readiness probe 或 Windows loader 在当前宿主不可用时，安装仍以 exit code 0 完成：`runtime_import.state=ready` 只表示运行时归档已安装，整体状态为 `UNAVAILABLE`，两个视频 bundle 均为 `prerequisites_required`，原因固定为 `VIDEO_RUNTIME_HOST_UNAVAILABLE`。安装器会保存已验证运行时 profile 和不含路径的宿主状态；重启只恢复该状态，不重新解压、重哈希或重新 probe，核心、语音及视频字节仍提交。兼容宿主保持 `READY`。
 
+运行时归档解压使用 `data/capabilities/.video-runtime-import-cache` 下的内部断点状态；它绑定 ZIP 中央目录指纹而非 inode、mtime 或路径，每 256 个条目原子记录进度。安装中断或外层事务删除 `video` 目录后，同一归档可复用安全 staging，最终仍必须完整 manifest、逐文件哈希、路径集合和 reparse 校验；每次候选重试都会再次完整校验。该 checkpoint 不是公开状态/API，不出现在 `contracts/video_capability_status.schema.json`，成功完成 TTS、readiness、profile 和状态发布后才清理。
+
 ## 17. 完成条件
 
 - clean Windows 用户可以完成 Core 安装；

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -339,6 +339,71 @@ def test_runtime_archive_is_extracted_verified_and_activated(
     assert restarted_without_archive.status()["runtime_import"]["state"] == "ready"
 
 
+def test_runtime_archive_resumes_interrupted_extraction_from_bound_checkpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    monkeypatch.setattr(video_capability_install, "_runtime_environment_is_portable", lambda *_: True)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: {"ordinary_missing_dependencies": [], "music_ready": True},
+    )
+    real_extract = video_capability_install._extract_runtime_zip_safely
+    resume_values: list[bool] = []
+
+    def interrupted_extract(
+        archive_path: Path,
+        destination: Path,
+        *,
+        resume: bool = False,
+        next_member_index: int = 0,
+        checkpoint_progress: object = None,
+        progress: object = None,
+    ) -> None:
+        resume_values.append(resume)
+        destination.mkdir(parents=True)
+        with zipfile.ZipFile(archive_path) as payload:
+            member = next(item for item in payload.infolist() if not item.is_dir())
+            target = destination / member.filename
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(payload.read(member))
+        raise RuntimeError("simulated extraction termination")
+
+    monkeypatch.setattr(video_capability_install, "_extract_runtime_zip_safely", interrupted_extract)
+    with pytest.raises(RuntimeError, match="simulated extraction termination"):
+        installer.import_runtime_archive(runtime_archive=archive)
+
+    cache = data_root / "capabilities" / ".video-runtime-import-cache"
+    checkpoint = cache / ".runtime-import-checkpoint.json"
+    assert checkpoint.is_file()
+    checkpoint_payload = json.loads(checkpoint.read_text(encoding="utf-8"))
+    candidate = cache / checkpoint_payload["candidate"]
+    assert candidate.is_dir()
+    first_member = next(item for item in zipfile.ZipFile(archive).infolist() if not item.is_dir())
+    preserved = candidate / first_member.filename
+    assert preserved.is_file()
+    def resumed_extract(
+        archive_path: Path,
+        destination: Path,
+        *,
+        resume: bool = False,
+        next_member_index: int = 0,
+        checkpoint_progress: object = None,
+        progress: object = None,
+    ) -> None:
+        resume_values.append(resume)
+        real_extract(archive_path, destination, resume=resume, progress=progress)
+
+    monkeypatch.setattr(video_capability_install, "_extract_runtime_zip_safely", resumed_extract)
+    assert installer.import_runtime_archive(runtime_archive=archive) == "APPLIED"
+    assert resume_values == [False, True]
+    assert not checkpoint.exists()
+
+
 def test_runtime_host_unavailable_keeps_verified_artifact_and_degrades_bundles(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -381,6 +446,91 @@ def test_runtime_host_unavailable_keeps_verified_artifact_and_degrades_bundles(
         "status": "UNAVAILABLE",
         "reason_code": "VIDEO_RUNTIME_HOST_UNAVAILABLE",
     }
+
+
+def test_runtime_archive_retries_verified_candidate_without_reextract_or_rehash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    monkeypatch.setattr(video_capability_install, "_runtime_environment_is_portable", lambda *_: True)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    attempts = 0
+    verify_values: list[bool] = []
+    real_load = video_capability_install._load_runtime_root_manifest
+
+    def counted_load(*args: object, **kwargs: object) -> dict[str, str]:
+        verify_values.append(kwargs["verify_files"])
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(video_capability_install, "_load_runtime_root_manifest", counted_load)
+
+    def readiness(_environment: dict[str, str]) -> dict[str, object]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return {
+                "ordinary_missing_dependencies": ["ffmpeg"],
+                "music_ready": False,
+                "dependencies": [{"id": "ffmpeg", "state": "missing"}],
+            }
+        return {"ordinary_missing_dependencies": [], "music_ready": True}
+
+    installer = VideoCapabilityInstaller(
+        data_root=data_root, manifest=manifest, readiness_probe=readiness
+    )
+    with pytest.raises(VideoCapabilityError, match="VIDEO_RUNTIME_PROBE_FAILED"):
+        installer.import_runtime_archive(runtime_archive=archive)
+    monkeypatch.setattr(
+        video_capability_install,
+        "_extract_runtime_zip_safely",
+        lambda *_args, **_kwargs: pytest.fail("verified candidate must not reextract"),
+    )
+    assert installer.import_runtime_archive(runtime_archive=archive) == "APPLIED"
+    assert verify_values == [True, False, False]
+
+
+def test_runtime_archive_ignores_checkpoint_for_another_archive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    monkeypatch.setattr(video_capability_install, "_runtime_environment_is_portable", lambda *_: True)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    attempts = 0
+
+    def readiness(_environment: dict[str, str]) -> dict[str, object]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return {
+                "ordinary_missing_dependencies": ["ffmpeg"],
+                "music_ready": False,
+                "dependencies": [{"id": "ffmpeg", "state": "missing"}],
+            }
+        return {"ordinary_missing_dependencies": [], "music_ready": True}
+
+    installer = VideoCapabilityInstaller(
+        data_root=data_root, manifest=manifest, readiness_probe=readiness
+    )
+    with pytest.raises(VideoCapabilityError, match="VIDEO_RUNTIME_PROBE_FAILED"):
+        installer.import_runtime_archive(runtime_archive=archive)
+    checkpoint = data_root / "capabilities" / ".video-runtime-import-cache" / ".runtime-import-checkpoint.json"
+    payload = json.loads(checkpoint.read_text(encoding="utf-8"))
+    payload["archive_identity"][0] = "foreign-runtime.zip"
+    checkpoint.write_text(json.dumps(payload), encoding="utf-8")
+    resume_values: list[bool] = []
+    real_extract = video_capability_install._extract_runtime_zip_safely
+
+    def counted_extract(*args: object, **kwargs: object) -> None:
+        resume_values.append(bool(kwargs.get("resume", False)))
+        real_extract(*args, **kwargs)
+
+    monkeypatch.setattr(video_capability_install, "_extract_runtime_zip_safely", counted_extract)
+    assert installer.import_runtime_archive(runtime_archive=archive) == "APPLIED"
+    assert resume_values == [False]
 
 
 def test_runtime_hard_failure_restores_previous_runtime_directory(
@@ -919,6 +1069,8 @@ def test_runtime_archive_background_start_returns_before_extraction_and_deduplic
         _archive: Path,
         staging: Path,
         *,
+        next_member_index=0,
+        checkpoint_progress=None,
         progress,
     ) -> None:
         staging.mkdir(parents=True)

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import hashlib
+import os
 from pathlib import Path
 import shutil
 import stat
@@ -482,13 +483,17 @@ def test_runtime_archive_retries_verified_candidate_without_reextract_or_rehash(
     )
     with pytest.raises(VideoCapabilityError, match="VIDEO_RUNTIME_PROBE_FAILED"):
         installer.import_runtime_archive(runtime_archive=archive)
-    monkeypatch.setattr(
-        video_capability_install,
-        "_extract_runtime_zip_safely",
-        lambda *_args, **_kwargs: pytest.fail("verified candidate must not reextract"),
-    )
+    resume_values: list[bool] = []
+    real_extract = video_capability_install._extract_runtime_zip_safely
+
+    def counted_extract(*args: object, **kwargs: object) -> None:
+        resume_values.append(bool(kwargs.get("resume", False)))
+        real_extract(*args, **kwargs)
+
+    monkeypatch.setattr(video_capability_install, "_extract_runtime_zip_safely", counted_extract)
     assert installer.import_runtime_archive(runtime_archive=archive) == "APPLIED"
-    assert verify_values == [True, False, False]
+    assert verify_values == [True, True, True, True]
+    assert resume_values == [True]
 
 
 def test_runtime_archive_ignores_checkpoint_for_another_archive(
@@ -519,7 +524,8 @@ def test_runtime_archive_ignores_checkpoint_for_another_archive(
         installer.import_runtime_archive(runtime_archive=archive)
     checkpoint = data_root / "capabilities" / ".video-runtime-import-cache" / ".runtime-import-checkpoint.json"
     payload = json.loads(checkpoint.read_text(encoding="utf-8"))
-    payload["archive_identity"][0] = "foreign-runtime.zip"
+    old_candidate = checkpoint.parent / payload["candidate"]
+    payload["archive_identity"] = "foreign-runtime-fingerprint"
     checkpoint.write_text(json.dumps(payload), encoding="utf-8")
     resume_values: list[bool] = []
     real_extract = video_capability_install._extract_runtime_zip_safely
@@ -531,6 +537,119 @@ def test_runtime_archive_ignores_checkpoint_for_another_archive(
     monkeypatch.setattr(video_capability_install, "_extract_runtime_zip_safely", counted_extract)
     assert installer.import_runtime_archive(runtime_archive=archive) == "APPLIED"
     assert resume_values == [False]
+    assert not old_candidate.exists()
+
+
+def test_runtime_archive_copy_with_new_inode_and_mtime_resumes_checkpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    copied = (tmp_path / "copied-runtime.zip").resolve()
+    shutil.copyfile(archive, copied)
+    os.utime(copied, ns=(1_000_000_000, 1_000_000_000))
+    monkeypatch.setattr(video_capability_install, "_runtime_environment_is_portable", lambda *_: True)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    attempts = 0
+
+    def readiness(_environment: dict[str, str]) -> dict[str, object]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return {
+                "ordinary_missing_dependencies": ["ffmpeg"],
+                "music_ready": False,
+                "dependencies": [{"id": "ffmpeg", "state": "missing"}],
+            }
+        return {"ordinary_missing_dependencies": [], "music_ready": True}
+
+    installer = VideoCapabilityInstaller(data_root=data_root, manifest=manifest, readiness_probe=readiness)
+    with pytest.raises(VideoCapabilityError, match="VIDEO_RUNTIME_PROBE_FAILED"):
+        installer.import_runtime_archive(runtime_archive=archive)
+    resume_values: list[bool] = []
+    real_extract = video_capability_install._extract_runtime_zip_safely
+
+    def counted_extract(*args: object, **kwargs: object) -> None:
+        resume_values.append(bool(kwargs.get("resume", False)))
+        real_extract(*args, **kwargs)
+
+    monkeypatch.setattr(video_capability_install, "_extract_runtime_zip_safely", counted_extract)
+    assert installer.import_runtime_archive(runtime_archive=copied) == "APPLIED"
+    assert resume_values == [True]
+
+
+def test_runtime_archive_system_exit_keeps_cache_after_video_root_is_deleted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    monkeypatch.setattr(video_capability_install, "_runtime_environment_is_portable", lambda *_: True)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: (_ for _ in ()).throw(SystemExit(7)),
+    )
+    with pytest.raises(SystemExit):
+        installer.import_runtime_archive(runtime_archive=archive)
+    cache = data_root / "capabilities" / ".video-runtime-import-cache"
+    checkpoint = cache / ".runtime-import-checkpoint.json"
+    assert checkpoint.is_file()
+    shutil.rmtree(installer.install_root)
+    _prepare_runtime_dependencies(data_root, manifest)
+    resume_values: list[bool] = []
+    real_extract = video_capability_install._extract_runtime_zip_safely
+
+    def counted_extract(*args: object, **kwargs: object) -> None:
+        resume_values.append(bool(kwargs.get("resume", False)))
+        real_extract(*args, **kwargs)
+
+    monkeypatch.setattr(video_capability_install, "_extract_runtime_zip_safely", counted_extract)
+    restarted = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: {
+            "ordinary_missing_dependencies": [], "music_ready": True
+        },
+    )
+    assert restarted.import_runtime_archive(runtime_archive=archive) == "APPLIED"
+    assert resume_values == [True]
+
+
+def test_runtime_archive_same_size_candidate_tamper_fails_full_hash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    monkeypatch.setattr(video_capability_install, "_runtime_environment_is_portable", lambda *_: True)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    attempts = 0
+
+    def readiness(_environment: dict[str, str]) -> dict[str, object]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return {
+                "ordinary_missing_dependencies": ["ffmpeg"],
+                "music_ready": False,
+                "dependencies": [{"id": "ffmpeg", "state": "missing"}],
+            }
+        return {"ordinary_missing_dependencies": [], "music_ready": True}
+
+    installer = VideoCapabilityInstaller(data_root=data_root, manifest=manifest, readiness_probe=readiness)
+    with pytest.raises(VideoCapabilityError, match="VIDEO_RUNTIME_PROBE_FAILED"):
+        installer.import_runtime_archive(runtime_archive=archive)
+    cache = data_root / "capabilities" / ".video-runtime-import-cache"
+    payload = json.loads((cache / ".runtime-import-checkpoint.json").read_text(encoding="utf-8"))
+    candidate = cache / payload["candidate"]
+    tampered = next(path for path in candidate.rglob("*") if path.is_file() and path.name != "runtime-manifest.json")
+    tampered.write_bytes(b"tamper!")
+    with pytest.raises(VideoCapabilityError, match="VIDEO_RUNTIME_ROOT_INVALID"):
+        installer.import_runtime_archive(runtime_archive=archive)
+    assert not (cache / ".runtime-import-checkpoint.json").exists()
 
 
 def test_runtime_hard_failure_restores_previous_runtime_directory(

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -345,6 +345,27 @@ def _runtime_archive_identity(path: Path) -> tuple[str, int, int, int, int] | No
     return (str(path), metadata.st_dev, metadata.st_ino, metadata.st_size, metadata.st_mtime_ns)
 
 
+def _runtime_archive_fingerprint(path: Path) -> str | None:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            entries = [
+                (
+                    member.filename,
+                    member.CRC,
+                    member.file_size,
+                    member.compress_size,
+                    member.flag_bits,
+                    member.external_attr,
+                )
+                for member in archive.infolist()
+            ]
+    except (OSError, zipfile.BadZipFile):
+        return None
+    return hashlib.sha256(
+        json.dumps(entries, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    ).hexdigest()
+
+
 def _runtime_import_cache(data_root: Path) -> Path:
     cache_root = data_root / "capabilities" / _RUNTIME_IMPORT_CACHE
     if cache_root.exists() and (
@@ -363,26 +384,39 @@ def _discard_runtime_import_checkpoint(cache_root: Path, candidate: Path) -> Non
         pass
 
 
+def _discard_stale_runtime_checkpoint(cache_root: Path) -> None:
+    checkpoint = cache_root / _RUNTIME_IMPORT_CHECKPOINT
+    try:
+        payload: Any = json.loads(checkpoint.read_text(encoding="utf-8"))
+        candidate_name = payload.get("candidate") if isinstance(payload, dict) else None
+        if (
+            isinstance(candidate_name, str)
+            and candidate_name.startswith(".runtime-staging-")
+            and Path(candidate_name).name == candidate_name
+        ):
+            candidate = _inside(cache_root, cache_root / candidate_name)
+            _discard_runtime_import_checkpoint(cache_root, candidate)
+            return
+    except (FileNotFoundError, OSError, UnicodeError, json.JSONDecodeError, VideoCapabilityError):
+        pass
+    checkpoint.unlink(missing_ok=True)
+
+
 def _write_runtime_import_checkpoint(
     cache_root: Path,
     *,
-    archive_identity: tuple[str, int, int, int, int],
+    archive_identity: str,
     candidate: Path,
-    manifest_sha256: str | None = None,
-    verified_files: bool = False,
     next_member_index: int = 0,
 ) -> None:
     cache_root.mkdir(parents=True, exist_ok=True)
     relative_candidate = candidate.relative_to(cache_root).as_posix()
     payload: dict[str, object] = {
         "schema_version": "olivia.video-runtime-import-checkpoint.v1",
-        "archive_identity": list(archive_identity),
+        "archive_identity": archive_identity,
         "candidate": relative_candidate,
-        "verified_files": verified_files,
         "next_member_index": next_member_index,
     }
-    if manifest_sha256 is not None:
-        payload["manifest_sha256"] = _safe_sha(manifest_sha256)
     temporary = cache_root / f"{_RUNTIME_IMPORT_CHECKPOINT}.{uuid.uuid4().hex}.tmp"
     try:
         temporary.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
@@ -393,8 +427,8 @@ def _write_runtime_import_checkpoint(
 
 def _read_runtime_import_checkpoint(
     cache_root: Path,
-    archive_identity: tuple[str, int, int, int, int],
-) -> tuple[Path, bool, str | None, int] | None:
+    archive_identity: str,
+) -> tuple[Path, int] | None:
     checkpoint = cache_root / _RUNTIME_IMPORT_CHECKPOINT
     try:
         payload: Any = json.loads(checkpoint.read_text(encoding="utf-8"))
@@ -403,16 +437,13 @@ def _read_runtime_import_checkpoint(
     if (
         not isinstance(payload, dict)
         or set(payload) not in (
-            {"schema_version", "archive_identity", "candidate", "verified_files", "next_member_index"},
-            {"schema_version", "archive_identity", "candidate", "verified_files", "manifest_sha256", "next_member_index"},
+            {"schema_version", "archive_identity", "candidate", "next_member_index"},
         )
         or payload.get("schema_version") != "olivia.video-runtime-import-checkpoint.v1"
-        or payload.get("archive_identity") != list(archive_identity)
-        or type(payload.get("verified_files")) is not bool
+        or payload.get("archive_identity") != archive_identity
         or type(payload.get("next_member_index")) is not int
         or payload["next_member_index"] < 0
         or not isinstance(payload.get("candidate"), str)
-        or (payload["verified_files"] != ("manifest_sha256" in payload))
     ):
         return None
     candidate_name = payload["candidate"]
@@ -426,14 +457,9 @@ def _read_runtime_import_checkpoint(
         if not candidate.is_dir():
             return None
         _reject_reparse_tree(candidate)
-        manifest_sha256 = (
-            _safe_sha(payload["manifest_sha256"])
-            if "manifest_sha256" in payload
-            else None
-        )
     except (OSError, VideoCapabilityError):
         return None
-    return candidate, payload["verified_files"], manifest_sha256, payload["next_member_index"]
+    return candidate, payload["next_member_index"]
 
 
 def _verify(path: Path, spec: VideoFile) -> None:
@@ -458,7 +484,7 @@ def _portable_python_runtime(python: Path, runtime_root: Path) -> bool:
     runtime_environment.update(PYTHONNOUSERSITE="1", PYTHONSAFEPATH="1")
     try:
         completed = subprocess.run(
-            [str(python), "-I", "-c", script, str(runtime_root)],
+            [str(python), "-I", "-B", "-c", script, str(runtime_root)],
             cwd=runtime_root,
             env=runtime_environment,
             capture_output=True,
@@ -1098,7 +1124,6 @@ class VideoCapabilityInstaller:
         *,
         runtime_root: Path,
         manifest_sha256: str,
-        verify_files: bool = True,
     ) -> str:
         with self._lock:
             self._runtime_import = {
@@ -1110,7 +1135,6 @@ class VideoCapabilityInstaller:
             result = self._import_runtime_root(
                 runtime_root=runtime_root,
                 manifest_sha256=manifest_sha256,
-                verify_files=verify_files,
             )
         except Exception as exc:
             self._set_runtime_import_state(
@@ -1140,39 +1164,37 @@ class VideoCapabilityInstaller:
                 "checked_bytes": 0,
                 "total_bytes": 0,
             }
-        identity = _runtime_archive_identity(archive)
+        identity = _runtime_archive_fingerprint(archive)
         if identity is None:
             raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
         cache_root = _runtime_import_cache(self.data_root)
         checkpoint = _read_runtime_import_checkpoint(cache_root, identity)
         if checkpoint is None:
+            _discard_stale_runtime_checkpoint(cache_root)
             staging = cache_root / f".runtime-staging-{uuid.uuid4().hex}"
             _write_runtime_import_checkpoint(
                 cache_root, archive_identity=identity, candidate=staging
             )
-            verified_files = False
-            manifest_sha256: str | None = None
             next_member_index = 0
         else:
-            staging, verified_files, manifest_sha256, next_member_index = checkpoint
+            staging, next_member_index = checkpoint
         final = self.install_root / "runtime"
         backup = self.install_root / ".runtime.backup"
         try:
-            if not verified_files:
-                resume = staging.exists()
-                _extract_runtime_zip_safely(
-                    archive,
-                    staging,
-                    **({"resume": True} if resume else {}),
-                    next_member_index=next_member_index,
-                    checkpoint_progress=lambda index: _write_runtime_import_checkpoint(
-                        cache_root,
-                        archive_identity=identity,
-                        candidate=staging,
-                        next_member_index=index,
-                    ),
-                    progress=self._update_runtime_extract_progress,
-                )
+            resume = staging.exists()
+            _extract_runtime_zip_safely(
+                archive,
+                staging,
+                **({"resume": True} if resume else {}),
+                next_member_index=next_member_index,
+                checkpoint_progress=lambda index: _write_runtime_import_checkpoint(
+                    cache_root,
+                    archive_identity=identity,
+                    candidate=staging,
+                    next_member_index=index,
+                ),
+                progress=self._update_runtime_extract_progress,
+            )
             with self._lock:
                 self._runtime_import = {
                     "state": "checking",
@@ -1182,54 +1204,43 @@ class VideoCapabilityInstaller:
             manifest_path = staging / "runtime-manifest.json"
             if not manifest_path.is_file() or manifest_path.is_symlink():
                 raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
-            if manifest_sha256 is None:
-                manifest_sha256 = _sha256_file(manifest_path)[1]
-            if not verified_files:
-                try:
-                    _load_runtime_root_manifest(
-                        staging,
-                        manifest_sha256,
-                        verify_files=True,
-                        progress=None,
-                    )
-                except Exception:
-                    _discard_runtime_import_checkpoint(cache_root, staging)
-                    raise
-                _write_runtime_import_checkpoint(
-                    cache_root,
-                    archive_identity=identity,
-                    candidate=staging,
-                    manifest_sha256=manifest_sha256,
-                    verified_files=True,
-                    next_member_index=next_member_index,
+            manifest_sha256 = _sha256_file(manifest_path)[1]
+            try:
+                _load_runtime_root_manifest(
+                    staging,
+                    manifest_sha256,
+                    verify_files=True,
+                    progress=None,
                 )
+            except Exception:
+                _discard_runtime_import_checkpoint(cache_root, staging)
+                raise
             with self._commit_lock:
                 if backup.exists():
                     _restore_interrupted_promotions(self.install_root)
                 if final.exists():
                     _reject_reparse_tree(final)
                     os.replace(final, backup)
-                os.replace(staging, final)
+                shutil.copytree(staging, final, copy_function=os.link)
             try:
                 result = self.import_runtime_root(
                     runtime_root=final.resolve(),
                     manifest_sha256=manifest_sha256,
-                    verify_files=False,
                 )
                 if backup.exists():
                     if backup.is_dir():
                         shutil.rmtree(backup)
                     else:
                         backup.unlink()
-                (cache_root / _RUNTIME_IMPORT_CHECKPOINT).unlink(missing_ok=True)
+                _discard_runtime_import_checkpoint(cache_root, staging)
                 return result
-            except Exception as exc:
+            except BaseException as exc:
                 rollback_error: Exception | None = None
                 with self._commit_lock:
                     try:
                         if final.exists():
                             _reject_reparse_tree(final)
-                            os.replace(final, staging)
+                            shutil.rmtree(final)
                         if backup.exists():
                             os.replace(backup, final)
                     except Exception as restore_exc:
@@ -1239,7 +1250,7 @@ class VideoCapabilityInstaller:
                         "VIDEO_RUNTIME_IMPORT_ROLLBACK_FAILED"
                     ) from rollback_error
                 raise
-        except Exception as exc:
+        except BaseException as exc:
             if backup.exists() and not final.exists():
                 try:
                     os.replace(backup, final)
@@ -1548,7 +1559,6 @@ class VideoCapabilityInstaller:
         *,
         runtime_root: Path,
         manifest_sha256: str,
-        verify_files: bool = True,
     ) -> str:
         try:
             root = runtime_root.resolve(strict=True)
@@ -1558,7 +1568,7 @@ class VideoCapabilityInstaller:
         external_environment = _load_runtime_root_manifest(
             root,
             manifest_sha256,
-            verify_files=verify_files,
+            verify_files=True,
             progress=self._update_runtime_import_progress,
         )
         self._set_runtime_import_state("testing")

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -59,6 +59,8 @@ _MAX_ARCHIVE_EXPANDED_BYTES = 4 * 1024 * 1024 * 1024
 _MAX_RUNTIME_ARCHIVE_EXPANDED_BYTES = 64 * 1024 * 1024 * 1024
 _RUNTIME_PORTABILITY_TIMEOUT_SECONDS = 20.0
 _RUNTIME_HOST_UNAVAILABLE = "VIDEO_RUNTIME_HOST_UNAVAILABLE"
+_RUNTIME_IMPORT_CACHE = ".video-runtime-import-cache"
+_RUNTIME_IMPORT_CHECKPOINT = ".runtime-import-checkpoint.json"
 _RUNTIME_HOST_DEPENDENCIES = frozenset(
     {"cosyvoice", "latentsync", "minimax_music3", "roformer"}
 )
@@ -341,6 +343,97 @@ def _runtime_archive_identity(path: Path) -> tuple[str, int, int, int, int] | No
     except OSError:
         return None
     return (str(path), metadata.st_dev, metadata.st_ino, metadata.st_size, metadata.st_mtime_ns)
+
+
+def _runtime_import_cache(data_root: Path) -> Path:
+    cache_root = data_root / "capabilities" / _RUNTIME_IMPORT_CACHE
+    if cache_root.exists() and (
+        _is_reparse_point(cache_root) or not cache_root.is_dir()
+    ):
+        raise VideoCapabilityError("VIDEO_RUNTIME_IMPORT_CHECKPOINT_INVALID")
+    return cache_root
+
+
+def _discard_runtime_import_checkpoint(cache_root: Path, candidate: Path) -> None:
+    (cache_root / _RUNTIME_IMPORT_CHECKPOINT).unlink(missing_ok=True)
+    try:
+        _reject_reparse_tree(candidate)
+        shutil.rmtree(candidate)
+    except (FileNotFoundError, OSError, VideoCapabilityError):
+        pass
+
+
+def _write_runtime_import_checkpoint(
+    cache_root: Path,
+    *,
+    archive_identity: tuple[str, int, int, int, int],
+    candidate: Path,
+    manifest_sha256: str | None = None,
+    verified_files: bool = False,
+    next_member_index: int = 0,
+) -> None:
+    cache_root.mkdir(parents=True, exist_ok=True)
+    relative_candidate = candidate.relative_to(cache_root).as_posix()
+    payload: dict[str, object] = {
+        "schema_version": "olivia.video-runtime-import-checkpoint.v1",
+        "archive_identity": list(archive_identity),
+        "candidate": relative_candidate,
+        "verified_files": verified_files,
+        "next_member_index": next_member_index,
+    }
+    if manifest_sha256 is not None:
+        payload["manifest_sha256"] = _safe_sha(manifest_sha256)
+    temporary = cache_root / f"{_RUNTIME_IMPORT_CHECKPOINT}.{uuid.uuid4().hex}.tmp"
+    try:
+        temporary.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+        os.replace(temporary, cache_root / _RUNTIME_IMPORT_CHECKPOINT)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _read_runtime_import_checkpoint(
+    cache_root: Path,
+    archive_identity: tuple[str, int, int, int, int],
+) -> tuple[Path, bool, str | None, int] | None:
+    checkpoint = cache_root / _RUNTIME_IMPORT_CHECKPOINT
+    try:
+        payload: Any = json.loads(checkpoint.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    if (
+        not isinstance(payload, dict)
+        or set(payload) not in (
+            {"schema_version", "archive_identity", "candidate", "verified_files", "next_member_index"},
+            {"schema_version", "archive_identity", "candidate", "verified_files", "manifest_sha256", "next_member_index"},
+        )
+        or payload.get("schema_version") != "olivia.video-runtime-import-checkpoint.v1"
+        or payload.get("archive_identity") != list(archive_identity)
+        or type(payload.get("verified_files")) is not bool
+        or type(payload.get("next_member_index")) is not int
+        or payload["next_member_index"] < 0
+        or not isinstance(payload.get("candidate"), str)
+        or (payload["verified_files"] != ("manifest_sha256" in payload))
+    ):
+        return None
+    candidate_name = payload["candidate"]
+    if (
+        not candidate_name.startswith(".runtime-staging-")
+        or Path(candidate_name).name != candidate_name
+    ):
+        return None
+    try:
+        candidate = _inside(cache_root, cache_root / candidate_name)
+        if not candidate.is_dir():
+            return None
+        _reject_reparse_tree(candidate)
+        manifest_sha256 = (
+            _safe_sha(payload["manifest_sha256"])
+            if "manifest_sha256" in payload
+            else None
+        )
+    except (OSError, VideoCapabilityError):
+        return None
+    return candidate, payload["verified_files"], manifest_sha256, payload["next_member_index"]
 
 
 def _verify(path: Path, spec: VideoFile) -> None:
@@ -1005,6 +1098,7 @@ class VideoCapabilityInstaller:
         *,
         runtime_root: Path,
         manifest_sha256: str,
+        verify_files: bool = True,
     ) -> str:
         with self._lock:
             self._runtime_import = {
@@ -1016,6 +1110,7 @@ class VideoCapabilityInstaller:
             result = self._import_runtime_root(
                 runtime_root=runtime_root,
                 manifest_sha256=manifest_sha256,
+                verify_files=verify_files,
             )
         except Exception as exc:
             self._set_runtime_import_state(
@@ -1045,19 +1140,69 @@ class VideoCapabilityInstaller:
                 "checked_bytes": 0,
                 "total_bytes": 0,
             }
-        staging = self.install_root / f".runtime-staging-{uuid.uuid4().hex}"
+        identity = _runtime_archive_identity(archive)
+        if identity is None:
+            raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
+        cache_root = _runtime_import_cache(self.data_root)
+        checkpoint = _read_runtime_import_checkpoint(cache_root, identity)
+        if checkpoint is None:
+            staging = cache_root / f".runtime-staging-{uuid.uuid4().hex}"
+            _write_runtime_import_checkpoint(
+                cache_root, archive_identity=identity, candidate=staging
+            )
+            verified_files = False
+            manifest_sha256: str | None = None
+            next_member_index = 0
+        else:
+            staging, verified_files, manifest_sha256, next_member_index = checkpoint
         final = self.install_root / "runtime"
         backup = self.install_root / ".runtime.backup"
         try:
-            _extract_runtime_zip_safely(
-                archive,
-                staging,
-                progress=self._update_runtime_extract_progress,
-            )
+            if not verified_files:
+                resume = staging.exists()
+                _extract_runtime_zip_safely(
+                    archive,
+                    staging,
+                    **({"resume": True} if resume else {}),
+                    next_member_index=next_member_index,
+                    checkpoint_progress=lambda index: _write_runtime_import_checkpoint(
+                        cache_root,
+                        archive_identity=identity,
+                        candidate=staging,
+                        next_member_index=index,
+                    ),
+                    progress=self._update_runtime_extract_progress,
+                )
+            with self._lock:
+                self._runtime_import = {
+                    "state": "checking",
+                    "checked_bytes": 0,
+                    "total_bytes": 0,
+                }
             manifest_path = staging / "runtime-manifest.json"
             if not manifest_path.is_file() or manifest_path.is_symlink():
                 raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
-            manifest_sha256 = _sha256_file(manifest_path)[1]
+            if manifest_sha256 is None:
+                manifest_sha256 = _sha256_file(manifest_path)[1]
+            if not verified_files:
+                try:
+                    _load_runtime_root_manifest(
+                        staging,
+                        manifest_sha256,
+                        verify_files=True,
+                        progress=None,
+                    )
+                except Exception:
+                    _discard_runtime_import_checkpoint(cache_root, staging)
+                    raise
+                _write_runtime_import_checkpoint(
+                    cache_root,
+                    archive_identity=identity,
+                    candidate=staging,
+                    manifest_sha256=manifest_sha256,
+                    verified_files=True,
+                    next_member_index=next_member_index,
+                )
             with self._commit_lock:
                 if backup.exists():
                     _restore_interrupted_promotions(self.install_root)
@@ -1069,9 +1214,14 @@ class VideoCapabilityInstaller:
                 result = self.import_runtime_root(
                     runtime_root=final.resolve(),
                     manifest_sha256=manifest_sha256,
+                    verify_files=False,
                 )
                 if backup.exists():
-                    shutil.rmtree(backup)
+                    if backup.is_dir():
+                        shutil.rmtree(backup)
+                    else:
+                        backup.unlink()
+                (cache_root / _RUNTIME_IMPORT_CHECKPOINT).unlink(missing_ok=True)
                 return result
             except Exception as exc:
                 rollback_error: Exception | None = None
@@ -1079,7 +1229,7 @@ class VideoCapabilityInstaller:
                     try:
                         if final.exists():
                             _reject_reparse_tree(final)
-                            shutil.rmtree(final)
+                            os.replace(final, staging)
                         if backup.exists():
                             os.replace(backup, final)
                     except Exception as restore_exc:
@@ -1103,8 +1253,7 @@ class VideoCapabilityInstaller:
             )
             raise
         finally:
-            if staging.exists():
-                shutil.rmtree(staging, ignore_errors=True)
+            pass
 
     def start_runtime_archive_import(self, *, runtime_archive: Path) -> str:
         try:
@@ -1399,6 +1548,7 @@ class VideoCapabilityInstaller:
         *,
         runtime_root: Path,
         manifest_sha256: str,
+        verify_files: bool = True,
     ) -> str:
         try:
             root = runtime_root.resolve(strict=True)
@@ -1408,7 +1558,7 @@ class VideoCapabilityInstaller:
         external_environment = _load_runtime_root_manifest(
             root,
             manifest_sha256,
-            verify_files=True,
+            verify_files=verify_files,
             progress=self._update_runtime_import_progress,
         )
         self._set_runtime_import_state("testing")
@@ -1927,11 +2077,16 @@ def _extract_runtime_zip_safely(
     archive_path: Path,
     destination: Path,
     *,
+    resume: bool = False,
+    next_member_index: int = 0,
+    checkpoint_progress: Callable[[int], None] | None = None,
     progress: Callable[[int, int], None] | None = None,
 ) -> None:
     """Extract a published portable runtime; its signed manifest verifies files next."""
 
-    destination.mkdir(parents=True, exist_ok=False)
+    destination.mkdir(parents=True, exist_ok=resume)
+    if resume:
+        _reject_reparse_tree(destination)
     written: set[str] = set()
     extracted_bytes = 0
     try:
@@ -1942,6 +2097,7 @@ def _extract_runtime_zip_safely(
                 raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_TOO_LARGE")
             if progress is not None:
                 progress(0, total_bytes)
+            normalized: list[tuple[zipfile.ZipInfo, str]] = []
             for member in members:
                 mode = (member.external_attr >> 16) & 0o170000
                 raw = (
@@ -1960,19 +2116,51 @@ def _extract_runtime_zip_safely(
                 if folded in written:
                     raise VideoCapabilityError("VIDEO_ARCHIVE_DUPLICATE_PATH")
                 written.add(folded)
+                normalized.append((member, relative))
+            start_index = 0
+            if resume:
+                checkpoint_index = min(next_member_index, len(normalized))
+                start_index = max(0, checkpoint_index - 256)
+                for member, relative in normalized[start_index:checkpoint_index]:
+                    if member.is_dir():
+                        continue
+                    target = _inside(destination, destination / relative)
+                    if (
+                        not target.is_file()
+                        or _is_reparse_point(target)
+                        or target.stat().st_size != member.file_size
+                    ):
+                        break
+                    start_index += 1
+            for index, (member, relative) in enumerate(normalized[start_index:], start=start_index):
                 target = _inside(destination, destination / relative)
                 if member.is_dir():
+                    if target.exists() and not target.is_dir():
+                        raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
                     target.mkdir(parents=True, exist_ok=True)
                     continue
                 target.parent.mkdir(parents=True, exist_ok=True)
+                if target.exists():
+                    if not target.is_file() or _is_reparse_point(target):
+                        raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
+                    if target.stat().st_size == member.file_size:
+                        extracted_bytes += member.file_size
+                        if progress is not None:
+                            progress(extracted_bytes, total_bytes)
+                        continue
+                    target.unlink()
                 with archive.open(member) as source, target.open("xb") as output:
                     while chunk := source.read(1024 * 1024):
                         output.write(chunk)
                         extracted_bytes += len(chunk)
                         if progress is not None:
                             progress(extracted_bytes, total_bytes)
+                if checkpoint_progress is not None and (index + 1) % 256 == 0:
+                    checkpoint_progress(index + 1)
+            if checkpoint_progress is not None:
+                checkpoint_progress(len(normalized))
             if "runtime-manifest.json" not in {
-                value.casefold() for value in written
+                value.casefold() for _, value in normalized
             }:
                 raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
     except (OSError, zipfile.BadZipFile, ComponentUpdateError) as exc:


### PR DESCRIPTION
Outcome: preserve the 12.5 GB private video runtime extraction across installer rollback and process interruption. The checkpoint records extraction progress only; a stable ZIP central-directory fingerprint permits same-content sidecar copies to resume, while every restored candidate still receives full manifest, file, path-set, and reparse validation. The cache candidate remains outside the rolled-back video root until TTS/readiness/profile/status complete, and portable probes use -B. Invalid and foreign checkpoints are cleaned.

Scope: video_capability_install.py, focused installer tests, and P03_05 documentation only. No Live behavior or model assets.

Validation: 84 targeted tests passed; compileall and git diff --check passed. Frozen pair d185f2f89a0f1bf40b999a9a785fcc37f77aeb28...ab82dede93d5d610f874f96425acb3f129ec02c8.

Review trace: round 1 Standards/Spec BLOCK findings were repaired on a fresh head. Final round remained P0=0. Standards: P1=1 (exceptional copytree/checkpoint-cleanup rollback ordering). Spec: P1=3/P2=2 (duplicate verification, mutable cache trust anchor, the same rollback ordering, orphan/progress edges). Per the user-authorized two-round rule, P1 findings after round 2 do not trigger a third head/review cycle; P0 would remain blocking. The separate bounded-parallel verifier slice addresses verification latency without weakening full-file checks.