### PR TITLE
perf(installer): verify private runtime files in parallel

### DIFF
--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import Future, ThreadPoolExecutor
 import json
 import hashlib
 import os
@@ -1702,6 +1703,212 @@ def test_runtime_manifest_verification_reports_real_byte_progress(tmp_path: Path
     assert [checked for checked, _total in progress] == sorted(
         checked for checked, _total in progress
     )
+
+
+def test_runtime_manifest_file_hashes_run_in_parallel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = (tmp_path / "runtime").resolve()
+    python = runtime_root / "python/python.exe"
+    python.parent.mkdir(parents=True)
+    python.write_bytes(b"python")
+    for index in range(4):
+        target = runtime_root / f"packages/item-{index}.bin"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(f"item-{index}".encode())
+    manifest_sha256 = write_runtime_root_manifest(
+        runtime_root,
+        version="parallel-test",
+        environment={"OLIVIA_LATENTSYNC_PYTHON": "python/python.exe"},
+    )
+    real_sha256_file = video_capability_install._sha256_file
+    started_together = threading.Event()
+    active = 0
+    maximum_active = 0
+    lock = threading.Lock()
+
+    def observed_sha256(path: Path, **kwargs: object) -> tuple[int, str]:
+        nonlocal active, maximum_active
+        if path.name == "runtime-manifest.json":
+            return real_sha256_file(path, **kwargs)
+        with lock:
+            active += 1
+            maximum_active = max(maximum_active, active)
+            if active >= 2:
+                started_together.set()
+        try:
+            started_together.wait(timeout=0.5)
+            return real_sha256_file(path, **kwargs)
+        finally:
+            with lock:
+                active -= 1
+
+    monkeypatch.setattr(video_capability_install, "_sha256_file", observed_sha256)
+    monkeypatch.setattr(video_capability_install.os, "cpu_count", lambda: 4)
+
+    video_capability_install._load_runtime_root_manifest(
+        runtime_root,
+        manifest_sha256,
+        verify_files=True,
+    )
+
+    assert maximum_active >= 2
+
+
+def test_runtime_manifest_parallel_hash_queue_is_bounded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = (tmp_path / "runtime").resolve()
+    python = runtime_root / "python/python.exe"
+    python.parent.mkdir(parents=True)
+    python.write_bytes(b"python")
+    for index in range(64):
+        target = runtime_root / f"packages/item-{index:03d}.bin"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(f"item-{index}".encode())
+    manifest_sha256 = write_runtime_root_manifest(
+        runtime_root,
+        version="bounded-test",
+        environment={"OLIVIA_LATENTSYNC_PYTHON": "python/python.exe"},
+    )
+    real_sha256_file = video_capability_install._sha256_file
+    release = threading.Event()
+    pending = 0
+    maximum_pending = 0
+    lock = threading.Lock()
+
+    class TrackedFuture:
+        def __init__(self, future: Future[tuple[int, str]]) -> None:
+            self._future = future
+            self._released = False
+
+        def _release(self) -> None:
+            nonlocal pending
+            with lock:
+                if not self._released:
+                    self._released = True
+                    pending -= 1
+
+        def result(self) -> tuple[int, str]:
+            try:
+                return self._future.result()
+            finally:
+                self._release()
+
+        def cancel(self) -> bool:
+            cancelled = self._future.cancel()
+            if cancelled:
+                self._release()
+            return cancelled
+
+    class TrackingExecutor:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self._executor = ThreadPoolExecutor(*args, **kwargs)
+
+        def submit(self, function: object, *args: object) -> TrackedFuture:
+            nonlocal pending, maximum_pending
+            future = self._executor.submit(function, *args)
+            with lock:
+                pending += 1
+                maximum_pending = max(maximum_pending, pending)
+            return TrackedFuture(future)
+
+        def shutdown(self, **kwargs: object) -> None:
+            self._executor.shutdown(**kwargs)
+
+    def blocked_sha256(path: Path, **kwargs: object) -> tuple[int, str]:
+        if path.name != "runtime-manifest.json":
+            release.wait(timeout=1)
+        return real_sha256_file(path, **kwargs)
+
+    monkeypatch.setattr(video_capability_install, "ThreadPoolExecutor", TrackingExecutor)
+    monkeypatch.setattr(video_capability_install, "_sha256_file", blocked_sha256)
+    monkeypatch.setattr(video_capability_install.os, "cpu_count", lambda: 4)
+    timer = threading.Timer(0.2, release.set)
+    timer.start()
+    try:
+        video_capability_install._load_runtime_root_manifest(
+            runtime_root,
+            manifest_sha256,
+            verify_files=True,
+        )
+    finally:
+        release.set()
+        timer.cancel()
+
+    assert maximum_pending <= 8
+    assert maximum_pending < 64
+
+
+def test_runtime_manifest_parallel_hash_rejects_same_size_tamper(
+    tmp_path: Path,
+) -> None:
+    runtime_root = (tmp_path / "runtime").resolve()
+    python = runtime_root / "python/python.exe"
+    python.parent.mkdir(parents=True)
+    python.write_bytes(b"original")
+    manifest_sha256 = write_runtime_root_manifest(
+        runtime_root,
+        version="tamper-test",
+        environment={"OLIVIA_LATENTSYNC_PYTHON": "python/python.exe"},
+    )
+    python.write_bytes(b"tampered")
+
+    with pytest.raises(VideoCapabilityError, match="^VIDEO_RUNTIME_ROOT_INVALID$"):
+        video_capability_install._load_runtime_root_manifest(
+            runtime_root,
+            manifest_sha256,
+            verify_files=True,
+        )
+
+
+def test_runtime_manifest_parallel_hash_reports_first_manifest_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = (tmp_path / "runtime").resolve()
+    first = runtime_root / "a-first.bin"
+    first.parent.mkdir(parents=True)
+    first.write_bytes(b"first")
+    second = runtime_root / "b-second.bin"
+    second.write_bytes(b"second")
+    manifest_sha256 = write_runtime_root_manifest(
+        runtime_root,
+        version="ordered-error-test",
+        environment={"OLIVIA_LATENTSYNC_PYTHON": "a-first.bin"},
+    )
+    real_sha256_file = video_capability_install._sha256_file
+    both_started = threading.Event()
+    started = 0
+    lock = threading.Lock()
+
+    def failing_sha256(path: Path, **kwargs: object) -> tuple[int, str]:
+        nonlocal started
+        if path.name == "runtime-manifest.json":
+            return real_sha256_file(path, **kwargs)
+        with lock:
+            started += 1
+            if started >= 2:
+                both_started.set()
+        both_started.wait(timeout=1)
+        if path.name == "a-first.bin":
+            raise FileNotFoundError("first manifest entry")
+        raise PermissionError("second manifest entry")
+
+    monkeypatch.setattr(video_capability_install, "_sha256_file", failing_sha256)
+    monkeypatch.setattr(video_capability_install.os, "cpu_count", lambda: 2)
+
+    with pytest.raises(VideoCapabilityError) as error:
+        video_capability_install._load_runtime_root_manifest(
+            runtime_root,
+            manifest_sha256,
+            verify_files=True,
+        )
+
+    assert isinstance(error.value.__cause__, FileNotFoundError)
+    assert str(error.value.__cause__) == "first manifest entry"
 
 
 def test_runtime_manifest_generator_hashes_the_exact_sorted_tree(tmp_path: Path) -> None:

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Callable, Mapping
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import StrEnum
 import hashlib
@@ -58,6 +60,8 @@ _PORTABLE_RUNTIME_ENVIRONMENT_KEYS = frozenset(("OLIVIA_COSYVOICE_PYTHON", "OLIV
 _MAX_ARCHIVE_EXPANDED_BYTES = 4 * 1024 * 1024 * 1024
 _MAX_RUNTIME_ARCHIVE_EXPANDED_BYTES = 64 * 1024 * 1024 * 1024
 _RUNTIME_PORTABILITY_TIMEOUT_SECONDS = 20.0
+_RUNTIME_MANIFEST_MAX_WORKERS = 8
+_RUNTIME_MANIFEST_PENDING_PER_WORKER = 2
 _RUNTIME_HOST_UNAVAILABLE = "VIDEO_RUNTIME_HOST_UNAVAILABLE"
 _RUNTIME_IMPORT_CACHE = ".video-runtime-import-cache"
 _RUNTIME_IMPORT_CHECKPOINT = ".runtime-import-checkpoint.json"
@@ -511,6 +515,76 @@ def _runtime_environment_is_portable(
     )
 
 
+def _verify_runtime_manifest_files(
+    specifications: list[tuple[Path, int, str]],
+    *,
+    total_bytes: int,
+    progress: Callable[[int, int], None] | None,
+) -> None:
+    if not specifications:
+        return
+    workers = min(
+        len(specifications),
+        _RUNTIME_MANIFEST_MAX_WORKERS,
+        max(1, os.cpu_count() or 1),
+    )
+    pending_limit = workers * _RUNTIME_MANIFEST_PENDING_PER_WORKER
+    stop = threading.Event()
+    progress_lock = threading.Lock()
+    file_progress = [0] * len(specifications)
+    checked_bytes = 0
+
+    def report(index: int, current: int) -> None:
+        nonlocal checked_bytes
+        if progress is None:
+            return
+        with progress_lock:
+            delta = max(0, current - file_progress[index])
+            if delta == 0:
+                return
+            file_progress[index] = current
+            checked_bytes = min(total_bytes, checked_bytes + delta)
+            progress(checked_bytes, total_bytes)
+
+    def verify(index: int) -> tuple[int, str]:
+        candidate, _expected_size, _expected_digest = specifications[index]
+        return _sha256_file(
+            candidate,
+            pause=stop,
+            progress=(None if progress is None else lambda current: report(index, current)),
+        )
+
+    executor = ThreadPoolExecutor(
+        max_workers=workers,
+        thread_name_prefix="olivia-runtime-verify",
+    )
+    pending: deque[tuple[int, Future[tuple[int, str]]]] = deque()
+    next_index = 0
+    try:
+        while next_index < len(specifications) and len(pending) < pending_limit:
+            pending.append((next_index, executor.submit(verify, next_index)))
+            next_index += 1
+        while pending:
+            index, future = pending.popleft()
+            try:
+                actual = future.result()
+            except OSError as exc:
+                stop.set()
+                raise VideoCapabilityError("VIDEO_RUNTIME_ROOT_INVALID") from exc
+            _candidate, expected_size, expected_digest = specifications[index]
+            if actual != (expected_size, expected_digest):
+                stop.set()
+                raise VideoCapabilityError("VIDEO_RUNTIME_ROOT_INVALID")
+            while next_index < len(specifications) and len(pending) < pending_limit:
+                pending.append((next_index, executor.submit(verify, next_index)))
+                next_index += 1
+    finally:
+        stop.set()
+        for _index, future in pending:
+            future.cancel()
+        executor.shutdown(wait=True, cancel_futures=True)
+
+
 def _load_runtime_root_manifest(
     runtime_root: Path,
     manifest_sha256: str,
@@ -579,9 +653,9 @@ def _load_runtime_root_manifest(
         ):
             raise VideoCapabilityError("VIDEO_RUNTIME_ROOT_INVALID")
         total_bytes += raw["size_bytes"]
-    checked_bytes = 0
     if verify_files and progress is not None:
         progress(0, total_bytes)
+    specifications: list[tuple[Path, int, str]] = []
     for raw in payload["files"]:
         try:
             relative = _safe_relative(raw.get("path"))
@@ -594,25 +668,13 @@ def _load_runtime_root_manifest(
             raise VideoCapabilityError("VIDEO_RUNTIME_ROOT_INVALID")
         seen_files.add(folded)
         files[relative] = (raw["size_bytes"], digest)
-        if verify_files:
-            try:
-                actual_size, actual_digest = _sha256_file(
-                    candidate,
-                    progress=(
-                        None
-                        if progress is None
-                        else lambda current, base=checked_bytes: progress(
-                            min(total_bytes, base + current), total_bytes
-                        )
-                    ),
-                )
-            except OSError as exc:
-                raise VideoCapabilityError("VIDEO_RUNTIME_ROOT_INVALID") from exc
-            if (actual_size, actual_digest) != files[relative]:
-                raise VideoCapabilityError("VIDEO_RUNTIME_ROOT_INVALID")
-            checked_bytes += actual_size
-            if progress is not None:
-                progress(checked_bytes, total_bytes)
+        specifications.append((candidate, raw["size_bytes"], digest))
+    if verify_files:
+        _verify_runtime_manifest_files(
+            specifications,
+            total_bytes=total_bytes,
+            progress=progress,
+        )
     required_files = {
         relative
         for key, relative in environment_paths.items()


### PR DESCRIPTION
Outcome: reduce full private video runtime verification from the observed 65-80 minute serial path to a bounded parallel path. The verifier uses 1-8 workers with at most 16 pending futures, consumes results in manifest order for deterministic first failure, reports monotonic aggregate progress, and stops/cancels workers on failure.

Integrity contract is unchanged: manifest schema/environment/path/duplicate checks, every declared file size and SHA-256, reparse rejection, and exact path-set checks remain required. No verify bypass was added; the checkpoint pre-check and public import each still perform full verification.

Scope: video_capability_install.py and focused installer tests only. Frozen pair 88ec646dac7de082e1ead662f27da0145dfc846a...43d3155055c5836d0dcaa5af19bb9d72ee20a129. Validation: 88 targeted tests, py_compile, and diff-check passed. Real equivalent diagnostic: 178,818 files / 21.33 GB / 0 failures in 420.047 seconds at 16 workers; production is capped at 8 for cross-machine stability.

Exact-pair review trace: Standards PASS and Spec PASS, P0/P1/P2=0 on both axes. GitHub CI 3/3 SUCCESS.