### PR TITLE
fix(installer): show progress and retry runtime archive locks

### DIFF
--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -64,6 +64,85 @@ function Write-SetupDiagnosticResult {
     }
 }
 
+$script:SetupProgressPhases = @(
+    'PREPARE',
+    'VERIFY_OFFICIAL',
+    'VERIFY_CORE',
+    'INSTALL_CORE',
+    'INSTALL_PATCH',
+    'COPY_VIDEO_RUNTIME',
+    'VERIFY_VIDEO_OFFLINE',
+    'INSTALL_ORDINARY_VIDEO',
+    'INSTALL_MUSIC_VIDEO',
+    'EXTRACT_VIDEO_RUNTIME',
+    'VERIFY_VIDEO_RUNTIME',
+    'TEST_VIDEO_RUNTIME',
+    'FINALIZE'
+)
+$script:SetupProgressLinePattern = '^OLIVIA_SETUP_PROGRESS=(?<phase>' +
+    (($script:SetupProgressPhases | ForEach-Object { [regex]::Escape($_) }) -join '|') +
+    ')\|(?<current>[0-9]{1,19})\|(?<total>[0-9]{1,19})$'
+
+function Write-SetupProgress {
+    param(
+        [Parameter(Mandatory)][string]$Phase,
+        [Parameter(Mandatory)][int64]$CurrentBytes,
+        [Parameter(Mandatory)][int64]$TotalBytes
+    )
+
+    try {
+        if (
+            $script:SetupProgressPhases -cnotcontains $Phase -or
+            $CurrentBytes -lt 0 -or
+            $TotalBytes -lt 0 -or
+            ($TotalBytes -gt 0 -and $CurrentBytes -gt $TotalBytes)
+        ) {
+            return
+        }
+        $line = 'OLIVIA_SETUP_PROGRESS=' + $Phase + '|' +
+            $CurrentBytes.ToString([Globalization.CultureInfo]::InvariantCulture) + '|' +
+            $TotalBytes.ToString([Globalization.CultureInfo]::InvariantCulture)
+        [Console]::Out.WriteLine($line)
+        [Console]::Out.Flush()
+    } catch {
+        # Progress is advisory and must never change installation behavior.
+    }
+}
+
+function Forward-SetupProgressLine {
+    param([Parameter(Mandatory)][string]$Line)
+
+    try {
+        $match = [regex]::Match($Line, $script:SetupProgressLinePattern)
+        if (-not $match.Success) { return $false }
+        [int64]$current = 0
+        [int64]$total = 0
+        if (
+            -not [int64]::TryParse(
+                $match.Groups['current'].Value,
+                [Globalization.NumberStyles]::None,
+                [Globalization.CultureInfo]::InvariantCulture,
+                [ref]$current
+            ) -or
+            -not [int64]::TryParse(
+                $match.Groups['total'].Value,
+                [Globalization.NumberStyles]::None,
+                [Globalization.CultureInfo]::InvariantCulture,
+                [ref]$total
+            ) -or
+            $current -lt 0 -or
+            $total -lt 0 -or
+            ($total -gt 0 -and $current -gt $total)
+        ) {
+            return $false
+        }
+        Write-SetupProgress -Phase $match.Groups['phase'].Value -CurrentBytes $current -TotalBytes $total
+        return $true
+    } catch {
+        return $false
+    }
+}
+
 trap {
     $safeCode = Get-SafeSetupErrorCode -Code ([string]$_.Exception.Message)
     Write-SetupDiagnosticResult -Diagnostic $script:OfficialSourceDiagnostic
@@ -722,6 +801,8 @@ function Copy-FileWithSha256 {
     )
 
     $sourceStream, $destinationStream, $hasher = $null, $null, $null
+    [int64]$totalBytes = [IO.FileInfo]::new($Source).Length
+    Write-SetupProgress -Phase 'COPY_VIDEO_RUNTIME' -CurrentBytes 0 -TotalBytes $totalBytes
     try {
         $sourceStream = [IO.File]::Open($Source, [IO.FileMode]::Open, [IO.FileAccess]::Read, [IO.FileShare]::Read)
         $destinationStream = [IO.File]::Open($Destination, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
@@ -733,6 +814,7 @@ function Copy-FileWithSha256 {
             [void]$hasher.TransformBlock($buffer, 0, $read, $buffer, 0)
             $destinationStream.Write($buffer, 0, $read)
             $size += $read
+            Write-SetupProgress -Phase 'COPY_VIDEO_RUNTIME' -CurrentBytes $size -TotalBytes $totalBytes
         }
         [void]$hasher.TransformFinalBlock($empty, 0, 0)
         $destinationStream.Flush($true)
@@ -1563,8 +1645,10 @@ function Test-ManagedServerDependencies {
     }
 }
 
+Write-SetupProgress -Phase 'PREPARE' -CurrentBytes 0 -TotalBytes 0
 Assert-ManagedRuntimeParent -ProductRoot $productRoot -RuntimePath $runtimeRoot
 Repair-ManagedInstallTransaction -ProductRoot $productRoot -InstallRoot $Destination -RuntimeRoot $runtimeRoot
+Write-SetupProgress -Phase 'VERIFY_OFFICIAL' -CurrentBytes 0 -TotalBytes 0
 $selectedOfficial = $OfficialRoot
 if (-not $selectedOfficial -and -not $NonInteractive) {
     $selectedOfficial = Read-Host 'Steam 游戏目录（留空则按 AppID 自动发现）'
@@ -1580,7 +1664,10 @@ if (Test-PathsOverlap -Left $productRoot -Right $selectedOfficial) {
 $script:OfficialSourceDiagnostic = New-OfficialSourceDiagnostic -Selection $officialSelection -ManifestPath $manifestPath
 Write-SetupDiagnosticResult -Diagnostic $script:OfficialSourceDiagnostic
 Assert-OfficialSource -SourceRoot $selectedOfficial -ManifestPath $manifestPath
+Write-SetupProgress -Phase 'VERIFY_OFFICIAL' -CurrentBytes 1 -TotalBytes 1
+Write-SetupProgress -Phase 'VERIFY_CORE' -CurrentBytes 0 -TotalBytes 0
 $coreAssets = Get-OfflineCoreAssets -Root $offlineRoot -ManifestPath $offlineManifestPath -RequirementsPath $requirements -VideoRuntimePath $VideoRuntimePath -VideoOfflineRoot $VideoOfflineRoot
+Write-SetupProgress -Phase 'VERIFY_CORE' -CurrentBytes 1 -TotalBytes 1
 New-Item -ItemType Directory -Force -Path $productRoot | Out-Null
 $installRootExisted = [IO.Directory]::Exists($Destination); $runtimeRootExisted = Test-Path -LiteralPath $runtimeRoot
 $installTransactionId = [guid]::NewGuid().ToString('N')
@@ -1593,6 +1680,7 @@ New-ManagedInstallRollbackSnapshot -InstallRoot $Destination -Snapshot $installR
 Set-DurableTransactionState -Path "$installTransaction.active" -State $installState
 New-Item -ItemType Directory -Force -Path (Split-Path -Parent $runtimeRoot) | Out-Null
 try {
+    Write-SetupProgress -Phase 'INSTALL_CORE' -CurrentBytes 0 -TotalBytes 0
     Expand-Archive -LiteralPath $coreAssets.Runtime -DestinationPath $runtimeStaging -Force
     if (-not [IO.File]::Exists((Join-Path $runtimeStaging 'python.exe'))) {
         throw 'OFFLINE_CORE_RUNTIME_INVALID'
@@ -1633,6 +1721,7 @@ try {
         }
         throw 'OFFLINE_CORE_RUNTIME_PUBLISH_FAILED'
     }
+    Write-SetupProgress -Phase 'INSTALL_CORE' -CurrentBytes 1 -TotalBytes 1
 } catch {
     Repair-ManagedInstallTransaction -ProductRoot $productRoot -InstallRoot $Destination -RuntimeRoot $runtimeRoot
     throw
@@ -1643,6 +1732,7 @@ $arguments = @('install', '--payload', $PayloadRoot, '--destination', $Destinati
 $oldPythonPath = if ($env:PYTHONPATH) { $env:PYTHONPATH } else { '' }
 $env:PYTHONPATH = $PayloadRoot + [IO.Path]::PathSeparator + $oldPythonPath
 $bootstrap = Join-Path $PayloadRoot 'installer\bootstrap_install.py'
+Write-SetupProgress -Phase 'INSTALL_PATCH' -CurrentBytes 0 -TotalBytes 0
 $installOutput = @(& $runner.File @($runner.Args + @($bootstrap, $PayloadRoot) + $arguments))
 $installExitCode = $LASTEXITCODE
 if ($installExitCode -ne 0) {
@@ -1666,6 +1756,7 @@ if ($installExitCode -ne 0) {
     if (-not $SetupResultPath) { $installOutput | Write-Output }
     exit $installExitCode
 }
+Write-SetupProgress -Phase 'INSTALL_PATCH' -CurrentBytes 1 -TotalBytes 1
 try {
     $privateVideoPending = "$installTransaction.private-video-pending"
     $privateVideoTransaction = $null
@@ -1680,6 +1771,7 @@ try {
     }
     Install-ManagedVoiceReference -VoiceReference $coreAssets.VoiceReference -InstallRoot $Destination
     if ($null -ne $coreAssets.VideoOffline) {
+        Write-SetupProgress -Phase 'VERIFY_VIDEO_OFFLINE' -CurrentBytes 0 -TotalBytes 0
         $privateVideoActivator = Join-Path $PayloadRoot 'installer\activate_private_video.py'
         if (-not [IO.File]::Exists($privateVideoActivator)) {
             throw 'VIDEO_PRIVATE_ACTIVATION_FAILED'
@@ -1697,7 +1789,14 @@ try {
             '--expected-size-bytes', [string]$coreAssets.VideoOffline.size_bytes,
             '--timeout-seconds', '14400'
         )
-        $privateVideoOutput = @(& $runner.File @($runner.Args + @($privateVideoActivator) + $privateVideoArguments))
+        $privateVideoOutput = [Collections.Generic.List[string]]::new()
+        & $runner.File @($runner.Args + @($privateVideoActivator) + $privateVideoArguments) |
+            ForEach-Object {
+                $line = [string]$_
+                if (-not (Forward-SetupProgressLine -Line $line)) {
+                    [void]$privateVideoOutput.Add($line)
+                }
+            }
         $privateVideoExitCode = $LASTEXITCODE
         $privateVideoStatus = $null
         $privateVideoFailure = 'VIDEO_PRIVATE_ACTIVATION_FAILED'
@@ -1724,6 +1823,7 @@ try {
         }
         if ($privateVideoExitCode -ne 0) { throw $privateVideoFailure }
         if ($privateVideoStatus -notin @('READY', 'UNAVAILABLE')) { throw 'VIDEO_PRIVATE_NOT_READY' }
+        Write-SetupProgress -Phase 'VERIFY_VIDEO_OFFLINE' -CurrentBytes 1 -TotalBytes 1
     }
 } catch {
     $assetFailure = [string]$_.Exception.Message
@@ -1744,10 +1844,12 @@ try {
     throw $assetFailure
 }
 
+Write-SetupProgress -Phase 'FINALIZE' -CurrentBytes 0 -TotalBytes 0
 try { [IO.File]::Move("$installTransaction.active", "$installTransaction.cleanup"); Repair-ManagedInstallTransaction -ProductRoot $productRoot -InstallRoot $Destination -RuntimeRoot $runtimeRoot }
 catch { throw 'VOICE_REFERENCE_INSTALL_CLEANUP_FAILED' }
 try { Complete-ManagedVideoRuntimeTransaction -Transaction $videoRuntimeTransaction }
 catch { Write-Warning 'VIDEO_RUNTIME_INSTALL_CLEANUP_DEFERRED' }
+Write-SetupProgress -Phase 'FINALIZE' -CurrentBytes 1 -TotalBytes 1
 if (-not $SetupResultPath) { $installOutput | Write-Output }
 
 $LASTEXITCODE = 0

--- a/installer/activate_private_video.py
+++ b/installer/activate_private_video.py
@@ -31,6 +31,7 @@ OFFLINE_ROOT_NAME = "Olivia-video-offline-private"
 RUNTIME_ARCHIVE_NAME = "Olivia-video-runtime-private.zip"
 _ASSEMBLED_STATES = {"ready", "prerequisites_required"}
 _ACTIVE_STATES = {"missing", "queued", "downloading", "verifying"}
+_SETUP_PROGRESS_PREFIX = "OLIVIA_SETUP_PROGRESS="
 
 
 class PrivateVideoActivationError(RuntimeError):
@@ -45,11 +46,50 @@ class _ManifestSnapshot:
         return self._payload.decode(encoding)
 
 
-def _sha256(path: Path) -> str:
+def _report_progress(
+    progress: Callable[[str, int, int], object] | None,
+    phase: str,
+    current: int,
+    total: int,
+) -> None:
+    if progress is None:
+        return
+    try:
+        progress(phase, max(0, current), max(0, total))
+    except Exception:
+        pass
+
+
+def _setup_progress_writer(
+    write_line: Callable[[str], object] | None = None,
+) -> Callable[[str, int, int], None]:
+    if write_line is None:
+        write_line = lambda line: print(line, flush=True)
+    reported: dict[str, tuple[int, int]] = {}
+
+    def emit(phase: str, current: int, total: int) -> None:
+        previous = reported.get(phase)
+        if previous == (current, total):
+            return
+        if total > 0 and current not in {0, total}:
+            minimum_delta = max(64 * 1024 * 1024, total // 1_000)
+            if previous is not None and current - previous[0] < minimum_delta:
+                return
+        reported[phase] = (current, total)
+        write_line(f"{_SETUP_PROGRESS_PREFIX}{phase}|{current}|{total}")
+
+    return emit
+
+
+def _sha256(path: Path, *, progress: Callable[[int], object] | None = None) -> str:
     digest = hashlib.sha256()
+    checked = 0
     with path.open("rb") as stream:
         for block in iter(lambda: stream.read(1 << 20), b""):
             digest.update(block)
+            checked += len(block)
+            if progress is not None:
+                progress(checked)
     return digest.hexdigest()
 
 
@@ -107,6 +147,7 @@ def _verify_offline_root(
     *,
     expected_file_count: int,
     expected_size_bytes: int,
+    progress: Callable[[str, int, int], object] | None = None,
 ) -> Path:
     candidate = _absolute_path(root, code="VIDEO_PRIVATE_OFFLINE_INVALID")
     if candidate.name != OFFLINE_ROOT_NAME or not candidate.is_dir() or _is_reparse_point(candidate):
@@ -164,18 +205,37 @@ def _verify_offline_root(
     }
     if set(actual) != set(expected) or actual_directories - expected_directories:
         raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID")
+    checked_bytes = 0
+    _report_progress(
+        progress, "VERIFY_VIDEO_OFFLINE", checked_bytes, expected_size_bytes
+    )
     for folded, (_, size, digest) in expected.items():
         path = actual[folded]
         try:
-            if path.stat().st_size != size or _sha256(path) != digest:
+            if path.stat().st_size != size or _sha256(
+                path,
+                progress=lambda current, base=checked_bytes: _report_progress(
+                    progress,
+                    "VERIFY_VIDEO_OFFLINE",
+                    base + current,
+                    expected_size_bytes,
+                ),
+            ) != digest:
                 raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID")
         except OSError as exc:
             raise PrivateVideoActivationError("VIDEO_PRIVATE_OFFLINE_INVALID") from exc
+        checked_bytes += size
+        _report_progress(
+            progress, "VERIFY_VIDEO_OFFLINE", checked_bytes, expected_size_bytes
+        )
     return candidate
 
 
 def _create_installer(
-    *, install_root: Path, manifest: VideoManifest
+    *,
+    install_root: Path,
+    manifest: VideoManifest,
+    runtime_progress: Callable[[str, int, int], object] | None = None,
 ) -> VideoCapabilityInstaller:
     data_root = install_root / "data"
     environment = _load_fixed_video_assets_environment(
@@ -205,6 +265,7 @@ def _create_installer(
         manifest=manifest,
         readiness_probe=readiness,
         runtime_environment_applier=os.environ.update,
+        runtime_progress=runtime_progress,
     )
 
 
@@ -225,11 +286,14 @@ def _wait_for_bundle(
     deadline: float,
     clock: Callable[[], float],
     sleep: Callable[[float], object],
+    phase: str,
+    progress: Callable[[str, int, int], object] | None,
 ) -> None:
     while True:
         item = _bundle_state(installer.status(), bundle_id)
         state = item.get("state")
         if state in _ASSEMBLED_STATES:
+            _report_progress(progress, phase, 1, 1)
             return
         if state not in _ACTIVE_STATES:
             reason = item.get("reason_code")
@@ -237,6 +301,14 @@ def _wait_for_bundle(
             raise PrivateVideoActivationError(code)
         if clock() >= deadline:
             raise PrivateVideoActivationError("VIDEO_PRIVATE_ACTIVATION_TIMEOUT")
+        current = item.get("downloaded_bytes")
+        total = item.get("total_bytes")
+        _report_progress(
+            progress,
+            phase,
+            current if type(current) is int else 0,
+            total if type(total) is int else 0,
+        )
         sleep(0.1)
 
 
@@ -254,6 +326,7 @@ def activate_private_video(
     installer_factory: Callable[..., Any] = _create_installer,
     clock: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], object] = time.sleep,
+    progress: Callable[[str, int, int], object] | None = None,
 ) -> dict[str, object]:
     if timeout_seconds <= 0:
         raise PrivateVideoActivationError("VIDEO_PRIVATE_ACTIVATION_TIMEOUT")
@@ -271,6 +344,7 @@ def activate_private_video(
         manifest,
         expected_file_count=expected_file_count,
         expected_size_bytes=expected_size_bytes,
+        progress=progress,
     )
     runtime = _absolute_path(
         runtime_archive, code="VIDEO_RUNTIME_ARCHIVE_INVALID"
@@ -282,11 +356,32 @@ def activate_private_video(
     ):
         raise PrivateVideoActivationError("VIDEO_RUNTIME_ARCHIVE_INVALID")
     try:
-        installer = installer_factory(install_root=root, manifest=manifest)
+        def report_runtime(state: str, current: int, total: int) -> None:
+            phase = {
+                "queued": "EXTRACT_VIDEO_RUNTIME",
+                "extracting": "EXTRACT_VIDEO_RUNTIME",
+                "checking": "VERIFY_VIDEO_RUNTIME",
+                "testing": "TEST_VIDEO_RUNTIME",
+                "ready": "TEST_VIDEO_RUNTIME",
+            }.get(state)
+            if phase is not None:
+                _report_progress(progress, phase, current, total)
+
+        installer = installer_factory(
+            install_root=root,
+            manifest=manifest,
+            runtime_progress=report_runtime,
+        )
         deadline = clock() + timeout_seconds
         for bundle_id in ("ordinary_video", "music_video"):
+            phase = (
+                "INSTALL_ORDINARY_VIDEO"
+                if bundle_id == "ordinary_video"
+                else "INSTALL_MUSIC_VIDEO"
+            )
             current = _bundle_state(installer.status(), bundle_id)
             if current.get("state") not in _ASSEMBLED_STATES:
+                _report_progress(progress, phase, 0, 0)
                 installer.import_offline(
                     bundle_id=bundle_id,
                     offline_root=offline / bundle_id,
@@ -299,7 +394,12 @@ def activate_private_video(
                     deadline=deadline,
                     clock=clock,
                     sleep=sleep,
+                    phase=phase,
+                    progress=progress,
                 )
+            else:
+                _report_progress(progress, phase, 1, 1)
+        _report_progress(progress, "EXTRACT_VIDEO_RUNTIME", 0, 0)
         installer.import_runtime_archive(runtime_archive=runtime)
         final = installer.status()
     except PrivateVideoActivationError:
@@ -337,6 +437,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--expected-size-bytes", type=int, required=True)
     parser.add_argument("--timeout-seconds", type=float, default=14_400)
     args = parser.parse_args(argv)
+
+    emit_progress = _setup_progress_writer()
+
     try:
         result = activate_private_video(
             install_root=args.install_root,
@@ -348,6 +451,7 @@ def main(argv: list[str] | None = None) -> int:
             expected_file_count=args.expected_file_count,
             expected_size_bytes=args.expected_size_bytes,
             timeout_seconds=args.timeout_seconds,
+            progress=emit_progress,
         )
         print(json.dumps(result, ensure_ascii=False, sort_keys=True))
         return 0

--- a/installer/windows_setup.iss
+++ b/installer/windows_setup.iss
@@ -50,8 +50,108 @@ var
   InstallDirPage: TInputDirWizardPage;
   OfficialDirPage: TInputQueryWizardPage;
   OfficialBrowseButton: TNewButton;
+  InstallProgressPage: TOutputProgressWizardPage;
   StableInstallCode: String;
   SetupResultPath: String;
+  LastInstallPhase: String;
+
+function InstallPhaseCaption(const Phase: String): String;
+begin
+  if Phase = 'PREPARE' then
+    Result := '正在准备安装…'
+  else if Phase = 'VERIFY_OFFICIAL' then
+    Result := '正在校验正版游戏文件…'
+  else if Phase = 'VERIFY_CORE' then
+    Result := '正在校验本地核心组件…'
+  else if Phase = 'INSTALL_CORE' then
+    Result := '正在安装本地运行环境…'
+  else if Phase = 'INSTALL_PATCH' then
+    Result := '正在安装 Olivia 本地补丁…'
+  else if Phase = 'COPY_VIDEO_RUNTIME' then
+    Result := '正在复制视频运行包…'
+  else if Phase = 'VERIFY_VIDEO_OFFLINE' then
+    Result := '正在校验视频离线组件…'
+  else if Phase = 'INSTALL_ORDINARY_VIDEO' then
+    Result := '正在安装普通视频回信组件…'
+  else if Phase = 'INSTALL_MUSIC_VIDEO' then
+    Result := '正在安装音乐视频回信组件…'
+  else if Phase = 'EXTRACT_VIDEO_RUNTIME' then
+    Result := '正在解压视频运行环境…'
+  else if Phase = 'VERIFY_VIDEO_RUNTIME' then
+    Result := '正在校验视频运行环境…'
+  else if Phase = 'TEST_VIDEO_RUNTIME' then
+    Result := '正在检测视频运行环境…'
+  else if Phase = 'FINALIZE' then
+    Result := '正在完成安装…'
+  else
+    Result := '';
+end;
+
+procedure InstallOutputLine(const S: String; const Error, FirstLine: Boolean);
+var
+  Prefix: String;
+  Payload: String;
+  Remaining: String;
+  Phase: String;
+  CurrentText: String;
+  TotalText: String;
+  Caption: String;
+  Detail: String;
+  Separator: Integer;
+  CurrentBytes: Int64;
+  TotalBytes: Int64;
+  Position: Longint;
+begin
+  if Error then
+  begin
+    Log('Olivia installer progress stream unavailable.');
+    Exit;
+  end;
+
+  Prefix := 'OLIVIA_SETUP_PROGRESS=';
+  if Copy(S, 1, Length(Prefix)) <> Prefix then
+    Exit;
+  Payload := Copy(S, Length(Prefix) + 1, MaxInt);
+  Separator := Pos('|', Payload);
+  if Separator <= 1 then
+    Exit;
+  Phase := Copy(Payload, 1, Separator - 1);
+  Remaining := Copy(Payload, Separator + 1, MaxInt);
+  Separator := Pos('|', Remaining);
+  if Separator <= 1 then
+    Exit;
+  CurrentText := Copy(Remaining, 1, Separator - 1);
+  TotalText := Copy(Remaining, Separator + 1, MaxInt);
+  if (TotalText = '') or (Pos('|', TotalText) > 0) then
+    Exit;
+  Caption := InstallPhaseCaption(Phase);
+  if Caption = '' then
+    Exit;
+  CurrentBytes := StrToInt64Def(CurrentText, -1);
+  TotalBytes := StrToInt64Def(TotalText, -1);
+  if (CurrentBytes < 0) or (TotalBytes < 0) or
+    ((TotalBytes > 0) and (CurrentBytes > TotalBytes)) then
+    Exit;
+
+  if Phase <> LastInstallPhase then
+  begin
+    Log('Olivia installer phase: ' + Phase);
+    LastInstallPhase := Phase;
+  end;
+  if TotalBytes > 0 then
+  begin
+    Position := (CurrentBytes * 10000) div TotalBytes;
+    InstallProgressPage.SetProgress(Position, 10000);
+    Detail := '已处理 ' + IntToStr(CurrentBytes div 1048576) +
+      ' MiB / ' + IntToStr(TotalBytes div 1048576) + ' MiB';
+  end
+  else
+  begin
+    InstallProgressPage.SetProgress(0, 1);
+    Detail := '请保持窗口开启。';
+  end;
+  InstallProgressPage.SetText(Caption, Detail);
+end;
 
 procedure OfficialBrowseButtonClick(Sender: TObject);
 var
@@ -99,6 +199,12 @@ end;
 
 procedure InitializeWizard;
 begin
+  InstallProgressPage := CreateOutputProgressPage(
+    '正在安装 Olivia 本地版',
+    '进度来自安装程序实际处理量。'
+  );
+  LastInstallPhase := '';
+
   InstallDirPage := CreateInputDirPage(
     wpSelectDir,
     '选择产品目录',
@@ -154,6 +260,7 @@ var
   PowerShell: String;
   Params: String;
   ExitCode: Integer;
+  ExecSucceeded: Boolean;
   DiagnosticContent: AnsiString;
 begin
   Result := '';
@@ -162,58 +269,71 @@ begin
   DeleteFile(SetupResultPath);
   DeleteFile(SetupResultPath + '.diagnostic.json');
   ExitCode := -1;
+  InstallProgressPage.SetText('正在解包安装文件…', '请保持窗口开启。');
+  InstallProgressPage.SetProgress(0, 1);
+  InstallProgressPage.Show;
   try
-    ExtractTemporaryFiles('{tmp}\OliviaPayload\*');
-  except
-    StableInstallCode := 'SETUP_PAYLOAD_EXTRACT_FAILED';
-    Log('Olivia installer code: ' + StableInstallCode);
-    Result := '安装失败：' + StableInstallCode + '。请保留安装日志后重试。';
-    Exit;
-  end;
+    try
+      ExtractTemporaryFiles('{tmp}\OliviaPayload\*');
+    except
+      StableInstallCode := 'SETUP_PAYLOAD_EXTRACT_FAILED';
+      Log('Olivia installer code: ' + StableInstallCode);
+      Result := '安装失败：' + StableInstallCode + '。请保留安装日志后重试。';
+      Exit;
+    end;
 
-  WizardForm.StatusLabel.Caption := '正在校验并安装离线核心组件…';
-  PowerShell := ExpandConstant('{sysnative}\WindowsPowerShell\v1.0\powershell.exe');
-  Params := '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File ' +
-    AddQuotes(ExpandConstant('{tmp}\OliviaPayload\installer\Install.ps1')) +
-    ' -PayloadRoot ' + AddQuotes(ExpandConstant('{tmp}\OliviaPayload')) +
-    ' -Destination ' + AddQuotes(InstallDirPage.Values[0]) +
-    ' -OfflineAssetsRoot ' + AddQuotes(ExpandConstant('{tmp}\OliviaPayload\offline')) +
-    ' -SetupResultPath ' + AddQuotes(SetupResultPath) +
-    ' -NonInteractive' +
-    ' -SkipShortcut';
+    PowerShell := ExpandConstant('{sysnative}\WindowsPowerShell\v1.0\powershell.exe');
+    Params := '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File ' +
+      AddQuotes(ExpandConstant('{tmp}\OliviaPayload\installer\Install.ps1')) +
+      ' -PayloadRoot ' + AddQuotes(ExpandConstant('{tmp}\OliviaPayload')) +
+      ' -Destination ' + AddQuotes(InstallDirPage.Values[0]) +
+      ' -OfflineAssetsRoot ' + AddQuotes(ExpandConstant('{tmp}\OliviaPayload\offline')) +
+      ' -SetupResultPath ' + AddQuotes(SetupResultPath) +
+      ' -NonInteractive' +
+      ' -SkipShortcut';
 #ifdef PrivatePayload
-  Params := Params +
-    ' -VideoRuntimePath ' + AddQuotes(
-      ExpandConstant('{src}\Olivia-video-runtime-private.zip')
-    ) +
-    ' -VideoOfflineRoot ' + AddQuotes(
-      ExpandConstant('{src}\Olivia-video-offline-private')
-    );
+    Params := Params +
+      ' -VideoRuntimePath ' + AddQuotes(
+        ExpandConstant('{src}\Olivia-video-runtime-private.zip')
+      ) +
+      ' -VideoOfflineRoot ' + AddQuotes(
+        ExpandConstant('{src}\Olivia-video-offline-private')
+      );
 #endif
-  if Trim(OfficialDirPage.Values[0]) <> '' then
-    Params := Params + ' -OfficialRoot ' + AddQuotes(OfficialDirPage.Values[0]);
+    if Trim(OfficialDirPage.Values[0]) <> '' then
+      Params := Params + ' -OfficialRoot ' + AddQuotes(OfficialDirPage.Values[0]);
 
-  if (not Exec(
-       PowerShell,
-       Params,
-       '',
-       SW_HIDE,
-       ewWaitUntilTerminated,
-       ExitCode
-     )) or
-     (ExitCode <> 0) then
-  begin
-    StableInstallCode := LoadStableInstallCode(SetupResultPath);
-    if StableInstallCode = '' then
-      StableInstallCode := 'SETUP_INSTALL_FAILED';
-    Log('Olivia installer code: ' + StableInstallCode);
-    if LoadStringFromFile(SetupResultPath + '.diagnostic.json', DiagnosticContent) then
-      Log('Olivia installer diagnostic: ' + String(DiagnosticContent));
-    if StableInstallCode = 'OFFICIAL_INSTALL_AMBIGUOUS' then
-      Result := '检测到多个 Olivia 正版目录，且无法自动确认当前副本。请点击“上一步”，明确选择 Steam 中正在使用的正版游戏目录。'
-    else if StableInstallCode <> '' then
-      Result := '安装失败：' + StableInstallCode + '。请保留安装日志后重试。'
-    else
-      Result := Format('安装失败（进程错误码 %d）。请保留安装日志后重试。', [ExitCode]);
+    try
+      ExecSucceeded := ExecAndLogOutput(
+        PowerShell,
+        Params,
+        '',
+        SW_HIDE,
+        ewWaitUntilTerminated,
+        ExitCode,
+        @InstallOutputLine
+      );
+    except
+      ExecSucceeded := False;
+      ExitCode := -1;
+      Log('Olivia installer progress capture failed.');
+    end;
+    if (not ExecSucceeded) or (ExitCode <> 0) then
+    begin
+      StableInstallCode := LoadStableInstallCode(SetupResultPath);
+      if StableInstallCode = '' then
+        StableInstallCode := 'SETUP_INSTALL_FAILED';
+      Log('Olivia installer code: ' + StableInstallCode);
+      if LoadStringFromFile(SetupResultPath + '.diagnostic.json', DiagnosticContent) then
+        Log('Olivia installer diagnostic: ' + String(DiagnosticContent));
+      if StableInstallCode = 'OFFICIAL_INSTALL_AMBIGUOUS' then
+        Result := '检测到多个 Olivia 正版目录，且无法自动确认当前副本。请点击“上一步”，明确选择 Steam 中正在使用的正版游戏目录。'
+      else if StableInstallCode <> '' then
+        Result := '安装失败：' + StableInstallCode + '。请保留安装日志后重试。'
+      else
+        Result := Format('安装失败（进程错误码 %d）。请保留安装日志后重试。', [ExitCode]);
+    end;
+  finally
+    InstallProgressPage.Hide;
   end;
 end;

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -41,6 +41,25 @@ def _managed_video_runtime(product: Path) -> Path:
     return product / "install/downloads/Olivia-video-runtime-private.zip"
 
 
+def _setup_progress(output: str) -> list[tuple[str, int, int]]:
+    prefix = "OLIVIA_SETUP_PROGRESS="
+    records: list[tuple[str, int, int]] = []
+    for line in output.splitlines():
+        if not line.startswith(prefix):
+            continue
+        phase, current, total = line.removeprefix(prefix).split("|")
+        records.append((phase, int(current), int(total)))
+    return records
+
+
+def _video_runtime_zip_bytes(payload_size: int) -> bytes:
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w", compression=zipfile.ZIP_STORED, allowZip64=True) as archive:
+        archive.writestr("runtime-manifest.json", "{}")
+        archive.writestr("runtime/fixture.bin", b"x" * payload_size)
+    return payload.getvalue()
+
+
 def test_first_install_consumes_only_bundled_core_assets() -> None:
     script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
 
@@ -85,7 +104,10 @@ def test_installer_accepts_only_complete_private_video_runtime_manifest() -> Non
 def test_private_video_activation_must_finish_before_install_transaction_commit() -> None:
     script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
 
-    activation = "$privateVideoOutput = @(& $runner.File @($runner.Args + @($privateVideoActivator) + $privateVideoArguments))"
+    activation = (
+        "& $runner.File @($runner.Args + @($privateVideoActivator) + "
+        "$privateVideoArguments) |"
+    )
     assert activation in script
     assert "--manifest-version" in script
     assert "--manifest-sha256" in script
@@ -280,6 +302,7 @@ def _run_runtime_publish_fixture(
     interrupt_voice_staging: bool = False, interrupt_after_bootstrap: bool = False, existing_runtime: bool = True, seed_existing_install: bool = True,
     private_video_exit_code: int = 0,
     private_video_status: str | None = None,
+    private_video_progress_lines: tuple[str, ...] = (),
     private_video_mutates_tree: bool = False,
     interrupt_after_private_video: bool = False,
     fail_core_asset_preflight: bool = False,
@@ -311,8 +334,12 @@ def _run_runtime_publish_fixture(
         encoding="utf-8",
     )
     private_status = private_video_status or ("READY" if private_video_exit_code == 0 else "ERROR")
+    private_progress = "".join(
+        f"print({line!r}, flush=True)\n" for line in private_video_progress_lines
+    )
     (payload_installer / "activate_private_video.py").write_text(
         "import json, pathlib, sys\n"
+        + private_progress
         + (
             "install_root = pathlib.Path(sys.argv[sys.argv.index('--install-root') + 1])\n"
             "video_root = install_root / 'data/capabilities/video'\n"
@@ -415,11 +442,12 @@ def _run_runtime_publish_fixture(
         assert script.count(marker) == 1
         script = script.replace(marker, "[Environment]::FailFast('SYNTHETIC_BOOTSTRAP_INTERRUPTION')\n" + marker)
     if interrupt_after_private_video:
-        marker = "$privateVideoOutput = @(& $runner.File @($runner.Args + @($privateVideoActivator) + $privateVideoArguments))"
+        marker = "$privateVideoExitCode = $LASTEXITCODE"
         assert script.count(marker) == 1
         script = script.replace(
             marker,
-            marker + "\n        [Environment]::FailFast('SYNTHETIC_PRIVATE_VIDEO_INTERRUPTION')",
+            "[Environment]::FailFast('SYNTHETIC_PRIVATE_VIDEO_INTERRUPTION')\n        "
+            + marker,
         )
     if block_voice_sidecar:
         marker = "$privateVideoTransaction = Start-ManagedPrivateVideoTransaction -InstallRoot $Destination -TransactionId $installTransactionId -PendingMarker $privateVideoPending -VideoRuntime $coreAssets.VideoRuntime"
@@ -560,6 +588,83 @@ def test_first_install_publishes_voice_reference_to_preserved_data_path(tmp_path
     schema = json.loads((ROOT / "contracts/managed_voice_reference.schema.json").read_text())
     Draft202012Validator.check_schema(schema)
     assert not list(Draft202012Validator(schema).iter_errors(integrity))
+
+
+def test_first_install_emits_setup_progress_contract(tmp_path: Path) -> None:
+    result, _product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=0,
+        voice_reference=_voice_reference_bytes(),
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    progress = _setup_progress(result.stdout)
+    phases = [phase for phase, _current, _total in progress]
+    for phase in (
+        "PREPARE",
+        "VERIFY_OFFICIAL",
+        "VERIFY_CORE",
+        "INSTALL_CORE",
+        "INSTALL_PATCH",
+        "VERIFY_VIDEO_OFFLINE",
+        "FINALIZE",
+    ):
+        assert phase in phases
+    assert progress[-1] == ("FINALIZE", 1, 1)
+
+
+def test_fresh_linli_install_reports_real_video_runtime_copy_bytes(
+    tmp_path: Path,
+) -> None:
+    runtime = _video_runtime_zip_bytes((4 * 1024 * 1024) + 17)
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        product_root=tmp_path / "linli",
+        bootstrap_exit_code=0,
+        voice_reference=_voice_reference_bytes(),
+        video_runtime=runtime,
+        existing_runtime=False,
+        seed_existing_install=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    managed = _managed_video_runtime(product)
+    assert managed.read_bytes() == runtime
+    with zipfile.ZipFile(managed) as archive:
+        assert archive.testzip() is None
+    copy_progress = [
+        (current, total)
+        for phase, current, total in _setup_progress(result.stdout)
+        if phase == "COPY_VIDEO_RUNTIME"
+    ]
+    assert copy_progress[0] == (0, len(runtime))
+    assert copy_progress[-1] == (len(runtime), len(runtime))
+    assert any(0 < current < total for current, total in copy_progress)
+    assert [current for current, _total in copy_progress] == sorted(
+        current for current, _total in copy_progress
+    )
+
+
+def test_private_video_progress_is_forwarded_without_losing_error_contract(
+    tmp_path: Path,
+) -> None:
+    progress_line = (
+        "OLIVIA_SETUP_PROGRESS=INSTALL_ORDINARY_VIDEO|1048576|4194304"
+    )
+    result, _product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=0,
+        voice_reference=_voice_reference_bytes(),
+        private_video_progress_lines=(progress_line,),
+        private_video_exit_code=2,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert progress_line in result.stdout.splitlines()
+    assert "VIDEO_PRIVATE_ACTIVATION_FAILED" in output
+
+
 def test_voice_publish_failure_restores_managed_app_runtime_and_voice(tmp_path: Path) -> None:
     result, product = _run_runtime_publish_fixture(
         tmp_path, bootstrap_exit_code=0, bootstrap_replaces_managed_app=True,

--- a/tests/installer/test_private_video_activation.py
+++ b/tests/installer/test_private_video_activation.py
@@ -11,9 +11,29 @@ import pytest
 
 from installer.activate_private_video import (
     PrivateVideoActivationError,
+    _setup_progress_writer,
     activate_private_video,
     main as activate_private_video_main,
 )
+
+
+def test_setup_progress_writer_throttles_large_and_repeated_updates() -> None:
+    lines: list[str] = []
+    emit = _setup_progress_writer(lines.append)
+    total = 100 * 1024 * 1024 * 1024
+
+    for current in range(0, total + 1, 1024 * 1024):
+        emit("VERIFY_VIDEO_RUNTIME", min(current, total), total)
+    emit("VERIFY_VIDEO_RUNTIME", total, total)
+    for _ in range(1_000):
+        emit("TEST_VIDEO_RUNTIME", 0, 0)
+
+    assert lines[0] == f"OLIVIA_SETUP_PROGRESS=VERIFY_VIDEO_RUNTIME|0|{total}"
+    assert lines[-2] == (
+        f"OLIVIA_SETUP_PROGRESS=VERIFY_VIDEO_RUNTIME|{total}|{total}"
+    )
+    assert lines[-1] == "OLIVIA_SETUP_PROGRESS=TEST_VIDEO_RUNTIME|0|0"
+    assert len(lines) < 1_100
 
 
 def test_private_activation_cli_bootstraps_payload_root_under_isolated_python() -> None:
@@ -172,6 +192,46 @@ def test_private_activation_uses_existing_installer_in_strict_ready_order(
     assert result["status"] == "READY"
     assert result["runtime_import"]["state"] == "ready"
     assert [item["state"] for item in result["bundles"]] == ["ready", "ready"]
+
+
+def test_private_activation_reports_verified_bytes_and_named_install_stages(
+    tmp_path: Path,
+) -> None:
+    manifest, offline, manifest_sha256 = _manifest_fixture(tmp_path)
+    runtime = tmp_path / "Olivia-video-runtime-private.zip"
+    runtime.write_bytes(b"runtime")
+    installer = _FakeInstaller([])
+    progress: list[tuple[str, int, int]] = []
+
+    activate_private_video(
+        install_root=tmp_path / "install",
+        offline_root=offline,
+        runtime_archive=runtime,
+        manifest_path=manifest,
+        expected_manifest_version="fixture-video",
+        expected_manifest_sha256=manifest_sha256,
+        expected_file_count=2,
+        expected_size_bytes=len(b"ordinary") + len(b"music"),
+        installer_factory=lambda **_kwargs: installer,
+        timeout_seconds=1,
+        progress=lambda phase, current, total: progress.append(
+            (phase, current, total)
+        ),
+    )
+
+    assert progress[0] == (
+        "VERIFY_VIDEO_OFFLINE",
+        0,
+        len(b"ordinary") + len(b"music"),
+    )
+    assert (
+        "VERIFY_VIDEO_OFFLINE",
+        len(b"ordinary") + len(b"music"),
+        len(b"ordinary") + len(b"music"),
+    ) in progress
+    assert ("INSTALL_ORDINARY_VIDEO", 1, 1) in progress
+    assert ("INSTALL_MUSIC_VIDEO", 1, 1) in progress
+    assert ("EXTRACT_VIDEO_RUNTIME", 0, 0) in progress
 
 
 def test_private_activation_accepts_verified_runtime_with_unavailable_host(

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import threading
 import time
+from types import SimpleNamespace
 import zipfile
 
 import pytest
@@ -339,6 +340,147 @@ def test_runtime_archive_is_extracted_verified_and_activated(
         readiness_probe=lambda _environment: pytest.fail("installed runtime must not reprobe"),
     )
     assert restarted_without_archive.status()["runtime_import"]["state"] == "ready"
+
+
+def test_runtime_archive_import_retries_a_transient_archive_open_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: {
+            "ordinary_missing_dependencies": [],
+            "music_ready": True,
+        },
+    )
+    real_zip_file = zipfile.ZipFile
+    archive_opens = 0
+    observed_delays: list[float] = []
+
+    def transient_zip_file(*args: object, **kwargs: object) -> zipfile.ZipFile:
+        nonlocal archive_opens
+        archive_opens += 1
+        if archive_opens == 1:
+            raise PermissionError("archive is temporarily held by another process")
+        return real_zip_file(*args, **kwargs)
+
+    monkeypatch.setattr(video_capability_install.zipfile, "ZipFile", transient_zip_file)
+    monkeypatch.setattr(
+        video_capability_install,
+        "time",
+        SimpleNamespace(sleep=observed_delays.append),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        video_capability_install,
+        "_runtime_environment_is_portable",
+        lambda *_: True,
+    )
+
+    assert installer.import_runtime_archive(runtime_archive=archive) == "APPLIED"
+    assert archive_opens >= 2
+    assert observed_delays == [0.1]
+
+
+def test_runtime_archive_import_does_not_retry_bad_zip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = tmp_path / "corrupt.zip"
+    archive.write_bytes(b"not a zip")
+    installer = VideoCapabilityInstaller(
+        data_root=(tmp_path / "data").resolve(),
+        manifest=_runtime_ready_manifest(),
+    )
+    archive_opens = 0
+
+    def corrupt_zip_file(*_args: object, **_kwargs: object) -> zipfile.ZipFile:
+        nonlocal archive_opens
+        archive_opens += 1
+        raise zipfile.BadZipFile
+
+    monkeypatch.setattr(video_capability_install.zipfile, "ZipFile", corrupt_zip_file)
+    monkeypatch.setattr(
+        video_capability_install,
+        "time",
+        SimpleNamespace(
+            sleep=lambda _delay: pytest.fail("corrupt archives must not be retried")
+        ),
+        raising=False,
+    )
+
+    with pytest.raises(VideoCapabilityError, match="^VIDEO_RUNTIME_ARCHIVE_INVALID$"):
+        installer.import_runtime_archive(runtime_archive=archive)
+    assert archive_opens == 1
+
+
+def test_runtime_archive_import_bounds_transient_open_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = tmp_path / "locked.zip"
+    archive.write_bytes(b"present")
+    installer = VideoCapabilityInstaller(
+        data_root=(tmp_path / "data").resolve(),
+        manifest=_runtime_ready_manifest(),
+    )
+    archive_opens = 0
+    observed_delays: list[float] = []
+
+    def locked_zip_file(*_args: object, **_kwargs: object) -> zipfile.ZipFile:
+        nonlocal archive_opens
+        archive_opens += 1
+        raise PermissionError("archive remains locked")
+
+    monkeypatch.setattr(video_capability_install.zipfile, "ZipFile", locked_zip_file)
+    monkeypatch.setattr(
+        video_capability_install,
+        "time",
+        SimpleNamespace(sleep=observed_delays.append),
+        raising=False,
+    )
+
+    with pytest.raises(VideoCapabilityError, match="^VIDEO_RUNTIME_ARCHIVE_INVALID$"):
+        installer.import_runtime_archive(runtime_archive=archive)
+    assert archive_opens == 8
+    assert observed_delays == [0.1, 0.2, 0.4, 0.8, 1.6, 2.0, 2.0]
+
+
+def test_runtime_archive_import_publishes_extract_verify_and_test_progress(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _runtime_archive(tmp_path)
+    manifest = _runtime_ready_manifest()
+    data_root = (tmp_path / "data").resolve()
+    _prepare_runtime_dependencies(data_root, manifest)
+    observed: list[tuple[str, int, int]] = []
+    monkeypatch.setattr(
+        video_capability_install,
+        "_runtime_environment_is_portable",
+        lambda *_: True,
+    )
+    installer = VideoCapabilityInstaller(
+        data_root=data_root,
+        manifest=manifest,
+        readiness_probe=lambda _environment: {
+            "ordinary_missing_dependencies": [],
+            "music_ready": True,
+        },
+        runtime_progress=lambda state, current, total: observed.append(
+            (state, current, total)
+        ),
+    )
+
+    assert installer.import_runtime_archive(runtime_archive=archive) == "APPLIED"
+    assert any(state == "extracting" and total > 0 for state, _, total in observed)
+    assert any(
+        state == "checking" and total > 0 and current == total
+        for state, current, total in observed
+    )
+    assert any(state == "testing" for state, _, _ in observed)
+    assert observed[-1][0] == "ready"
 
 
 def test_runtime_archive_resumes_interrupted_extraction_from_bound_checkpoint(

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -1624,8 +1624,37 @@ def test_inno_wrapper_is_current_user_offline_and_delegates_to_install_ps1() -> 
     assert "Install.ps1" in script
     assert "-NonInteractive" in script
     assert "GetInstallRoot" in script
-    assert "Exec(" in script
-    assert "ExecAndLogOutput" not in script
+    assert "CreateOutputProgressPage" in script
+    assert "InstallProgressPage.Show" in script
+    assert "InstallProgressPage.Hide" in script
+    assert "ExecAndLogOutput(" in script
+    assert "@InstallOutputLine" in script
+    assert "SW_HIDE" in script
+    assert "OLIVIA_SETUP_PROGRESS=" in script
+    assert "Separator := Pos('|', Payload)" in script
+    assert "Pos('|', TotalText) > 0" in script
+    for phase in (
+        "PREPARE",
+        "VERIFY_OFFICIAL",
+        "VERIFY_CORE",
+        "INSTALL_CORE",
+        "INSTALL_PATCH",
+        "COPY_VIDEO_RUNTIME",
+        "VERIFY_VIDEO_OFFLINE",
+        "INSTALL_ORDINARY_VIDEO",
+        "INSTALL_MUSIC_VIDEO",
+        "EXTRACT_VIDEO_RUNTIME",
+        "VERIFY_VIDEO_RUNTIME",
+        "TEST_VIDEO_RUNTIME",
+        "FINALIZE",
+    ):
+        assert f"Phase = '{phase}'" in script
+    assert "Caption := InstallPhaseCaption(Phase)" in script
+    assert "if Caption = '' then" in script
+    assert "InstallProgressPage.SetText" in script
+    assert "InstallProgressPage.SetProgress" in script
+    assert "StrToInt64Def" in script
+    assert "Log(S)" not in script
     assert "StableInstallCode" in script
     assert "SetupResultPath" in script
     assert "OLIVIA_SETUP_ERROR=" in script

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -14,6 +14,7 @@ from pathlib import Path, PurePosixPath
 import shutil
 import subprocess
 import threading
+import time
 from typing import Any
 import uuid
 from urllib.error import HTTPError, URLError
@@ -350,20 +351,29 @@ def _runtime_archive_identity(path: Path) -> tuple[str, int, int, int, int] | No
 
 
 def _runtime_archive_fingerprint(path: Path) -> str | None:
-    try:
-        with zipfile.ZipFile(path) as archive:
-            entries = [
-                (
-                    member.filename,
-                    member.CRC,
-                    member.file_size,
-                    member.compress_size,
-                    member.flag_bits,
-                    member.external_attr,
-                )
-                for member in archive.infolist()
-            ]
-    except (OSError, zipfile.BadZipFile):
+    entries = None
+    for attempt in range(8):
+        try:
+            with zipfile.ZipFile(path) as archive:
+                entries = [
+                    (
+                        member.filename,
+                        member.CRC,
+                        member.file_size,
+                        member.compress_size,
+                        member.flag_bits,
+                        member.external_attr,
+                    )
+                    for member in archive.infolist()
+                ]
+            break
+        except zipfile.BadZipFile:
+            return None
+        except OSError:
+            if attempt == 7:
+                return None
+            time.sleep(min(0.1 * (2**attempt), 2.0))
+    if entries is None:
         return None
     return hashlib.sha256(
         json.dumps(entries, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
@@ -843,6 +853,7 @@ class VideoCapabilityInstaller:
         runtime_archives: tuple[Path, ...] = (),
         runtime_archive_roots: tuple[Path, ...] = (),
         runtime_environment_applier: Callable[[Mapping[str, str]], object] | None = None,
+        runtime_progress: Callable[[str, int, int], object] | None = None,
     ) -> None:
         if not data_root.is_absolute():
             raise VideoCapabilityError("VIDEO_DATA_ROOT_INVALID")
@@ -867,6 +878,7 @@ class VideoCapabilityInstaller:
             raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
         self._runtime_archive_roots = tuple(root.resolve() for root in runtime_archive_roots)
         self._runtime_environment_applier = runtime_environment_applier
+        self._runtime_progress = runtime_progress
         self._lock = threading.RLock()
         self._commit_lock = _PROMOTION_LOCK
         self._pause = threading.Event()
@@ -1078,6 +1090,19 @@ class VideoCapabilityInstaller:
             self._runtime_import.pop("reason_code", None)
             if reason_code:
                 self._runtime_import["reason_code"] = reason_code
+            checked_bytes = int(self._runtime_import.get("checked_bytes", 0))
+            total_bytes = int(self._runtime_import.get("total_bytes", 0))
+        self._report_runtime_progress(state, checked_bytes, total_bytes)
+
+    def _report_runtime_progress(
+        self, state: str, checked_bytes: int, total_bytes: int
+    ) -> None:
+        if self._runtime_progress is None:
+            return
+        try:
+            self._runtime_progress(state, checked_bytes, total_bytes)
+        except Exception:
+            pass
 
     @staticmethod
     def _runtime_import_error_code(exc: Exception) -> str:
@@ -1092,6 +1117,7 @@ class VideoCapabilityInstaller:
                 "checked_bytes": checked_bytes,
                 "total_bytes": total_bytes,
             }
+        self._report_runtime_progress("checking", checked_bytes, total_bytes)
 
     def _set(self, bundle: VideoBundle, state: VideoCapabilityState, downloaded: int, *, current: str | None = None, source: str | None = None, reason: str | None = None) -> None:
         self._status[bundle.identifier] = VideoBundleStatus(bundle.identifier, state, downloaded, sum(item.size_bytes for item in bundle.files), current, source, reason)
@@ -1187,12 +1213,7 @@ class VideoCapabilityInstaller:
         runtime_root: Path,
         manifest_sha256: str,
     ) -> str:
-        with self._lock:
-            self._runtime_import = {
-                "state": "checking",
-                "checked_bytes": 0,
-                "total_bytes": 0,
-            }
+        self._update_runtime_import_progress(0, 0)
         try:
             result = self._import_runtime_root(
                 runtime_root=runtime_root,
@@ -1206,6 +1227,9 @@ class VideoCapabilityInstaller:
         with self._lock:
             self._runtime_import["state"] = "ready"
             self._runtime_import["checked_bytes"] = self._runtime_import["total_bytes"]
+            checked_bytes = int(self._runtime_import["checked_bytes"])
+            total_bytes = int(self._runtime_import["total_bytes"])
+        self._report_runtime_progress("ready", checked_bytes, total_bytes)
         return result
 
     def import_runtime_archive(self, *, runtime_archive: Path) -> str:
@@ -1217,15 +1241,9 @@ class VideoCapabilityInstaller:
             not archive.is_file()
             or archive.is_symlink()
             or archive.suffix.casefold() != ".zip"
-            or not zipfile.is_zipfile(archive)
         ):
             raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
-        with self._lock:
-            self._runtime_import = {
-                "state": "extracting",
-                "checked_bytes": 0,
-                "total_bytes": 0,
-            }
+        self._update_runtime_extract_progress(0, 0)
         identity = _runtime_archive_fingerprint(archive)
         if identity is None:
             raise VideoCapabilityError("VIDEO_RUNTIME_ARCHIVE_INVALID")
@@ -1272,7 +1290,7 @@ class VideoCapabilityInstaller:
                     staging,
                     manifest_sha256,
                     verify_files=True,
-                    progress=None,
+                    progress=self._update_runtime_import_progress,
                 )
             except Exception:
                 _discard_runtime_import_checkpoint(cache_root, staging)
@@ -1374,6 +1392,7 @@ class VideoCapabilityInstaller:
                 "checked_bytes": checked_bytes,
                 "total_bytes": total_bytes,
             }
+        self._report_runtime_progress("extracting", checked_bytes, total_bytes)
 
     def _resume_persisted_runtime(self) -> bool:
         try:


### PR DESCRIPTION
修复 Windows 私有安装器在杀毒/索引器短暂占用已复制视频运行包时误报 VIDEO_RUNTIME_ARCHIVE_INVALID；仅对 OSError 做有界重试，坏 ZIP 立即失败。安装窗口现在实时显示核心安装、12.5GB 运行包复制、视频离线资产校验、组件安装、运行环境解压/校验等实际阶段与字节进度。\n\n定向验证：\n- runtime archive: 19 passed\n- private activation: 9 passed\n- offline installer: 43 passed\n- Inno wrapper: 2 passed\n- PowerShell parser / py_compile / diff-check: PASS\n- Inno Setup 6.7.3 public compile: PASS\n\n未运行全量测试；用户要求改哪测哪。