### PR TITLE
fix(installer): create desktop shortcut by default

### DIFF
--- a/installer/windows_setup.iss
+++ b/installer/windows_setup.iss
@@ -36,7 +36,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Source: "{#PayloadRoot}\*"; Excludes: "offline\video-runtime\*"; DestDir: "{tmp}\OliviaPayload"; Flags: recursesubdirs createallsubdirs dontcopy noencryption ignoreversion
 
 [Tasks]
-Name: "desktopicon"; Description: "创建桌面快捷方式"; GroupDescription: "附加选项："; Flags: unchecked
+Name: "desktopicon"; Description: "创建桌面快捷方式"; GroupDescription: "附加选项："
 
 [Icons]
 Name: "{userprograms}\Olivia 本地版"; Filename: "{sys}\wscript.exe"; Parameters: "//B //Nologo ""{code:GetInstallRoot}\install\START.vbs"""; WorkingDir: "{code:GetInstallRoot}\install"; IconFilename: "{code:GetInstallRoot}\install\local_backend\installer\assets\olivia.ico"

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -1679,6 +1679,10 @@ def test_inno_wrapper_creates_launch_shortcuts_and_offers_immediate_start() -> N
 
     assert '[Tasks]' in script
     assert 'Name: "desktopicon"' in script
+    desktop_task = next(
+        line for line in script.splitlines() if 'Name: "desktopicon"' in line
+    )
+    assert "unchecked" not in desktop_task.casefold()
     assert '[Icons]' in script
     assert '{userprograms}\\Olivia 本地版' in script
     assert '{userdesktop}\\Olivia 本地版' in script


### PR DESCRIPTION
Scope: select the existing desktop shortcut task by default, preserve the Start-menu shortcut and hidden launcher contract, and add one focused regression assertion. TDD RED: focused test failed while the task contained the unchecked flag. GREEN: 1 focused test passed after removing only that flag. git diff --check passed. No runtime, media, provider, or client behavior changed.