### PR TITLE
fix: restore mailbox for saved lite sessions

### DIFF
--- a/patch_feapp.py
+++ b/patch_feapp.py
@@ -44,6 +44,16 @@ MAILBOX_LOGIN_REPLACEMENT_0627 = (
     'await t.replace({name:ve.Collection}),'
     'await h(z.uid.toString(),z.modelGatewayToken||"",!1))'
 )
+MAILBOX_SAVED_SESSION_ANCHOR_0627 = (
+    "P.value===Se.LITE||Ce>=bo.SURVEY_ANALYZED?("
+    's.replace({name:ve.Home}),G(T.value,Fe||"",!1)):'
+    "s.replace({name:ve.Login})"
+)
+MAILBOX_SAVED_SESSION_REPLACEMENT_0627 = (
+    "P.value===Se.LITE||Ce>=bo.SURVEY_ANALYZED?("
+    "s.replace({name:P.value===Se.LITE?ve.Collection:ve.Home}),"
+    'G(T.value,Fe||"",!1)):s.replace({name:ve.Login})'
+)
 MAILBOX_WRITE_ANCHOR_0627 = '"hide-write":o(p)||!o(N3)'
 MAILBOX_WRITE_REPLACEMENT_0627 = '"hide-write":!1'
 
@@ -57,6 +67,8 @@ class _PatchProfile:
     mailbox_anchor: str
     mailbox_replacement: str
     collection_route: str
+    saved_session_anchor: str | None
+    saved_session_replacement: str | None
     mailbox_write_anchor: str | None
     mailbox_write_replacement: str | None
 
@@ -72,6 +84,8 @@ _PATCH_PROFILES = (
         "await t.replace({name:ye.Collection})",
         None,
         None,
+        None,
+        None,
     ),
     _PatchProfile(
         MAIN_JS_0627,
@@ -81,6 +95,8 @@ _PATCH_PROFILES = (
         MAILBOX_LOGIN_ANCHOR_0627,
         MAILBOX_LOGIN_REPLACEMENT_0627,
         "await t.replace({name:ve.Collection})",
+        MAILBOX_SAVED_SESSION_ANCHOR_0627,
+        MAILBOX_SAVED_SESSION_REPLACEMENT_0627,
         MAILBOX_WRITE_ANCHOR_0627,
         MAILBOX_WRITE_REPLACEMENT_0627,
     ),
@@ -183,6 +199,25 @@ def _patch_mailbox_default_route(
     )
 
 
+def _patch_saved_session_mailbox_default_route(
+    javascript: str,
+    profile: _PatchProfile,
+) -> str:
+    if profile.saved_session_anchor is None:
+        return javascript
+    if profile.saved_session_replacement is None:
+        raise ValueError("saved lite session mailbox replacement is missing")
+    if javascript.count(profile.saved_session_anchor) != 1:
+        raise ValueError(
+            "saved lite session mailbox anchor is missing or not unique"
+        )
+    return javascript.replace(
+        profile.saved_session_anchor,
+        profile.saved_session_replacement,
+        1,
+    )
+
+
 def _patch_mailbox_write_access(
     javascript: str,
     profile: _PatchProfile,
@@ -265,6 +300,10 @@ def patch_feapp(feapp_path: str | os.PathLike[str], new_ws: str | None,
                 patched_javascript,
                 profile,
             )
+            mailbox_javascript = _patch_saved_session_mailbox_default_route(
+                mailbox_javascript,
+                profile,
+            )
             main_path.write_text(
                 _patch_mailbox_write_access(mailbox_javascript, profile),
                 encoding="utf-8",
@@ -282,6 +321,10 @@ def patch_feapp(feapp_path: str | os.PathLike[str], new_ws: str | None,
                 or new_ws not in patched_js
                 or 'localStorage.setItem("appMode","lite")' not in patched_js
                 or profile.collection_route not in patched_js
+                or (
+                    profile.saved_session_replacement is not None
+                    and profile.saved_session_replacement not in patched_js
+                )
                 or (
                     profile.mailbox_write_replacement is not None
                     and profile.mailbox_write_replacement not in patched_js

--- a/tests/test_baseline_hardening.py
+++ b/tests/test_baseline_hardening.py
@@ -1161,6 +1161,9 @@ def test_patch_feapp_supports_original_client_0_0_9_627(
         '!z.isNew||$?(await t.replace({name:ve.Home}),'
         'await h(z.uid.toString(),z.modelGatewayToken||"",!1))'
         '"hide-write":o(p)||!o(N3)'
+        "P.value===Se.LITE||Ce>=bo.SURVEY_ANALYZED?("
+        's.replace({name:ve.Home}),G(T.value,Fe||"",!1)):'
+        "s.replace({name:ve.Login})"
     )
     with zipfile.ZipFile(feapp, "w", zipfile.ZIP_DEFLATED) as archive:
         archive.writestr(main_member, javascript)
@@ -1179,8 +1182,95 @@ def test_patch_feapp_supports_original_client_0_0_9_627(
     assert 'localStorage.setItem("appMode","lite")' in patched
     assert "await t.replace({name:ve.Collection})" in patched
     assert "await t.replace({name:ve.Home})" not in patched
+    assert (
+        "s.replace({name:P.value===Se.LITE?ve.Collection:ve.Home})"
+        in patched
+    )
     assert '"hide-write":!1' in patched
     assert '"hide-write":o(p)||!o(N3)' not in patched
+
+
+def test_patch_feapp_routes_saved_lite_session_to_mailbox_without_moving_pro_home(
+    tmp_path: Path,
+) -> None:
+    import zipfile
+
+    import patch_feapp
+
+    feapp = tmp_path / "feapp.dat"
+    main_member = "assets/main-31595bd3.js"
+    saved_session_route = (
+        "P.value===Se.LITE||Ce>=bo.SURVEY_ANALYZED?("
+        "s.replace({name:ve.Home}),G(T.value,Fe||\"\",!1)):"
+        "s.replace({name:ve.Login})"
+    )
+    javascript = (
+        'We=e=>new Promise((t,s)=>{try{,'
+        '"query.response":io(a)}}),t(c)},onFailure:'
+        '!z.isNew||$?(await t.replace({name:ve.Home}),'
+        'await h(z.uid.toString(),z.modelGatewayToken||"",!1))'
+        '"hide-write":o(p)||!o(N3)'
+        + saved_session_route
+    )
+    with zipfile.ZipFile(feapp, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(main_member, javascript)
+
+    patch_feapp.patch_feapp(
+        feapp,
+        "ws://127.0.0.1:8899/ws",
+        work_root=tmp_path,
+    )
+
+    with zipfile.ZipFile(feapp) as archive:
+        patched = archive.read(main_member).decode("utf-8")
+
+    assert saved_session_route not in patched
+    assert (
+        "P.value===Se.LITE||Ce>=bo.SURVEY_ANALYZED?("
+        "s.replace({name:P.value===Se.LITE?ve.Collection:ve.Home}),"
+        'G(T.value,Fe||"",!1)):s.replace({name:ve.Login})'
+    ) in patched
+
+
+@pytest.mark.parametrize("saved_session_copies", (0, 2))
+def test_patch_feapp_rejects_ambiguous_saved_session_route_without_mutation(
+    tmp_path: Path,
+    saved_session_copies: int,
+) -> None:
+    import zipfile
+
+    import patch_feapp
+
+    feapp = tmp_path / "feapp.dat"
+    main_member = "assets/main-31595bd3.js"
+    saved_session_route = (
+        "P.value===Se.LITE||Ce>=bo.SURVEY_ANALYZED?("
+        "s.replace({name:ve.Home}),G(T.value,Fe||\"\",!1)):"
+        "s.replace({name:ve.Login})"
+    )
+    javascript = (
+        'We=e=>new Promise((t,s)=>{try{,'
+        '"query.response":io(a)}}),t(c)},onFailure:'
+        '!z.isNew||$?(await t.replace({name:ve.Home}),'
+        'await h(z.uid.toString(),z.modelGatewayToken||"",!1))'
+        '"hide-write":o(p)||!o(N3)'
+        + (saved_session_route * saved_session_copies)
+    )
+    with zipfile.ZipFile(feapp, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(main_member, javascript)
+    before = feapp.read_bytes()
+
+    with pytest.raises(
+        ValueError,
+        match="saved lite session mailbox anchor is missing or not unique",
+    ):
+        patch_feapp.patch_feapp(
+            feapp,
+            "ws://127.0.0.1:8899/ws",
+            work_root=tmp_path,
+        )
+
+    assert feapp.read_bytes() == before
 
 
 def test_patch_feapp_requires_explicit_local_ws_and_rolls_back_on_failure(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes the installed original-client restart path that sent an already signed-in lite user back to Home/曲库. The existing first-login patch already routed to Collection; this adds the corresponding saved-session route while preserving PRO users on Home.\n\nEvidence:\n- focused patch_feapp tests: 8 passed, 37 deselected\n- real 0.0.9.627 feapp.dat.orig copied to a temporary archive and patched successfully\n- lite route resolves to Collection/MailBoxView; PRO route remains Home\n- missing or duplicate saved-session anchor fails closed and leaves the archive byte-identical\n- git diff --check passed\n\nBoundary: no full pytest run by request; no backend, memory, media, installer UI, or user-data changes.