### PR TITLE
fix(imports): restore offline letter pairs

### DIFF
--- a/docs/B04_LOCAL_MEMORY.md
+++ b/docs/B04_LOCAL_MEMORY.md
@@ -19,6 +19,8 @@ SQLite 表、FTS 索引和配置都属于本机数据，位于被 `.gitignore` �
 
 `tools.memory_import.LegacyLetterImporter` 支持 JSON、JSONL、CSV 和逐行文本。支持显式映射、BOM/UTF-8/常见本地编码、路径根限制、dry-run 和 checkpoint；格式、编码、JSON 行和字段错误返回稳定代码，不把正文或路径放入报告。默认 `atomic=true`，坏行或存储失败整批回滚；内容 SHA-256 用于幂等重复检测。
 
+本机已有成对文字备份时，`python -m runtime.imports.offline_letter_pairs --source <json> --memory-root <memory-root>` 默认只 dry-run；用户确认后附加 `--apply` 才会原子写入。输入必须是只含非空 `content`/`reply` 的 JSON 数组，输出仅含计数、状态和源文件 SHA-256。恢复记录使用独立的 typed provenance 与 `offline_mailbox_publish_status=validated_pair_v1`，可作为 `scope=legacy`、`read_only=true`、已读历史显示在默认信箱；它不会调用 LLM、Mem0、PrivateWorld 或媒体，也不会写 `history.evidence.v1`、`official_history_publish_status` 或官方历史记忆语义。通用 HTTP legacy import 会剥离这些本机发布字段，不能伪造默认信箱可见性；原始备份仍不进入仓库或安装包。
+
 metadata 先规范化为 JSON 数据模型，再作为完整 JSON 文本存储；超过安全上限会拒绝整条记录，绝不会截断序列化后的 JSON。`export_records(domains=...)` 要求调用方显式选择域，并在返回前校验可以生成有效 JSON；未选择域会拒绝。
 
 ## Prompt 与删除语义

--- a/local_server.py
+++ b/local_server.py
@@ -2117,19 +2117,23 @@ def _official_history_mailbox_projection() -> list[dict]:
     projected: list[dict] = []
     for letter in _legacy_letter_collection():
         metadata = letter.get("metadata")
+        offline_pair = is_published_offline_letter_pair(metadata)
         official_history_completed = bool(
             isinstance(metadata, Mapping)
             and metadata.get("import_kind") == "official_text_reply"
             and metadata.get(OFFICIAL_HISTORY_PUBLISH_STATUS_KEY)
             == OFFICIAL_HISTORY_PUBLISH_STATUS_COMPLETED
         )
-        if not official_history_completed and not is_published_offline_letter_pair(
-            metadata
-        ):
+        if not official_history_completed and not offline_pair:
             continue
         projected.append(
             {
                 **letter,
+                **(
+                    {"created_at": None, "replied_at": None}
+                    if offline_pair
+                    else {}
+                ),
                 "letter_status": "COMPLETED",
                 "is_read": 1,
                 "read_only": True,

--- a/local_server.py
+++ b/local_server.py
@@ -125,6 +125,11 @@ from runtime.memory.private_world_runtime import (
     resolve_private_world_database,
 )
 from runtime.imports.official_letters import collect_default_official_text_replies
+from runtime.imports.offline_letter_pairs import (
+    OFFLINE_LETTER_PAIR_PROVENANCE_KEY,
+    OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY,
+    is_published_offline_letter_pair,
+)
 from runtime.imports.historical_memory import (
     HistoricalMigrationResult,
     apply_historical_private_world,
@@ -1428,14 +1433,16 @@ def letter_to_out(l):
     published = l.get("reply_not_before", 0.0) <= time.time()
     failed = l.get("letter_status") in {"FAILED", "CANCELED", "CANCELLED"}
     metadata = l.get("metadata")
-    imported_official = isinstance(metadata, dict) and (
-        metadata.get("import_kind") == "official_text_reply"
-    )
+    imported_history = (
+        isinstance(metadata, dict)
+        and metadata.get("import_kind") == "official_text_reply"
+    ) or is_published_offline_letter_pair(metadata)
     summary = (
         l.get("content")
-        if imported_official
+        if imported_history
         else l.get("reply_text") or l.get("content")
-    ) or ""
+    )
+    summary = summary or ""
     return {
         "letter_id": l["letter_id"],
         "summary": summary[:50],
@@ -2110,11 +2117,14 @@ def _official_history_mailbox_projection() -> list[dict]:
     projected: list[dict] = []
     for letter in _legacy_letter_collection():
         metadata = letter.get("metadata")
-        if (
-            not isinstance(metadata, Mapping)
-            or metadata.get("import_kind") != "official_text_reply"
-            or metadata.get(OFFICIAL_HISTORY_PUBLISH_STATUS_KEY)
-            != OFFICIAL_HISTORY_PUBLISH_STATUS_COMPLETED
+        official_history_completed = bool(
+            isinstance(metadata, Mapping)
+            and metadata.get("import_kind") == "official_text_reply"
+            and metadata.get(OFFICIAL_HISTORY_PUBLISH_STATUS_KEY)
+            == OFFICIAL_HISTORY_PUBLISH_STATUS_COMPLETED
+        )
+        if not official_history_completed and not is_published_offline_letter_pair(
+            metadata
         ):
             continue
         projected.append(
@@ -2234,6 +2244,8 @@ def _legacy_records(body: dict) -> list[LegacyLetter] | None:
         metadata = dict(submitted_metadata)
         metadata.pop(OFFICIAL_HISTORY_PUBLISH_STATUS_KEY, None)
         metadata.pop(OFFICIAL_HISTORY_MEMORY_SEMANTICS_KEY, None)
+        metadata.pop(OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY, None)
+        metadata.pop(OFFLINE_LETTER_PAIR_PROVENANCE_KEY, None)
         records.append(
             LegacyLetter(
                 content=item.get("content", ""),

--- a/runtime/imports/offline_letter_pairs.py
+++ b/runtime/imports/offline_letter_pairs.py
@@ -1,0 +1,242 @@
+"""Restore paired local letters into the read-only archive without providers."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass, replace
+import hashlib
+import json
+from pathlib import Path
+import re
+import sqlite3
+from typing import Mapping, Sequence
+
+from runtime.memory.local_memory import LocalMemoryAdapter
+from runtime.memory.memory_port import LegacyLetter
+
+
+_MAX_SOURCE_BYTES = 16 * 1024 * 1024
+_MAX_PAIR_CHARS = 200_000
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+OFFLINE_LETTER_PAIR_IMPORT_KIND = "offline_recovered_text_reply"
+OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY = "offline_mailbox_publish_status"
+OFFLINE_LETTER_PAIR_PUBLISH_STATUS = "validated_pair_v1"
+OFFLINE_LETTER_PAIR_PROVENANCE_KEY = "offline_letter_pair_provenance"
+
+
+@dataclass(frozen=True)
+class OfflineLetterPairProvenance:
+    source_sha256: str
+    source_index: int
+    schema_version: int = 1
+    timestamp_status: str = "unknown"
+
+    def __post_init__(self) -> None:
+        if not _SHA256_RE.fullmatch(self.source_sha256):
+            raise ValueError("offline source digest is invalid")
+        if type(self.source_index) is not int or self.source_index < 1:
+            raise ValueError("offline source index is invalid")
+        if self.schema_version != 1 or self.timestamp_status != "unknown":
+            raise ValueError("offline provenance version is invalid")
+
+    @classmethod
+    def from_metadata(cls, value: object) -> "OfflineLetterPairProvenance":
+        try:
+            if not isinstance(value, Mapping):
+                raise TypeError
+            return cls(**dict(value))  # type: ignore[arg-type]
+        except TypeError as exc:
+            raise ValueError("offline provenance metadata is invalid") from exc
+
+
+@dataclass(frozen=True)
+class OfflineLetterPairRecoveryReport:
+    status: str
+    source_sha256: str
+    seen: int
+    accepted: int
+    would_insert: int
+    inserted: int = 0
+    duplicates: int = 0
+    rejected: int = 0
+    read_only: bool = True
+    history_audit: str = "not_written"
+    provider_calls: int = 0
+
+
+def is_published_offline_letter_pair(metadata: object) -> bool:
+    if not isinstance(metadata, Mapping):
+        return False
+    if (
+        metadata.get("import_kind") != OFFLINE_LETTER_PAIR_IMPORT_KIND
+        or metadata.get(OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY)
+        != OFFLINE_LETTER_PAIR_PUBLISH_STATUS
+    ):
+        return False
+    try:
+        OfflineLetterPairProvenance.from_metadata(
+            metadata.get(OFFLINE_LETTER_PAIR_PROVENANCE_KEY)
+        )
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _pair_archive_content(pair: tuple[str, str]) -> str:
+    return f"User letter:\n{pair[0]}\nLinli reply:\n{pair[1]}"
+
+
+def _build_records(
+    raw: bytes,
+    pairs: tuple[tuple[str, str], ...],
+) -> tuple[LegacyLetter, ...]:
+    source_sha256 = hashlib.sha256(raw).hexdigest()
+    records: list[LegacyLetter] = []
+    for index, pair in enumerate(pairs, start=1):
+        records.append(
+            LegacyLetter(
+                content=_pair_archive_content(pair),
+                source_record_id=f"offline-letter-pairs:{source_sha256}:{index:06d}",
+                source="offline-letter-pairs",
+                occurred_at=None,
+                metadata={
+                    "user_content": pair[0],
+                    "reply_text": pair[1],
+                    "import_kind": OFFLINE_LETTER_PAIR_IMPORT_KIND,
+                    OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY: OFFLINE_LETTER_PAIR_PUBLISH_STATUS,
+                    OFFLINE_LETTER_PAIR_PROVENANCE_KEY: asdict(
+                        OfflineLetterPairProvenance(source_sha256, index)
+                    ),
+                },
+            )
+        )
+    return tuple(records)
+
+
+def _parse_source(path: Path) -> tuple[bytes, tuple[tuple[str, str], ...]]:
+    raw = path.read_bytes()
+    if len(raw) > _MAX_SOURCE_BYTES:
+        raise ValueError("OFFLINE_LETTER_SOURCE_TOO_LARGE")
+    try:
+        loaded = json.loads(raw.decode("utf-8-sig"))
+    except (UnicodeError, ValueError) as exc:
+        raise ValueError("OFFLINE_LETTER_SOURCE_INVALID") from exc
+    if not isinstance(loaded, list) or not loaded:
+        raise ValueError("OFFLINE_LETTER_SOURCE_INVALID")
+    pairs: list[tuple[str, str]] = []
+    for value in loaded:
+        if not isinstance(value, dict) or set(value) != {"content", "reply"}:
+            raise ValueError("OFFLINE_LETTER_PAIR_INVALID")
+        content = value.get("content")
+        reply = value.get("reply")
+        if not all(isinstance(item, str) and item.strip() for item in (content, reply)):
+            raise ValueError("OFFLINE_LETTER_PAIR_INVALID")
+        pair = (content, reply)
+        if len(_pair_archive_content(pair)) > _MAX_PAIR_CHARS:
+            raise ValueError("OFFLINE_LETTER_PAIR_TOO_LARGE")
+        pairs.append(pair)
+    return raw, tuple(pairs)
+
+
+def _read_existing_hashes(database_path: Path) -> set[str]:
+    if not database_path.is_file():
+        return set()
+    connection = sqlite3.connect(f"file:{database_path.as_posix()}?mode=ro", uri=True)
+    try:
+        try:
+            rows = connection.execute("SELECT content_hash FROM legacy_letters").fetchall()
+        except sqlite3.OperationalError as exc:
+            if "no such table" not in str(exc):
+                raise
+            return set()
+        return {str(row[0]) for row in rows}
+    finally:
+        connection.close()
+
+
+def _recovery_plan(
+    raw: bytes,
+    pairs: tuple[tuple[str, str], ...],
+    database_path: Path,
+) -> OfflineLetterPairRecoveryReport:
+    existing = _read_existing_hashes(database_path)
+    batch: set[str] = set()
+    duplicates = 0
+    for pair in pairs:
+        digest = hashlib.sha256(_pair_archive_content(pair).encode()).hexdigest()
+        if digest in existing or digest in batch:
+            duplicates += 1
+        batch.add(digest)
+    return OfflineLetterPairRecoveryReport(
+        status="dry_run",
+        source_sha256=hashlib.sha256(raw).hexdigest(),
+        seen=len(pairs),
+        accepted=len(pairs),
+        would_insert=len(pairs) - duplicates,
+        duplicates=duplicates,
+    )
+
+
+def plan_offline_letter_pair_recovery(
+    source_path: str | Path,
+    *,
+    database_path: str | Path,
+) -> OfflineLetterPairRecoveryReport:
+    raw, pairs = _parse_source(Path(source_path))
+    return _recovery_plan(raw, pairs, Path(database_path))
+
+
+def apply_offline_letter_pair_recovery(
+    source_path: str | Path,
+    *,
+    database_path: str | Path,
+) -> OfflineLetterPairRecoveryReport:
+    database = Path(database_path)
+    raw, pairs = _parse_source(Path(source_path))
+    plan = _recovery_plan(raw, pairs, database)
+    archive = LocalMemoryAdapter(database)
+    try:
+        result = archive.import_legacy_records(
+            _build_records(raw, pairs),
+            atomic=True,
+            promote_duplicate_metadata=True,
+        )
+    finally:
+        archive.close()
+    return replace(
+        plan,
+        status="rolled_back" if result.rolled_back else "committed",
+        inserted=result.inserted,
+        duplicates=result.duplicates,
+        rejected=result.rejected,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--memory-root", required=True)
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args(argv)
+    database_path = Path(args.memory_root) / "memory.sqlite3"
+    try:
+        report = (
+            apply_offline_letter_pair_recovery(args.source, database_path=database_path)
+            if args.apply
+            else plan_offline_letter_pair_recovery(args.source, database_path=database_path)
+        )
+    except (OSError, sqlite3.Error, ValueError) as exc:
+        error_code = str(exc)
+        if not re.fullmatch(r"OFFLINE_LETTER_[A-Z0-9_]+", error_code):
+            error_code = "OFFLINE_LETTER_SOURCE_UNAVAILABLE"
+        failure = dict(error_code=error_code, history_audit="not_written",
+                       provider_calls=0, read_only=True, status="rejected")
+        print(json.dumps(failure, ensure_ascii=True, sort_keys=True))
+        return 2
+    print(json.dumps(asdict(report), ensure_ascii=True, sort_keys=True))
+    return 0 if report.status in {"dry_run", "committed"} else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/imports/offline_letter_pairs.py
+++ b/runtime/imports/offline_letter_pairs.py
@@ -84,7 +84,12 @@ def is_published_offline_letter_pair(metadata: object) -> bool:
 
 
 def _pair_archive_content(pair: tuple[str, str]) -> str:
-    return f"User letter:\n{pair[0]}\nLinli reply:\n{pair[1]}"
+    return json.dumps(
+        {"content": pair[0], "reply": pair[1]},
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
 
 
 def _build_records(
@@ -200,7 +205,6 @@ def apply_offline_letter_pair_recovery(
         result = archive.import_legacy_records(
             _build_records(raw, pairs),
             atomic=True,
-            promote_duplicate_metadata=True,
         )
     finally:
         archive.close()

--- a/tests/imports/test_offline_letter_pairs.py
+++ b/tests/imports/test_offline_letter_pairs.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+
+from runtime.imports.offline_letter_pairs import (
+    OFFLINE_LETTER_PAIR_IMPORT_KIND,
+    OFFLINE_LETTER_PAIR_PROVENANCE_KEY,
+    OFFLINE_LETTER_PAIR_PUBLISH_STATUS,
+    OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY,
+    main,
+)
+from runtime.memory.local_memory import LocalMemoryAdapter
+from runtime.memory.memory_port import LegacyImportResult
+
+
+def _write_pairs(path: Path) -> bytes:
+    raw = json.dumps(
+        [
+            {"content": "synthetic old letter one", "reply": "synthetic old reply one"},
+            {"content": "synthetic old letter two", "reply": "synthetic old reply two"},
+        ],
+        ensure_ascii=False,
+    ).encode("utf-8")
+    path.write_bytes(raw)
+    return raw
+
+
+def _run_cli(source: Path, memory_root: Path, capsys, *, apply: bool = False):
+    args = ["--source", str(source), "--memory-root", str(memory_root)]
+    exit_code = main([*args, "--apply"] if apply else args)
+    output = capsys.readouterr().out
+    return exit_code, output, json.loads(output)
+
+
+def _offline_metadata(digest: str) -> dict[str, object]:
+    return {
+        "import_kind": OFFLINE_LETTER_PAIR_IMPORT_KIND,
+        OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY: OFFLINE_LETTER_PAIR_PUBLISH_STATUS,
+        OFFLINE_LETTER_PAIR_PROVENANCE_KEY: dict(
+            schema_version=1, source_index=1, source_sha256=digest,
+            timestamp_status="unknown",
+        ),
+    }
+
+
+def test_offline_letter_pair_cli_dry_run_is_content_free_and_side_effect_free(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = tmp_path / "letter-pairs.json"
+    raw = _write_pairs(source)
+    memory_root = tmp_path / "memory"
+
+    exit_code, output, report = _run_cli(source, memory_root, capsys)
+    assert exit_code == 0
+    assert report["status"] == "dry_run"
+    assert report["source_sha256"] == hashlib.sha256(raw).hexdigest()
+    assert (report["seen"], report["accepted"], report["would_insert"]) == (2, 2, 2)
+    assert report["history_audit"] == "not_written" and report["provider_calls"] == 0
+    assert "synthetic old letter" not in output
+    assert "synthetic old reply" not in output
+    assert not memory_root.exists()
+
+
+def test_offline_letter_pair_cli_apply_is_atomic_typed_and_idempotent(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = tmp_path / "letter-pairs.json"
+    raw = _write_pairs(source)
+    memory_root = tmp_path / "memory"
+
+    first_exit, first_output, first = _run_cli(source, memory_root, capsys, apply=True)
+    second_exit, second_output, second = _run_cli(source, memory_root, capsys, apply=True)
+    assert first_exit == second_exit == 0
+    assert (first["status"], first["inserted"], first["duplicates"]) == (
+        "committed", 2, 0
+    )
+    assert first["source_sha256"] == hashlib.sha256(raw).hexdigest()
+    assert (second["status"], second["inserted"], second["duplicates"]) == (
+        "committed", 0, 2
+    )
+    assert second["would_insert"] == 0
+    assert "synthetic old letter" not in first_output + second_output
+    assert "synthetic old reply" not in first_output + second_output
+
+    archive = LocalMemoryAdapter(memory_root / "memory.sqlite3")
+    try:
+        letters = archive.list_legacy()
+    finally:
+        archive.close()
+    assert len(letters) == 2
+    observed_indexes = set()
+    for letter in letters:
+        metadata = letter["metadata"]
+        assert metadata["import_kind"] == OFFLINE_LETTER_PAIR_IMPORT_KIND
+        assert (
+            metadata[OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY]
+            == OFFLINE_LETTER_PAIR_PUBLISH_STATUS
+        )
+        provenance = metadata[OFFLINE_LETTER_PAIR_PROVENANCE_KEY]
+        observed_indexes.add(provenance["source_index"])
+        assert provenance == {
+            "schema_version": 1,
+            "source_index": provenance["source_index"],
+            "source_sha256": hashlib.sha256(raw).hexdigest(),
+            "timestamp_status": "unknown",
+        }
+        assert "official_history_publish_status" not in metadata
+        assert "official_history_memory_semantics" not in metadata
+    assert observed_indexes == {1, 2}
+
+
+def test_offline_letter_pair_cli_rejects_whole_invalid_batch_without_echo(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = tmp_path / "invalid.json"
+    source.write_text(
+        json.dumps(
+            [
+                {"content": "private-looking synthetic text", "reply": "valid reply"},
+                {"content": "second private-looking synthetic text"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    memory_root = tmp_path / "memory"
+
+    exit_code, output, report = _run_cli(source, memory_root, capsys, apply=True)
+    assert exit_code == 2
+    assert report["error_code"] == "OFFLINE_LETTER_PAIR_INVALID"
+    assert report["status"] == "rejected"
+    assert report["history_audit"] == "not_written" and report["provider_calls"] == 0
+    assert "private-looking" not in output
+    assert str(source) not in output
+    assert not memory_root.exists()
+
+
+def test_validated_offline_pairs_are_read_only_in_the_default_mailbox(
+    monkeypatch,
+) -> None:
+    import local_server
+
+    imported = {
+        "letter_id": "offline-pair-1",
+        "created_at": 1710000000,
+        "content": "synthetic recovered letter",
+        "reply_text": "synthetic recovered reply",
+        "is_read": 0,
+        "read_only": True,
+        "metadata": _offline_metadata("a" * 64),
+    }
+    monkeypatch.setattr(local_server.store, "letters", [])
+    monkeypatch.setattr(local_server, "_legacy_letter_collection", lambda *, strict=False: [imported])
+
+    listed = asyncio.run(local_server.route("GET", "/toy/letter/list", {}, {}))
+    unread = asyncio.run(local_server.route("GET", "/toy/letter/unread_count", {}, {}))
+    detail = asyncio.run(
+        local_server.route(
+            "GET",
+            "/toy/letter/detail",
+            {},
+            {"letter_id": "offline-pair-1"},
+        )
+    )
+
+    assert listed["data"]["total"] == 1
+    assert listed["data"]["list"][0]["summary"] == "synthetic recovered letter"
+    assert unread["data"]["unread_count"] == 0
+    assert detail["data"]["reply_text"] == "synthetic recovered reply"
+    assert detail["data"]["scope"] == "legacy"
+    assert detail["data"]["read_only"] is True
+    assert local_server._letter_collection("current")[0]["is_read"] == 1
+
+
+def test_generic_legacy_http_import_cannot_forge_offline_mailbox_publication(
+    monkeypatch,
+) -> None:
+    import local_server
+
+    class Archive:
+        enabled = True
+
+        def __init__(self) -> None:
+            self.records = ()
+
+        def import_legacy_records(self, records, **_kwargs):
+            self.records = tuple(records)
+            return LegacyImportResult(seen=len(self.records), inserted=len(self.records))
+
+    archive = Archive()
+    monkeypatch.setattr(local_server, "_legacy_import_adapter", lambda: archive)
+    payload = {
+        "mode": "read_only",
+        "letters": [
+            {
+                "source_record_id": "untrusted-1",
+                "content": "synthetic combined pair",
+                "metadata": {
+                    **_offline_metadata("b" * 64),
+                    "reply_text": "synthetic reply",
+                },
+            }
+        ],
+    }
+
+    imported = asyncio.run(local_server.route("POST", "/toy/letter/legacy/import", payload, {}))
+
+    assert imported["code"] == 0
+    assert len(archive.records) == 1
+    metadata = archive.records[0].metadata
+    assert OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY not in metadata
+    assert OFFLINE_LETTER_PAIR_PROVENANCE_KEY not in metadata
+    assert metadata["reply_text"] == "synthetic reply"

--- a/tests/imports/test_offline_letter_pairs.py
+++ b/tests/imports/test_offline_letter_pairs.py
@@ -18,11 +18,8 @@ from runtime.memory.memory_port import LegacyImportResult
 
 def _write_pairs(path: Path) -> bytes:
     raw = json.dumps(
-        [
-            {"content": "synthetic old letter one", "reply": "synthetic old reply one"},
-            {"content": "synthetic old letter two", "reply": "synthetic old reply two"},
-        ],
-        ensure_ascii=False,
+        [{"content": f"synthetic old letter {n}", "reply": f"synthetic old reply {n}"}
+         for n in ("one", "two")], ensure_ascii=False,
     ).encode("utf-8")
     path.write_bytes(raw)
     return raw
@@ -39,17 +36,12 @@ def _offline_metadata(digest: str) -> dict[str, object]:
     return {
         "import_kind": OFFLINE_LETTER_PAIR_IMPORT_KIND,
         OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY: OFFLINE_LETTER_PAIR_PUBLISH_STATUS,
-        OFFLINE_LETTER_PAIR_PROVENANCE_KEY: dict(
-            schema_version=1, source_index=1, source_sha256=digest,
-            timestamp_status="unknown",
-        ),
+        OFFLINE_LETTER_PAIR_PROVENANCE_KEY: dict(schema_version=1, source_index=1,
+            source_sha256=digest, timestamp_status="unknown"),
     }
 
 
-def test_offline_letter_pair_cli_dry_run_is_content_free_and_side_effect_free(
-    tmp_path: Path,
-    capsys,
-) -> None:
+def test_offline_letter_pair_cli_dry_run_is_content_free_and_side_effect_free(tmp_path, capsys):
     source = tmp_path / "letter-pairs.json"
     raw = _write_pairs(source)
     memory_root = tmp_path / "memory"
@@ -59,31 +51,26 @@ def test_offline_letter_pair_cli_dry_run_is_content_free_and_side_effect_free(
     assert report["status"] == "dry_run"
     assert report["source_sha256"] == hashlib.sha256(raw).hexdigest()
     assert (report["seen"], report["accepted"], report["would_insert"]) == (2, 2, 2)
-    assert report["history_audit"] == "not_written" and report["provider_calls"] == 0
-    assert "synthetic old letter" not in output
-    assert "synthetic old reply" not in output
+    assert (report["history_audit"], report["provider_calls"]) == ("not_written", 0)
+    assert "synthetic old letter" not in output and "synthetic old reply" not in output
     assert not memory_root.exists()
 
 
-def test_offline_letter_pair_cli_apply_is_atomic_typed_and_idempotent(
-    tmp_path: Path,
-    capsys,
-) -> None:
+def test_offline_letter_pair_cli_apply_is_atomic_typed_and_idempotent(tmp_path, capsys):
     source = tmp_path / "letter-pairs.json"
     raw = _write_pairs(source)
     memory_root = tmp_path / "memory"
 
     first_exit, first_output, first = _run_cli(source, memory_root, capsys, apply=True)
+    _dry_exit, _dry_output, dry = _run_cli(source, memory_root, capsys)
     second_exit, second_output, second = _run_cli(source, memory_root, capsys, apply=True)
     assert first_exit == second_exit == 0
-    assert (first["status"], first["inserted"], first["duplicates"]) == (
-        "committed", 2, 0
-    )
+    assert (first["status"], first["inserted"], first["duplicates"]) == ("committed", 2, 0)
     assert first["source_sha256"] == hashlib.sha256(raw).hexdigest()
-    assert (second["status"], second["inserted"], second["duplicates"]) == (
-        "committed", 0, 2
-    )
-    assert second["would_insert"] == 0
+    assert (second["status"], second["inserted"], second["duplicates"]) == ("committed", 0, 2)
+    assert (second["would_insert"], second["duplicates"]) == (
+        dry["would_insert"], dry["duplicates"]
+    ) == (0, 2)
     assert "synthetic old letter" not in first_output + second_output
     assert "synthetic old reply" not in first_output + second_output
 
@@ -97,10 +84,7 @@ def test_offline_letter_pair_cli_apply_is_atomic_typed_and_idempotent(
     for letter in letters:
         metadata = letter["metadata"]
         assert metadata["import_kind"] == OFFLINE_LETTER_PAIR_IMPORT_KIND
-        assert (
-            metadata[OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY]
-            == OFFLINE_LETTER_PAIR_PUBLISH_STATUS
-        )
+        assert metadata[OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY] == OFFLINE_LETTER_PAIR_PUBLISH_STATUS
         provenance = metadata[OFFLINE_LETTER_PAIR_PROVENANCE_KEY]
         observed_indexes.add(provenance["source_index"])
         assert provenance == {
@@ -113,20 +97,28 @@ def test_offline_letter_pair_cli_apply_is_atomic_typed_and_idempotent(
         assert "official_history_memory_semantics" not in metadata
     assert observed_indexes == {1, 2}
 
+    different_source = tmp_path / "same-pairs-different-source.json"
+    different_source.write_text(
+        json.dumps(json.loads(raw), ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    before = letters
+    _exit, _output, dry_duplicate = _run_cli(different_source, memory_root, capsys)
+    _exit, _output, applied_duplicate = _run_cli(different_source, memory_root, capsys, apply=True)
+    archive = LocalMemoryAdapter(memory_root / "memory.sqlite3")
+    try:
+        after = archive.list_legacy()
+    finally:
+        archive.close()
+    assert (dry_duplicate["would_insert"], dry_duplicate["duplicates"]) == (0, 2)
+    assert (applied_duplicate["inserted"], applied_duplicate["duplicates"]) == (0, 2)
+    assert after == before
 
-def test_offline_letter_pair_cli_rejects_whole_invalid_batch_without_echo(
-    tmp_path: Path,
-    capsys,
-) -> None:
+
+def test_offline_letter_pair_cli_rejects_whole_invalid_batch_without_echo(tmp_path, capsys):
     source = tmp_path / "invalid.json"
     source.write_text(
-        json.dumps(
-            [
-                {"content": "private-looking synthetic text", "reply": "valid reply"},
-                {"content": "second private-looking synthetic text"},
-            ]
-        ),
-        encoding="utf-8",
+        json.dumps([{"content": "private-looking synthetic text", "reply": "valid reply"},
+                    {"content": "second private-looking synthetic text"}]), encoding="utf-8",
     )
     memory_root = tmp_path / "memory"
 
@@ -134,52 +126,63 @@ def test_offline_letter_pair_cli_rejects_whole_invalid_batch_without_echo(
     assert exit_code == 2
     assert report["error_code"] == "OFFLINE_LETTER_PAIR_INVALID"
     assert report["status"] == "rejected"
-    assert report["history_audit"] == "not_written" and report["provider_calls"] == 0
+    assert (report["history_audit"], report["provider_calls"]) == ("not_written", 0)
     assert "private-looking" not in output
     assert str(source) not in output
     assert not memory_root.exists()
 
 
-def test_validated_offline_pairs_are_read_only_in_the_default_mailbox(
-    monkeypatch,
-) -> None:
+def test_pair_identity_does_not_collide_on_display_delimiters(tmp_path, capsys):
+    source = tmp_path / "delimiter-pairs.json"
+    source.write_text(
+        json.dumps([{"content": "alpha\nLinli reply:\nbeta", "reply": "gamma"},
+                    {"content": "alpha", "reply": "beta\nLinli reply:\ngamma"}]),
+        encoding="utf-8",
+    )
+    memory_root = tmp_path / "memory"
+
+    _exit, _output, dry = _run_cli(source, memory_root, capsys)
+    _exit, _output, applied = _run_cli(source, memory_root, capsys, apply=True)
+
+    assert (dry["would_insert"], dry["duplicates"]) == (2, 0)
+    assert (applied["inserted"], applied["duplicates"]) == (2, 0)
+
+
+def test_cli_recovery_keeps_unknown_time_in_the_default_mailbox(tmp_path, capsys, monkeypatch):
     import local_server
 
-    imported = {
-        "letter_id": "offline-pair-1",
-        "created_at": 1710000000,
-        "content": "synthetic recovered letter",
-        "reply_text": "synthetic recovered reply",
-        "is_read": 0,
-        "read_only": True,
-        "metadata": _offline_metadata("a" * 64),
-    }
+    source = tmp_path / "letter-pairs.json"
+    _write_pairs(source)
+    memory_root = tmp_path / "memory"
+    exit_code, _output, report = _run_cli(source, memory_root, capsys, apply=True)
+    assert exit_code == 0 and report["inserted"] == 2
+
+    archive = LocalMemoryAdapter(memory_root / "memory.sqlite3")
     monkeypatch.setattr(local_server.store, "letters", [])
-    monkeypatch.setattr(local_server, "_legacy_letter_collection", lambda *, strict=False: [imported])
+    monkeypatch.setattr(local_server, "memory_adapter", archive)
+    try:
+        stored_times = archive.connection.execute("SELECT occurred_at FROM legacy_letters").fetchall()
+        assert {row[0] for row in stored_times} == {None}
+        listed = asyncio.run(local_server.route("GET", "/toy/letter/list", {}, {}))
+        unread = asyncio.run(local_server.route("GET", "/toy/letter/unread_count", {}, {}))
+        item = listed["data"]["list"][0]
+        detail = asyncio.run(local_server.route(
+            "GET", "/toy/letter/detail", {}, {"letter_id": item["letter_id"]}))
+    finally:
+        archive.close()
 
-    listed = asyncio.run(local_server.route("GET", "/toy/letter/list", {}, {}))
-    unread = asyncio.run(local_server.route("GET", "/toy/letter/unread_count", {}, {}))
-    detail = asyncio.run(
-        local_server.route(
-            "GET",
-            "/toy/letter/detail",
-            {},
-            {"letter_id": "offline-pair-1"},
-        )
-    )
-
-    assert listed["data"]["total"] == 1
-    assert listed["data"]["list"][0]["summary"] == "synthetic recovered letter"
+    assert listed["data"]["total"] == 2
+    assert item["summary"].startswith("synthetic old letter")
+    assert item["created_at"] is None
     assert unread["data"]["unread_count"] == 0
-    assert detail["data"]["reply_text"] == "synthetic recovered reply"
+    assert detail["data"]["reply_text"].startswith("synthetic old reply")
+    assert detail["data"]["created_at"] is None
+    assert detail["data"]["replied_at"] is None
     assert detail["data"]["scope"] == "legacy"
     assert detail["data"]["read_only"] is True
-    assert local_server._letter_collection("current")[0]["is_read"] == 1
 
 
-def test_generic_legacy_http_import_cannot_forge_offline_mailbox_publication(
-    monkeypatch,
-) -> None:
+def test_generic_legacy_http_import_cannot_forge_offline_mailbox_publication(monkeypatch):
     import local_server
 
     class Archive:
@@ -194,19 +197,10 @@ def test_generic_legacy_http_import_cannot_forge_offline_mailbox_publication(
 
     archive = Archive()
     monkeypatch.setattr(local_server, "_legacy_import_adapter", lambda: archive)
-    payload = {
-        "mode": "read_only",
-        "letters": [
-            {
-                "source_record_id": "untrusted-1",
-                "content": "synthetic combined pair",
-                "metadata": {
-                    **_offline_metadata("b" * 64),
-                    "reply_text": "synthetic reply",
-                },
-            }
-        ],
-    }
+    payload = {"mode": "read_only", "letters": [{
+        "source_record_id": "untrusted-1", "content": "synthetic combined pair",
+        "metadata": {**_offline_metadata("b" * 64), "reply_text": "synthetic reply"},
+    }]}
 
     imported = asyncio.run(local_server.route("POST", "/toy/letter/legacy/import", payload, {}))
 

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1861,6 +1861,7 @@ def test_install_isolated_copy_activates_original_client_surfaces(
     assert (installed / "local_backend" / "original_client_setup_api.py").is_file()
     assert (installed / "local_backend" / "original_client_capability_api.py").is_file()
     assert (installed / "local_backend" / "original_client_update_api.py").is_file()
+    assert (installed / "local_backend/runtime/imports/offline_letter_pairs.py").is_file()
     assert "toyApiUrl" in main
     assert "await t.replace({name:ye.Collection})" in main
 


### PR DESCRIPTION
Restores privacy-safe offline letter-pair recovery after the official server shutdown. Unknown historical timestamps remain unknown; canonical pair identity prevents delimiter collisions; duplicate imports do not mutate existing rows. Scope: 5 files, +488/-11. Validation: focused import and CLI-to-SQLite-to-HTTP tests PASS; full pytest 1976 passed, 3 skipped, 1 deselected; hardening, compileall, and diff-check PASS. Frozen exact pair: 3b63f27b54e86754e1ad631c324df5ddcca0c39d...d4ca85b72c688b7c565a08a94f77aa9ae02b75ba. Standards PASS; Spec PASS; P0/P1/P2=0. No real letter body was logged or returned, and provider, Mem0, PrivateWorld, and media calls remain zero. Real client import is not claimed by this PR.