### PR TITLE
fix(update): use stable shortcut script

### DIFF
--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -135,7 +135,7 @@ webplayer.dat.orig
 
 普通用户在客户端 Settings 的“补丁更新”中选择已下载的 `.oliviapatch`，粘贴发布页提供的 Manifest SHA-256 后安装；成功后关闭并重新打开 Olivia。该页面也提供回滚到上一版本的入口。命令行入口继续保留用于维护和故障排查。
 
-状态指针成功切换后，更新器会以 best-effort 方式发现桌面和开始菜单中仍然存在的快捷方式，并把图标刷新到当前激活版本。属于当前安装、仍指向旧 `START.cmd` 的快捷方式会同时迁移为 `%WINDIR%\System32\wscript.exe //B //Nologo "<安装目录>\START.vbs"` 隐藏启动；已经采用该隐藏入口的当前安装快捷方式只刷新图标。其他安装或无关的 wscript 快捷方式不会被改写。路径发现失败、PowerShell 不可用或启动失败、执行超时、非零退出以及单个快捷方式保存失败，都不会撤销已经完成的补丁激活，也不会把成功更新改报为失败。
+状态指针成功切换后，更新器只会调用完整安装包写入 `launcher/Create-Shortcut.ps1` 的稳定副本，以 best-effort 方式发现桌面和开始菜单中仍然存在的快捷方式并刷新图标；不会执行刚激活补丁载荷里的脚本。属于当前安装、仍指向旧 `START.cmd` 的快捷方式会同时迁移为 `%WINDIR%\System32\wscript.exe //B //Nologo "<安装目录>\START.vbs"` 隐藏启动；已经采用该隐藏入口的当前安装快捷方式只刷新图标。其他安装或无关的 wscript 快捷方式不会被改写。路径发现失败、PowerShell 不可用或启动失败、执行超时、非零退出以及单个快捷方式保存失败，都不会撤销已经完成的补丁激活，也不会把成功更新改报为失败。
 
 客户端补丁入口的鉴权、请求、响应、重启语义和稳定错误码见 `contracts/local_update_api_contract.json` 及其 schema。
 

--- a/installer/component_update.py
+++ b/installer/component_update.py
@@ -383,13 +383,13 @@ def _resolve_state_payload(
     return current
 
 
-def _refresh_existing_shortcuts(root: Path, active_version: Path) -> None:
+def _refresh_existing_shortcuts(root: Path, _active_version: Path) -> None:
     """Best-effort icon refresh for shortcuts that the user kept."""
 
     if os.name != "nt":
         return
     try:
-        script = active_version / "installer" / "Create-Shortcut.ps1"
+        script = root / "launcher" / "Create-Shortcut.ps1"
         powershell = (
             Path(os.environ.get("WINDIR", r"C:\Windows"))
             / "System32"

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -515,6 +515,14 @@ def _write_start_scripts(root: Path, port: int) -> None:
     launcher = root / "launcher" / "version_launcher.py"
     launcher.parent.mkdir(parents=True, exist_ok=True)
     _copy_file(root / "local_backend" / "installer" / "version_launcher.py", launcher)
+    _copy_file(
+        root / "local_backend" / "installer" / "Create-Shortcut.ps1",
+        launcher.parent / "Create-Shortcut.ps1",
+    )
+    _copy_file(
+        root / "local_backend" / "installer" / "start_hidden.vbs.txt",
+        launcher.parent / "start_hidden.vbs.txt",
+    )
     (root / "START.cmd").write_text(
         f"@echo off\nsetlocal\nset ROOT=%~dp0\nset OLIVIA_PORT={port}\nset PYTHON_EXE=%ROOT%..\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" start --port %OLIVIA_PORT%\nexit /b %ERRORLEVEL%\n",
         encoding="utf-8",

--- a/tests/installer/test_component_update.py
+++ b/tests/installer/test_component_update.py
@@ -229,6 +229,40 @@ def test_component_update_stays_applied_when_shortcut_refresh_raises(
     assert (installation / ".olivia-update-state.json").is_file()
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows shortcut refresh is required")
+def test_shortcut_refresh_executes_only_the_stable_installed_script(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    installation = tmp_path / "installation"
+    stable_script = installation / "launcher" / "Create-Shortcut.ps1"
+    stable_script.parent.mkdir(parents=True)
+    stable_script.write_text("# trusted stable fixture", encoding="utf-8")
+    active_version = installation / "versions" / "local_backend" / "untrusted"
+    payload_script = active_version / "installer" / "Create-Shortcut.ps1"
+    payload_script.parent.mkdir(parents=True)
+    payload_script.write_text("throw 'must not execute'", encoding="utf-8")
+    windows = tmp_path / "Windows"
+    powershell = windows / "System32/WindowsPowerShell/v1.0/powershell.exe"
+    powershell.parent.mkdir(parents=True)
+    powershell.write_bytes(b"fixture")
+    monkeypatch.setenv("WINDIR", str(windows))
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        component_update.subprocess,
+        "run",
+        lambda command, **_kwargs: commands.append(command)
+        or subprocess.CompletedProcess(command, 0),
+    )
+
+    component_update._refresh_existing_shortcuts(installation, active_version)
+
+    assert len(commands) == 1
+    command = commands[0]
+    assert command[command.index("-File") + 1] == str(stable_script)
+    assert str(payload_script) not in command
+
+
 @pytest.mark.parametrize("failure", ["probe", "timeout", "nonzero"])
 def test_shortcut_refresh_ignores_probe_timeout_and_nonzero_exit(
     tmp_path: Path,
@@ -236,7 +270,7 @@ def test_shortcut_refresh_ignores_probe_timeout_and_nonzero_exit(
     failure: str,
 ) -> None:
     active_version = tmp_path / "active"
-    script = active_version / "installer" / "Create-Shortcut.ps1"
+    script = tmp_path / "launcher" / "Create-Shortcut.ps1"
     script.parent.mkdir(parents=True)
     script.write_text("# fixture", encoding="utf-8")
 
@@ -280,6 +314,8 @@ def test_windows_patch_docs_define_shortcut_refresh_as_best_effort() -> None:
     assert "正常关闭返回 `0` 时不会弹出错误" in documentation
     assert "其他安装或无关的 wscript 快捷方式不会被改写" in documentation
     assert "不会撤销已经完成的补丁激活" in documentation
+    assert "`launcher/Create-Shortcut.ps1` 的稳定副本" in documentation
+    assert "不会执行刚激活补丁载荷里的脚本" in documentation
 
 
 def test_stable_launcher_resolves_the_atomically_selected_backend(

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1988,6 +1988,12 @@ def test_install_scripts_dispatch_through_the_stable_version_launcher(
     assert stable_launcher.read_bytes() == (
         payload / "installer" / "version_launcher.py"
     ).read_bytes()
+    assert (target / "launcher" / "Create-Shortcut.ps1").read_bytes() == (
+        payload / "installer" / "Create-Shortcut.ps1"
+    ).read_bytes()
+    assert (target / "launcher" / "start_hidden.vbs.txt").read_bytes() == (
+        payload / "installer" / "start_hidden.vbs.txt"
+    ).read_bytes()
     actions = {
         "START.cmd": "start",
         "CONFIGURE.cmd": "configure",


### PR DESCRIPTION
## Scope\n- refresh shortcuts only through the stable installer-owned launcher script\n- install the stable shortcut helper beside the version launcher\n- add focused regression coverage and align the Windows patch contract\n\n## Frozen evidence\n- base: db62bb76d89fae14205a40bbafa7b15b69151694\n- head: a5aa0ed5e0bc1efb3bb71a547f6eabf93028813c\n- Standards: PASS (P0/P1/P2=0)\n- Spec: PASS (P0/P1/P2=0)\n- focused: 100 passed, 1 skipped\n- hardening / compileall / diff-check: PASS\n\n## Boundary\nNo real client, shortcut-shell, install, or end-to-end acceptance is claimed by this PR.