### PR TITLE
fix(http): 接入原生信箱兼容路由

### DIFF
--- a/docs/B02_ERROR_CODES.md
+++ b/docs/B02_ERROR_CODES.md
@@ -11,7 +11,7 @@
 | 400 | `INVALID_CONTENT` | FAILED | 否 | 内容为空 |
 | 400 | `CONTENT_TOO_LONG` | FAILED | 否 | 超出 10000 字符边界 |
 | 400 | `INVALID_SCOPE` / `INVALID_PROFILE` | FAILED | 否 | 未知只读 scope 或 health profile |
-| 403 | `CORS_ORIGIN_DENIED` | FAILED | 否 | 非 localhost/127.0.0.1 Origin |
+| 403 | `CORS_ORIGIN_DENIED` | FAILED | 否 | Origin 既不是 loopback，也未精确命中固定信任源 `https://olivia.local` / `https://toy-cnbeta01.olivia.miyoushe.com`；相似后缀和子域同样拒绝 |
 | 403 | `READ_ONLY_SCOPE` | FAILED | 否 | 对 legacy 只读视图尝试写入 |
 | 404 | `LETTER_NOT_FOUND` / `MIDI_JOB_NOT_FOUND` | FAILED | 否 | 资源不存在 |
 | 405 | `METHOD_NOT_ALLOWED` | FAILED | 否 | 方法不在 route contract 中 |

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -35,6 +35,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 | 信件只读 | `/toy/letter/list`, `/toy/letter/detail`, `/toy/letter/unread_count` | available | `scope=current` 默认；`scope=legacy` 只读隔离视图 |
 | 发信 | `/toy/letter/send` | available/degraded | 先确认 `PENDING`，后台调用 LLM adapter；失败写入 detail，不生成占位回信 |
 | 回信重发/分享 | `/toy/letter/resend`, `/toy/letter/share` | unavailable | 501 稳定错误；未实现不伪造写入 |
+| 原生信箱兼容别名 | `/letter/list`, `/letter/detail`, `/letter/unread_count`, `/letter/send`, `/letter/resend`, `/letter/share` | 与对应 `/toy/letter/*` 路由一致 | 仅精确路径映射；方法、查询、请求体、延迟回信与错误状态均沿用对应版本化路由，未知 `/letter/*` 前缀不会被映射 |
 | 音乐目录 | `/toy/getMusicTypeInfo`, `/toy/searchSongs`, `/toy/searchPlaylist`, `/toy/searchUserSongs`, `/toy/searchPerformances`, `/toy/getSongStats` | available | 只返回脱敏 fixture 或显式空数据 |
 | 音乐写操作 | `/toy/addPerformance` 等 | unavailable | 501 `MUSIC_WRITE_NOT_IMPLEMENTED` |
 | MIDI | `/toy/midi/*` | terminal/partial | 任务状态兼容现有原型；生成/上传/分享码导入明确 501 |

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -44,6 +44,10 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 | 长期记忆重试 | `/toy/companion/memory/retry` | available/degraded | 仅接受带确认头的 `POST`；返回 `INITIALIZING`、`AVAILABLE`、`DEGRADED`、`UNAVAILABLE` 或 `DISABLED`，其中显式禁用的 `DISABLED` 不可重试；重试真实 Mem0 factory，并在 delegate 已就绪时重新启动 durable outbox，不要求退出重进 |
 | 诊断包导出 | `/toy/diagnostics/export` | available | 设置页显式触发，只在本机生成并下载严格白名单 ZIP；不上传，不包含密钥、正文、记忆、真实 ID、绝对路径、完整 URL 或原始日志 |
 
+CORS 仅允许 loopback Origin，或精确命中原生客户端固定信任源
+`https://olivia.local`、`https://toy-cnbeta01.olivia.miyoushe.com`。匹配是完整字符串匹配；
+相似后缀、子域和其他 HTTPS Origin 均返回 `403 CORS_ORIGIN_DENIED`。
+
 原生 WebSocket、ASR、TTS、Live 没有假 route；`/health` 的 capability registry 明确为 `unavailable`，错误码分别为 `WEBSOCKET_UNAVAILABLE`、`ASR_UNAVAILABLE`、`TTS_UNAVAILABLE`、`LIVE_UNAVAILABLE`。
 
 ## 输入、空数据和重试

--- a/http_contract.py
+++ b/http_contract.py
@@ -157,6 +157,22 @@ def _route(
 
 # Paths are the stable local compatibility paths.  The source protocol uses
 # the same /toy base path; no source URL or private identifier is retained.
+NATIVE_LETTER_ROUTE_ALIASES = {
+    "/letter/list": "/toy/letter/list",
+    "/letter/unread_count": "/toy/letter/unread_count",
+    "/letter/detail": "/toy/letter/detail",
+    "/letter/send": "/toy/letter/send",
+    "/letter/resend": "/toy/letter/resend",
+    "/letter/share": "/toy/letter/share",
+}
+
+
+def canonical_route_path(path: str) -> str:
+    """Resolve an exact native-client compatibility path to its toy route."""
+
+    return NATIVE_LETTER_ROUTE_ALIASES.get(path, path)
+
+
 ROUTES: dict[str, dict[str, Any]] = {
     "/health": _route(["GET"], "core.health", read_only=True, evidence="local"),
     "/toy/signIn": _route(["GET", "POST"], "core.session", read_only=True),

--- a/http_contract.py
+++ b/http_contract.py
@@ -500,9 +500,10 @@ PROFILES: dict[str, dict[str, Any]] = {
 
 
 def route_spec(path: str) -> dict[str, Any] | None:
-    """Return a defensive copy of the normalized route metadata."""
+    """Return a defensive copy of the route metadata for the requested path."""
 
-    return deepcopy(ROUTES.get(path.rstrip("/") or "/"))
+    normalized_path = path.rstrip("/") if path.startswith("/toy/") else path
+    return deepcopy(ROUTES.get(normalized_path or "/"))
 
 
 def contract_document() -> dict[str, Any]:

--- a/http_contract.py
+++ b/http_contract.py
@@ -308,6 +308,19 @@ ROUTES: dict[str, dict[str, Any]] = {
     ),
 }
 
+# The native webview calls these exact non-/toy paths.  Publish them in the
+# versioned machine contract while keeping their behavior tied to the canonical
+# route metadata.
+ROUTES.update(
+    {
+        native_path: {
+            **deepcopy(ROUTES[canonical_path]),
+            "evidence": "local",
+        }
+        for native_path, canonical_path in NATIVE_LETTER_ROUTE_ALIASES.items()
+    }
+)
+
 
 CAPABILITIES: dict[str, dict[str, Any]] = {
     "core.health": {

--- a/local_server.py
+++ b/local_server.py
@@ -1523,7 +1523,9 @@ async def handler(request: web.Request):
     if request.path.startswith("/toy/media/"):
         return await _media_handler(request)
     path = request.path  # /toy/xxx
-    canonical_path = contract.canonical_route_path(path.rstrip("/"))
+    canonical_path = contract.canonical_route_path(path)
+    if canonical_path.startswith("/toy/"):
+        canonical_path = canonical_path.rstrip("/")
     method = request.method
     origin = request.headers.get('Origin', '')
     if origin and not origin_allowed(origin):
@@ -2451,7 +2453,12 @@ async def route(
     defer_reply: bool = False,
     companion_confirmed: bool = False,
 ):
-    p = contract.canonical_route_path(path.rstrip("/"))
+    canonical_path = contract.canonical_route_path(path)
+    p = (
+        canonical_path.rstrip("/")
+        if canonical_path.startswith("/toy/")
+        else canonical_path
+    )
     official_import = False
 
     spec = contract.route_spec(p)

--- a/local_server.py
+++ b/local_server.py
@@ -1523,6 +1523,7 @@ async def handler(request: web.Request):
     if request.path.startswith("/toy/media/"):
         return await _media_handler(request)
     path = request.path  # /toy/xxx
+    canonical_path = contract.canonical_route_path(path.rstrip("/"))
     method = request.method
     origin = request.headers.get('Origin', '')
     if origin and not origin_allowed(origin):
@@ -1574,7 +1575,7 @@ async def handler(request: web.Request):
                 path,
                 body,
                 query,
-                defer_reply=(method == "POST" and path.rstrip("/") == "/toy/letter/send"),
+                defer_reply=(method == "POST" and canonical_path == "/toy/letter/send"),
                 companion_confirmed=(
                     request.headers.get("X-Olivia-Companion-Action") == "confirmed"
                 ),
@@ -2449,7 +2450,7 @@ async def route(
     defer_reply: bool = False,
     companion_confirmed: bool = False,
 ):
-    p = path.rstrip("/")
+    p = contract.canonical_route_path(path.rstrip("/"))
     official_import = False
 
     spec = contract.route_spec(p)

--- a/local_server.py
+++ b/local_server.py
@@ -1609,6 +1609,7 @@ async def handler(request: web.Request):
     )
 
 TRUSTED_FRONTEND_ORIGINS = frozenset({
+    'https://olivia.local',
     'https://toy-cnbeta01.olivia.miyoushe.com',
 })
 ALLOWED_HEADERS = ', '.join((

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from aiohttp import web
 
+import http_contract as contract
 from control_center.private_world_candidate_api import CandidateReviewBackend
 from control_center.private_world_candidate_backend import (
     SQLiteCandidateReviewBackend,
@@ -295,7 +296,14 @@ def mount_original_mailbox_wire_adapter(
         raise RuntimeError("ORIGINAL_CLIENT_MAILBOX_ALREADY_MOUNTED")
 
     async def adapted(request: web.Request) -> web.StreamResponse:
-        response = await fallback_handler(request)
+        canonical_path = contract.canonical_route_path(request.path.rstrip("/"))
+        canonical_request = request
+        if canonical_path != request.path.rstrip("/"):
+            canonical_url = request.rel_url.with_path(canonical_path).with_query(
+                request.rel_url.query
+            )
+            canonical_request = request.clone(rel_url=canonical_url)
+        response = await fallback_handler(canonical_request)
         if not isinstance(response, web.Response):
             return response
         payload = _response_payload(response)
@@ -303,7 +311,7 @@ def mount_original_mailbox_wire_adapter(
             return response
         try:
             adapted_payload = _adapt_mailbox_payload(
-                request,
+                canonical_request,
                 payload,
                 letter_collection,
             )
@@ -316,6 +324,12 @@ def mount_original_mailbox_wire_adapter(
     app.router.add_get("/toy/letter/unread_count", adapted)
     app.router.add_get("/toy/letter/detail", adapted)
     app.router.add_post("/toy/letter/send", adapted)
+    for native_path, toy_path in contract.NATIVE_LETTER_ROUTE_ALIASES.items():
+        spec = contract.route_spec(toy_path)
+        if spec is None:
+            raise RuntimeError("ORIGINAL_CLIENT_MAILBOX_ALIAS_INVALID")
+        for method in spec["methods"]:
+            app.router.add_route(method, native_path, adapted)
 
 
 @dataclass(frozen=True)

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -296,9 +296,9 @@ def mount_original_mailbox_wire_adapter(
         raise RuntimeError("ORIGINAL_CLIENT_MAILBOX_ALREADY_MOUNTED")
 
     async def adapted(request: web.Request) -> web.StreamResponse:
-        canonical_path = contract.canonical_route_path(request.path.rstrip("/"))
+        canonical_path = contract.canonical_route_path(request.path)
         canonical_request = request
-        if canonical_path != request.path.rstrip("/"):
+        if canonical_path != request.path:
             canonical_url = request.rel_url.with_path(canonical_path).with_query(
                 request.rel_url.query
             )

--- a/tests/http/test_native_letter_aliases.py
+++ b/tests/http/test_native_letter_aliases.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 import pytest
 
@@ -27,6 +28,31 @@ def test_native_letter_list_alias_matches_toy_route_contract() -> None:
     toy = asyncio.run(local_server.route("GET", "/toy/letter/list", {}, {}))
 
     assert native == toy
+
+
+def test_versioned_contract_registers_exact_native_letter_aliases() -> None:
+    import http_contract
+
+    document = http_contract.contract_document()
+    routes = document["routes"]
+
+    assert document["contract_version"] == http_contract.CONTRACT_VERSION
+    for (
+        native_path,
+        canonical_path,
+    ) in http_contract.NATIVE_LETTER_ROUTE_ALIASES.items():
+        expected = dict(routes[canonical_path])
+        expected["evidence"] = "local"
+        assert routes[native_path] == expected
+
+
+def test_native_letter_aliases_are_documented() -> None:
+    import http_contract
+
+    documentation = Path("docs/B02_HTTP_CONTRACT.md").read_text(encoding="utf-8")
+
+    for native_path in http_contract.NATIVE_LETTER_ROUTE_ALIASES:
+        assert f"`{native_path}`" in documentation
 
 
 @pytest.mark.parametrize(
@@ -326,32 +352,52 @@ def test_unknown_native_letter_path_is_not_prefix_mapped() -> None:
     }
 
 
-def test_native_webview_origin_can_preflight_letter_routes() -> None:
+def test_assembled_runtime_applies_cors_to_native_letter_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import local_server
-    from aiohttp import web
     from aiohttp.test_utils import TestClient, TestServer
+    from original_client_server import create_original_client_server_runtime
+
+    isolated_store = local_server.Store()
+    monkeypatch.setattr(local_server, "store", isolated_store)
 
     async def scenario() -> None:
-        app = web.Application()
-        app.router.add_route("*", "/{tail:.*}", local_server.handler)
-        async with TestClient(TestServer(app, access_log=None)) as client:
-            response = await client.options(
-                "/toy/letter/list",
+        runtime = create_original_client_server_runtime(
+            local_server.handler,
+            letter_collection=local_server._letter_collection,
+        )
+        async with TestClient(TestServer(runtime.app, access_log=None)) as client:
+            preflight = await client.options(
+                "/letter/list",
                 headers={
                     "Origin": "https://olivia.local",
                     "Access-Control-Request-Method": "GET",
                 },
             )
 
-            assert response.status == 204
+            assert preflight.status == 204
             assert (
-                response.headers["Access-Control-Allow-Origin"]
+                preflight.headers["Access-Control-Allow-Origin"]
                 == "https://olivia.local"
             )
-            assert response.headers["Access-Control-Allow-Credentials"] == "true"
+            assert preflight.headers["Access-Control-Allow-Credentials"] == "true"
+
+            listed = await client.get(
+                "/letter/list",
+                headers={"Origin": "https://olivia.local"},
+            )
+
+            assert listed.status == 200
+            assert (
+                listed.headers["Access-Control-Allow-Origin"]
+                == "https://olivia.local"
+            )
+            assert listed.headers["Access-Control-Allow-Credentials"] == "true"
+            assert (await listed.json())["code"] == 0
 
             spoofed = await client.options(
-                "/toy/letter/list",
+                "/letter/list",
                 headers={
                     "Origin": "https://olivia.local.example",
                     "Access-Control-Request-Method": "GET",
@@ -360,5 +406,6 @@ def test_native_webview_origin_can_preflight_letter_routes() -> None:
 
             assert spoofed.status == 403
             assert "Access-Control-Allow-Origin" not in spoofed.headers
+            assert (await spoofed.json())["message"] == "CORS_ORIGIN_DENIED"
 
     asyncio.run(scenario())

--- a/tests/http/test_native_letter_aliases.py
+++ b/tests/http/test_native_letter_aliases.py
@@ -44,6 +44,8 @@ def test_versioned_contract_registers_exact_native_letter_aliases() -> None:
         expected = dict(routes[canonical_path])
         expected["evidence"] = "local"
         assert routes[native_path] == expected
+        assert http_contract.route_spec(f"{native_path}/") is None
+        assert http_contract.route_spec(f"{canonical_path}/") == routes[canonical_path]
 
 
 def test_native_letter_aliases_are_documented() -> None:
@@ -352,31 +354,50 @@ def test_unknown_native_letter_path_is_not_prefix_mapped() -> None:
     }
 
 
-def test_assembled_runtime_rejects_trailing_slash_native_alias() -> None:
+@pytest.mark.parametrize(
+    ("native_path", "supported_method", "wrong_method"),
+    (
+        ("/letter/list", "GET", "POST"),
+        ("/letter/unread_count", "GET", "POST"),
+        ("/letter/detail", "GET", "POST"),
+        ("/letter/send", "POST", "GET"),
+        ("/letter/resend", "POST", "GET"),
+        ("/letter/share", "POST", "GET"),
+    ),
+)
+def test_assembled_runtime_rejects_trailing_slash_native_alias(
+    native_path: str,
+    supported_method: str,
+    wrong_method: str,
+) -> None:
     import local_server
     from aiohttp.test_utils import TestClient, TestServer
     from original_client_server import create_original_client_server_runtime
 
-    async def scenario() -> tuple[int, dict[str, object]]:
+    async def scenario() -> list[tuple[int, dict[str, object]]]:
         runtime = create_original_client_server_runtime(
             local_server.handler,
             letter_collection=local_server._letter_collection,
         )
         async with TestClient(TestServer(runtime.app, access_log=None)) as client:
-            response = await client.get("/letter/list/")
-            return response.status, await response.json()
+            responses: list[tuple[int, dict[str, object]]] = []
+            for method in (supported_method, wrong_method):
+                response = await client.request(method, f"{native_path}/", json={})
+                responses.append((response.status, await response.json()))
+            return responses
 
-    status, payload = asyncio.run(scenario())
+    responses = asyncio.run(scenario())
 
-    assert status == 501
-    assert payload == {
-        "code": 501,
-        "message": "NOT_IMPLEMENTED",
-        "data": {
-            "status": "NOT_IMPLEMENTED",
-            "error_code": "ROUTE_NOT_IMPLEMENTED",
-        },
-    }
+    for status, payload in responses:
+        assert status == 501
+        assert payload == {
+            "code": 501,
+            "message": "NOT_IMPLEMENTED",
+            "data": {
+                "status": "NOT_IMPLEMENTED",
+                "error_code": "ROUTE_NOT_IMPLEMENTED",
+            },
+        }
 
 
 def test_assembled_runtime_applies_cors_to_native_letter_routes(

--- a/tests/http/test_native_letter_aliases.py
+++ b/tests/http/test_native_letter_aliases.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+def _synthetic_letter() -> dict[str, object]:
+    return {
+        "letter_id": "synthetic-native-letter",
+        "content": "synthetic mailbox content",
+        "letter_status": "COMPLETED",
+        "audit_status": 2,
+        "reply_text": "synthetic mailbox reply",
+        "reply_mode": "text_letter",
+        "reply_not_before": 0.0,
+        "media_status": "NOT_REQUESTED",
+        "is_read": 0,
+        "created_at": 1_700_000_000,
+    }
+
+
+def test_native_letter_list_alias_matches_toy_route_contract() -> None:
+    import local_server
+
+    native = asyncio.run(local_server.route("GET", "/letter/list", {}, {}))
+    toy = asyncio.run(local_server.route("GET", "/toy/letter/list", {}, {}))
+
+    assert native == toy
+
+
+@pytest.mark.parametrize(
+    ("method", "native_path", "toy_path", "body", "query"),
+    (
+        (
+            "GET",
+            "/letter/unread_count",
+            "/toy/letter/unread_count",
+            {},
+            {"scope": "legacy"},
+        ),
+        (
+            "GET",
+            "/letter/detail",
+            "/toy/letter/detail",
+            {},
+            {"letter_id": "synthetic-missing", "scope": "current"},
+        ),
+        (
+            "POST",
+            "/letter/resend",
+            "/toy/letter/resend",
+            {"letter_id": "synthetic-resend"},
+            {},
+        ),
+        (
+            "POST",
+            "/letter/share",
+            "/toy/letter/share",
+            {"letter_id": "synthetic-share"},
+            {},
+        ),
+    ),
+)
+def test_native_letter_aliases_preserve_route_inputs(
+    method: str,
+    native_path: str,
+    toy_path: str,
+    body: dict[str, object],
+    query: dict[str, str],
+) -> None:
+    import local_server
+
+    native = asyncio.run(local_server.route(method, native_path, body, query))
+    toy = asyncio.run(local_server.route(method, toy_path, body, query))
+
+    assert native == toy
+
+
+def test_native_letter_send_alias_preserves_body_and_stays_deferred(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import local_server
+    from runtime.video_reply_settings import VideoReplySettingsStore
+
+    monkeypatch.setattr(local_server, "store", local_server.Store())
+    monkeypatch.setattr(local_server, "_state_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        local_server,
+        "video_reply_settings_store",
+        VideoReplySettingsStore.initialize(tmp_path),
+    )
+    scheduled: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        local_server,
+        "_schedule_reply_job",
+        lambda *args, **_kwargs: scheduled.append(args),
+    )
+    monkeypatch.setattr(
+        local_server.letters_adapter,
+        "reply",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("provider must remain deferred")
+        ),
+    )
+    body = {
+        "content": "synthetic native alias letter",
+        "idempotency_key": "synthetic-native-alias",
+    }
+
+    native = asyncio.run(
+        local_server.route(
+            "POST",
+            "/letter/send",
+            body,
+            {},
+            defer_reply=True,
+        )
+    )
+    toy = asyncio.run(
+        local_server.route(
+            "POST",
+            "/toy/letter/send",
+            body,
+            {},
+            defer_reply=True,
+        )
+    )
+
+    assert native == toy
+    assert native["data"]["status"] == "PENDING"
+    assert local_server.store.letters[0]["content"] == body["content"]
+    assert len(scheduled) == 1
+
+
+@pytest.mark.parametrize(
+    ("method", "native_path", "toy_path", "body"),
+    (
+        ("GET", "/letter/list?scope=legacy", "/toy/letter/list?scope=legacy", None),
+        ("GET", "/letter/unread_count", "/toy/letter/unread_count", None),
+        (
+            "GET",
+            "/letter/detail?letter_id=synthetic-native-letter",
+            "/toy/letter/detail?letter_id=synthetic-native-letter",
+            None,
+        ),
+        (
+            "POST",
+            "/letter/resend",
+            "/toy/letter/resend",
+            {"letter_id": "synthetic-native-letter"},
+        ),
+        (
+            "POST",
+            "/letter/share",
+            "/toy/letter/share",
+            {"letter_id": "synthetic-native-letter"},
+        ),
+    ),
+)
+def test_public_runtime_native_alias_matches_toy_contract(
+    method: str,
+    native_path: str,
+    toy_path: str,
+    body: dict[str, object] | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+    from aiohttp.test_utils import TestClient, TestServer
+    from original_client_server import create_original_client_server_runtime
+
+    isolated_store = local_server.Store()
+    isolated_store.letters.append(_synthetic_letter())
+    monkeypatch.setattr(local_server, "store", isolated_store)
+
+    async def scenario() -> None:
+        runtime = create_original_client_server_runtime(
+            local_server.handler,
+            letter_collection=local_server._letter_collection,
+        )
+        async with TestClient(TestServer(runtime.app, access_log=None)) as client:
+            native = await client.request(method, native_path, json=body)
+            native_payload = await native.json()
+            toy = await client.request(method, toy_path, json=body)
+            toy_payload = await toy.json()
+
+            assert native.status == toy.status
+            assert native_payload == toy_payload
+
+    asyncio.run(scenario())
+
+
+def test_public_handler_native_send_preserves_body_query_and_stays_deferred(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import local_server
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+    from runtime.video_reply_settings import VideoReplySettingsStore
+
+    monkeypatch.setattr(local_server, "store", local_server.Store())
+    monkeypatch.setattr(local_server, "_state_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        local_server,
+        "video_reply_settings_store",
+        VideoReplySettingsStore.initialize(tmp_path),
+    )
+    monkeypatch.setattr(
+        local_server,
+        "_conversation_memory_ready_for_reply",
+        lambda: True,
+    )
+    scheduled: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        local_server,
+        "_schedule_reply_job",
+        lambda *args, **_kwargs: scheduled.append(args),
+    )
+
+    async def provider_forbidden(*_args, **_kwargs):
+        raise AssertionError("provider must remain deferred")
+
+    monkeypatch.setattr(local_server, "generate_reply", provider_forbidden)
+
+    async def scenario() -> None:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            native = await client.post(
+                "/letter/send?request_id=synthetic-http-alias",
+                json={"content": "synthetic HTTP alias letter"},
+            )
+            native_payload = await native.json()
+            toy = await client.post(
+                "/toy/letter/send?request_id=synthetic-http-alias",
+                json={"content": "synthetic HTTP alias letter"},
+            )
+            toy_payload = await toy.json()
+
+            assert native.status == toy.status == 200
+            assert native_payload == toy_payload
+
+    asyncio.run(scenario())
+    assert local_server.store.letters[0]["content"] == "synthetic HTTP alias letter"
+    assert len(scheduled) == 1
+
+
+def test_public_runtime_native_send_matches_toy_contract_without_provider_call(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import local_server
+    from aiohttp.test_utils import TestClient, TestServer
+    from original_client_server import create_original_client_server_runtime
+    from runtime.video_reply_settings import VideoReplySettingsStore
+
+    monkeypatch.setattr(local_server, "store", local_server.Store())
+    monkeypatch.setattr(local_server, "_state_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        local_server,
+        "video_reply_settings_store",
+        VideoReplySettingsStore.initialize(tmp_path),
+    )
+    monkeypatch.setattr(
+        local_server,
+        "_conversation_memory_ready_for_reply",
+        lambda: True,
+    )
+    scheduled: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        local_server,
+        "_schedule_reply_job",
+        lambda *args, **_kwargs: scheduled.append(args),
+    )
+
+    async def provider_forbidden(*_args, **_kwargs):
+        raise AssertionError("provider must remain deferred")
+
+    monkeypatch.setattr(local_server, "generate_reply", provider_forbidden)
+
+    async def scenario() -> tuple[dict[str, object], dict[str, object]]:
+        runtime = create_original_client_server_runtime(
+            local_server.handler,
+            letter_collection=local_server._letter_collection,
+        )
+        async with TestClient(TestServer(runtime.app, access_log=None)) as client:
+            native = await client.post(
+                "/letter/send?request_id=synthetic-runtime-alias",
+                json={"content": "synthetic runtime alias letter"},
+            )
+            toy = await client.post(
+                "/toy/letter/send?request_id=synthetic-runtime-alias",
+                json={"content": "synthetic runtime alias letter"},
+            )
+            assert native.status == toy.status == 200
+            return await native.json(), await toy.json()
+
+    native_payload, toy_payload = asyncio.run(scenario())
+
+    assert native_payload == toy_payload
+    assert native_payload["data"]["letterId"] == native_payload["data"]["letter_id"]
+    assert local_server.store.request_keys["synthetic-runtime-alias"] == native_payload[
+        "data"
+    ]["letter_id"]
+    assert len(scheduled) == 1
+
+
+def test_unknown_native_letter_path_is_not_prefix_mapped() -> None:
+    import local_server
+
+    result = asyncio.run(
+        local_server.route(
+            "POST",
+            "/letter/legacy/import",
+            {"letters": []},
+            {"scope": "legacy"},
+        )
+    )
+
+    assert result == {
+        "code": 501,
+        "message": "NOT_IMPLEMENTED",
+        "data": {
+            "status": "NOT_IMPLEMENTED",
+            "error_code": "ROUTE_NOT_IMPLEMENTED",
+        },
+    }

--- a/tests/http/test_native_letter_aliases.py
+++ b/tests/http/test_native_letter_aliases.py
@@ -352,6 +352,33 @@ def test_unknown_native_letter_path_is_not_prefix_mapped() -> None:
     }
 
 
+def test_assembled_runtime_rejects_trailing_slash_native_alias() -> None:
+    import local_server
+    from aiohttp.test_utils import TestClient, TestServer
+    from original_client_server import create_original_client_server_runtime
+
+    async def scenario() -> tuple[int, dict[str, object]]:
+        runtime = create_original_client_server_runtime(
+            local_server.handler,
+            letter_collection=local_server._letter_collection,
+        )
+        async with TestClient(TestServer(runtime.app, access_log=None)) as client:
+            response = await client.get("/letter/list/")
+            return response.status, await response.json()
+
+    status, payload = asyncio.run(scenario())
+
+    assert status == 501
+    assert payload == {
+        "code": 501,
+        "message": "NOT_IMPLEMENTED",
+        "data": {
+            "status": "NOT_IMPLEMENTED",
+            "error_code": "ROUTE_NOT_IMPLEMENTED",
+        },
+    }
+
+
 def test_assembled_runtime_applies_cors_to_native_letter_routes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/http/test_native_letter_aliases.py
+++ b/tests/http/test_native_letter_aliases.py
@@ -324,3 +324,41 @@ def test_unknown_native_letter_path_is_not_prefix_mapped() -> None:
             "error_code": "ROUTE_NOT_IMPLEMENTED",
         },
     }
+
+
+def test_native_webview_origin_can_preflight_letter_routes() -> None:
+    import local_server
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    async def scenario() -> None:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            response = await client.options(
+                "/toy/letter/list",
+                headers={
+                    "Origin": "https://olivia.local",
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
+
+            assert response.status == 204
+            assert (
+                response.headers["Access-Control-Allow-Origin"]
+                == "https://olivia.local"
+            )
+            assert response.headers["Access-Control-Allow-Credentials"] == "true"
+
+            spoofed = await client.options(
+                "/toy/letter/list",
+                headers={
+                    "Origin": "https://olivia.local.example",
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
+
+            assert spoofed.status == 403
+            assert "Access-Control-Allow-Origin" not in spoofed.headers
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## 摘要

- 将六个原生信箱路径精确映射到现有版本化信件路由
- 保留仅 /toy 路由的尾斜杠兼容；未知原生尾路径稳定返回 501
- 为原生 WebView 固定来源补充精确 CORS 白名单，并覆盖错误方法与集成行为

## 冻结证据

- base: 6ee5a093b1d5f4287f535dc9d5429b0eea42ea8d
- head: f66560e83f4ba96556bec6994e974fda99e8a60a
- diff: 6 files, +524/-7

## 验证

- native alias: 23 passed
- HTTP: 305 passed, 1 deselected
- baseline hardening: PASS
- compileall: PASS
- git diff --check: PASS
- Standards: PASS, P0/P1/P2=0
- Spec: PASS, P0/P1/P2=0

## 边界

使用合成信件数据；未包含、记录或回传真实信件正文。上述证据不等同于真实原版客户端人工验收。