### PR TITLE
fix(installer): serialize installs and preserve user data

### DIFF
--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -12,6 +12,8 @@
 
 兼容旧流程：源码/调试场景仍可解压发布内容后双击 `INSTALL.cmd`。EXE 只是图形化外壳，最终仍调用同一份 `installer/Install.ps1`，不会形成第二套安装逻辑。安装阶段不填写 API key，也不会下载 Mem0、BGE 或其他可选模型。
 
+安装器使用 Inno `SetupMutex` 阻止同一用户重复启动图形安装，并在产品目录持有独占文件锁覆盖整个安装生命周期（包括事务恢复、载荷写入和快捷方式写回）。同时运行第二个脚本安装实例会在接触活动事务前以 `INSTALL_ALREADY_RUNNING` 失败；锁路径不安全或无法建立时以 `INSTALL_LOCK_UNAVAILABLE` 失败。锁句柄只在安装成功或统一失败出口释放，锁文件本身作为受管协调文件保留。全新安装失败时只清理安装器创建的受管项，不递归删除整个安装目录；`data`、`logs`、`third-party` 始终保留，避免用户在安装期间已产生的信件、日志或外部组件随回滚丢失。
+
 ## 离线核心资产
 
 发布包的 `offline/offline-core-assets.json` 固定 Python 3.12.10、pip 25.2 和 `installer/runtime-requirements.txt` 的 14 个 Windows x64 / CPython 3.12 wheel。安装前逐项校验路径、大小和 SHA-256，并要求 wheelhouse 与清单完全一致；缺失、多余或被修改的 wheel 都会使安装失败。pip 只使用 `--no-index --find-links` 读取本地 wheelhouse。

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -21,7 +21,6 @@ $requirements = Join-Path $PayloadRoot 'installer\runtime-requirements.txt'
 $setupDiagnosticPath = if ($SetupResultPath) { $SetupResultPath + '.diagnostic.json' } else { '' }
 $script:OfficialSourceDiagnostic = $null
 $script:InstallInstanceLock = $null
-$script:InstallInstanceLockPath = $null
 
 function Get-SafeSetupErrorCode {
     param([string]$Code)
@@ -145,49 +144,59 @@ function Forward-SetupProgressLine {
     }
 }
 
+function Assert-ManagedInstallLockPath {
+    param([Parameter(Mandatory)][string]$LiteralPath)
+
+    if (-not (Test-Path -LiteralPath $LiteralPath)) { return }
+    if (
+        -not [IO.File]::Exists($LiteralPath) -or
+        (([IO.File]::GetAttributes($LiteralPath) -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+    ) {
+        throw 'INSTALL_LOCK_UNAVAILABLE'
+    }
+}
+
 function Enter-ManagedInstallLock {
     param([Parameter(Mandatory)][string]$ProductRoot)
 
     try {
+        Assert-NoReparsePointsInPath -LiteralPath $ProductRoot -ErrorCode 'INSTALL_LOCK_UNAVAILABLE'
         [void][IO.Directory]::CreateDirectory($ProductRoot)
         Assert-NoReparsePointsInPath -LiteralPath $ProductRoot -ErrorCode 'INSTALL_LOCK_UNAVAILABLE'
     } catch {
         throw 'INSTALL_LOCK_UNAVAILABLE'
     }
     $lockPath = Join-Path $ProductRoot '.install.lock'
+    $lock = $null
     try {
+        Assert-ManagedInstallLockPath -LiteralPath $lockPath
         $lock = [IO.FileStream]::new(
             $lockPath,
             [IO.FileMode]::OpenOrCreate,
             [IO.FileAccess]::ReadWrite,
             [IO.FileShare]::None,
             4096,
-            [IO.FileOptions]::DeleteOnClose
+            [IO.FileOptions]::None
         )
-        $script:InstallInstanceLockPath = $lockPath
+        Assert-ManagedInstallLockPath -LiteralPath $lockPath
         return $lock
     } catch [IO.IOException] {
+        if ($null -ne $lock) { $lock.Dispose() }
         throw 'INSTALL_ALREADY_RUNNING'
     } catch {
+        if ($null -ne $lock) { $lock.Dispose() }
         throw 'INSTALL_LOCK_UNAVAILABLE'
     }
 }
 
 function Exit-ManagedInstallLock {
     if ($null -eq $script:InstallInstanceLock) { return }
-    $lockPath = $script:InstallInstanceLockPath
     try {
         $script:InstallInstanceLock.Dispose()
     } catch {
         # Process exit releases the handle even if disposal reports an error.
     }
     $script:InstallInstanceLock = $null
-    $script:InstallInstanceLockPath = $null
-    try {
-        if ($lockPath) { [IO.File]::Delete($lockPath) }
-    } catch {
-        # A racing installer owns the path now; never delete its active lock.
-    }
 }
 
 trap {
@@ -1295,6 +1304,10 @@ function Get-ManagedInstallTransactionNames {
     return @('local_backend', 'launcher', 'START.cmd', 'START.vbs', 'CONFIGURE.cmd', 'UNINSTALL.cmd', '.olivia-full-patch.json')
 }
 
+function Get-FreshInstallTransactionNames {
+    return @((Get-ManagedInstallTransactionNames) + @('app'))
+}
+
 function New-ManagedInstallRollbackSnapshot {
     param([Parameter(Mandatory)][string]$InstallRoot, [Parameter(Mandatory)][string]$Snapshot)
     if (-not (Test-Path -LiteralPath $InstallRoot)) { return }
@@ -1317,7 +1330,8 @@ function New-ManagedInstallRollbackSnapshot {
 function Restore-ManagedInstallRollbackSnapshot {
     param([Parameter(Mandatory)][string]$InstallRoot, [Parameter(Mandatory)][bool]$InstallRootExisted, [string]$Snapshot = '')
     if ($InstallRootExisted -and (-not $Snapshot -or -not [IO.Directory]::Exists($Snapshot))) { throw 'VOICE_REFERENCE_INSTALL_ROLLBACK_FAILED' }
-    foreach ($name in Get-ManagedInstallTransactionNames) {
+    $transactionNames = if ($InstallRootExisted) { Get-ManagedInstallTransactionNames } else { Get-FreshInstallTransactionNames }
+    foreach ($name in $transactionNames) {
         $active = Join-Path $InstallRoot $name
         if (Test-Path -LiteralPath $active) { Remove-Item -LiteralPath $active -Recurse -Force }
         if (-not $InstallRootExisted) { continue }
@@ -1899,9 +1913,8 @@ Write-SetupProgress -Phase 'FINALIZE' -CurrentBytes 1 -TotalBytes 1
 if (-not $SetupResultPath) { $installOutput | Write-Output }
 
 $LASTEXITCODE = 0
-Exit-ManagedInstallLock
-
 if (-not $SkipShortcut) {
     & (Join-Path $PSScriptRoot 'Create-Shortcut.ps1') -InstallRoot $Destination
 }
+Exit-ManagedInstallLock
 exit 0

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -20,6 +20,8 @@ $offlineManifestPath = if ($OfflineAssetsRoot) { Join-Path $OfflineAssetsRoot 'o
 $requirements = Join-Path $PayloadRoot 'installer\runtime-requirements.txt'
 $setupDiagnosticPath = if ($SetupResultPath) { $SetupResultPath + '.diagnostic.json' } else { '' }
 $script:OfficialSourceDiagnostic = $null
+$script:InstallInstanceLock = $null
+$script:InstallInstanceLockPath = $null
 
 function Get-SafeSetupErrorCode {
     param([string]$Code)
@@ -143,10 +145,56 @@ function Forward-SetupProgressLine {
     }
 }
 
+function Enter-ManagedInstallLock {
+    param([Parameter(Mandatory)][string]$ProductRoot)
+
+    try {
+        [void][IO.Directory]::CreateDirectory($ProductRoot)
+        Assert-NoReparsePointsInPath -LiteralPath $ProductRoot -ErrorCode 'INSTALL_LOCK_UNAVAILABLE'
+    } catch {
+        throw 'INSTALL_LOCK_UNAVAILABLE'
+    }
+    $lockPath = Join-Path $ProductRoot '.install.lock'
+    try {
+        $lock = [IO.FileStream]::new(
+            $lockPath,
+            [IO.FileMode]::OpenOrCreate,
+            [IO.FileAccess]::ReadWrite,
+            [IO.FileShare]::None,
+            4096,
+            [IO.FileOptions]::DeleteOnClose
+        )
+        $script:InstallInstanceLockPath = $lockPath
+        return $lock
+    } catch [IO.IOException] {
+        throw 'INSTALL_ALREADY_RUNNING'
+    } catch {
+        throw 'INSTALL_LOCK_UNAVAILABLE'
+    }
+}
+
+function Exit-ManagedInstallLock {
+    if ($null -eq $script:InstallInstanceLock) { return }
+    $lockPath = $script:InstallInstanceLockPath
+    try {
+        $script:InstallInstanceLock.Dispose()
+    } catch {
+        # Process exit releases the handle even if disposal reports an error.
+    }
+    $script:InstallInstanceLock = $null
+    $script:InstallInstanceLockPath = $null
+    try {
+        if ($lockPath) { [IO.File]::Delete($lockPath) }
+    } catch {
+        # A racing installer owns the path now; never delete its active lock.
+    }
+}
+
 trap {
     $safeCode = Get-SafeSetupErrorCode -Code ([string]$_.Exception.Message)
     Write-SetupDiagnosticResult -Diagnostic $script:OfficialSourceDiagnostic
     Write-SetupErrorResult -Code $safeCode
+    Exit-ManagedInstallLock
     if (-not $SetupResultPath) { Write-Output $safeCode }
     exit 2
 }
@@ -1268,14 +1316,11 @@ function New-ManagedInstallRollbackSnapshot {
 
 function Restore-ManagedInstallRollbackSnapshot {
     param([Parameter(Mandatory)][string]$InstallRoot, [Parameter(Mandatory)][bool]$InstallRootExisted, [string]$Snapshot = '')
-    if (-not $InstallRootExisted) {
-        if (Test-Path -LiteralPath $InstallRoot) { Remove-Item -LiteralPath $InstallRoot -Recurse -Force }
-        return
-    }
-    if (-not $Snapshot -or -not [IO.Directory]::Exists($Snapshot)) { throw 'VOICE_REFERENCE_INSTALL_ROLLBACK_FAILED' }
+    if ($InstallRootExisted -and (-not $Snapshot -or -not [IO.Directory]::Exists($Snapshot))) { throw 'VOICE_REFERENCE_INSTALL_ROLLBACK_FAILED' }
     foreach ($name in Get-ManagedInstallTransactionNames) {
         $active = Join-Path $InstallRoot $name
         if (Test-Path -LiteralPath $active) { Remove-Item -LiteralPath $active -Recurse -Force }
+        if (-not $InstallRootExisted) { continue }
         $backup = Join-Path $Snapshot $name
         if ([IO.Directory]::Exists($backup)) { Copy-Item -LiteralPath $backup -Destination $active -Recurse -Force }
         elseif ([IO.File]::Exists($backup)) { [IO.File]::Copy($backup, $active, $true) }
@@ -1647,6 +1692,7 @@ function Test-ManagedServerDependencies {
 
 Write-SetupProgress -Phase 'PREPARE' -CurrentBytes 0 -TotalBytes 0
 Assert-ManagedRuntimeParent -ProductRoot $productRoot -RuntimePath $runtimeRoot
+$script:InstallInstanceLock = Enter-ManagedInstallLock -ProductRoot $productRoot
 Repair-ManagedInstallTransaction -ProductRoot $productRoot -InstallRoot $Destination -RuntimeRoot $runtimeRoot
 Write-SetupProgress -Phase 'VERIFY_OFFICIAL' -CurrentBytes 0 -TotalBytes 0
 $selectedOfficial = $OfficialRoot
@@ -1853,6 +1899,7 @@ Write-SetupProgress -Phase 'FINALIZE' -CurrentBytes 1 -TotalBytes 1
 if (-not $SetupResultPath) { $installOutput | Write-Output }
 
 $LASTEXITCODE = 0
+Exit-ManagedInstallLock
 
 if (-not $SkipShortcut) {
     & (Join-Path $PSScriptRoot 'Create-Shortcut.ps1') -InstallRoot $Destination

--- a/installer/windows_setup.iss
+++ b/installer/windows_setup.iss
@@ -17,6 +17,7 @@ DefaultDirName={localappdata}\BSideOliviaLocal
 CreateAppDir=no
 Uninstallable=no
 PrivilegesRequired=lowest
+SetupMutex=BSideOliviaLocalInstaller
 ArchitecturesAllowed=x64compatible
 OutputDir={#OutputDir}
 OutputBaseFilename=Olivia-Setup-x64

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -120,6 +120,28 @@ def test_private_video_activation_must_finish_before_install_transaction_commit(
     )
 
 
+def test_installer_holds_product_lock_through_shortcut_writeback() -> None:
+    script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
+
+    shortcut_writeback = (
+        "& (Join-Path $PSScriptRoot 'Create-Shortcut.ps1') -InstallRoot $Destination"
+    )
+    assert script.index(shortcut_writeback) < script.rindex("Exit-ManagedInstallLock")
+
+
+def test_installer_lock_rejects_reparse_paths_without_delete_on_close() -> None:
+    script = (ROOT / "installer" / "Install.ps1").read_text(encoding="utf-8-sig")
+    enter = script[script.index("function Enter-ManagedInstallLock") :]
+    enter = enter[: enter.index("function Exit-ManagedInstallLock")]
+
+    assert enter.index(
+        "Assert-NoReparsePointsInPath -LiteralPath $ProductRoot"
+    ) < enter.index("[void][IO.Directory]::CreateDirectory($ProductRoot)")
+    assert "Assert-ManagedInstallLockPath -LiteralPath $lockPath" in enter
+    assert "[IO.FileOptions]::DeleteOnClose" not in enter
+    assert "[IO.File]::Delete($lockPath)" not in script
+
+
 def test_offline_core_asset_example_matches_its_public_schema() -> None:
     schema = json.loads(
         (ROOT / "contracts" / "offline_core_assets.schema.json").read_text(
@@ -343,6 +365,29 @@ def test_second_installer_fails_before_touching_the_active_transaction(
         holder.wait(timeout=5)
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows reparse-point contract")
+def test_installer_rejects_a_reparse_point_at_the_lock_file(
+    tmp_path: Path,
+) -> None:
+    product = tmp_path / "product"
+    product.mkdir()
+    outside = tmp_path / "outside-lock-target"
+    outside.write_text("do-not-touch", encoding="utf-8")
+    lock_path = product / ".install.lock"
+    try:
+        lock_path.symlink_to(outside)
+    except OSError:
+        pytest.skip("file symbolic-link creation is unavailable")
+    try:
+        result = _run_install_preflight(product, tmp_path)
+
+        assert result.returncode == 2
+        assert "INSTALL_LOCK_UNAVAILABLE" in result.stdout + result.stderr
+        assert outside.read_text(encoding="utf-8") == "do-not-touch"
+    finally:
+        lock_path.unlink(missing_ok=True)
+
+
 def _run_runtime_publish_fixture(
     tmp_path: Path,
     *,
@@ -384,6 +429,8 @@ def _run_runtime_publish_fixture(
                             "(destination / 'data').mkdir(parents=True, exist_ok=True)\n"
         if bootstrap_preserved_paths:
             bootstrap_actions += (
+                "(destination / 'app').mkdir(parents=True, exist_ok=True)\n"
+                "(destination / 'app/partial-client.exe').write_text('partial')\n"
                 "(destination / 'data/letters.json').write_text('keep')\n"
                 "(destination / 'logs').mkdir(parents=True, exist_ok=True)\n"
                 "(destination / 'logs/launcher.jsonl').write_text('keep')\n"
@@ -1062,6 +1109,7 @@ def test_patch_failure_restores_existing_runtime_and_cleans_transaction_paths(
     assert (fresh_product / "install/data/letters.json").read_text() == "keep"
     assert (fresh_product / "install/logs/launcher.jsonl").read_text() == "keep"
     assert (fresh_product / "install/third-party/user.bin").read_text() == "keep"
+    assert not (fresh_product / "install/app").exists()
     assert not (fresh_product / "install/local_backend").exists()
     assert not (fresh_product / "runtime/python-3.12.10-embed-amd64").exists()
 
@@ -1074,7 +1122,8 @@ def test_interrupted_bootstrap_recovers_original_install_on_reentry(tmp_path: Pa
     backend = product / "install/local_backend"
     assert retried.returncode == 23
     assert (backend / "old-backend.txt").is_file() and not (backend / "new-backend.txt").exists()
-    assert not list(product.glob(".install.*"))
+    assert (product / ".install.lock").is_file()
+    assert not [path for path in product.glob(".install.*") if path.name != ".install.lock"]
 
 
 def test_patch_success_discards_runtime_backup_after_install(

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import shutil
 import subprocess
 import sys
+import time
 import wave
 import zipfile
 
@@ -247,6 +248,12 @@ def test_first_install_rebuilds_and_atomically_replaces_any_existing_runtime() -
     assert "$lockedWheelHashes.SetEquals($manifestWheelHashes)" in script
     assert "[IO.Directory]::Move($runtimeRoot, $runtimeBackup)" in script
     assert "[IO.Directory]::Move($runtimeBackup, $runtimeRoot)" in script
+    assert script.index(
+        "$script:InstallInstanceLock = Enter-ManagedInstallLock"
+    ) < script.index(
+        "Repair-ManagedInstallTransaction -ProductRoot $productRoot"
+    )
+    assert "Remove-Item -LiteralPath $InstallRoot -Recurse -Force" not in script
     assert script.rindex(
         "$selectedOfficial = Resolve-OfficialInstall"
     ) < script.index("$coreAssets = Get-OfflineCoreAssets")
@@ -285,6 +292,57 @@ def _run_install_preflight(
     )
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows file sharing is required")
+def test_second_installer_fails_before_touching_the_active_transaction(
+    tmp_path: Path,
+) -> None:
+    product = tmp_path / "product"
+    product.mkdir()
+    transaction = product / ".install.transaction"
+    transaction.write_text("active-owner-sentinel", encoding="utf-8")
+    lock_path = product / ".install.lock"
+    ready = tmp_path / "lock-ready"
+    release = tmp_path / "lock-release"
+
+    def ps_literal(path: Path) -> str:
+        return "'" + str(path).replace("'", "''") + "'"
+
+    holder = subprocess.Popen(
+        [
+            "powershell",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            (
+                "$stream = [IO.File]::Open("
+                f"{ps_literal(lock_path)}, 'OpenOrCreate', 'ReadWrite', 'None'); "
+                f"[IO.File]::WriteAllText({ps_literal(ready)}, 'ready'); "
+                f"while (-not (Test-Path -LiteralPath {ps_literal(release)})) "
+                "{ Start-Sleep -Milliseconds 25 }; $stream.Dispose()"
+            ),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        for _ in range(200):
+            if ready.is_file():
+                break
+            if holder.poll() is not None:
+                pytest.fail("synthetic installer lock holder exited early")
+            time.sleep(0.025)
+        assert ready.is_file()
+
+        result = _run_install_preflight(product, tmp_path)
+
+        assert result.returncode == 2
+        assert "INSTALL_ALREADY_RUNNING" in result.stdout + result.stderr
+        assert transaction.read_text(encoding="utf-8") == "active-owner-sentinel"
+    finally:
+        release.touch()
+        holder.wait(timeout=5)
+
+
 def _run_runtime_publish_fixture(
     tmp_path: Path,
     *,
@@ -299,7 +357,9 @@ def _run_runtime_publish_fixture(
     block_video_cleanup: bool = False,
     block_voice_sidecar: bool = False, cleanup_obstruction: str | None = None,
     product_root: Path | None = None, existing_voice_pair: bool = False,
-    interrupt_voice_staging: bool = False, interrupt_after_bootstrap: bool = False, existing_runtime: bool = True, seed_existing_install: bool = True,
+    interrupt_voice_staging: bool = False, interrupt_after_bootstrap: bool = False,
+    existing_runtime: bool = True, seed_existing_install: bool = True,
+    bootstrap_preserved_paths: bool = False,
     private_video_exit_code: int = 0,
     private_video_status: str | None = None,
     private_video_progress_lines: tuple[str, ...] = (),
@@ -322,6 +382,14 @@ def _run_runtime_publish_fixture(
     if bootstrap_exit_code == 0 or bootstrap_replaces_managed_app:
         bootstrap_actions = "destination = pathlib.Path(sys.argv[sys.argv.index('--destination') + 1])\n" \
                             "(destination / 'data').mkdir(parents=True, exist_ok=True)\n"
+        if bootstrap_preserved_paths:
+            bootstrap_actions += (
+                "(destination / 'data/letters.json').write_text('keep')\n"
+                "(destination / 'logs').mkdir(parents=True, exist_ok=True)\n"
+                "(destination / 'logs/launcher.jsonl').write_text('keep')\n"
+                "(destination / 'third-party').mkdir(parents=True, exist_ok=True)\n"
+                "(destination / 'third-party/user.bin').write_text('keep')\n"
+            )
         if bootstrap_replaces_managed_app:
             bootstrap_actions += "shutil.rmtree(destination / 'local_backend', ignore_errors=True)\n" \
                 "(destination / 'local_backend').mkdir()\n" \
@@ -982,8 +1050,20 @@ def test_patch_failure_restores_existing_runtime_and_cleans_transaction_paths(
     assert not (runtime / "python.exe").exists()
     assert not list(runtime_parent.glob("python-3.12.10-embed-amd64.backup.*"))
     assert not list(runtime_parent.glob("python-3.12.10-embed-amd64.staging.*"))
-    fresh, fresh_product = _run_runtime_publish_fixture(tmp_path / "fresh", bootstrap_exit_code=23, bootstrap_replaces_managed_app=True, existing_runtime=False, seed_existing_install=False)
-    assert fresh.returncode == 23 and not (fresh_product / "install").exists() and not (fresh_product / "runtime/python-3.12.10-embed-amd64").exists()
+    fresh, fresh_product = _run_runtime_publish_fixture(
+        tmp_path / "fresh",
+        bootstrap_exit_code=23,
+        bootstrap_replaces_managed_app=True,
+        existing_runtime=False,
+        seed_existing_install=False,
+        bootstrap_preserved_paths=True,
+    )
+    assert fresh.returncode == 23
+    assert (fresh_product / "install/data/letters.json").read_text() == "keep"
+    assert (fresh_product / "install/logs/launcher.jsonl").read_text() == "keep"
+    assert (fresh_product / "install/third-party/user.bin").read_text() == "keep"
+    assert not (fresh_product / "install/local_backend").exists()
+    assert not (fresh_product / "runtime/python-3.12.10-embed-amd64").exists()
 
 
 def test_interrupted_bootstrap_recovers_original_install_on_reentry(tmp_path: Path) -> None:

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -1617,6 +1617,7 @@ def test_inno_wrapper_is_current_user_offline_and_delegates_to_install_ps1() -> 
     script = (ROOT / "installer" / "windows_setup.iss").read_text(encoding="utf-8")
 
     assert "PrivilegesRequired=lowest" in script
+    assert "SetupMutex=BSideOliviaLocalInstaller" in script
     assert "CreateAppDir=no" in script
     assert "Uninstallable=no" in script
     assert "LicenseFile=" in script

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -1726,6 +1726,19 @@ def test_windows_installer_documents_ambiguous_source_diagnostic_contract() -> N
     assert "observed_webplayer_sha256" in documentation
 
 
+def test_windows_installer_documents_single_instance_and_fresh_rollback_contract() -> None:
+    documentation = (ROOT / "docs" / "WINDOWS_FULL_PATCH.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "SetupMutex" in documentation
+    assert "INSTALL_ALREADY_RUNNING" in documentation
+    assert "INSTALL_LOCK_UNAVAILABLE" in documentation
+    assert "整个安装生命周期" in documentation
+    assert "data`、`logs`、`third-party" in documentation
+    assert "只清理安装器创建的受管项" in documentation
+
+
 def test_github_build_publishes_setup_and_checksum_for_merged_main() -> None:
     workflow = (ROOT / ".github" / "workflows" / "windows-setup.yml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Summary
- serialize graphical and script installs with Inno and product-root locks
- keep the lock through transaction recovery, payload publication, and shortcut writeback
- make fresh-install rollback remove only managed paths while preserving data, logs, and third-party state
- document stable lock failures and rollback ownership

## Verification
- python -m pytest -q tests/installer/test_offline_core_assets.py tests/installer/test_windows_setup_exe.py: 153 passed, 1 skipped
- python baseline_hardening_scan.py --mode all: PASS
- git diff --check: PASS

## Boundary
Synthetic installer fixtures only; no real installation, original-client launch, or user-data mutation was performed.