### PR TITLE
fix(installer): retire unsigned update state safely

### DIFF
--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -131,6 +131,8 @@ webplayer.dat.orig
 
 ## 本地组件补丁与回滚
 
+完整安装器刷新会退役旧的无签名组件更新状态：成功刷新后删除 `.olivia-update-state.json` 与整个 `versions/`，稳定启动器重新使用本次完整安装写入的 `local_backend`。这不是保留旧补丁或旧回滚点的升级方式；如需保留旧版本，应在运行完整安装器前另行备份。刷新失败会恢复原有更新状态和版本目录，同时保留 `data/`、`logs/` 与 `third-party/` 用户数据。
+
 安装后的 `START.cmd`、`CONFIGURE.cmd` 和 `UNINSTALL.cmd` 只调用安装根目录中的稳定启动器 `launcher/version_launcher.py`。稳定启动器读取一次 `.olivia-update-state.json` 原子指针，从 `versions/local_backend/<version>-<manifest-sha256>` 选择完整后端；没有更新状态时继续使用初装的 `local_backend`。因此更新期间不会把正在使用的后端目录临时移走，也不会要求用户重新运行完整安装器。
 
 v0.1 不接受用户手动导入或应用 `.oliviapatch`。客户端选择与应用动作、以及 `apply-update` 命令都稳定返回 `UPDATE_ACTION_UNAVAILABLE`；升级只能使用维护者发布的完整安装包。内部补丁格式与构建器暂时保留用于后续签名机制开发，但不构成 v0.1 的用户发布面。公开契约及示例见：

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -1301,7 +1301,7 @@ function Complete-ManagedPrivateRuntimeSidecarTransaction {
 }
 
 function Get-ManagedInstallTransactionNames {
-    return @('local_backend', 'launcher', 'START.cmd', 'START.vbs', 'CONFIGURE.cmd', 'UNINSTALL.cmd', '.olivia-full-patch.json')
+    return @('local_backend', 'launcher', 'START.cmd', 'START.vbs', 'CONFIGURE.cmd', 'UNINSTALL.cmd', '.olivia-full-patch.json', '.olivia-update-state.json', 'versions')
 }
 
 function Get-FreshInstallTransactionNames {

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -565,6 +565,7 @@ def _refresh_existing_install(
         "UNINSTALL.cmd",
         MARKER_NAME,
     )
+    retired_names = (".olivia-update-state.json", "versions")
     try:
         copied = copy_project_payload(payload, staging / "local_backend")
         _write_start_scripts(staging, port)
@@ -580,6 +581,12 @@ def _refresh_existing_install(
             encoding="utf-8",
         )
         rollback.mkdir()
+        for name in retired_names:
+            active = target / name
+            backup = rollback / name
+            if active.exists() or active.is_symlink():
+                os.replace(active, backup)
+                backed_up.append((active, backup))
         for name in names:
             active = target / name
             staged = staging / name

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import uuid
 from pathlib import Path
@@ -544,6 +545,20 @@ def _write_start_scripts(root: Path, port: int) -> None:
     )
 
 
+def _managed_entry_metadata(path: Path) -> os.stat_result | None:
+    try:
+        return path.lstat()
+    except FileNotFoundError:
+        return None
+
+
+def _managed_entry_is_reparse(metadata: os.stat_result) -> bool:
+    return stat.S_ISLNK(metadata.st_mode) or bool(
+        getattr(metadata, "st_file_attributes", 0)
+        & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    )
+
+
 def _refresh_existing_install(
     target: Path,
     payload: Path,
@@ -584,7 +599,10 @@ def _refresh_existing_install(
         for name in retired_names:
             active = target / name
             backup = rollback / name
-            if active.exists() or active.is_symlink():
+            metadata = _managed_entry_metadata(active)
+            if metadata is not None:
+                if _managed_entry_is_reparse(metadata):
+                    raise OSError("managed update state is a reparse point")
                 os.replace(active, backup)
                 backed_up.append((active, backup))
         for name in names:
@@ -604,7 +622,7 @@ def _refresh_existing_install(
             else:
                 active.unlink(missing_ok=True)
         for active, backup in reversed(backed_up):
-            if backup.exists():
+            if _managed_entry_metadata(backup) is not None:
                 os.replace(backup, active)
         raise PatchInstallError("PATCH_PAYLOAD_REFRESH_FAILED") from exc
     finally:

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -1150,6 +1150,30 @@ def test_asset_failure_restores_preinstall_component_state_and_versions(
     ) == "preserve"
 
 
+def test_successful_full_refresh_retires_component_state_and_preserves_user_data(
+    tmp_path: Path,
+) -> None:
+    product = tmp_path / "product"
+    letters = product / "install/data/letters.json"
+    letters.parent.mkdir(parents=True)
+    letters.write_text("private-user-data", encoding="utf-8")
+
+    result, _ = _run_runtime_publish_fixture(
+        tmp_path,
+        product_root=product,
+        bootstrap_exit_code=0,
+        bootstrap_retires_update_state=True,
+        seed_update_state=True,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert not (product / "install/.olivia-update-state.json").exists()
+    assert not (product / "install/versions").exists()
+    assert letters.read_text(encoding="utf-8") == "private-user-data"
+    assert not list(product.glob(".install.transaction*"))
+    assert not list(product.glob(".install.rollback.*"))
+
+
 def test_interrupted_bootstrap_recovers_original_install_on_reentry(tmp_path: Path) -> None:
     product = tmp_path / "product"
     interrupted, _ = _run_runtime_publish_fixture(tmp_path / "first", product_root=product, bootstrap_exit_code=0, bootstrap_replaces_managed_app=True, interrupt_after_bootstrap=True)

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -392,6 +392,8 @@ def _run_runtime_publish_fixture(
     tmp_path: Path,
     *,
     bootstrap_exit_code: int, bootstrap_replaces_managed_app: bool = False,
+    bootstrap_retires_update_state: bool = False,
+    seed_update_state: bool = False,
     voice_reference: bytes | None = None, voice_reference_sha256: str | None = None,
     voice_reference_wave: dict[str, object] | None = None, voice_reference_missing: bool = False,
     video_runtime: bytes | None = None, video_runtime_sha256: str | None = None,
@@ -424,7 +426,7 @@ def _run_runtime_publish_fixture(
     ):
         shutil.copy2(ROOT / "installer" / name, payload_installer / name)
     bootstrap_actions = ""
-    if bootstrap_exit_code == 0 or bootstrap_replaces_managed_app:
+    if bootstrap_exit_code == 0 or bootstrap_replaces_managed_app or bootstrap_retires_update_state:
         bootstrap_actions = "destination = pathlib.Path(sys.argv[sys.argv.index('--destination') + 1])\n" \
                             "(destination / 'data').mkdir(parents=True, exist_ok=True)\n"
         if bootstrap_preserved_paths:
@@ -441,6 +443,11 @@ def _run_runtime_publish_fixture(
             bootstrap_actions += "shutil.rmtree(destination / 'local_backend', ignore_errors=True)\n" \
                 "(destination / 'local_backend').mkdir()\n" \
                 "(destination / 'local_backend/new-backend.txt').write_text('new')\n"
+        if bootstrap_retires_update_state:
+            bootstrap_actions += (
+                "(destination / '.olivia-update-state.json').unlink(missing_ok=True)\n"
+                "shutil.rmtree(destination / 'versions', ignore_errors=True)\n"
+            )
     (payload_installer / "bootstrap_install.py").write_text(
         "import json, pathlib, shutil, sys\n"
         + bootstrap_actions
@@ -604,6 +611,13 @@ def _run_runtime_publish_fixture(
         old_video_runtime = _managed_video_runtime(product)
         old_video_runtime.parent.mkdir(parents=True)
         old_video_runtime.write_bytes(b"old-video-runtime")
+    if seed_update_state:
+        versioned = product / "install/versions/local_backend/unsigned"
+        versioned.mkdir(parents=True)
+        (versioned / "old-version.txt").write_text("preserve", encoding="utf-8")
+        (product / "install/.olivia-update-state.json").write_text(
+            '{"synthetic":"old-state"}', encoding="utf-8"
+        )
     if block_voice_sidecar:
         installed = _managed_reference(product)
         installed.parent.mkdir(parents=True)
@@ -1112,6 +1126,28 @@ def test_patch_failure_restores_existing_runtime_and_cleans_transaction_paths(
     assert not (fresh_product / "install/app").exists()
     assert not (fresh_product / "install/local_backend").exists()
     assert not (fresh_product / "runtime/python-3.12.10-embed-amd64").exists()
+
+
+def test_asset_failure_restores_preinstall_component_state_and_versions(
+    tmp_path: Path,
+) -> None:
+    result, product = _run_runtime_publish_fixture(
+        tmp_path,
+        bootstrap_exit_code=0,
+        bootstrap_replaces_managed_app=True,
+        bootstrap_retires_update_state=True,
+        seed_update_state=True,
+        voice_reference=_voice_reference_bytes(),
+        voice_reference_sha256="0" * 64,
+    )
+
+    assert result.returncode != 0
+    assert (product / "install/.olivia-update-state.json").read_text(
+        encoding="utf-8"
+    ) == '{"synthetic":"old-state"}'
+    assert (product / "install/versions/local_backend/unsigned/old-version.txt").read_text(
+        encoding="utf-8"
+    ) == "preserve"
 
 
 def test_interrupted_bootstrap_recovers_original_install_on_reentry(tmp_path: Path) -> None:

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -2090,6 +2090,47 @@ def test_repeat_install_rolls_back_the_active_payload_when_publish_fails(
     assert old_version.read_text(encoding="utf-8") == "old version"
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows junction semantics are required")
+def test_repeat_install_rejects_a_broken_versions_junction_without_mutation(
+    fixture_inputs,
+    tmp_path: Path,
+) -> None:
+    official, payload, manifest, _feapp, _webplayer = fixture_inputs
+    target = tmp_path / "installed"
+    install_full_patch(official, target, payload, manifest)
+    outside = tmp_path / "retired-versions-target"
+    outside.mkdir()
+    versions = target / "versions"
+    linked = subprocess.run(
+        ["cmd", "/d", "/c", "mklink", "/J", str(versions), str(outside)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if linked.returncode != 0:
+        pytest.skip("junction creation is unavailable")
+    shutil.rmtree(outside)
+    marker = target / ".olivia-full-patch.json"
+    marker_before = marker.read_bytes()
+
+    with pytest.raises(PatchInstallError, match="PATCH_PAYLOAD_REFRESH_FAILED"):
+        install_full_patch(official, target, payload, manifest)
+
+    assert os.path.lexists(versions)
+    assert marker.read_bytes() == marker_before
+
+
+def test_windows_patch_docs_define_full_refresh_update_state_retirement() -> None:
+    documentation = (
+        Path(__file__).parents[2] / "docs" / "WINDOWS_FULL_PATCH.md"
+    ).read_text(encoding="utf-8")
+
+    assert "完整安装器刷新会退役" in documentation
+    assert "`.olivia-update-state.json`" in documentation
+    assert "`versions/`" in documentation
+    assert "刷新失败会恢复" in documentation
+
+
 def test_incomplete_old_marker_is_not_treated_as_current_install(
     fixture_inputs,
     tmp_path: Path,

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -27,6 +27,7 @@ from installer.start_local import (
     _client_environment,
     _client_executable,
 )
+from installer.version_launcher import resolve_active_backend
 
 
 CURRENT_TEST_CLIENT_VERSION = "0.0.9.627"
@@ -1975,6 +1976,41 @@ def test_install_is_idempotent_and_unknown_target_is_not_overwritten(
     ).read_text(encoding="utf-8") == "keep"
 
 
+def test_repeat_install_retires_unsigned_component_state_to_stable_backend(
+    fixture_inputs,
+    tmp_path: Path,
+) -> None:
+    official, payload, manifest, _feapp, _webplayer = fixture_inputs
+    target = tmp_path / "installed"
+    install_full_patch(official, target, payload, manifest)
+    digest = "a" * 64
+    active = target / "versions" / "local_backend" / f"1.1.0-{digest}"
+    active.mkdir(parents=True)
+    (active / "unsigned.py").write_text("old unsigned payload", encoding="utf-8")
+    state = {
+        "schema_version": "olivia.update-state.v1",
+        "active_components": {
+            "local_backend": {
+                "version": "1.1.0",
+                "manifest_sha256": digest,
+                "payload_path": active.relative_to(target).as_posix(),
+            }
+        },
+        "previous_components": {},
+    }
+    (target / ".olivia-update-state.json").write_text(
+        json.dumps(state), encoding="utf-8"
+    )
+    assert resolve_active_backend(target) == active
+
+    repeated = install_full_patch(official, target, payload, manifest)
+
+    assert repeated["status"] == "ALREADY_INSTALLED"
+    assert not (target / ".olivia-update-state.json").exists()
+    assert not (target / "versions").exists()
+    assert resolve_active_backend(target) == target / "local_backend"
+
+
 def test_install_scripts_dispatch_through_the_stable_version_launcher(
     fixture_inputs,
     tmp_path: Path,
@@ -2032,6 +2068,11 @@ def test_repeat_install_rolls_back_the_active_payload_when_publish_fails(
     install_full_patch(official, target, payload, manifest)
     launcher = target / "local_backend" / "installer" / "start_local.py"
     launcher.write_text("old launcher", encoding="utf-8")
+    update_state = target / ".olivia-update-state.json"
+    update_state.write_text('{"synthetic":"old-state"}', encoding="utf-8")
+    old_version = target / "versions/local_backend/old/old-version.txt"
+    old_version.parent.mkdir(parents=True)
+    old_version.write_text("old version", encoding="utf-8")
     original_replace = full_patch.os.replace
 
     def fail_staged_start(source: str | Path, destination: str | Path) -> None:
@@ -2045,6 +2086,8 @@ def test_repeat_install_rolls_back_the_active_payload_when_publish_fails(
         install_full_patch(official, target, payload, manifest)
 
     assert launcher.read_text(encoding="utf-8") == "old launcher"
+    assert update_state.read_text(encoding="utf-8") == '{"synthetic":"old-state"}'
+    assert old_version.read_text(encoding="utf-8") == "old version"
 
 
 def test_incomplete_old_marker_is_not_treated_as_current_install(


### PR DESCRIPTION
## 结果\n- 完整刷新时移除旧的未签名更新状态与 versions 树\n- Windows symlink/reparse 项在任何变异前 fail closed\n- 刷新失败恢复旧状态；data/logs/third-party 始终保留\n- 外层 Install.ps1 端到端测试覆盖成功刷新与事务清理\n\n## 验证\n- 104 passed, 1 skipped\n- baseline hardening PASS\n- compileall PASS\n- git diff --check PASS\n\n边界：未执行真实安装器 GUI；最终安装 E2E 在新包构建后统一完成。\n