### PR TITLE
fix(update): disable unsigned manual patch routing

### DIFF
--- a/contracts/local_update_api_contract.json
+++ b/contracts/local_update_api_contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "olivia.local-update-api-contract.v1",
   "status_schema_version": "olivia.local-update.v1",
-  "execution": "serialized-apply-rollback-off-event-loop",
+  "execution": "manual-apply-disabled-rollback-off-event-loop",
   "authorization": {
     "origins": "explicit-trusted-https-or-loopback-only",
     "login_required": true,
@@ -16,16 +16,14 @@
       "methods": ["POST", "OPTIONS"],
       "actions": {
         "select": {
-          "request_fields": ["action"],
-          "response_fields": ["status", "package_path", "restart_required"],
-          "status_values": ["SELECTED", "CANCELLED"],
-          "restart_required": false
+          "available": false,
+          "error_code": "UPDATE_ACTION_UNAVAILABLE",
+          "http_status": 503
         },
         "apply": {
-          "request_fields": ["action", "package_path", "manifest_sha256"],
-          "response_fields": ["status", "component", "version", "restart_required"],
-          "status_values": ["APPLIED"],
-          "restart_required": true
+          "available": false,
+          "error_code": "UPDATE_ACTION_UNAVAILABLE",
+          "http_status": 503
         },
         "rollback": {
           "request_fields": ["action"],
@@ -46,7 +44,6 @@
     "UPDATE_REQUEST_TOO_LARGE": 413,
     "UPDATE_CONTENT_TYPE_INVALID": 415,
     "UPDATE_ACTION_UNAVAILABLE": 503,
-    "UPDATE_PICKER_UNAVAILABLE": 503,
     "UPDATE_RESULT_INVALID": 503
   },
   "component_error_pattern": "UPDATE_[A-Z0-9_]{3,90}",

--- a/contracts/local_update_api_contract.schema.json
+++ b/contracts/local_update_api_contract.schema.json
@@ -17,7 +17,7 @@
   "properties": {
     "schema_version": {"const": "olivia.local-update-api-contract.v1"},
     "status_schema_version": {"const": "olivia.local-update.v1"},
-    "execution": {"const": "serialized-apply-rollback-off-event-loop"},
+    "execution": {"const": "manual-apply-disabled-rollback-off-event-loop"},
     "authorization": {
       "const": {
         "origins": "explicit-trusted-https-or-loopback-only",
@@ -45,8 +45,8 @@
               "additionalProperties": false,
               "required": ["select", "apply", "rollback"],
               "properties": {
-                "select": {"$ref": "#/$defs/action"},
-                "apply": {"$ref": "#/$defs/action"},
+                "select": {"$ref": "#/$defs/unavailableAction"},
+                "apply": {"$ref": "#/$defs/unavailableAction"},
                 "rollback": {"$ref": "#/$defs/action"}
               }
             }
@@ -63,6 +63,16 @@
     "component_error_http_status": {"const": 409}
   },
   "$defs": {
+    "unavailableAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["available", "error_code", "http_status"],
+      "properties": {
+        "available": {"const": false},
+        "error_code": {"const": "UPDATE_ACTION_UNAVAILABLE"},
+        "http_status": {"const": 503}
+      }
+    },
     "action": {
       "type": "object",
       "additionalProperties": false,

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -133,9 +133,9 @@ webplayer.dat.orig
 
 安装后的 `START.cmd`、`CONFIGURE.cmd` 和 `UNINSTALL.cmd` 只调用安装根目录中的稳定启动器 `launcher/version_launcher.py`。稳定启动器读取一次 `.olivia-update-state.json` 原子指针，从 `versions/local_backend/<version>-<manifest-sha256>` 选择完整后端；没有更新状态时继续使用初装的 `local_backend`。因此更新期间不会把正在使用的后端目录临时移走，也不会要求用户重新运行完整安装器。
 
-当前版本只提供经过外部渠道取得的本地 `.oliviapatch` 文件安装，不联网检查或下载更新。包必须是 ZIP，并且只能包含一个 `manifest.json` 和清单声明的 `payload/...` 普通文件。`local_backend` 包必须包含 `installer/start_local.py`、`installer/configure.py` 和 `installer/uninstall.py` 三个普通文件入口，否则不会激活。公开契约及示例见：
+v0.1 不接受用户手动导入或应用 `.oliviapatch`。客户端选择与应用动作、以及 `apply-update` 命令都稳定返回 `UPDATE_ACTION_UNAVAILABLE`；升级只能使用维护者发布的完整安装包。内部补丁格式与构建器暂时保留用于后续签名机制开发，但不构成 v0.1 的用户发布面。公开契约及示例见：
 
-普通用户在客户端 Settings 的“补丁更新”中选择已下载的 `.oliviapatch`，粘贴发布页提供的 Manifest SHA-256 后安装；成功后关闭并重新打开 Olivia。该页面也提供回滚到上一版本的入口。命令行入口继续保留用于维护和故障排查。
+客户端 Settings 的“补丁更新”只保留已安装版本的回滚入口，并明确提示使用完整安装包更新；不显示文件选择、Manifest SHA-256 或本地补丁安装控件。
 
 状态指针成功切换后，更新器只会调用完整安装包写入 `launcher/Create-Shortcut.ps1` 的稳定副本，以 best-effort 方式发现桌面和开始菜单中仍然存在的快捷方式并刷新图标；不会执行刚激活补丁载荷里的脚本。属于当前安装、仍指向旧 `START.cmd` 的快捷方式会同时迁移为 `%WINDIR%\System32\wscript.exe //B //Nologo "<安装目录>\START.vbs"` 隐藏启动；已经采用该隐藏入口的当前安装快捷方式只刷新图标。其他安装或无关的 wscript 快捷方式不会被改写。路径发现失败、PowerShell 不可用或启动失败、执行超时、非零退出以及单个快捷方式保存失败，都不会撤销已经完成的补丁激活，也不会把成功更新改报为失败。
 
@@ -154,13 +154,7 @@ python -m installer build-update --source <源码目录> --output <发布目录>
 
 命令拒绝 tracked 文件有改动或 HEAD 与 `--source-commit` 不一致的源码，并生成 `.manifest.sha256`（供客户端安装页粘贴）和 `.sha256`（用于核对整个补丁文件）。相同源码提交和版本会生成字节一致的包。
 
-安装命令：
-
-```powershell
-python -m installer apply-update --installation <安装目录> --package <补丁.oliviapatch> --manifest-sha256 <64位小写SHA-256>
-```
-
-`--manifest-sha256` 是包外信任锚，必须来自经过认证的发布元数据或用户已验证的官方发布页面，不能从同一个补丁包内自行读取后当作可信值。当前实现不包含签名验证或在线发布元数据获取；自动下载器接入前必须保持这条边界。
+后续若重新开放补丁应用，必须先把签名公钥固化到稳定安装面，并在激活前验证签名。单独提供同渠道可替换的 Manifest SHA-256 不能作为 QQ 转发场景的信任锚。
 
 每个 payload 文件还会按清单校验大小和 SHA-256。路径会按 Windows 规则拒绝目录穿越、大小写别名、尾随点/空格、ADS、设备名、符号链接和 reparse point；解包完成后会重新枚举暂存目录并逐文件复验。校验成功后先发布不可变版本目录，最后仅用一次原子替换切换状态指针。指针替换失败时，旧指针或初装后端仍可启动，新目录只是未激活版本。
 

--- a/installer/__main__.py
+++ b/installer/__main__.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from .component_package import ComponentPackageBuildError, build_component_package
 from .component_update import (
     ComponentUpdateError,
-    apply_component_update,
     rollback_component_update,
 )
 from .full_patch import PatchInstallError, discover_steam_install, install_full_patch, load_manifest, uninstall_full_patch, validate_official_source
@@ -51,11 +50,7 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "uninstall":
             result = uninstall_full_patch(args.installation, apply=args.apply)
         elif args.command == "apply-update":
-            result = apply_component_update(
-                args.installation,
-                args.package,
-                expected_manifest_sha256=args.manifest_sha256,
-            )
+            raise ComponentUpdateError("UPDATE_ACTION_UNAVAILABLE")
         elif args.command == "build-update":
             result = build_component_package(
                 args.source,

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -1613,64 +1613,14 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     const heading = text("h3", "本地补丁", "text-text-title text-title-m");
     const summary = text(
       "p",
-      "从我们的 Release 手动下载 .oliviapatch，再在这里安装。",
+      "v0.1 暂停手动补丁导入；请使用我们发布的完整安装包更新。",
       "text-text-secondary text-body-m font-regular"
     );
-    let packagePath = "";
-    const selectedPatch = text(
-      "p",
-      "尚未选择补丁文件。",
-      "text-text-secondary text-body-m font-regular"
-    );
-    const digest = setupInput("发布页提供的 Manifest SHA-256");
-    digest.input.maxLength = 64;
-    digest.input.autocomplete = "off";
     const result = text("p", "", "text-text-secondary text-body-m font-regular");
     result.setAttribute("aria-live", "polite");
-    const choose = button("选择已下载的补丁", async () => {
-      setButtonsBusy([choose], true);
-      try {
-        const payload = await requestUpdate({ action: "select" });
-        if (payload.status === "SELECTED" && typeof payload.package_path === "string") {
-          packagePath = payload.package_path;
-          selectedPatch.textContent = `已选择：${packagePath.split(/[\\/]/).pop()}`;
-          result.textContent = "";
-        }
-      } catch (error) {
-        result.textContent = `无法选择补丁：${error && error.code ? error.code : "UPDATE_PICKER_UNAVAILABLE"}`;
-      } finally {
-        setButtonsBusy([choose], false);
-      }
-    });
-    const install = button("安装本地补丁", async () => {
-      const manifestSha256 = digest.input.value.trim().toLowerCase();
-      if (!packagePath) {
-        result.textContent = "请选择已下载的 .oliviapatch 文件。";
-        return;
-      }
-      if (!/^[0-9a-f]{64}$/.test(manifestSha256)) {
-        result.textContent = "请输入发布页提供的 64 位 Manifest SHA-256。";
-        return;
-      }
-      if (!await confirmAction("确认校验并安装这个本地补丁？")) return;
-      setButtonsBusy([install, rollback], true);
-      result.textContent = "正在校验并安装补丁……";
-      try {
-        const payload = await requestUpdate({
-          action: "apply",
-          package_path: packagePath,
-          manifest_sha256: manifestSha256,
-        });
-        result.textContent = `版本 ${payload.version} 已安装，关闭并重新打开 Olivia 后生效。`;
-      } catch (error) {
-        result.textContent = `补丁安装失败：${error && error.code ? error.code : "UPDATE_ACTION_UNAVAILABLE"}`;
-      } finally {
-        setButtonsBusy([install, rollback], false);
-      }
-    });
     const rollback = button("回滚上一版本", async () => {
       if (!await confirmAction("确认回滚到上一版本？关闭并重新打开 Olivia 后生效。")) return;
-      setButtonsBusy([install, rollback], true);
+      setButtonsBusy([rollback], true);
       result.textContent = "正在切换到上一版本……";
       try {
         const payload = await requestUpdate({ action: "rollback" });
@@ -1678,19 +1628,12 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       } catch (error) {
         result.textContent = `无法回滚：${error && error.code ? error.code : "UPDATE_ACTION_UNAVAILABLE"}`;
       } finally {
-        setButtonsBusy([install, rollback], false);
+        setButtonsBusy([rollback], false);
       }
     });
     const controls = actions();
-    controls.append(choose, install, rollback);
-    panel.replaceChildren(
-      heading,
-      summary,
-      selectedPatch,
-      digest.wrapper,
-      controls,
-      result
-    );
+    controls.append(rollback);
+    panel.replaceChildren(heading, summary, controls, result);
   };
 
   const loadDialogData = async (statusNode, panels, initialMode) => {

--- a/original_client_update_api.py
+++ b/original_client_update_api.py
@@ -188,7 +188,10 @@ def mount_original_client_update_api(
         except Exception as exc:
             raise UpdateAPIError("UPDATE_LOGIN_REQUIRED", status=403) from exc
         payload = await _json_body(request)
-        if payload.get("action") in {"select", "apply"}:
+        action_value = payload.get("action")
+        if not isinstance(action_value, str):
+            raise UpdateAPIError("UPDATE_FIELDS_INVALID", status=400)
+        if action_value in {"select", "apply"}:
             raise UpdateAPIError("UPDATE_ACTION_UNAVAILABLE", status=503)
         if payload == {"action": "rollback"}:
             call = updater.rollback

--- a/original_client_update_api.py
+++ b/original_client_update_api.py
@@ -1,14 +1,12 @@
-"""Loopback-only actions for user-downloaded local Olivia patches."""
+"""Loopback-only rollback with v0.1 manual patch actions fail-closed."""
 
 from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Mapping, Sequence
 import json
-import os
 import re
 from pathlib import Path
-import subprocess
 from typing import Any, Protocol
 from urllib.parse import urlsplit
 
@@ -25,12 +23,10 @@ ACTION_PATH = "/toy/updates/local/action"
 CONFIRM_HEADER = "X-Olivia-Update-Action"
 SESSION_HEADER = "X-Olivia-Setup-Session"
 _MAX_JSON_BYTES = 8_192
-_SHA256_RE = re.compile(r"[0-9a-f]{64}")
 _VERSION_RE = re.compile(r"[0-9A-Za-z][0-9A-Za-z.+-]{0,63}")
 _LOOPBACK_ORIGIN_RE = re.compile(r"^http://(?:127\.0\.0\.1|localhost):[0-9]{1,5}$")
 _ORIGINS_KEY = web.AppKey("original_client_update_origins", frozenset)
 _MOUNTED_KEY = web.AppKey("original_client_update_mounted", bool)
-_REPARSE_POINT = 0x0400
 
 
 class UpdateAPIError(RuntimeError):
@@ -47,7 +43,6 @@ class ComponentUpdater(Protocol):
 
 
 SessionAuthorizer = Callable[[str], None]
-PatchPicker = Callable[[], Path | None]
 
 
 class LocalComponentUpdater:
@@ -135,59 +130,6 @@ async def _json_body(request: web.Request) -> dict[str, object]:
     return payload
 
 
-def _package_path(value: object) -> Path:
-    if not isinstance(value, str) or not value or len(value) > 4_096:
-        raise UpdateAPIError("UPDATE_FIELDS_INVALID", status=400)
-    path = Path(value).expanduser()
-    if not path.is_absolute() or path.suffix.casefold() != ".oliviapatch":
-        raise UpdateAPIError("UPDATE_FIELDS_INVALID", status=400)
-    try:
-        metadata = path.lstat()
-        if path.is_symlink() or bool(
-            getattr(metadata, "st_file_attributes", 0) & _REPARSE_POINT
-        ) or not path.is_file():
-            raise UpdateAPIError("UPDATE_FIELDS_INVALID", status=400)
-        return path.resolve(strict=True)
-    except OSError as exc:
-        raise UpdateAPIError("UPDATE_FIELDS_INVALID", status=400) from exc
-
-
-def _select_windows_patch() -> Path | None:
-    if os.name != "nt":
-        raise UpdateAPIError("UPDATE_PICKER_UNAVAILABLE", status=503)
-    powershell = (
-        Path(os.environ.get("SystemRoot", "C:\\Windows"))
-        / "System32"
-        / "WindowsPowerShell"
-        / "v1.0"
-        / "powershell.exe"
-    )
-    script = (
-        "Add-Type -AssemblyName System.Windows.Forms;"
-        "$dialog = New-Object System.Windows.Forms.OpenFileDialog;"
-        "$dialog.Filter = 'Olivia patch (*.oliviapatch)|*.oliviapatch';"
-        "$dialog.CheckFileExists = $true;"
-        "$dialog.Multiselect = $false;"
-        "if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) "
-        "{ [Console]::Out.Write($dialog.FileName) }"
-    )
-    try:
-        completed = subprocess.run(
-            [str(powershell), "-NoProfile", "-STA", "-Command", script],
-            capture_output=True,
-            text=True,
-            timeout=300,
-            check=False,
-            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
-        )
-    except (OSError, subprocess.SubprocessError) as exc:
-        raise UpdateAPIError("UPDATE_PICKER_UNAVAILABLE", status=503) from exc
-    if completed.returncode != 0:
-        raise UpdateAPIError("UPDATE_PICKER_UNAVAILABLE", status=503)
-    selected = completed.stdout.strip()
-    return None if not selected else _package_path(selected)
-
-
 def _public_result(value: Mapping[str, object]) -> dict[str, object]:
     status = value.get("status")
     component = value.get("component")
@@ -213,7 +155,6 @@ def mount_original_client_update_api(
     *,
     trusted_origins: Sequence[str],
     authorize_session: SessionAuthorizer,
-    select_patch: PatchPicker | None = None,
 ) -> None:
     if app.get(_MOUNTED_KEY, False):
         raise RuntimeError("UPDATE_API_ALREADY_MOUNTED")
@@ -222,7 +163,6 @@ def mount_original_client_update_api(
     app[_ORIGINS_KEY] = _normalize_origins(trusted_origins)
     app[_MOUNTED_KEY] = True
     control_lock = asyncio.Lock()
-    picker = select_patch or _select_windows_patch
 
     @web.middleware
     async def errors(request: web.Request, handler):
@@ -248,31 +188,9 @@ def mount_original_client_update_api(
         except Exception as exc:
             raise UpdateAPIError("UPDATE_LOGIN_REQUIRED", status=403) from exc
         payload = await _json_body(request)
-        if payload == {"action": "select"}:
-            try:
-                selected = await asyncio.to_thread(picker)
-                if selected is None:
-                    result = {"status": "CANCELLED", "restart_required": False}
-                else:
-                    result = {
-                        "status": "SELECTED",
-                        "package_path": str(_package_path(str(selected))),
-                        "restart_required": False,
-                    }
-            except UpdateAPIError:
-                raise
-            except Exception as exc:
-                raise UpdateAPIError("UPDATE_PICKER_UNAVAILABLE", status=503) from exc
-            return web.json_response(result, headers=_headers(origin))
-        if payload.get("action") == "apply" and set(payload) == {
-            "action", "package_path", "manifest_sha256"
-        }:
-            digest = payload.get("manifest_sha256")
-            if not isinstance(digest, str) or not _SHA256_RE.fullmatch(digest):
-                raise UpdateAPIError("UPDATE_FIELDS_INVALID", status=400)
-            call = updater.apply
-            args = (_package_path(payload.get("package_path")), digest)
-        elif payload == {"action": "rollback"}:
+        if payload.get("action") in {"select", "apply"}:
+            raise UpdateAPIError("UPDATE_ACTION_UNAVAILABLE", status=503)
+        if payload == {"action": "rollback"}:
             call = updater.rollback
             args = ()
         else:
@@ -297,7 +215,6 @@ __all__ = [
     "ACTION_PATH",
     "CONFIRM_HEADER",
     "LocalComponentUpdater",
-    "PatchPicker",
     "SESSION_HEADER",
     "UpdateAPIError",
     "mount_original_client_update_api",

--- a/tests/http/test_original_client_server.py
+++ b/tests/http/test_original_client_server.py
@@ -133,7 +133,9 @@ def test_successful_sign_in_authorizes_on_demand_capability_install(tmp_path: Pa
     asyncio.run(scenario())
 
 
-def test_successful_sign_in_authorizes_local_component_update(tmp_path: Path) -> None:
+def test_successful_sign_in_still_cannot_apply_unsigned_local_component_update(
+    tmp_path: Path,
+) -> None:
     async def signed_in(_request: web.Request) -> web.Response:
         return web.json_response({"code": 0, "message": "ok", "data": {}})
 
@@ -178,8 +180,12 @@ def test_successful_sign_in_authorizes_local_component_update(tmp_path: Path) ->
                     "manifest_sha256": "a" * 64,
                 },
             )
-            assert response.status == 200
-            assert updater.applied == [package.resolve()]
+            assert response.status == 503
+            assert await response.json() == {
+                "status": "FAILED",
+                "error_code": "UPDATE_ACTION_UNAVAILABLE",
+            }
+            assert updater.applied == []
 
     asyncio.run(scenario())
 

--- a/tests/http/test_original_client_update_api.py
+++ b/tests/http/test_original_client_update_api.py
@@ -101,6 +101,39 @@ def test_update_api_disables_manual_patch_selection_and_apply_but_keeps_rollback
     asyncio.run(scenario())
 
 
+def test_update_api_rejects_non_string_action_values_with_the_public_contract() -> None:
+    async def scenario() -> None:
+        updater = _Updater()
+        app = web.Application()
+        mount_original_client_update_api(
+            app,
+            updater,
+            trusted_origins=(TRUSTED_ORIGIN,),
+            authorize_session=lambda _value: None,
+        )
+        headers = {
+            "Origin": TRUSTED_ORIGIN,
+            CONFIRM_HEADER: "confirmed",
+            SESSION_HEADER: "signed-in-session",
+        }
+        async with TestClient(TestServer(app)) as client:
+            for invalid_action in (["apply"], {"name": "apply"}):
+                response = await client.post(
+                    ACTION_PATH,
+                    headers=headers,
+                    json={"action": invalid_action},
+                )
+                assert response.status == 400
+                assert await response.json() == {
+                    "status": "FAILED",
+                    "error_code": "UPDATE_FIELDS_INVALID",
+                }
+        assert updater.applied == []
+        assert updater.rollbacks == 0
+
+    asyncio.run(scenario())
+
+
 def test_update_api_contract_matches_its_schema() -> None:
     contract = json.loads(
         (ROOT / "contracts" / "local_update_api_contract.json").read_text(

--- a/tests/http/test_original_client_update_api.py
+++ b/tests/http/test_original_client_update_api.py
@@ -34,7 +34,7 @@ class _Updater:
         return {"status": "ROLLED_BACK", "component": "local_backend", "version": "1.2.2"}
 
 
-def test_update_api_requires_login_confirmation_and_applies_or_rolls_back(
+def test_update_api_disables_manual_patch_selection_and_apply_but_keeps_rollback(
     tmp_path: Path,
 ) -> None:
     async def scenario() -> None:
@@ -46,7 +46,6 @@ def test_update_api_requires_login_confirmation_and_applies_or_rolls_back(
             app,
             updater,
             trusted_origins=(TRUSTED_ORIGIN,),
-            select_patch=lambda: package,
             authorize_session=lambda value: (
                 None
                 if value == "signed-in-session"
@@ -77,21 +76,18 @@ def test_update_api_requires_login_confirmation_and_applies_or_rolls_back(
                 headers=headers,
                 json={"action": "select"},
             )
-            assert selected.status == 200
+            assert selected.status == 503
             assert await selected.json() == {
-                "status": "SELECTED",
-                "package_path": str(package.resolve()),
-                "restart_required": False,
+                "status": "FAILED",
+                "error_code": "UPDATE_ACTION_UNAVAILABLE",
             }
             applied = await client.post(ACTION_PATH, headers=headers, json=body)
-            assert applied.status == 200
+            assert applied.status == 503
             assert await applied.json() == {
-                "status": "APPLIED",
-                "component": "local_backend",
-                "version": "1.2.3",
-                "restart_required": True,
+                "status": "FAILED",
+                "error_code": "UPDATE_ACTION_UNAVAILABLE",
             }
-            assert updater.applied == [(package.resolve(), "a" * 64)]
+            assert updater.applied == []
 
             rolled_back = await client.post(
                 ACTION_PATH,
@@ -117,11 +113,24 @@ def test_update_api_contract_matches_its_schema() -> None:
         )
     )
     assert not list(Draft202012Validator(schema).iter_errors(contract))
+    assert contract["execution"] == "manual-apply-disabled-rollback-off-event-loop"
     route = contract["routes"][ACTION_PATH]
-    assert route["actions"]["select"]["response_fields"] == [
-        "status",
-        "package_path",
-        "restart_required",
-    ]
-    assert route["actions"]["apply"]["restart_required"] is True
+    unavailable = {
+        "available": False,
+        "error_code": "UPDATE_ACTION_UNAVAILABLE",
+        "http_status": 503,
+    }
+    assert route["actions"]["select"] == unavailable
+    assert route["actions"]["apply"] == unavailable
     assert route["actions"]["rollback"]["restart_required"] is True
+
+
+def test_v01_release_docs_require_full_installer_updates() -> None:
+    documentation = (ROOT / "docs" / "WINDOWS_FULL_PATCH.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "v0.1 不接受用户手动导入或应用 `.oliviapatch`" in documentation
+    assert "稳定返回 `UPDATE_ACTION_UNAVAILABLE`" in documentation
+    assert "python -m installer apply-update" not in documentation
+    assert "QQ 转发场景" in documentation

--- a/tests/installer/test_component_update.py
+++ b/tests/installer/test_component_update.py
@@ -1217,7 +1217,7 @@ def test_component_update_rejects_untrusted_manifest_before_activation(
     assert not (installation / ".olivia-update-state.json").exists()
 
 
-def test_installer_cli_applies_a_verified_local_component_package(
+def test_installer_cli_rejects_manual_component_package_apply(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -1241,12 +1241,12 @@ def test_installer_cli_applies_a_verified_local_component_package(
         ]
     )
 
-    assert exit_code == 0
+    assert exit_code == 2
     assert json.loads(capsys.readouterr().out) == {
-        "status": "APPLIED",
-        "component": "local_backend",
-        "version": "1.1.0",
+        "status": "ERROR",
+        "code": "UPDATE_ACTION_UNAVAILABLE",
     }
+    assert not (installation / ".olivia-update-state.json").exists()
 
 
 def test_uninstall_removes_update_state_and_abandoned_update_staging(

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -214,20 +214,18 @@ def test_selected_settings_tab_keeps_a_distinct_visual_state() -> None:
     assert "tab.style.background =" not in source
 
 
-def test_original_settings_can_apply_a_user_downloaded_patch_and_roll_back() -> None:
+def test_original_settings_does_not_render_manual_patch_import_controls() -> None:
     source = BOOTSTRAP_JAVASCRIPT
 
     assert 'const UPDATE_ACTION_PATH = "/toy/updates/local/action";' in source
-    assert 'action: "select"' in source
-    assert "选择已下载的补丁" in source
-    assert "payload.package_path" in source
     assert "File.path" not in source
     assert "patch.files" not in source
-    assert "发布页提供的 Manifest SHA-256" in source
-    assert 'action: "apply"' in source
     assert 'action: "rollback"' in source
-    assert "安装本地补丁" in source
+    assert "完整安装包" in source
     assert "回滚上一版本" in source
+    assert "controls.append(choose, install, rollback);" not in source
+    assert "controls.append(rollback);" in source
+    assert "panel.replaceChildren(heading, summary, controls, result);" in source
     assert "关闭并重新打开 Olivia 后生效" in source
 
 


### PR DESCRIPTION
## Summary
- reject manual patch selection and apply actions across HTTP, UI, and CLI for v0.1
- keep rollback available while unsigned update packages remain internal-only
- validate the update action type before routing so arrays and objects return 400 UPDATE_FIELDS_INVALID
- align the public update contract and release documentation

## Verification
- focused update/server/UI tests: 74 passed
- repository hardening scan: PASS
- compileall and git diff --check: PASS

## Boundary
No patch package was applied and no real installation or user data was modified.