### PR TITLE
feat(installer): preserve native client window layout

### DIFF
--- a/installer/native_window_layout.py
+++ b/installer/native_window_layout.py
@@ -32,6 +32,7 @@ class WindowSnapshot:
     handle: int
     rect: Rect
     executable: Path
+    process_id: int = 0
     minimized: bool = False
     maximized: bool = False
 
@@ -52,10 +53,6 @@ class WindowApi(Protocol):
     def move_window(self, handle: int, target: Rect) -> bool: ...
 
 
-def _clamp(value: int, lower: int, upper: int) -> int:
-    return min(max(value, lower), upper)
-
-
 def plan_native_window_layout(
     *,
     main: Rect,
@@ -66,35 +63,35 @@ def plan_native_window_layout(
     """Return the main rectangle that keeps its right sidebar in the work area."""
 
     gap = sidebar.left - main.right
-    sidebar_top = sidebar.top - main.top
-    sidebar_bottom = sidebar.bottom - main.top
-    combined_top = min(0, sidebar_top)
-    combined_bottom = max(main.height, sidebar_bottom)
-    target_width = min(main.width, work_area.width - gap - sidebar.width)
     if (
         not 0 <= gap <= 32
         or sidebar.width <= 0
         or sidebar.height <= 0
-        or target_width < minimum_main_width
         or main.height <= 0
-        or combined_bottom - combined_top > work_area.height
     ):
         return None
-    target_left = _clamp(
-        main.left,
-        work_area.left,
-        work_area.right - target_width - gap - sidebar.width,
-    )
-    target_top = _clamp(
-        main.top,
-        work_area.top - combined_top,
-        work_area.bottom - combined_bottom,
-    )
+    if (
+        sidebar.left >= work_area.left
+        and sidebar.top >= work_area.top
+        and sidebar.right <= work_area.right
+        and sidebar.bottom <= work_area.bottom
+    ):
+        return main
+    if (
+        sidebar.left < work_area.left
+        or sidebar.top < work_area.top
+        or sidebar.bottom > work_area.bottom
+    ):
+        return None
+    target_right = work_area.right - gap - sidebar.width
+    target_width = target_right - main.left
+    if target_width < minimum_main_width or target_width >= main.width:
+        return None
     return Rect(
-        target_left,
-        target_top,
-        target_left + target_width,
-        target_top + main.height,
+        main.left,
+        main.top,
+        target_right,
+        main.bottom,
     )
 
 
@@ -117,6 +114,7 @@ def _window_pair(
             w
             for w in matching
             if w.handle != main.handle
+            and w.process_id == main.process_id
             and 40 <= w.rect.width <= 96
             and 72 <= w.rect.height <= 240
             and 0 <= w.rect.left - main.rect.right <= 32
@@ -222,6 +220,8 @@ def guard_native_window_layout(
     stable = 0
     while not stop.is_set():
         pair = _window_pair(api.visible_windows(), client_executable)
+        if stop.is_set():
+            return LayoutStatus.SKIPPED
         if pair is None:
             previous, stable = None, 0
         elif pair == previous:
@@ -229,11 +229,19 @@ def guard_native_window_layout(
         else:
             previous, stable = pair, 1
         if pair is not None and stable >= 2:
+            if stop.is_set() or time.monotonic() >= deadline:
+                return LayoutStatus.SKIPPED
             status = _adjust_pair(api, pair)
             if status is not LayoutStatus.ADJUSTED:
                 return status
-            time.sleep(max(0.0, poll_interval))
+            remaining = max(0.0, deadline - time.monotonic())
+            if stop.wait(min(max(0.0, poll_interval), remaining)):
+                return LayoutStatus.SKIPPED
+            if time.monotonic() >= deadline:
+                return LayoutStatus.SKIPPED
             verified = _window_pair(api.visible_windows(), client_executable)
+            if stop.is_set():
+                return LayoutStatus.SKIPPED
             if verified is None:
                 return LayoutStatus.SKIPPED
             return (
@@ -241,9 +249,11 @@ def guard_native_window_layout(
                 if _pair_target(api, verified)[0] is LayoutStatus.ALREADY_VISIBLE
                 else LayoutStatus.SKIPPED
             )
-        if time.monotonic() >= deadline:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
             return LayoutStatus.NOT_OBSERVED
-        time.sleep(max(0.0, poll_interval))
+        if stop.wait(min(max(0.0, poll_interval), remaining)):
+            return LayoutStatus.SKIPPED
     return LayoutStatus.SKIPPED
 
 
@@ -329,6 +339,7 @@ class _CtypesWindowApi:
                         handle,
                         self._rect(rect),
                         executable,
+                        process_id=int(process_id.value),
                         minimized=bool(self.user32.IsIconic(hwnd)),
                         maximized=bool(self.user32.IsZoomed(hwnd)),
                     )

--- a/installer/native_window_layout.py
+++ b/installer/native_window_layout.py
@@ -40,6 +40,7 @@ class WindowSnapshot:
 class LayoutStatus(str, Enum):
     ADJUSTED = "adjusted"
     ALREADY_VISIBLE = "already_visible"
+    FAILED = "failed"
     NOT_OBSERVED = "not_observed"
     SKIPPED = "skipped"
     UNSUPPORTED = "unsupported"
@@ -47,6 +48,8 @@ class LayoutStatus(str, Enum):
 
 class WindowApi(Protocol):
     def visible_windows(self) -> tuple[WindowSnapshot, ...]: ...
+
+    def window_snapshot(self, handle: int) -> WindowSnapshot | None: ...
 
     def monitor_geometry(self, handle: int) -> tuple[Rect, Rect] | None: ...
 
@@ -190,8 +193,37 @@ def _adjust_pair(
         return status, target
     if cancelled is not None and cancelled():
         return LayoutStatus.SKIPPED, target
+    if not _same_main_window(api, pair[0]):
+        return LayoutStatus.SKIPPED, target
     moved = api.move_window(pair[0].handle, target)
     return (LayoutStatus.ADJUSTED if moved else LayoutStatus.SKIPPED), target
+
+
+def _same_main_window(api: WindowApi, expected: WindowSnapshot) -> bool:
+    current = api.window_snapshot(expected.handle)
+    return bool(
+        current is not None
+        and expected.process_id > 0
+        and current.process_id == expected.process_id
+        and _normalized_path(current.executable)
+        == _normalized_path(expected.executable)
+        and current.rect.width >= 600
+        and current.rect.height >= 400
+        and not current.minimized
+        and not current.maximized
+    )
+
+
+def _rollback_main_window(
+    api: WindowApi, original: WindowSnapshot
+) -> LayoutStatus:
+    if not _same_main_window(api, original):
+        return LayoutStatus.FAILED
+    return (
+        LayoutStatus.SKIPPED
+        if api.move_window(original.handle, original.rect)
+        else LayoutStatus.FAILED
+    )
 
 
 def create_window_api() -> WindowApi | None:
@@ -260,12 +292,12 @@ def guard_native_window_layout(
                 return status
             remaining = max(0.0, deadline - time.monotonic())
             if stop.wait(min(max(0.0, poll_interval), remaining)):
-                return LayoutStatus.SKIPPED
+                return _rollback_main_window(api, pair[0])
             if time.monotonic() >= deadline:
-                return LayoutStatus.SKIPPED
+                return _rollback_main_window(api, pair[0])
             observed = api.visible_windows()
             if stop.is_set() or time.monotonic() >= deadline:
-                return LayoutStatus.SKIPPED
+                return _rollback_main_window(api, pair[0])
             verified_main = next(
                 (
                     window
@@ -285,7 +317,7 @@ def guard_native_window_layout(
                 None,
             )
             if verified_main is None or verified_sidebar is None:
-                return LayoutStatus.SKIPPED
+                return _rollback_main_window(api, pair[0])
             verified = verified_main, verified_sidebar
             sidebar_dx = target.right - pair[0].rect.right
             sidebar_dy = target.top - pair[0].rect.top
@@ -299,15 +331,13 @@ def guard_native_window_layout(
                 verified[0].rect != target
                 or verified[1].rect != expected_sidebar
             ):
-                return LayoutStatus.SKIPPED
+                return _rollback_main_window(api, pair[0])
             verified_status = _pair_target(api, verified)[0]
             if stop.is_set() or time.monotonic() >= deadline:
-                return LayoutStatus.SKIPPED
-            return (
-                LayoutStatus.ADJUSTED
-                if verified_status is LayoutStatus.ALREADY_VISIBLE
-                else LayoutStatus.SKIPPED
-            )
+                return _rollback_main_window(api, pair[0])
+            if verified_status is LayoutStatus.ALREADY_VISIBLE:
+                return LayoutStatus.ADJUSTED
+            return _rollback_main_window(api, pair[0])
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             return LayoutStatus.NOT_OBSERVED
@@ -338,6 +368,7 @@ class _CtypesWindowApi:
         )
         self.user32 = ctypes.WinDLL("user32", use_last_error=True)
         self.kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        self.user32.GetAncestor.restype = wintypes.HWND
         self.user32.MonitorFromWindow.restype = wintypes.HANDLE
         self.kernel32.OpenProcess.restype = wintypes.HANDLE
 
@@ -404,6 +435,36 @@ class _CtypesWindowApi:
                     )
                 )
         return tuple(windows)
+
+    def window_snapshot(self, handle: int) -> WindowSnapshot | None:
+        hwnd = self.w.HWND(handle)
+        ancestor = self.user32.GetAncestor(hwnd, self.w.UINT(2))
+        ancestor_handle = int(getattr(ancestor, "value", ancestor) or 0)
+        if (
+            not self.user32.IsWindow(hwnd)
+            or not self.user32.IsWindowVisible(hwnd)
+            or ancestor_handle != handle
+        ):
+            return None
+        rect, process_id = self.w.RECT(), self.w.DWORD()
+        if not self.user32.GetWindowRect(hwnd, self.c.byref(rect)):
+            return None
+        self.user32.GetWindowThreadProcessId(hwnd, self.c.byref(process_id))
+        executable = self._executable(int(process_id.value)) if process_id.value else None
+        if (
+            executable is None
+            or rect.right <= rect.left
+            or rect.bottom <= rect.top
+        ):
+            return None
+        return WindowSnapshot(
+            handle,
+            self._rect(rect),
+            executable,
+            process_id=int(process_id.value),
+            minimized=bool(self.user32.IsIconic(hwnd)),
+            maximized=bool(self.user32.IsZoomed(hwnd)),
+        )
 
     def monitor_geometry(self, handle: int) -> tuple[Rect, Rect] | None:
         monitor = self.user32.MonitorFromWindow(self.w.HWND(handle), self.w.DWORD(2))

--- a/installer/native_window_layout.py
+++ b/installer/native_window_layout.py
@@ -1,0 +1,372 @@
+"""Keep Olivia's native sidebar beside its main window on Windows desktops."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import os
+from pathlib import Path
+from threading import Event
+import time
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class Rect:
+    left: int
+    top: int
+    right: int
+    bottom: int
+
+    @property
+    def width(self) -> int:
+        return self.right - self.left
+
+    @property
+    def height(self) -> int:
+        return self.bottom - self.top
+
+
+@dataclass(frozen=True, slots=True)
+class WindowSnapshot:
+    handle: int
+    rect: Rect
+    executable: Path
+    minimized: bool = False
+    maximized: bool = False
+
+
+class LayoutStatus(str, Enum):
+    ADJUSTED = "adjusted"
+    ALREADY_VISIBLE = "already_visible"
+    NOT_OBSERVED = "not_observed"
+    SKIPPED = "skipped"
+    UNSUPPORTED = "unsupported"
+
+
+class WindowApi(Protocol):
+    def visible_windows(self) -> tuple[WindowSnapshot, ...]: ...
+
+    def monitor_geometry(self, handle: int) -> tuple[Rect, Rect] | None: ...
+
+    def move_window(self, handle: int, target: Rect) -> bool: ...
+
+
+def _clamp(value: int, lower: int, upper: int) -> int:
+    return min(max(value, lower), upper)
+
+
+def plan_native_window_layout(
+    *,
+    main: Rect,
+    sidebar: Rect,
+    work_area: Rect,
+    minimum_main_width: int = 640,
+) -> Rect | None:
+    """Return the main rectangle that keeps its right sidebar in the work area."""
+
+    gap = sidebar.left - main.right
+    sidebar_top = sidebar.top - main.top
+    sidebar_bottom = sidebar.bottom - main.top
+    combined_top = min(0, sidebar_top)
+    combined_bottom = max(main.height, sidebar_bottom)
+    target_width = min(main.width, work_area.width - gap - sidebar.width)
+    if (
+        not 0 <= gap <= 32
+        or sidebar.width <= 0
+        or sidebar.height <= 0
+        or target_width < minimum_main_width
+        or main.height <= 0
+        or combined_bottom - combined_top > work_area.height
+    ):
+        return None
+    target_left = _clamp(
+        main.left,
+        work_area.left,
+        work_area.right - target_width - gap - sidebar.width,
+    )
+    target_top = _clamp(
+        main.top,
+        work_area.top - combined_top,
+        work_area.bottom - combined_bottom,
+    )
+    return Rect(
+        target_left,
+        target_top,
+        target_left + target_width,
+        target_top + main.height,
+    )
+
+
+def _normalized_path(path: Path) -> str:
+    return os.path.normcase(os.path.abspath(os.fspath(path)))
+
+
+def _window_pair(
+    windows: tuple[WindowSnapshot, ...], executable: Path
+) -> tuple[WindowSnapshot, WindowSnapshot] | None:
+    expected = _normalized_path(executable)
+    matching = [w for w in windows if _normalized_path(w.executable) == expected]
+    mains = sorted(
+        (w for w in matching if w.rect.width >= 600 and w.rect.height >= 400),
+        key=lambda w: w.rect.width * w.rect.height,
+        reverse=True,
+    )
+    for main in mains:
+        sidebars = [
+            w
+            for w in matching
+            if w.handle != main.handle
+            and 40 <= w.rect.width <= 96
+            and 72 <= w.rect.height <= 240
+            and 0 <= w.rect.left - main.rect.right <= 32
+            and w.rect.top < main.rect.bottom
+            and w.rect.bottom > main.rect.top
+        ]
+        if sidebars:
+            return main, min(
+                sidebars,
+                key=lambda w: (
+                    w.rect.left - main.rect.right,
+                    abs(
+                        w.rect.top
+                        + w.rect.bottom
+                        - main.rect.top
+                        - main.rect.bottom
+                    ),
+                ),
+            )
+    return None
+
+
+def _pair_target(
+    api: WindowApi,
+    pair: tuple[WindowSnapshot, WindowSnapshot],
+) -> tuple[LayoutStatus, Rect | None]:
+    main, sidebar = pair
+    geometry = api.monitor_geometry(main.handle)
+    if geometry is None:
+        return LayoutStatus.SKIPPED, None
+    monitor, work_area = geometry
+    if main.minimized or main.maximized or (
+        main.rect.left <= monitor.left
+        and main.rect.top <= monitor.top
+        and main.rect.right >= monitor.right
+        and main.rect.bottom >= monitor.bottom
+    ):
+        return LayoutStatus.SKIPPED, None
+    target = plan_native_window_layout(
+        main=main.rect,
+        sidebar=sidebar.rect,
+        work_area=work_area,
+    )
+    if target is None:
+        return LayoutStatus.SKIPPED, None
+    if target == main.rect:
+        return LayoutStatus.ALREADY_VISIBLE, target
+    return LayoutStatus.ADJUSTED, target
+
+
+def _adjust_pair(
+    api: WindowApi, pair: tuple[WindowSnapshot, WindowSnapshot]
+) -> LayoutStatus:
+    status, target = _pair_target(api, pair)
+    if status is not LayoutStatus.ADJUSTED or target is None:
+        return status
+    return (
+        LayoutStatus.ADJUSTED
+        if api.move_window(pair[0].handle, target)
+        else LayoutStatus.SKIPPED
+    )
+
+
+def create_window_api() -> WindowApi | None:
+    """Create the Win32 adapter without changing DPI awareness or focus."""
+
+    if os.name != "nt":
+        return None
+    try:
+        return _CtypesWindowApi()
+    except (AttributeError, OSError):
+        return None
+
+
+def adjust_native_window_layout(
+    client_executable: Path, *, api: WindowApi | None = None
+) -> LayoutStatus:
+    """Adjust one observed main/sidebar pair without activating it."""
+
+    api = api or create_window_api()
+    if api is None:
+        return LayoutStatus.UNSUPPORTED
+    pair = _window_pair(api.visible_windows(), client_executable)
+    return LayoutStatus.NOT_OBSERVED if pair is None else _adjust_pair(api, pair)
+
+
+def guard_native_window_layout(
+    client_executable: Path,
+    *,
+    api: WindowApi | None = None,
+    stop_event: Event | None = None,
+    timeout_seconds: float = 15.0,
+    poll_interval: float = 0.1,
+) -> LayoutStatus:
+    """Wait for two stable observations, adjust once, and verify once."""
+
+    api = api or create_window_api()
+    if api is None:
+        return LayoutStatus.UNSUPPORTED
+    stop = stop_event or Event()
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    previous = None
+    stable = 0
+    while not stop.is_set():
+        pair = _window_pair(api.visible_windows(), client_executable)
+        if pair is None:
+            previous, stable = None, 0
+        elif pair == previous:
+            stable += 1
+        else:
+            previous, stable = pair, 1
+        if pair is not None and stable >= 2:
+            status = _adjust_pair(api, pair)
+            if status is not LayoutStatus.ADJUSTED:
+                return status
+            time.sleep(max(0.0, poll_interval))
+            verified = _window_pair(api.visible_windows(), client_executable)
+            if verified is None:
+                return LayoutStatus.SKIPPED
+            return (
+                LayoutStatus.ADJUSTED
+                if _pair_target(api, verified)[0] is LayoutStatus.ALREADY_VISIBLE
+                else LayoutStatus.SKIPPED
+            )
+        if time.monotonic() >= deadline:
+            return LayoutStatus.NOT_OBSERVED
+        time.sleep(max(0.0, poll_interval))
+    return LayoutStatus.SKIPPED
+
+
+class _CtypesWindowApi:
+    """Small user32/kernel32 boundary; no DPI, focus, or style calls."""
+
+    def __init__(self) -> None:
+        import ctypes
+        from ctypes import wintypes
+
+        class MonitorInfo(ctypes.Structure):
+            _fields_ = [
+                ("cbSize", wintypes.DWORD),
+                ("rcMonitor", wintypes.RECT),
+                ("rcWork", wintypes.RECT),
+                ("dwFlags", wintypes.DWORD),
+            ]
+
+        self.c, self.w = ctypes, wintypes
+        self.monitor_info = MonitorInfo
+        self.callback = ctypes.WINFUNCTYPE(
+            wintypes.BOOL, wintypes.HWND, wintypes.LPARAM
+        )
+        self.user32 = ctypes.WinDLL("user32", use_last_error=True)
+        self.kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        self.user32.MonitorFromWindow.restype = wintypes.HANDLE
+        self.kernel32.OpenProcess.restype = wintypes.HANDLE
+
+    @staticmethod
+    def _rect(value) -> Rect:
+        return Rect(value.left, value.top, value.right, value.bottom)
+
+    def _handles(self) -> tuple[int, ...]:
+        handles: list[int] = []
+
+        @self.callback
+        def collect(handle, _parameter) -> bool:
+            handles.append(int(handle))
+            return True
+
+        return (
+            tuple(handles)
+            if self.user32.EnumWindows(collect, self.w.LPARAM(0))
+            else ()
+        )
+
+    def _executable(self, process_id: int) -> Path | None:
+        process = self.kernel32.OpenProcess(
+            self.w.DWORD(0x1000), self.w.BOOL(False), self.w.DWORD(process_id)
+        )
+        if not process:
+            return None
+        try:
+            buffer = self.c.create_unicode_buffer(32768)
+            length = self.w.DWORD(len(buffer))
+            if not self.kernel32.QueryFullProcessImageNameW(
+                self.w.HANDLE(process), self.w.DWORD(0), buffer, self.c.byref(length)
+            ):
+                return None
+            return Path(buffer.value) if buffer.value else None
+        finally:
+            self.kernel32.CloseHandle(self.w.HANDLE(process))
+
+    def visible_windows(self) -> tuple[WindowSnapshot, ...]:
+        windows: list[WindowSnapshot] = []
+        executables: dict[int, Path | None] = {}
+        for handle in self._handles():
+            hwnd = self.w.HWND(handle)
+            if not self.user32.IsWindowVisible(hwnd):
+                continue
+            rect, process_id = self.w.RECT(), self.w.DWORD()
+            if not self.user32.GetWindowRect(hwnd, self.c.byref(rect)):
+                continue
+            self.user32.GetWindowThreadProcessId(hwnd, self.c.byref(process_id))
+            if not process_id.value or rect.right <= rect.left or rect.bottom <= rect.top:
+                continue
+            if process_id.value not in executables:
+                executables[process_id.value] = self._executable(process_id.value)
+            executable = executables[process_id.value]
+            if executable is not None:
+                windows.append(
+                    WindowSnapshot(
+                        handle,
+                        self._rect(rect),
+                        executable,
+                        minimized=bool(self.user32.IsIconic(hwnd)),
+                        maximized=bool(self.user32.IsZoomed(hwnd)),
+                    )
+                )
+        return tuple(windows)
+
+    def monitor_geometry(self, handle: int) -> tuple[Rect, Rect] | None:
+        monitor = self.user32.MonitorFromWindow(self.w.HWND(handle), self.w.DWORD(2))
+        info = self.monitor_info()
+        info.cbSize = self.c.sizeof(info)
+        if not monitor or not self.user32.GetMonitorInfoW(
+            self.w.HANDLE(monitor), self.c.byref(info)
+        ):
+            return None
+        return self._rect(info.rcMonitor), self._rect(info.rcWork)
+
+    def move_window(self, handle: int, target: Rect) -> bool:
+        flags = 0x0004 | 0x0010 | 0x0200  # no z-order, activation, or owner z-order
+        return bool(
+            self.user32.SetWindowPos(
+                self.w.HWND(handle),
+                None,
+                target.left,
+                target.top,
+                target.width,
+                target.height,
+                self.w.UINT(flags),
+            )
+        )
+
+
+__all__ = [
+    "LayoutStatus",
+    "Rect",
+    "WindowApi",
+    "WindowSnapshot",
+    "adjust_native_window_layout",
+    "create_window_api",
+    "guard_native_window_layout",
+    "plan_native_window_layout",
+]

--- a/installer/native_window_layout.py
+++ b/installer/native_window_layout.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from threading import Event
 import time
-from typing import Protocol
+from typing import Callable, Protocol
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,7 +105,11 @@ def _window_pair(
     expected = _normalized_path(executable)
     matching = [w for w in windows if _normalized_path(w.executable) == expected]
     mains = sorted(
-        (w for w in matching if w.rect.width >= 600 and w.rect.height >= 400),
+        (
+            w
+            for w in matching
+            if w.process_id > 0 and w.rect.width >= 600 and w.rect.height >= 400
+        ),
         key=lambda w: w.rect.width * w.rect.height,
         reverse=True,
     )
@@ -153,6 +157,16 @@ def _pair_target(
         and main.rect.bottom >= monitor.bottom
     ):
         return LayoutStatus.SKIPPED, None
+    sidebar_geometry = api.monitor_geometry(sidebar.handle)
+    if sidebar_geometry is not None:
+        _, sidebar_work_area = sidebar_geometry
+        if (
+            sidebar.rect.left >= sidebar_work_area.left
+            and sidebar.rect.top >= sidebar_work_area.top
+            and sidebar.rect.right <= sidebar_work_area.right
+            and sidebar.rect.bottom <= sidebar_work_area.bottom
+        ):
+            return LayoutStatus.ALREADY_VISIBLE, main.rect
     target = plan_native_window_layout(
         main=main.rect,
         sidebar=sidebar.rect,
@@ -166,16 +180,18 @@ def _pair_target(
 
 
 def _adjust_pair(
-    api: WindowApi, pair: tuple[WindowSnapshot, WindowSnapshot]
-) -> LayoutStatus:
+    api: WindowApi,
+    pair: tuple[WindowSnapshot, WindowSnapshot],
+    *,
+    cancelled: Callable[[], bool] | None = None,
+) -> tuple[LayoutStatus, Rect | None]:
     status, target = _pair_target(api, pair)
     if status is not LayoutStatus.ADJUSTED or target is None:
-        return status
-    return (
-        LayoutStatus.ADJUSTED
-        if api.move_window(pair[0].handle, target)
-        else LayoutStatus.SKIPPED
-    )
+        return status, target
+    if cancelled is not None and cancelled():
+        return LayoutStatus.SKIPPED, target
+    moved = api.move_window(pair[0].handle, target)
+    return (LayoutStatus.ADJUSTED if moved else LayoutStatus.SKIPPED), target
 
 
 def create_window_api() -> WindowApi | None:
@@ -198,7 +214,11 @@ def adjust_native_window_layout(
     if api is None:
         return LayoutStatus.UNSUPPORTED
     pair = _window_pair(api.visible_windows(), client_executable)
-    return LayoutStatus.NOT_OBSERVED if pair is None else _adjust_pair(api, pair)
+    return (
+        LayoutStatus.NOT_OBSERVED
+        if pair is None
+        else _adjust_pair(api, pair)[0]
+    )
 
 
 def guard_native_window_layout(
@@ -231,22 +251,61 @@ def guard_native_window_layout(
         if pair is not None and stable >= 2:
             if stop.is_set() or time.monotonic() >= deadline:
                 return LayoutStatus.SKIPPED
-            status = _adjust_pair(api, pair)
-            if status is not LayoutStatus.ADJUSTED:
+            status, target = _adjust_pair(
+                api,
+                pair,
+                cancelled=lambda: stop.is_set() or time.monotonic() >= deadline,
+            )
+            if status is not LayoutStatus.ADJUSTED or target is None:
                 return status
             remaining = max(0.0, deadline - time.monotonic())
             if stop.wait(min(max(0.0, poll_interval), remaining)):
                 return LayoutStatus.SKIPPED
             if time.monotonic() >= deadline:
                 return LayoutStatus.SKIPPED
-            verified = _window_pair(api.visible_windows(), client_executable)
-            if stop.is_set():
+            observed = api.visible_windows()
+            if stop.is_set() or time.monotonic() >= deadline:
                 return LayoutStatus.SKIPPED
-            if verified is None:
+            verified_main = next(
+                (
+                    window
+                    for window in observed
+                    if window.handle == pair[0].handle
+                    and window.process_id == pair[0].process_id
+                ),
+                None,
+            )
+            verified_sidebar = next(
+                (
+                    window
+                    for window in observed
+                    if window.handle == pair[1].handle
+                    and window.process_id == pair[1].process_id
+                ),
+                None,
+            )
+            if verified_main is None or verified_sidebar is None:
+                return LayoutStatus.SKIPPED
+            verified = verified_main, verified_sidebar
+            sidebar_dx = target.right - pair[0].rect.right
+            sidebar_dy = target.top - pair[0].rect.top
+            expected_sidebar = Rect(
+                pair[1].rect.left + sidebar_dx,
+                pair[1].rect.top + sidebar_dy,
+                pair[1].rect.right + sidebar_dx,
+                pair[1].rect.bottom + sidebar_dy,
+            )
+            if (
+                verified[0].rect != target
+                or verified[1].rect != expected_sidebar
+            ):
+                return LayoutStatus.SKIPPED
+            verified_status = _pair_target(api, verified)[0]
+            if stop.is_set() or time.monotonic() >= deadline:
                 return LayoutStatus.SKIPPED
             return (
                 LayoutStatus.ADJUSTED
-                if _pair_target(api, verified)[0] is LayoutStatus.ALREADY_VISIBLE
+                if verified_status is LayoutStatus.ALREADY_VISIBLE
                 else LayoutStatus.SKIPPED
             )
         remaining = deadline - time.monotonic()
@@ -357,7 +416,8 @@ class _CtypesWindowApi:
         return self._rect(info.rcMonitor), self._rect(info.rcWork)
 
     def move_window(self, handle: int, target: Rect) -> bool:
-        flags = 0x0004 | 0x0010 | 0x0200  # no z-order, activation, or owner z-order
+        # Keep z-order/focus unchanged and never block on another input queue.
+        flags = 0x0004 | 0x0010 | 0x0200 | 0x4000
         return bool(
             self.user32.SetWindowPos(
                 self.w.HWND(handle),

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -12,6 +12,7 @@ import re
 import socket
 import subprocess
 import sys
+from threading import Event, Thread
 import time
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
@@ -21,6 +22,7 @@ from patch_companion_settings import (
     CompanionSettingsPatchError,
     patch_companion_settings,
 )
+from installer.native_window_layout import LayoutStatus, guard_native_window_layout
 from video_capability_install import (
     VideoCapabilityError,
     load_video_runtime_environment,
@@ -484,6 +486,56 @@ def _client_environment(environment: dict[str, str], roaming: Path, local: Path)
     return client_environment
 
 
+def _run_client_with_native_layout(
+    client: Path,
+    local: Path,
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    data_root: Path,
+    attempt: int,
+) -> int:
+    """Run the copied client while a bounded guard preserves its native layout."""
+
+    stop = Event()
+    outcome: list[LayoutStatus] = []
+
+    def protect_layout() -> None:
+        try:
+            outcome.append(
+                guard_native_window_layout(client, stop_event=stop)
+            )
+        except Exception:
+            outcome.append(LayoutStatus.FAILED)
+
+    worker = Thread(
+        target=protect_layout,
+        name="olivia-native-window-layout",
+        daemon=True,
+    )
+    worker.start()
+    try:
+        return subprocess.call(
+            _client_command(client, local),
+            cwd=cwd,
+            env=environment,
+        )
+    finally:
+        stop.set()
+        worker.join(timeout=1.0)
+        status = (
+            outcome[0]
+            if outcome and not worker.is_alive()
+            else LayoutStatus.FAILED
+        )
+        _append_launcher_event(
+            data_root,
+            "client_layout",
+            attempt=attempt,
+            status=status.value,
+        )
+
+
 def _backend_executable() -> Path:
     """Prefer the windowless interpreter used by the known-good launcher."""
 
@@ -771,10 +823,13 @@ def main(argv: list[str] | None = None) -> int:
         roaming.mkdir(parents=True, exist_ok=True)
         local.mkdir(parents=True, exist_ok=True)
         _append_launcher_event(data_root, "client_start", attempt=1)
-        exit_code = subprocess.call(
-            _client_command(client, local),
+        exit_code = _run_client_with_native_layout(
+            client,
+            local,
             cwd=root / "app",
-            env=_client_environment(client_environment, roaming, local),
+            environment=_client_environment(client_environment, roaming, local),
+            data_root=data_root,
+            attempt=1,
         )
         _append_launcher_event(
             data_root,
@@ -790,10 +845,13 @@ def main(argv: list[str] | None = None) -> int:
                 reason="known_fresh_profile_exit",
             )
             _append_launcher_event(data_root, "client_start", attempt=2)
-            exit_code = subprocess.call(
-                _client_command(client, local),
+            exit_code = _run_client_with_native_layout(
+                client,
+                local,
                 cwd=root / "app",
-                env=_client_environment(client_environment, roaming, local),
+                environment=_client_environment(client_environment, roaming, local),
+                data_root=data_root,
+                attempt=2,
             )
             _append_launcher_event(
                 data_root,

--- a/tests/installer/test_native_window_layout.py
+++ b/tests/installer/test_native_window_layout.py
@@ -5,6 +5,7 @@ from threading import Event
 import pytest
 
 from installer import native_window_layout
+from installer import start_local
 from installer.native_window_layout import (
     LayoutStatus,
     Rect,
@@ -48,10 +49,18 @@ def test_layout_plan_keeps_the_native_pair_in_one_work_area(
 class FakeApi:
     def __init__(self, *observations: tuple[WindowSnapshot, ...]) -> None:
         self.observations = iter(observations)
+        self.current_windows: tuple[WindowSnapshot, ...] = ()
         self.moves: list[tuple[int, Rect]] = []
 
     def visible_windows(self) -> tuple[WindowSnapshot, ...]:
-        return next(self.observations)
+        self.current_windows = next(self.observations)
+        return self.current_windows
+
+    def window_snapshot(self, handle: int) -> WindowSnapshot | None:
+        return next(
+            (window for window in self.current_windows if window.handle == handle),
+            None,
+        )
 
     def monitor_geometry(self, _handle: int) -> tuple[Rect, Rect]:
         return Rect(0, 0, 1080, 1080), Rect(0, 0, 1080, 1040)
@@ -127,6 +136,50 @@ def test_adjustment_pairs_before_ranking_and_moves_only_the_matching_main() -> N
     assert api.moves == [(2, Rect(0, 0, 1021, 914))]
 
 
+def test_adjustment_rejects_a_reused_main_handle_before_the_forward_move() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+
+    class ReusedHandleApi(FakeApi):
+        def window_snapshot(self, handle: int) -> WindowSnapshot | None:
+            current = super().window_snapshot(handle)
+            if current is None:
+                return None
+            return WindowSnapshot(
+                current.handle,
+                current.rect,
+                current.executable,
+                process_id=11,
+            )
+
+    api = ReusedHandleApi(pair)
+
+    assert adjust_native_window_layout(client, api=api) is LayoutStatus.SKIPPED
+    assert api.moves == []
+
+
+def test_adjustment_rejects_a_reused_main_handle_with_a_different_executable() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+
+    class ReusedHandleApi(FakeApi):
+        def window_snapshot(self, handle: int) -> WindowSnapshot | None:
+            current = super().window_snapshot(handle)
+            if current is None:
+                return None
+            return WindowSnapshot(
+                current.handle,
+                current.rect,
+                Path(r"C:\Other\Olivia.exe"),
+                process_id=current.process_id,
+            )
+
+    api = ReusedHandleApi(pair)
+
+    assert adjust_native_window_layout(client, api=api) is LayoutStatus.SKIPPED
+    assert api.moves == []
+
+
 def test_adjustment_preserves_main_when_sidebar_is_visible_on_adjacent_monitor() -> None:
     client = Path(r"C:\Olivia\Olivia.exe")
 
@@ -185,7 +238,89 @@ def test_guard_never_chases_a_sidebar_that_did_not_follow_the_first_move() -> No
     assert guard_native_window_layout(
         client, api=api, timeout_seconds=1, poll_interval=0
     ) is LayoutStatus.SKIPPED
-    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+    assert api.moves == [
+        (2, Rect(0, 0, 1021, 914)),
+        (2, Rect(0, 0, 1100, 914)),
+    ]
+
+
+def test_guard_reports_failed_when_the_protected_rollback_fails() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+    sticky = (
+        WindowSnapshot(2, Rect(0, 0, 1021, 914), client, process_id=10),
+        pair[1],
+    )
+
+    class RollbackFailureApi(FakeApi):
+        def move_window(self, handle: int, target: Rect) -> bool:
+            self.moves.append((handle, target))
+            return len(self.moves) == 1
+
+    api = RollbackFailureApi(pair, pair, sticky)
+
+    assert guard_native_window_layout(
+        client, api=api, timeout_seconds=1, poll_interval=0
+    ) is LayoutStatus.FAILED
+    assert api.moves == [
+        (2, Rect(0, 0, 1021, 914)),
+        (2, Rect(0, 0, 1100, 914)),
+    ]
+
+
+def test_client_launch_runs_the_native_layout_guard_until_exit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = tmp_path / "app" / "Olivia.exe"
+    local = tmp_path / "profile" / "Local"
+    data_root = tmp_path / "data"
+    started = Event()
+    stopped = Event()
+    calls: list[tuple[list[str], Path, dict[str, str]]] = []
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def guard(
+        executable: Path,
+        *,
+        stop_event: Event,
+    ) -> LayoutStatus:
+        assert executable == client
+        started.set()
+        assert stop_event.wait(1)
+        stopped.set()
+        return LayoutStatus.SKIPPED
+
+    def call(command: list[str], *, cwd: Path, env: dict[str, str]) -> int:
+        assert started.wait(1)
+        calls.append((command, cwd, env))
+        return 0
+
+    monkeypatch.setattr(start_local, "guard_native_window_layout", guard)
+    monkeypatch.setattr(start_local.subprocess, "call", call)
+    monkeypatch.setattr(
+        start_local,
+        "_append_launcher_event",
+        lambda _root, event, **fields: events.append((event, fields)),
+    )
+
+    assert start_local._run_client_with_native_layout(
+        client,
+        local,
+        cwd=client.parent,
+        environment={"SYNTHETIC": "1"},
+        data_root=data_root,
+        attempt=1,
+    ) == 0
+    assert stopped.is_set()
+    assert calls == [
+        (
+            [str(client), f"--user-data-dir={local / 'cef'}"],
+            client.parent,
+            {"SYNTHETIC": "1"},
+        )
+    ]
+    assert events == [("client_layout", {"attempt": 1, "status": "skipped"})]
 
 
 def test_guard_does_not_verify_with_another_client_instance() -> None:
@@ -199,7 +334,7 @@ def test_guard_does_not_verify_with_another_client_instance() -> None:
 
     assert guard_native_window_layout(
         client, api=api, timeout_seconds=1, poll_interval=0
-    ) is LayoutStatus.SKIPPED
+    ) is LayoutStatus.FAILED
     assert api.moves == [(2, Rect(0, 0, 1021, 914))]
 
 
@@ -230,7 +365,7 @@ def test_guard_does_not_verify_when_the_original_handles_change_process() -> Non
 
     assert guard_native_window_layout(
         client, api=api, timeout_seconds=1, poll_interval=0
-    ) is LayoutStatus.SKIPPED
+    ) is LayoutStatus.FAILED
     assert api.moves == [(2, Rect(0, 0, 1021, 914))]
 
 
@@ -246,7 +381,10 @@ def test_guard_fails_safe_when_the_target_window_repositions_itself() -> None:
     assert guard_native_window_layout(
         client, api=api, timeout_seconds=1, poll_interval=0
     ) is LayoutStatus.SKIPPED
-    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+    assert api.moves == [
+        (2, Rect(0, 0, 1021, 914)),
+        (2, Rect(0, 0, 1100, 914)),
+    ]
 
 
 def test_guard_verifies_the_original_sidebar_reached_its_planned_rect() -> None:
@@ -261,7 +399,10 @@ def test_guard_verifies_the_original_sidebar_reached_its_planned_rect() -> None:
     assert guard_native_window_layout(
         client, api=api, timeout_seconds=1, poll_interval=0
     ) is LayoutStatus.SKIPPED
-    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+    assert api.moves == [
+        (2, Rect(0, 0, 1021, 914)),
+        (2, Rect(0, 0, 1100, 914)),
+    ]
 
 
 def test_guard_rechecks_cancellation_before_moving_a_stable_pair() -> None:
@@ -311,6 +452,38 @@ def test_guard_rechecks_cancellation_after_geometry_before_moving() -> None:
         poll_interval=0,
     ) is LayoutStatus.SKIPPED
     assert api.moves == []
+
+
+def test_guard_rolls_back_when_cancelled_after_the_forward_move() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+
+    class StopAfterForward:
+        waits = 0
+        stopped = False
+
+        def is_set(self) -> bool:
+            return self.stopped
+
+        def wait(self, _timeout: float) -> bool:
+            self.waits += 1
+            if self.waits == 2:
+                self.stopped = True
+            return self.stopped
+
+    api = FakeApi(pair, pair)
+
+    assert guard_native_window_layout(
+        client,
+        api=api,
+        stop_event=StopAfterForward(),  # type: ignore[arg-type]
+        timeout_seconds=1,
+        poll_interval=0,
+    ) is LayoutStatus.SKIPPED
+    assert api.moves == [
+        (2, Rect(0, 0, 1021, 914)),
+        (2, Rect(0, 0, 1100, 914)),
+    ]
 
 
 def test_guard_rechecks_deadline_after_geometry_before_moving(
@@ -366,7 +539,10 @@ def test_guard_does_not_report_adjusted_after_verification_deadline(
         timeout_seconds=1,
         poll_interval=0,
     ) is LayoutStatus.SKIPPED
-    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+    assert api.moves == [
+        (2, Rect(0, 0, 1021, 914)),
+        (2, Rect(0, 0, 1100, 914)),
+    ]
 
 
 def test_guard_rechecks_deadline_after_verification_geometry(
@@ -396,7 +572,35 @@ def test_guard_rechecks_deadline_after_verification_geometry(
         timeout_seconds=1,
         poll_interval=0,
     ) is LayoutStatus.SKIPPED
-    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+    assert api.moves == [
+        (2, Rect(0, 0, 1021, 914)),
+        (2, Rect(0, 0, 1100, 914)),
+    ]
+
+
+def test_guard_rolls_back_when_verification_geometry_disappears() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+    adjusted = _pair(client, main=Rect(0, 0, 1021, 914))
+
+    class MissingVerificationGeometryApi(FakeApi):
+        geometry_calls = 0
+
+        def monitor_geometry(self, handle: int) -> tuple[Rect, Rect] | None:
+            self.geometry_calls += 1
+            if self.geometry_calls == 3:
+                return None
+            return super().monitor_geometry(handle)
+
+    api = MissingVerificationGeometryApi(pair, pair, adjusted)
+
+    assert guard_native_window_layout(
+        client, api=api, timeout_seconds=1, poll_interval=0
+    ) is LayoutStatus.SKIPPED
+    assert api.moves == [
+        (2, Rect(0, 0, 1021, 914)),
+        (2, Rect(0, 0, 1100, 914)),
+    ]
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Win32 bindings are Windows-only")

--- a/tests/installer/test_native_window_layout.py
+++ b/tests/installer/test_native_window_layout.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from threading import Event
 
 import pytest
 
@@ -23,13 +24,14 @@ from installer.native_window_layout import (
             Rect(0, 0, 1080, 1040),
             Rect(0, 0, 1021, 914),
         ),
-        (Rect(-1940, 30, -840, 944), Rect(-837, 94, -781, 210), Rect(-1920, 0, 0, 1040), Rect(-1920, 30, -820, 944)),
-        (Rect(100, -20, 1000, 894), Rect(1003, 44, 1059, 160), Rect(0, 0, 1080, 1040), Rect(100, 0, 1000, 914)),
+        (Rect(-1940, 30, -840, 944), Rect(-837, 94, -781, 210), Rect(-1920, 0, 0, 1040), Rect(-1940, 30, -840, 944)),
+        (Rect(100, -20, 1000, 894), Rect(1003, 44, 1059, 160), Rect(0, 0, 1080, 1040), Rect(100, -20, 1000, 894)),
+        (Rect(100, 30, 1100, 944), Rect(1103, 94, 1159, 210), Rect(0, 0, 1080, 1040), Rect(100, 30, 1021, 944)),
         (Rect(20, 30, 920, 944), Rect(923, 94, 979, 210), Rect(0, 0, 1080, 1040), Rect(20, 30, 920, 944)),
         (Rect(0, 0, 900, 914), Rect(903, 64, 959, 180), Rect(0, 0, 640, 1040), None),
         (Rect(0, 0, 1000, 900), Rect(800, 50, 856, 166), Rect(0, 0, 1080, 1040), None),
     ),
-    ids=("wide", "negative-monitor", "vertical", "visible", "narrow", "not-right"),
+    ids=("wide", "negative-monitor", "vertical", "fixed-origin", "visible", "narrow", "not-right"),
 )
 def test_layout_plan_keeps_the_native_pair_in_one_work_area(
     main: Rect,
@@ -60,9 +62,40 @@ class FakeApi:
 
 def _pair(client: Path, *, main: Rect = Rect(0, 0, 1100, 914)) -> tuple[WindowSnapshot, ...]:
     return (
-        WindowSnapshot(2, main, client),
-        WindowSnapshot(3, Rect(main.right + 3, 64, main.right + 59, 180), client),
+        WindowSnapshot(2, main, client, process_id=10),
+        WindowSnapshot(
+            3,
+            Rect(main.right + 3, 64, main.right + 59, 180),
+            client,
+            process_id=10,
+        ),
     )
+
+
+def test_pairing_never_combines_windows_from_different_processes() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    main = WindowSnapshot(
+        2,
+        Rect(0, 0, 1100, 914),
+        client,
+        process_id=10,
+    )
+    wrong_process_sidebar = WindowSnapshot(
+        3,
+        Rect(1103, 64, 1159, 180),
+        client,
+        process_id=11,
+    )
+    correct_sidebar = WindowSnapshot(
+        4,
+        Rect(1110, 64, 1166, 180),
+        client,
+        process_id=10,
+    )
+    api = FakeApi((main, wrong_process_sidebar, correct_sidebar))
+
+    assert adjust_native_window_layout(client, api=api) is LayoutStatus.ADJUSTED
+    assert api.moves == [(2, Rect(0, 0, 1014, 914))]
 
 
 def test_adjustment_pairs_before_ranking_and_moves_only_the_matching_main() -> None:
@@ -88,6 +121,7 @@ def test_adjustment_leaves_special_window_states_untouched(state: str) -> None:
         2,
         main,
         client,
+        process_id=10,
         minimized=state == "minimized",
         maximized=state == "maximized",
     )
@@ -112,13 +146,41 @@ def test_guard_waits_for_stability_then_verifies_that_the_sidebar_followed() -> 
 def test_guard_never_chases_a_sidebar_that_did_not_follow_the_first_move() -> None:
     client = Path(r"C:\Olivia\Olivia.exe")
     pair = _pair(client)
-    sticky = (WindowSnapshot(2, Rect(0, 0, 1021, 914), client), pair[1])
+    sticky = (
+        WindowSnapshot(2, Rect(0, 0, 1021, 914), client, process_id=10),
+        pair[1],
+    )
     api = FakeApi(pair, pair, sticky)
 
     assert guard_native_window_layout(
         client, api=api, timeout_seconds=1, poll_interval=0
     ) is LayoutStatus.SKIPPED
     assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+
+
+def test_guard_rechecks_cancellation_before_moving_a_stable_pair() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    stop = Event()
+    pair = _pair(client)
+
+    class CancellingApi(FakeApi):
+        def visible_windows(self) -> tuple[WindowSnapshot, ...]:
+            value = super().visible_windows()
+            if value == pair and not stop.is_set() and hasattr(self, "seen_pair"):
+                stop.set()
+            self.seen_pair = True
+            return value
+
+    api = CancellingApi(pair, pair)
+
+    assert guard_native_window_layout(
+        client,
+        api=api,
+        stop_event=stop,
+        timeout_seconds=1,
+        poll_interval=0,
+    ) is LayoutStatus.SKIPPED
+    assert api.moves == []
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Win32 bindings are Windows-only")

--- a/tests/installer/test_native_window_layout.py
+++ b/tests/installer/test_native_window_layout.py
@@ -1,0 +1,126 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from installer.native_window_layout import (
+    LayoutStatus,
+    Rect,
+    WindowSnapshot,
+    adjust_native_window_layout,
+    create_window_api,
+    guard_native_window_layout,
+    plan_native_window_layout,
+)
+
+
+@pytest.mark.parametrize(
+    ("main", "sidebar", "work", "expected"),
+    (
+        (
+            Rect(0, 0, 1100, 914),
+            Rect(1103, 64, 1159, 180),
+            Rect(0, 0, 1080, 1040),
+            Rect(0, 0, 1021, 914),
+        ),
+        (Rect(-1940, 30, -840, 944), Rect(-837, 94, -781, 210), Rect(-1920, 0, 0, 1040), Rect(-1920, 30, -820, 944)),
+        (Rect(100, -20, 1000, 894), Rect(1003, 44, 1059, 160), Rect(0, 0, 1080, 1040), Rect(100, 0, 1000, 914)),
+        (Rect(20, 30, 920, 944), Rect(923, 94, 979, 210), Rect(0, 0, 1080, 1040), Rect(20, 30, 920, 944)),
+        (Rect(0, 0, 900, 914), Rect(903, 64, 959, 180), Rect(0, 0, 640, 1040), None),
+        (Rect(0, 0, 1000, 900), Rect(800, 50, 856, 166), Rect(0, 0, 1080, 1040), None),
+    ),
+    ids=("wide", "negative-monitor", "vertical", "visible", "narrow", "not-right"),
+)
+def test_layout_plan_keeps_the_native_pair_in_one_work_area(
+    main: Rect,
+    sidebar: Rect,
+    work: Rect,
+    expected: Rect | None,
+) -> None:
+    assert plan_native_window_layout(
+        main=main, sidebar=sidebar, work_area=work
+    ) == expected
+
+
+class FakeApi:
+    def __init__(self, *observations: tuple[WindowSnapshot, ...]) -> None:
+        self.observations = iter(observations)
+        self.moves: list[tuple[int, Rect]] = []
+
+    def visible_windows(self) -> tuple[WindowSnapshot, ...]:
+        return next(self.observations)
+
+    def monitor_geometry(self, _handle: int) -> tuple[Rect, Rect]:
+        return Rect(0, 0, 1080, 1080), Rect(0, 0, 1080, 1040)
+
+    def move_window(self, handle: int, target: Rect) -> bool:
+        self.moves.append((handle, target))
+        return True
+
+
+def _pair(client: Path, *, main: Rect = Rect(0, 0, 1100, 914)) -> tuple[WindowSnapshot, ...]:
+    return (
+        WindowSnapshot(2, main, client),
+        WindowSnapshot(3, Rect(main.right + 3, 64, main.right + 59, 180), client),
+    )
+
+
+def test_adjustment_pairs_before_ranking_and_moves_only_the_matching_main() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    windows = (
+        WindowSnapshot(1, Rect(0, 0, 1900, 1000), Path(r"C:\Other\Olivia.exe")),
+        WindowSnapshot(4, Rect(0, 0, 1920, 1080), client),
+        *_pair(client),
+        WindowSnapshot(5, Rect(20, 20, 500, 300), client),
+    )
+    api = FakeApi(windows)
+
+    assert adjust_native_window_layout(client, api=api) is LayoutStatus.ADJUSTED
+    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+
+
+@pytest.mark.parametrize("state", ("minimized", "maximized", "fullscreen"))
+def test_adjustment_leaves_special_window_states_untouched(state: str) -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    main = Rect(0, 0, 1080, 1080) if state == "fullscreen" else Rect(0, 0, 1100, 914)
+    windows = list(_pair(client, main=main))
+    windows[0] = WindowSnapshot(
+        2,
+        main,
+        client,
+        minimized=state == "minimized",
+        maximized=state == "maximized",
+    )
+    api = FakeApi(tuple(windows))
+
+    assert adjust_native_window_layout(client, api=api) is LayoutStatus.SKIPPED
+    assert api.moves == []
+
+
+def test_guard_waits_for_stability_then_verifies_that_the_sidebar_followed() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+    adjusted = _pair(client, main=Rect(0, 0, 1021, 914))
+    api = FakeApi((), pair, pair, adjusted)
+
+    assert guard_native_window_layout(
+        client, api=api, timeout_seconds=1, poll_interval=0
+    ) is LayoutStatus.ADJUSTED
+    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+
+
+def test_guard_never_chases_a_sidebar_that_did_not_follow_the_first_move() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+    sticky = (WindowSnapshot(2, Rect(0, 0, 1021, 914), client), pair[1])
+    api = FakeApi(pair, pair, sticky)
+
+    assert guard_native_window_layout(
+        client, api=api, timeout_seconds=1, poll_interval=0
+    ) is LayoutStatus.SKIPPED
+    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Win32 bindings are Windows-only")
+def test_win32_factory_loads_without_changing_a_window() -> None:
+    assert create_window_api() is not None

--- a/tests/installer/test_native_window_layout.py
+++ b/tests/installer/test_native_window_layout.py
@@ -4,6 +4,7 @@ from threading import Event
 
 import pytest
 
+from installer import native_window_layout
 from installer.native_window_layout import (
     LayoutStatus,
     Rect,
@@ -98,6 +99,20 @@ def test_pairing_never_combines_windows_from_different_processes() -> None:
     assert api.moves == [(2, Rect(0, 0, 1014, 914))]
 
 
+def test_pairing_rejects_unknown_process_ids() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    main, sidebar = _pair(client)
+    api = FakeApi(
+        (
+            WindowSnapshot(main.handle, main.rect, client, process_id=0),
+            WindowSnapshot(sidebar.handle, sidebar.rect, client, process_id=0),
+        )
+    )
+
+    assert adjust_native_window_layout(client, api=api) is LayoutStatus.NOT_OBSERVED
+    assert api.moves == []
+
+
 def test_adjustment_pairs_before_ranking_and_moves_only_the_matching_main() -> None:
     client = Path(r"C:\Olivia\Olivia.exe")
     windows = (
@@ -110,6 +125,21 @@ def test_adjustment_pairs_before_ranking_and_moves_only_the_matching_main() -> N
 
     assert adjust_native_window_layout(client, api=api) is LayoutStatus.ADJUSTED
     assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+
+
+def test_adjustment_preserves_main_when_sidebar_is_visible_on_adjacent_monitor() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+
+    class AdjacentMonitorApi(FakeApi):
+        def monitor_geometry(self, handle: int) -> tuple[Rect, Rect]:
+            if handle == 3:
+                return Rect(1080, 0, 2160, 1080), Rect(1080, 0, 2160, 1040)
+            return super().monitor_geometry(handle)
+
+    api = AdjacentMonitorApi(_pair(client))
+
+    assert adjust_native_window_layout(client, api=api) is LayoutStatus.ALREADY_VISIBLE
+    assert api.moves == []
 
 
 @pytest.mark.parametrize("state", ("minimized", "maximized", "fullscreen"))
@@ -158,6 +188,82 @@ def test_guard_never_chases_a_sidebar_that_did_not_follow_the_first_move() -> No
     assert api.moves == [(2, Rect(0, 0, 1021, 914))]
 
 
+def test_guard_does_not_verify_with_another_client_instance() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+    other_instance = (
+        WindowSnapshot(20, Rect(0, 0, 1021, 914), client, process_id=10),
+        WindowSnapshot(30, Rect(1024, 64, 1080, 180), client, process_id=10),
+    )
+    api = FakeApi(pair, pair, other_instance)
+
+    assert guard_native_window_layout(
+        client, api=api, timeout_seconds=1, poll_interval=0
+    ) is LayoutStatus.SKIPPED
+    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+
+
+def test_guard_verifies_original_pair_when_another_instance_is_larger() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+    adjusted = _pair(client, main=Rect(0, 0, 1021, 914))
+    larger_instance = (
+        WindowSnapshot(20, Rect(0, 0, 1050, 914), client, process_id=11),
+        WindowSnapshot(30, Rect(1053, 64, 1109, 180), client, process_id=11),
+    )
+    api = FakeApi(pair, pair, (*adjusted, *larger_instance))
+
+    assert guard_native_window_layout(
+        client, api=api, timeout_seconds=1, poll_interval=0
+    ) is LayoutStatus.ADJUSTED
+    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+
+
+def test_guard_does_not_verify_when_the_original_handles_change_process() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+    reused_handles = (
+        WindowSnapshot(2, Rect(0, 0, 1021, 914), client, process_id=11),
+        WindowSnapshot(3, Rect(1024, 64, 1080, 180), client, process_id=11),
+    )
+    api = FakeApi(pair, pair, reused_handles)
+
+    assert guard_native_window_layout(
+        client, api=api, timeout_seconds=1, poll_interval=0
+    ) is LayoutStatus.SKIPPED
+    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+
+
+def test_guard_fails_safe_when_the_target_window_repositions_itself() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+    self_repositioned = (
+        WindowSnapshot(2, Rect(20, 0, 1021, 914), client, process_id=10),
+        WindowSnapshot(3, Rect(1024, 64, 1080, 180), client, process_id=10),
+    )
+    api = FakeApi(pair, pair, self_repositioned)
+
+    assert guard_native_window_layout(
+        client, api=api, timeout_seconds=1, poll_interval=0
+    ) is LayoutStatus.SKIPPED
+    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+
+
+def test_guard_verifies_the_original_sidebar_reached_its_planned_rect() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+    independently_moved_sidebar = (
+        WindowSnapshot(2, Rect(0, 0, 1021, 914), client, process_id=10),
+        WindowSnapshot(3, Rect(1024, 100, 1080, 216), client, process_id=10),
+    )
+    api = FakeApi(pair, pair, independently_moved_sidebar)
+
+    assert guard_native_window_layout(
+        client, api=api, timeout_seconds=1, poll_interval=0
+    ) is LayoutStatus.SKIPPED
+    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+
+
 def test_guard_rechecks_cancellation_before_moving_a_stable_pair() -> None:
     client = Path(r"C:\Olivia\Olivia.exe")
     stop = Event()
@@ -183,6 +289,135 @@ def test_guard_rechecks_cancellation_before_moving_a_stable_pair() -> None:
     assert api.moves == []
 
 
+def test_guard_rechecks_cancellation_after_geometry_before_moving() -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    stop = Event()
+    pair = _pair(client)
+
+    class GeometryCancellingApi(FakeApi):
+        def monitor_geometry(self, handle: int) -> tuple[Rect, Rect]:
+            geometry = super().monitor_geometry(handle)
+            if handle == pair[1].handle:
+                stop.set()
+            return geometry
+
+    api = GeometryCancellingApi(pair, pair)
+
+    assert guard_native_window_layout(
+        client,
+        api=api,
+        stop_event=stop,
+        timeout_seconds=1,
+        poll_interval=0,
+    ) is LayoutStatus.SKIPPED
+    assert api.moves == []
+
+
+def test_guard_rechecks_deadline_after_geometry_before_moving(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+    now = [0.0]
+    monkeypatch.setattr(native_window_layout.time, "monotonic", lambda: now[0])
+
+    class SlowGeometryApi(FakeApi):
+        def monitor_geometry(self, handle: int) -> tuple[Rect, Rect]:
+            geometry = super().monitor_geometry(handle)
+            if handle == pair[1].handle:
+                now[0] = 2.0
+            return geometry
+
+    api = SlowGeometryApi(pair, pair)
+
+    assert guard_native_window_layout(
+        client,
+        api=api,
+        timeout_seconds=1,
+        poll_interval=0,
+    ) is LayoutStatus.SKIPPED
+    assert api.moves == []
+
+
+def test_guard_does_not_report_adjusted_after_verification_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+    adjusted = _pair(client, main=Rect(0, 0, 1021, 914))
+    now = [0.0]
+    monkeypatch.setattr(native_window_layout.time, "monotonic", lambda: now[0])
+
+    class SlowVerificationApi(FakeApi):
+        calls = 0
+
+        def visible_windows(self) -> tuple[WindowSnapshot, ...]:
+            value = super().visible_windows()
+            self.calls += 1
+            if self.calls == 3:
+                now[0] = 2.0
+            return value
+
+    api = SlowVerificationApi(pair, pair, adjusted)
+
+    assert guard_native_window_layout(
+        client,
+        api=api,
+        timeout_seconds=1,
+        poll_interval=0,
+    ) is LayoutStatus.SKIPPED
+    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+
+
+def test_guard_rechecks_deadline_after_verification_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = Path(r"C:\Olivia\Olivia.exe")
+    pair = _pair(client)
+    adjusted = _pair(client, main=Rect(0, 0, 1021, 914))
+    now = [0.0]
+    monkeypatch.setattr(native_window_layout.time, "monotonic", lambda: now[0])
+
+    class SlowVerificationGeometryApi(FakeApi):
+        geometry_calls = 0
+
+        def monitor_geometry(self, handle: int) -> tuple[Rect, Rect]:
+            geometry = super().monitor_geometry(handle)
+            self.geometry_calls += 1
+            if self.geometry_calls == 4:
+                now[0] = 2.0
+            return geometry
+
+    api = SlowVerificationGeometryApi(pair, pair, adjusted)
+
+    assert guard_native_window_layout(
+        client,
+        api=api,
+        timeout_seconds=1,
+        poll_interval=0,
+    ) is LayoutStatus.SKIPPED
+    assert api.moves == [(2, Rect(0, 0, 1021, 914))]
+
+
 @pytest.mark.skipif(os.name != "nt", reason="Win32 bindings are Windows-only")
 def test_win32_factory_loads_without_changing_a_window() -> None:
     assert create_window_api() is not None
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Win32 bindings are Windows-only")
+def test_win32_move_requests_async_cross_queue_dispatch() -> None:
+    api = create_window_api()
+    assert api is not None
+
+    class RecordingUser32:
+        flags = 0
+
+        def SetWindowPos(self, *_arguments) -> int:
+            self.flags = int(_arguments[-1].value)
+            return 1
+
+    user32 = RecordingUser32()
+    api.user32 = user32  # type: ignore[attr-defined]
+
+    assert api.move_window(2, Rect(10, 20, 810, 620)) is True
+    assert user32.flags & 0x4000

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -505,6 +505,7 @@ def test_fresh_profile_retries_known_first_exit_once(
     assert {run[1] for run in client_runs} == {root.resolve() / "app"}
     assert client_events == [
         {"attempt": 1, "event": "client_start"},
+        {"attempt": 1, "event": "client_layout", "status": "skipped"},
         {"attempt": 1, "event": "client_exit", "exit_code": 0x0E000003},
         {
             "attempt": 2,
@@ -512,6 +513,7 @@ def test_fresh_profile_retries_known_first_exit_once(
             "reason": "known_fresh_profile_exit",
         },
         {"attempt": 2, "event": "client_start"},
+        {"attempt": 2, "event": "client_layout", "status": "skipped"},
         {"attempt": 2, "event": "client_exit", "exit_code": 0},
     ]
     assert str(root.resolve()) not in launcher_log
@@ -555,6 +557,7 @@ def test_existing_profile_never_retries_known_exit(
     assert len(client_runs) == 1
     assert [event["event"] for event in client_events] == [
         "client_start",
+        "client_layout",
         "client_exit",
     ]
 
@@ -575,6 +578,7 @@ def test_fresh_profile_does_not_retry_other_exit(
     assert len(client_runs) == 1
     assert [event["event"] for event in client_events] == [
         "client_start",
+        "client_layout",
         "client_exit",
     ]
 


### PR DESCRIPTION
## Summary
- keep the official client window in its original placement while the local companion runs
- revalidate HWND/PID/executable identity before every move
- roll back failed or cancelled placement changes and record path-free launcher status

## Verification
- 34 focused tests passed
- installer compileall passed
- git diff check passed

## Boundary
- no private content or official asset bytes are included
- real installed-client validation follows in the final installer E2E