### PR TITLE
feat(installer): restore native mailbox navigation privately

### DIFF
--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -49,14 +49,15 @@ python installer/build_windows_setup.py `
   --voice-reference '<私有 WAV 的本机路径>' `
   --video-runtime '<Olivia-video-runtime-*.zip 的本机路径>' `
   --video-offline-root '<含 ordinary_video 与 music_video 的离线根目录>' `
+  --native-navigation-manifest '<私有兼容 manifest 的本机路径>' `
   --iscc 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
 ```
 
-私有构建器只接受三项显式输入：WAV、完整视频运行时 ZIP、完整视频离线根目录。它核对 PCM 帧、视频运行时根 manifest 与四个独立 Python 入口；再以 `installer/video-capability-manifest.json` 为唯一 BOM，要求离线根目录同时包含 `ordinary_video` 与 `music_video`，逐文件核对路径、大小和 SHA-256，并拒绝缺失、多余、重解析点或被修改的文件。随后把三项资产的固定名称和摘要写入内嵌 `offline/offline-core-assets.json`，其中 `distribution` 固定为 `private`。输入的 `offline` 目录不得预先夹带私有字段或资产；公开模式传入任一私有资产、私有模式缺少任一资产都会拒绝构建。
+私有构建器只接受四项显式输入：WAV、完整视频运行时 ZIP、完整视频离线根目录和本机私有兼容 manifest。它核对 PCM 帧、视频运行时根 manifest、四个独立 Python 入口以及兼容 manifest 的固定 schema、客户端版本、文件集合与边界；再以 `installer/video-capability-manifest.json` 为唯一视频 BOM，要求离线根目录同时包含 `ordinary_video` 与 `music_video`，逐文件核对路径、大小和 SHA-256，并拒绝缺失、多余、重解析点或被修改的文件。随后把前三项资产的固定名称和摘要写入内嵌 `offline/offline-core-assets.json`，其中 `distribution` 固定为 `private`；兼容 manifest 只复制到私有核心 payload。输入的 `offline` 目录不得预先夹带私有字段或资产；公开模式传入任一私有资产、私有模式缺少任一资产都会拒绝构建。
 
 公开构建仍是单个 `Olivia-Setup-x64.exe`。私有产物是自包含目录：`Olivia-Setup-x64.exe`、`Olivia-video-runtime-private.zip`、`Olivia-video-offline-private/`、`Olivia-Setup-x64.receipt.json` 和 `Olivia-Setup-x64.exe.sha256`。交付时必须把整个目录压成一个 ZIP，用户完整解压后再运行 EXE；Inno 只把小型核心 payload 解到 `{tmp}`，并把 `{src}` 下固定名称的 runtime ZIP 与 offline root 传给 `Install.ps1`。runtime 由既有事务原子复制到受管 `install/downloads`，ordinary/music 资产由既有视频能力导入链校验、组装与激活；两类大文件都不会进入 Inno `{tmp}`。缺少、改名或篡改任一 sidecar 都会在发布安装结果前失败。私有产物只保存在专用 `dist-private`，不得与公开 `dist` artifact 共置、替换或上传到公开 Release。
 
-除私有模式显式传入的 WAV、视频运行时 ZIP 与视频离线根目录外，构建器只复制 Git 已跟踪且相对 `HEAD` 未修改的发布文件，排除 `.github`、`docs`、测试和构建/CI 元数据，并在编译前复验离线 manifest、requirements 哈希、每个资产的大小与 SHA-256，以及实际资产集合。构建器先把两类大 sidecar 原子发布到输出目录并以这些最终字节生成内嵌 BOM；Inno 编译完成后再次复验，防止编译期间的替换进入交付。私有 receipt 记录 EXE、runtime ZIP 与 offline root 内每个文件的相对路径、大小和 SHA-256；`.sha256` 再覆盖这些文件及 receipt 本身，因而没有自引用。公开构建流程与原有输出保持不变，只校验并记录 EXE。
+除私有模式显式传入的 WAV、视频运行时 ZIP 与视频离线根目录外，构建器还只接受同模式显式传入的兼容 manifest；其余只复制 Git 已跟踪且相对 `HEAD` 未修改的发布文件，排除 `.github`、`docs`、测试和构建/CI 元数据，并在编译前复验离线 manifest、requirements 哈希、每个资产的大小与 SHA-256，以及实际资产集合。构建器先把两类大 sidecar 原子发布到输出目录并以这些最终字节生成内嵌 BOM；Inno 编译完成后再次复验，防止编译期间的替换进入交付。私有 receipt 记录 EXE、runtime ZIP 与 offline root 内每个文件的相对路径、大小和 SHA-256；`.sha256` 再覆盖这些文件及 receipt 本身，因而没有自引用。公开构建流程与原有输出保持不变，只校验并记录 EXE。
 
 GitHub Actions 只生成公开安装器 artifact；它会在 PR 和 `main` 更新时执行默认公开构建，不接受私有 WAV 或视频运行时，也不会生成私有安装器。私有安装包只能由维护者在隔离环境手工构建。当前产物未做商业代码签名；正式面向普通用户发布前应增加受信任的 Authenticode 签名，但签名不替代随包 SHA-256 校验。
 
@@ -79,7 +80,7 @@ webplayer.dat SHA-256：
 565b5e3e113c2a9dfb90d5fa4f2a0ccda9b0151c118ae3365e6ee0c8624a451d
 ```
 
-文件缺失时安装在写入目标目录前停止。自动发现多份 Steam 副本时，安装器优先选择上述双 SHA-256 精确匹配的第一份；仅发现一份非精确匹配副本时，由 Python 补丁器继续校验 ZIP 结构与补丁锚点。多份副本均不精确匹配时返回 `OFFICIAL_INSTALL_AMBIGUOUS`，用户必须返回上一步明确选择正版目录。
+文件缺失时安装在写入目标目录前停止。自动发现多份 Steam 副本时，安装器优先选择上述双 SHA-256 精确匹配的第一份；仅发现一份非精确匹配副本时，由 Python 补丁器继续校验 ZIP 结构。多份副本均不精确匹配时返回 `OFFICIAL_INSTALL_AMBIGUOUS`，用户必须返回上一步明确选择正版目录。
 
 安装器只在隔离副本中按顺序执行：
 
@@ -94,7 +95,7 @@ webplayer.dat
 5. 提供可选的显式 `uid` 本机回退，只为明确的 loopback `/toy/media/` 地址启用本机视频播放
 ```
 
-原版主包之外，设置界面只增加一个仓库自有 bootstrap；原版 `assets/main-31595bd3.js` 的业务代码除既有端点和 Collection 锚点外不做模糊替换。播放器的普通原版路径继续加载未修改的原模块。
+原版主包之外，设置界面只增加一个仓库自有 bootstrap。私有安装包在每次受管启动前读取安装器带入的兼容 manifest，会修改隔离副本中的业务 bundle 与两个原生 DLL，以恢复原位入口和离线信箱请求；修改只接受 manifest 固定的版本、结构、原始/目标哈希和唯一替换项。每个被修改文件都保留 `.native-nav.orig` 原始备份，发布失败会回滚。公开仓库不保存这些官方字节签名、压缩业务片段或 DLL 特征；它们只存在于授权分发者本机提供的私有兼容 manifest 中。manifest 缺失时公开安装保持未配置，manifest 无效或与隔离副本不匹配时私有启动关闭失败，不会猜测补丁位置。播放器的普通原版路径继续加载未修改的原模块。
 
 隔离副本保留：
 

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -21,6 +21,10 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from installer.component_update import ComponentUpdateError, _validate_relative_path
+from installer.patch_native_navigation import (
+    COMPATIBILITY_MANIFEST_NAME,
+    parse_compatibility_manifest,
+)
 
 
 MANIFEST_NAME = "offline-core-assets.json"
@@ -28,6 +32,7 @@ SETUP_NAME = "Olivia-Setup-x64.exe"
 VIDEO_RUNTIME_SIDECAR_NAME = "Olivia-video-runtime-private.zip"
 VIDEO_OFFLINE_SIDECAR_NAME = "Olivia-video-offline-private"
 PRIVATE_RECEIPT_NAME = "Olivia-Setup-x64.receipt.json"
+NATIVE_NAVIGATION_MANIFEST_NAME = COMPATIBILITY_MANIFEST_NAME
 VOICE_REFERENCE_PATH = "voice/olivia-reference.wav"
 FORBIDDEN_MEDIA_SUFFIXES = {
     ".aac",
@@ -162,6 +167,7 @@ RELEASE_INSTALLER_FILES = {
     "installer/full-patch-manifest.json",
     "installer/Install.ps1",
     "installer/activate_private_video.py",
+    "installer/patch_native_navigation.py",
     "installer/mem0-capability-manifest.json",
     "installer/mem0-runtime-artifacts.json",
     "installer/mem0-runtime-requirements.txt",
@@ -632,6 +638,23 @@ def _absolute_sidecar_source(
         raise SetupBuildError(error_code) from exc
 
 
+def _native_navigation_manifest_source(path: Path) -> Path:
+    candidate = _absolute_sidecar_source(
+        path,
+        directory=False,
+        error_code="SETUP_NATIVE_NAVIGATION_MANIFEST_INVALID",
+    )
+    try:
+        if not 1 <= candidate.stat().st_size <= 1024 * 1024:
+            raise ValueError
+        parse_compatibility_manifest(
+            json.loads(candidate.read_text(encoding="utf-8"))
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError, ValueError):
+        raise SetupBuildError("SETUP_NATIVE_NAVIGATION_MANIFEST_INVALID") from None
+    return candidate
+
+
 def _assert_no_reparse_tree(root: Path, *, error_code: str) -> None:
     try:
         for current, directories, filenames in os.walk(root, followlinks=False):
@@ -988,6 +1011,7 @@ def prepare_setup_payload(
     voice_reference: Path | None = None,
     video_runtime: Path | None = None,
     video_offline_root: Path | None = None,
+    native_navigation_manifest: Path | None = None,
     validate_schema: bool = True,
 ) -> None:
     source = source.expanduser().resolve()
@@ -1007,6 +1031,17 @@ def prepare_setup_payload(
         raise SetupBuildError("SETUP_VIDEO_OFFLINE_PRIVATE_ONLY")
     if distribution == "private" and video_offline_root is None:
         raise SetupBuildError("SETUP_PRIVATE_VIDEO_OFFLINE_REQUIRED")
+    if native_navigation_manifest is not None and distribution != "private":
+        raise SetupBuildError("SETUP_NATIVE_NAVIGATION_MANIFEST_PRIVATE_ONLY")
+    if distribution == "private" and native_navigation_manifest is None:
+        assert voice_reference is not None
+        native_navigation_manifest = (
+            voice_reference.parent / NATIVE_NAVIGATION_MANIFEST_NAME
+        )
+        if not native_navigation_manifest.is_file():
+            raise SetupBuildError(
+                "SETUP_PRIVATE_NATIVE_NAVIGATION_MANIFEST_REQUIRED"
+            )
     if destination.exists():
         raise SetupBuildError("SETUP_PAYLOAD_EXISTS")
     _load_and_verify_manifest(source, offline, validate_schema=validate_schema)
@@ -1037,6 +1072,14 @@ def prepare_setup_payload(
             target = staging.joinpath(*PurePosixPath(relative).parts)
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source_path, target)
+        if native_navigation_manifest is not None:
+            navigation_source = _native_navigation_manifest_source(
+                native_navigation_manifest
+            )
+            shutil.copy2(
+                navigation_source,
+                staging / "installer" / NATIVE_NAVIGATION_MANIFEST_NAME,
+            )
         shutil.copytree(offline, staging / "offline")
         if (
             voice_reference is not None
@@ -1127,6 +1170,7 @@ def build_windows_setup(
     voice_reference: Path | None = None,
     video_runtime: Path | None = None,
     video_offline_root: Path | None = None,
+    native_navigation_manifest: Path | None = None,
 ) -> dict[str, object]:
     source = source.expanduser().resolve()
     output = output.expanduser().resolve()
@@ -1178,6 +1222,7 @@ def build_windows_setup(
             video_offline_root=(
                 offline_sidecar if video_offline_root is not None else None
             ),
+            native_navigation_manifest=native_navigation_manifest,
         )
         command = [
             os.fspath(compiler),
@@ -1330,6 +1375,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--voice-reference", type=Path)
     parser.add_argument("--video-runtime", type=Path)
     parser.add_argument("--video-offline-root", type=Path)
+    parser.add_argument("--native-navigation-manifest", type=Path)
     args = parser.parse_args(argv)
     try:
         result = build_windows_setup(
@@ -1342,6 +1388,7 @@ def main(argv: list[str] | None = None) -> int:
             voice_reference=args.voice_reference,
             video_runtime=args.video_runtime,
             video_offline_root=args.video_offline_root,
+            native_navigation_manifest=args.native_navigation_manifest,
         )
         print(json.dumps(result, ensure_ascii=False, sort_keys=True))
         return 0

--- a/installer/patch_native_navigation.py
+++ b/installer/patch_native_navigation.py
@@ -4,81 +4,25 @@ from __future__ import annotations
 
 import hashlib
 import io
+import json
 import os
 from pathlib import Path
+import re
 import stat
 import uuid
 import zipfile
 
 
 CLIENT_VERSION = "0.0.9.627"
-MAIN_MEMBER = "assets/main-31595bd3.js"
-MAILBOX_DISABLED = "N3=!1,Ss=!1,wa=({onComplete"
-MAILBOX_ENABLED = "N3=!0,Ss=!1,wa=({onComplete"
-OFFLINE_WIDGETS_DISABLED = (
-    "e.isOfflineMode&&(l.value.mailWidget!==!1&&(l.value.mailWidget=!1),"
-    "l.value.musicWidget!==!1&&(l.value.musicWidget=!1))"
-)
-OFFLINE_WIDGETS_ENABLED = "l.value.mailWidget=!0,l.value.musicWidget=!0"
-OFFLINE_REQUEST_BLOCKED = "if(t.isOfflineMode)throw new Ol(e)"
-OFFLINE_REQUEST_ALLOWED = "if(!1)throw new Ol(e)"
-MAIL_FETCH_SKIPPED = "He(()=>{p.value||d.fetchMailList(!0)})"
-MAIL_FETCH_ALLOWED = "He(()=>{d.fetchMailList(!0)})"
-OFFLINE_POLL_SKIPPED = (
-    "s.isOfflineMode||(s.appMode===Se.PRO?Lt().proRestoreFromApi():"
-    "s.appMode===Se.LITE&&(Lt().liteStartPoll(),uo().startPolling()))"
-)
-OFFLINE_POLL_ALLOWED = (
-    "s.appMode===Se.PRO?Lt().proRestoreFromApi():"
-    "s.appMode===Se.LITE&&(s.isOfflineMode?uo().startPolling():"
-    "(Lt().liteStartPoll(),uo().startPolling()))"
-)
-OFFLINE_CALL_PATCH = bytes((0x33, 0xC0, 0x90, 0x90, 0x90, 0x90))
-STUDIO_SIGNATURES = (
-    bytes.fromhex("CB E8 D2 37 08 00 EB 1E FF 15 B2 EC 08 00 48 8D 8F A8"),
-    bytes.fromhex("CB E8 72 34 08 00 EB 1E FF 15 52 E9 08 00 48 8D 8F A8"),
-    bytes.fromhex("CB E8 B2 1F 08 00 EB 2B FF 15 92 D4 08 00 84 C0 75 14"),
-    bytes.fromhex("CB E8 FF 1D 08 00 EB 1C FF 15 DF D2 08 00 48 8D 4F 38"),
-)
-CONTAINER_SIGNATURE = bytes.fromhex(
-    "48 8B DA 48 8B F9 FF 15 61 A4 04 00 84 C0 0F 85"
-)
-
-# The only managed 0.0.9.627 inputs this patcher may mutate.  The frontend
-# "original" is the deterministic endpoint/settings-patched staging input;
-# the DLL originals are the byte-exact client copies.  Sizes reject truncation
-# before archive/signature inspection.  No private client bytes are distributed.
-_SUPPORTED_INPUT_FINGERPRINTS = {
-    "feapp": {
-        "original": (
-            27_769_992,
-            "2abf4bc1208d3f7f39fbd2b4556c980ce5d641c75cee8863c3ca69e6029f7dcf",
-        ),
-        "patched": (
-            27_769_978,
-            "71c30b40dbbbf9d6949828425d5b093ad32aaf2d7b3c53b3f1c5a4a42643cc42",
-        ),
-    },
-    "studio_ui": {
-        "original": (
-            1_297_376,
-            "3756767fc01c2a1c034a56c1ae2920651f13021a1b4cc0c3ed291fc92a9728e1",
-        ),
-        "patched": (
-            1_297_376,
-            "294dcfe023c84bc83bdd531d8431bf76b2b7a1fbc0941a250ae8f4cf2ed8fa99",
-        ),
-    },
-    "container_plugin": {
-        "original": (
-            498_144,
-            "53b61d8e9766c5b1cf2af29ed1a4ac7985052db65c37aa1829c71416050e31d1",
-        ),
-        "patched": (
-            498_144,
-            "d78112ca218f805d437d2b03fe4c772c7cb279848dccce16570cbd466fe66ab4",
-        ),
-    },
+COMPATIBILITY_MANIFEST_NAME = "native-navigation-compatibility.json"
+_MANIFEST_SCHEMA = "olivia.native-navigation-compatibility.v1"
+_MAX_MANIFEST_BYTES = 1024 * 1024
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_ID_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+_EXPECTED_FILES = {
+    "feapp": "resources/feapp.dat",
+    "studio_ui": "plugins/Studio/NutStudioUI.dll",
+    "container_plugin": "plugins/Container/NutContainerPlugin.dll",
 }
 
 
@@ -102,21 +46,25 @@ def _read_bytes(path: Path, error_code: str) -> bytes:
 
 
 def _matches_registered_state(
-    values: dict[str, bytes], state: str
+    values: dict[str, bytes], specs: dict[str, dict[str, object]], state: str
 ) -> bool:
     return all(
-        _matches_registered_file(name, values[name], state)
+        _matches_registered_file(specs[name], values[name], state)
         for name in values
     )
 
 
-def _matches_registered_file(name: str, value: bytes, state: str) -> bool:
-    return _fingerprint(value) == _SUPPORTED_INPUT_FINGERPRINTS[name][state]
+def _matches_registered_file(
+    spec: dict[str, object], value: bytes, state: str
+) -> bool:
+    fingerprints = spec["fingerprints"]
+    assert isinstance(fingerprints, dict)
+    return _fingerprint(value) == fingerprints[state]
 
 
-def _registered_file_state(name: str, value: bytes) -> str | None:
+def _registered_file_state(spec: dict[str, object], value: bytes) -> str | None:
     for state in ("original", "patched"):
-        if _matches_registered_file(name, value, state):
+        if _matches_registered_file(spec, value, state):
             return state
     return None
 
@@ -152,6 +100,182 @@ def _validate_managed_paths(work: Path, candidates: tuple[Path, ...]) -> None:
         raise NativeNavigationPatchError("NATIVE_NAV_UNSAFE_PATH") from None
 
 
+def _object_keys(value: object, keys: set[str]) -> dict[str, object]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise ValueError
+    return value
+
+
+def _file_fingerprint(value: object) -> tuple[int, str]:
+    record = _object_keys(value, {"size_bytes", "sha256"})
+    size = record["size_bytes"]
+    digest = record["sha256"]
+    if (
+        type(size) is not int
+        or not 1 <= size <= 1024 * 1024 * 1024
+        or not isinstance(digest, str)
+        or _SHA256_RE.fullmatch(digest) is None
+    ):
+        raise ValueError
+    return size, digest
+
+
+def _replacement_id(value: object) -> str:
+    if not isinstance(value, str) or _ID_RE.fullmatch(value) is None:
+        raise ValueError
+    return value
+
+
+def _text_replacements(value: object) -> tuple[tuple[str, str, str], ...]:
+    if not isinstance(value, list) or not 1 <= len(value) <= 16:
+        raise ValueError
+    result: list[tuple[str, str, str]] = []
+    seen: set[str] = set()
+    for raw in value:
+        item = _object_keys(raw, {"id", "before", "after"})
+        identifier = _replacement_id(item["id"])
+        before = item["before"]
+        after = item["after"]
+        if (
+            identifier in seen
+            or not isinstance(before, str)
+            or not isinstance(after, str)
+            or not before
+            or before == after
+            or len(before.encode("utf-8")) > 16 * 1024
+            or len(after.encode("utf-8")) > 16 * 1024
+        ):
+            raise ValueError
+        seen.add(identifier)
+        result.append((identifier, before, after))
+    return tuple(result)
+
+
+def _binary_replacements(
+    value: object,
+) -> tuple[tuple[str, bytes, int, bytes], ...]:
+    if not isinstance(value, list) or not 1 <= len(value) <= 16:
+        raise ValueError
+    result: list[tuple[str, bytes, int, bytes]] = []
+    seen: set[str] = set()
+    for raw in value:
+        item = _object_keys(
+            raw,
+            {"id", "signature_hex", "patch_offset", "replacement_hex"},
+        )
+        identifier = _replacement_id(item["id"])
+        signature_hex = item["signature_hex"]
+        replacement_hex = item["replacement_hex"]
+        offset = item["patch_offset"]
+        if (
+            identifier in seen
+            or not isinstance(signature_hex, str)
+            or not isinstance(replacement_hex, str)
+            or type(offset) is not int
+            or offset < 0
+        ):
+            raise ValueError
+        signature = bytes.fromhex(signature_hex)
+        replacement = bytes.fromhex(replacement_hex)
+        if (
+            not signature
+            or not replacement
+            or len(signature) > 1024
+            or len(replacement) > 256
+            or offset + len(replacement) > len(signature)
+        ):
+            raise ValueError
+        seen.add(identifier)
+        result.append((identifier, signature, offset, replacement))
+    return tuple(result)
+
+
+def parse_compatibility_manifest(
+    value: object,
+) -> dict[str, dict[str, object]]:
+    """Validate private compatibility metadata without persisting its bytes."""
+
+    manifest = _object_keys(
+        value,
+        {"schema_version", "client_version", "files"},
+    )
+    if (
+        manifest["schema_version"] != _MANIFEST_SCHEMA
+        or manifest["client_version"] != CLIENT_VERSION
+        or not isinstance(manifest["files"], list)
+        or len(manifest["files"]) != len(_EXPECTED_FILES)
+    ):
+        raise ValueError
+    specs: dict[str, dict[str, object]] = {}
+    for raw in manifest["files"]:
+        if not isinstance(raw, dict):
+            raise ValueError
+        identifier = raw.get("id")
+        relative = raw.get("relative_path")
+        if (
+            not isinstance(identifier, str)
+            or identifier in specs
+            or _EXPECTED_FILES.get(identifier) != relative
+        ):
+            raise ValueError
+        common = {"id", "relative_path", "original", "patched"}
+        original = _file_fingerprint(raw.get("original"))
+        patched = _file_fingerprint(raw.get("patched"))
+        if original == patched:
+            raise ValueError
+        spec: dict[str, object] = {
+            "relative_path": relative,
+            "fingerprints": {
+                "original": original,
+                "patched": patched,
+            },
+        }
+        if identifier == "feapp":
+            if set(raw) != common | {"archive_member", "text_replacements"}:
+                raise ValueError
+            member = raw["archive_member"]
+            if (
+                not isinstance(member, str)
+                or not member
+                or "\\" in member
+                or member.startswith("/")
+                or any(part in {"", ".", ".."} for part in member.split("/"))
+                or len(member.encode("utf-8")) > 512
+            ):
+                raise ValueError
+            spec["archive_member"] = member
+            spec["text_replacements"] = _text_replacements(
+                raw["text_replacements"]
+            )
+        else:
+            if set(raw) != common | {"binary_replacements"}:
+                raise ValueError
+            spec["binary_replacements"] = _binary_replacements(
+                raw["binary_replacements"]
+            )
+        specs[identifier] = spec
+    if set(specs) != set(_EXPECTED_FILES):
+        raise ValueError
+    return specs
+
+
+def _load_compatibility_manifest(
+    work: Path,
+) -> dict[str, dict[str, object]]:
+    path = work / "local_backend" / "installer" / COMPATIBILITY_MANIFEST_NAME
+    if not path.is_file():
+        raise NativeNavigationPatchError("NATIVE_NAV_MANIFEST_REQUIRED")
+    _validate_managed_paths(work, (path.parent.parent, path.parent, path))
+    try:
+        if path.stat().st_size > _MAX_MANIFEST_BYTES:
+            raise ValueError
+        return parse_compatibility_manifest(
+            json.loads(path.read_text(encoding="utf-8"))
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError, ValueError):
+        raise NativeNavigationPatchError("NATIVE_NAV_MANIFEST_INVALID") from None
+
+
 def _replace_unique(text: str, old: str, new: str, label: str) -> str:
     count = text.count(old)
     if count != 1:
@@ -161,11 +285,15 @@ def _replace_unique(text: str, old: str, new: str, label: str) -> str:
     return text.replace(old, new, 1)
 
 
-def _patched_feapp(source: bytes) -> bytes:
+def _patched_feapp(source: bytes, spec: dict[str, object]) -> bytes:
+    member = spec["archive_member"]
+    replacements = spec["text_replacements"]
+    assert isinstance(member, str)
+    assert isinstance(replacements, tuple)
     try:
         with zipfile.ZipFile(io.BytesIO(source)) as archive:
             infos = archive.infolist()
-            if sum(info.filename == MAIN_MEMBER for info in infos) != 1:
+            if sum(info.filename == member for info in infos) != 1:
                 raise NativeNavigationPatchError(
                     "supported frontend bundle must occur exactly once"
                 )
@@ -178,60 +306,32 @@ def _patched_feapp(source: bytes) -> bytes:
     with zipfile.ZipFile(output, "w") as archive:
         archive.comment = comment
         for info, payload in members:
-            if info.filename == MAIN_MEMBER:
+            if info.filename == member:
                 try:
                     javascript = payload.decode("utf-8")
                 except UnicodeError as exc:
                     raise NativeNavigationPatchError(
                         "supported frontend bundle is not UTF-8"
                     ) from exc
-                javascript = _replace_unique(
-                    javascript,
-                    MAILBOX_DISABLED,
-                    MAILBOX_ENABLED,
-                    "mailbox entry",
-                )
-                javascript = _replace_unique(
-                    javascript,
-                    OFFLINE_WIDGETS_DISABLED,
-                    OFFLINE_WIDGETS_ENABLED,
-                    "offline widgets",
-                )
-                javascript = _replace_unique(
-                    javascript,
-                    OFFLINE_REQUEST_BLOCKED,
-                    OFFLINE_REQUEST_ALLOWED,
-                    "offline request",
-                )
-                javascript = _replace_unique(
-                    javascript,
-                    MAIL_FETCH_SKIPPED,
-                    MAIL_FETCH_ALLOWED,
-                    "offline mail fetch",
-                )
-                javascript = _replace_unique(
-                    javascript,
-                    OFFLINE_POLL_SKIPPED,
-                    OFFLINE_POLL_ALLOWED,
-                    "offline mail polling",
-                )
+                for identifier, before, after in replacements:
+                    javascript = _replace_unique(
+                        javascript,
+                        before,
+                        after,
+                        f"frontend {identifier}",
+                    )
                 payload = javascript.encode("utf-8")
             archive.writestr(info, payload)
 
     patched = output.getvalue()
     try:
         with zipfile.ZipFile(io.BytesIO(patched)) as archive:
-            javascript = archive.read(MAIN_MEMBER).decode("utf-8")
+            javascript = archive.read(member).decode("utf-8")
     except (OSError, UnicodeError, zipfile.BadZipFile, KeyError) as exc:
         raise NativeNavigationPatchError(
             "patched frontend archive verification failed"
         ) from exc
-    if (
-        MAILBOX_ENABLED not in javascript
-        or MAILBOX_DISABLED in javascript
-        or OFFLINE_WIDGETS_ENABLED not in javascript
-        or OFFLINE_WIDGETS_DISABLED in javascript
-    ):
+    if any(after not in javascript or before in javascript for _, before, after in replacements):
         raise NativeNavigationPatchError(
             "patched frontend archive verification failed"
         )
@@ -254,33 +354,30 @@ def _unique_offset(source: bytes, signature: bytes, label: str) -> int:
     return offsets[0]
 
 
-def _patched_dll(
+def _patched_binary(
     source: bytes,
-    signatures: tuple[bytes, ...],
-    call_offset: int,
+    replacements: tuple[tuple[str, bytes, int, bytes], ...],
     label: str,
 ) -> bytes:
-    offsets = [
-        _unique_offset(source, signature, f"{label} #{index}")
-        for index, signature in enumerate(signatures, start=1)
-    ]
+    offsets = {
+        identifier: _unique_offset(source, signature, f"{label} {identifier}")
+        for identifier, signature, _, _ in replacements
+    }
     patched = bytearray(source)
-    for offset in offsets:
-        start = offset + call_offset
-        patched[start : start + len(OFFLINE_CALL_PATCH)] = OFFLINE_CALL_PATCH
+    for identifier, _, offset, replacement in replacements:
+        start = offsets[identifier] + offset
+        patched[start : start + len(replacement)] = replacement
     value = bytes(patched)
-    for index, (signature, offset) in enumerate(
-        zip(signatures, offsets, strict=True),
-        start=1,
-    ):
+    for identifier, signature, patch_offset, replacement in replacements:
+        offset = offsets[identifier]
         expected = (
-            signature[:call_offset]
-            + OFFLINE_CALL_PATCH
-            + signature[call_offset + len(OFFLINE_CALL_PATCH) :]
+            signature[:patch_offset]
+            + replacement
+            + signature[patch_offset + len(replacement) :]
         )
         if signature in value or value[offset : offset + len(signature)] != expected:
             raise NativeNavigationPatchError(
-                f"{label} #{index} patch verification failed"
+                f"{label} {identifier} patch verification failed"
             )
     return value
 
@@ -293,6 +390,19 @@ def _unlink_paths(paths: list[Path] | tuple[Path, ...]) -> list[BaseException]:
         except BaseException as exc:
             failures.append(exc)
     return failures
+
+
+def _cleanup_orphan_staging(paths: tuple[Path, ...], work: Path) -> None:
+    orphans: list[Path] = []
+    try:
+        for path in paths:
+            orphans.extend(path.parent.glob(path.name + ".native-nav-*.tmp"))
+        for orphan in orphans:
+            _validate_managed_paths(work, (orphan.parent, orphan))
+    except (OSError, NativeNavigationPatchError):
+        raise NativeNavigationPatchError("NATIVE_NAV_CLEANUP_FAILED") from None
+    if _unlink_paths(orphans):
+        raise NativeNavigationPatchError("NATIVE_NAV_CLEANUP_FAILED")
 
 
 def _stage_write(path: Path, value: bytes, work: Path) -> Path:
@@ -375,10 +485,11 @@ def patch_native_navigation(
         or root.name != CLIENT_VERSION
     ):
         raise NativeNavigationPatchError("NATIVE_NAV_UNMANAGED_ROOT")
-    feapp = root / "resources" / "feapp.dat"
-    studio = root / "plugins" / "Studio" / "NutStudioUI.dll"
-    container = (
-        root / "plugins" / "Container" / "NutContainerPlugin.dll"
+    specs = _load_compatibility_manifest(work)
+    feapp = root.joinpath(*str(specs["feapp"]["relative_path"]).split("/"))
+    studio = root.joinpath(*str(specs["studio_ui"]["relative_path"]).split("/"))
+    container = root.joinpath(
+        *str(specs["container_plugin"]["relative_path"]).split("/")
     )
     paths = (
         ("feapp", feapp),
@@ -399,6 +510,10 @@ def patch_native_navigation(
         *backups.values(),
     )
     _validate_managed_paths(work, managed_paths)
+    _cleanup_orphan_staging(
+        tuple(path for _, path in paths) + tuple(backups.values()),
+        work,
+    )
     for _, path in paths:
         if not path.is_file():
             raise NativeNavigationPatchError("NATIVE_NAV_INPUT_MISSING")
@@ -411,7 +526,7 @@ def patch_native_navigation(
     }
     live_by_name = {name: live[path] for name, path in paths}
     live_states = {
-        name: _registered_file_state(name, value)
+        name: _registered_file_state(specs[name], value)
         for name, value in live_by_name.items()
     }
     live_is_original = all(state == "original" for state in live_states.values())
@@ -424,7 +539,7 @@ def patch_native_navigation(
     if has_any_backup and not has_all_backups:
         for name, path in paths:
             if backup_states[path] and not _matches_registered_file(
-                name,
+                specs[name],
                 _read_bytes(
                     backups[path], "NATIVE_NAV_BACKUP_READ_FAILED"
                 ),
@@ -444,28 +559,26 @@ def patch_native_navigation(
         else dict(live)
     )
     if has_all_backups and not _matches_registered_state(
-        {name: originals[path] for name, path in paths}, "original"
+        {name: originals[path] for name, path in paths}, specs, "original"
     ):
         raise NativeNavigationPatchError("NATIVE_NAV_BACKUP_TAMPERED")
     if has_all_backups and any(state is None for state in live_states.values()):
         raise NativeNavigationPatchError("NATIVE_NAV_LIVE_TAMPERED")
     patched = {
-        feapp: _patched_feapp(originals[feapp]),
-        studio: _patched_dll(
+        feapp: _patched_feapp(originals[feapp], specs["feapp"]),
+        studio: _patched_binary(
             originals[studio],
-            STUDIO_SIGNATURES,
-            8,
+            specs["studio_ui"]["binary_replacements"],
             "NutStudioUI.dll offline call",
         ),
-        container: _patched_dll(
+        container: _patched_binary(
             originals[container],
-            (CONTAINER_SIGNATURE,),
-            6,
+            specs["container_plugin"]["binary_replacements"],
             "NutContainerPlugin.dll lite-bar call",
         ),
     }
     if not _matches_registered_state(
-        {name: patched[path] for name, path in paths}, "patched"
+        {name: patched[path] for name, path in paths}, specs, "patched"
     ):
         raise NativeNavigationPatchError("NATIVE_NAV_PATCH_MISMATCH")
     if has_all_backups:
@@ -505,6 +618,7 @@ def patch_native_navigation(
                 name: _read_bytes(path, "NATIVE_NAV_PUBLISHED_READ_FAILED")
                 for name, path in paths
             },
+            specs,
             "patched",
         ) or not _matches_registered_state(
             {
@@ -513,6 +627,7 @@ def patch_native_navigation(
                 )
                 for name, path in paths
             },
+            specs,
             "original",
         ):
             raise NativeNavigationPatchError("NATIVE_NAV_PUBLISHED_TAMPERED")

--- a/installer/patch_native_navigation.py
+++ b/installer/patch_native_navigation.py
@@ -307,7 +307,9 @@ def patch_native_navigation(
             raise NativeNavigationPatchError(
                 "native navigation rollback failed"
             ) from exc
-        raise
+        raise NativeNavigationPatchError(
+            "native navigation publication failed"
+        ) from exc
     finally:
         for temporary in staged:
             temporary.unlink(missing_ok=True)

--- a/installer/patch_native_navigation.py
+++ b/installer/patch_native_navigation.py
@@ -6,6 +6,7 @@ import hashlib
 import io
 import os
 from pathlib import Path
+import uuid
 import zipfile
 
 
@@ -18,6 +19,16 @@ OFFLINE_WIDGETS_DISABLED = (
     "l.value.musicWidget!==!1&&(l.value.musicWidget=!1))"
 )
 OFFLINE_WIDGETS_ENABLED = "l.value.mailWidget=!0,l.value.musicWidget=!0"
+OFFLINE_CALL_PATCH = bytes((0x33, 0xC0, 0x90, 0x90, 0x90, 0x90))
+STUDIO_SIGNATURES = (
+    bytes.fromhex("CB E8 D2 37 08 00 EB 1E FF 15 B2 EC 08 00 48 8D 8F A8"),
+    bytes.fromhex("CB E8 72 34 08 00 EB 1E FF 15 52 E9 08 00 48 8D 8F A8"),
+    bytes.fromhex("CB E8 B2 1F 08 00 EB 2B FF 15 92 D4 08 00 84 C0 75 14"),
+    bytes.fromhex("CB E8 FF 1D 08 00 EB 1C FF 15 DF D2 08 00 48 8D 4F 38"),
+)
+CONTAINER_SIGNATURE = bytes.fromhex(
+    "48 8B DA 48 8B F9 FF 15 61 A4 04 00 84 C0 0F 85"
+)
 
 
 class NativeNavigationPatchError(ValueError):
@@ -96,16 +107,109 @@ def _patched_feapp(source: bytes) -> bytes:
     return patched
 
 
-def _atomic_write(path: Path, value: bytes) -> None:
-    temporary = path.with_name(path.name + ".native-nav.tmp")
+def _unique_offset(source: bytes, signature: bytes, label: str) -> int:
+    offsets: list[int] = []
+    start = 0
+    while True:
+        offset = source.find(signature, start)
+        if offset < 0:
+            break
+        offsets.append(offset)
+        start = offset + 1
+    if len(offsets) != 1:
+        raise NativeNavigationPatchError(
+            f"{label} signature must occur exactly once; found {len(offsets)}"
+        )
+    return offsets[0]
+
+
+def _patched_dll(
+    source: bytes,
+    signatures: tuple[bytes, ...],
+    call_offset: int,
+    label: str,
+) -> bytes:
+    offsets = [
+        _unique_offset(source, signature, f"{label} #{index}")
+        for index, signature in enumerate(signatures, start=1)
+    ]
+    patched = bytearray(source)
+    for offset in offsets:
+        start = offset + call_offset
+        patched[start : start + len(OFFLINE_CALL_PATCH)] = OFFLINE_CALL_PATCH
+    value = bytes(patched)
+    for index, (signature, offset) in enumerate(
+        zip(signatures, offsets, strict=True),
+        start=1,
+    ):
+        expected = (
+            signature[:call_offset]
+            + OFFLINE_CALL_PATCH
+            + signature[call_offset + len(OFFLINE_CALL_PATCH) :]
+        )
+        if signature in value or value[offset : offset + len(signature)] != expected:
+            raise NativeNavigationPatchError(
+                f"{label} #{index} patch verification failed"
+            )
+    return value
+
+
+def _stage_write(path: Path, value: bytes) -> Path:
+    temporary = path.with_name(
+        path.name + f".native-nav-{uuid.uuid4().hex}.tmp"
+    )
     try:
         with temporary.open("wb") as stream:
             stream.write(value)
             stream.flush()
             os.fsync(stream.fileno())
-        os.replace(temporary, path)
-    finally:
+        if temporary.read_bytes() != value:
+            raise NativeNavigationPatchError("staged file verification failed")
+        return temporary
+    except Exception:
         temporary.unlink(missing_ok=True)
+        raise
+
+
+def _restore_published(
+    published: list[tuple[Path, bytes]],
+) -> list[BaseException]:
+    failures: list[BaseException] = []
+    for path, original in reversed(published):
+        temporary: Path | None = None
+        try:
+            temporary = _stage_write(path, original)
+            os.replace(temporary, path)
+        except BaseException as exc:
+            failures.append(exc)
+        finally:
+            if temporary is not None:
+                temporary.unlink(missing_ok=True)
+    return failures
+
+
+def _result(
+    paths: tuple[tuple[str, Path], ...],
+    originals: dict[Path, bytes],
+    patched: dict[Path, bytes],
+    status: str,
+) -> dict[str, object]:
+    return {
+        "status": status,
+        "client_version": CLIENT_VERSION,
+        "files": {
+            name: {
+                "path": str(path),
+                "backup_path": str(
+                    path.with_name(path.name + ".native-nav.orig")
+                ),
+                "source_sha256": _sha256(originals[path]),
+                "backup_sha256": _sha256(originals[path]),
+                "patched_sha256": _sha256(patched[path]),
+            }
+            for name, path in paths
+        },
+    }
 
 
 def patch_native_navigation(
@@ -121,38 +225,91 @@ def patch_native_navigation(
     if work_root is not None and not Path(work_root).expanduser().resolve().is_dir():
         raise FileNotFoundError(work_root)
     feapp = root / "resources" / "feapp.dat"
-    if not feapp.is_file():
-        raise FileNotFoundError(feapp)
+    studio = root / "plugins" / "Studio" / "NutStudioUI.dll"
+    container = (
+        root / "plugins" / "Container" / "NutContainerPlugin.dll"
+    )
+    paths = (
+        ("feapp", feapp),
+        ("studio_ui", studio),
+        ("container_plugin", container),
+    )
+    for _, path in paths:
+        if not path.is_file():
+            raise FileNotFoundError(path)
 
-    source = feapp.read_bytes()
-    patched = _patched_feapp(source)
-    backup = feapp.with_name(feapp.name + ".native-nav.orig")
-    created_backup = False
-    try:
-        if backup.exists():
-            if backup.read_bytes() != source:
-                raise NativeNavigationPatchError(
-                    "frontend backup does not match the original input"
-                )
-        else:
-            _atomic_write(backup, source)
-            created_backup = True
-        _atomic_write(feapp, patched)
-    except Exception:
-        if created_backup:
-            backup.unlink(missing_ok=True)
-        raise
-
-    return {
-        "status": "PATCHED",
-        "client_version": CLIENT_VERSION,
-        "files": {
-            "feapp": {
-                "path": str(feapp),
-                "backup_path": str(backup),
-                "source_sha256": _sha256(source),
-                "backup_sha256": _sha256(backup.read_bytes()),
-                "patched_sha256": _sha256(patched),
-            }
-        },
+    backups = {
+        path: path.with_name(path.name + ".native-nav.orig")
+        for _, path in paths
     }
+    backup_states = [backup.is_file() for backup in backups.values()]
+    if any(backup_states) and not all(backup_states):
+        raise NativeNavigationPatchError(
+            "native navigation backups are incomplete"
+        )
+    live = {path: path.read_bytes() for _, path in paths}
+    originals = (
+        {path: backups[path].read_bytes() for _, path in paths}
+        if all(backup_states)
+        else dict(live)
+    )
+    patched = {
+        feapp: _patched_feapp(originals[feapp]),
+        studio: _patched_dll(
+            originals[studio],
+            STUDIO_SIGNATURES,
+            8,
+            "NutStudioUI.dll offline call",
+        ),
+        container: _patched_dll(
+            originals[container],
+            (CONTAINER_SIGNATURE,),
+            6,
+            "NutContainerPlugin.dll lite-bar call",
+        ),
+    }
+    if all(backup_states):
+        if all(live[path] == patched[path] for _, path in paths):
+            return _result(paths, originals, patched, "ALREADY_PATCHED")
+        if not all(live[path] == originals[path] for _, path in paths):
+            raise NativeNavigationPatchError(
+                "private client files do not match original backups"
+            )
+
+    staged: list[Path] = []
+    staged_backups: list[tuple[Path, Path]] = []
+    staged_targets: list[tuple[Path, Path]] = []
+    published: list[tuple[Path, bytes]] = []
+    created_backups: list[Path] = []
+    try:
+        if not all(backup_states):
+            for _, path in paths:
+                temporary = _stage_write(backups[path], originals[path])
+                staged.append(temporary)
+                staged_backups.append((temporary, backups[path]))
+        for _, path in paths:
+            temporary = _stage_write(path, patched[path])
+            staged.append(temporary)
+            staged_targets.append((temporary, path))
+
+        for temporary, backup in staged_backups:
+            os.replace(temporary, backup)
+            created_backups.append(backup)
+        for temporary, path in staged_targets:
+            os.replace(temporary, path)
+            published.append((path, originals[path]))
+    except Exception as exc:
+        rollback_failures = _restore_published(published)
+        if not rollback_failures:
+            for backup in created_backups:
+                backup.unlink(missing_ok=True)
+        if rollback_failures:
+            raise NativeNavigationPatchError(
+                "native navigation rollback failed"
+            ) from exc
+        raise
+    finally:
+        for temporary in staged:
+            temporary.unlink(missing_ok=True)
+
+    return _result(paths, originals, patched, "PATCHED")

--- a/installer/patch_native_navigation.py
+++ b/installer/patch_native_navigation.py
@@ -97,18 +97,28 @@ def _fingerprint(value: bytes) -> tuple[int, str]:
 def _read_bytes(path: Path, error_code: str) -> bytes:
     try:
         return path.read_bytes()
-    except OSError as exc:
-        raise NativeNavigationPatchError(error_code) from exc
+    except OSError:
+        raise NativeNavigationPatchError(error_code) from None
 
 
 def _matches_registered_state(
     values: dict[str, bytes], state: str
 ) -> bool:
     return all(
-        _fingerprint(values[name])
-        == _SUPPORTED_INPUT_FINGERPRINTS[name][state]
+        _matches_registered_file(name, values[name], state)
         for name in values
     )
+
+
+def _matches_registered_file(name: str, value: bytes, state: str) -> bool:
+    return _fingerprint(value) == _SUPPORTED_INPUT_FINGERPRINTS[name][state]
+
+
+def _registered_file_state(name: str, value: bytes) -> str | None:
+    for state in ("original", "patched"):
+        if _matches_registered_file(name, value, state):
+            return state
+    return None
 
 
 def _absolute(path: str | os.PathLike[str]) -> Path:
@@ -138,8 +148,8 @@ def _validate_managed_paths(work: Path, candidates: tuple[Path, ...]) -> None:
                 current = current / part
                 if _is_reparse_point(current):
                     raise NativeNavigationPatchError("NATIVE_NAV_UNSAFE_PATH")
-    except (OSError, ValueError) as exc:
-        raise NativeNavigationPatchError("NATIVE_NAV_UNSAFE_PATH") from exc
+    except (OSError, ValueError):
+        raise NativeNavigationPatchError("NATIVE_NAV_UNSAFE_PATH") from None
 
 
 def _replace_unique(text: str, old: str, new: str, label: str) -> str:
@@ -275,6 +285,16 @@ def _patched_dll(
     return value
 
 
+def _unlink_paths(paths: list[Path] | tuple[Path, ...]) -> list[BaseException]:
+    failures: list[BaseException] = []
+    for path in paths:
+        try:
+            path.unlink(missing_ok=True)
+        except BaseException as exc:
+            failures.append(exc)
+    return failures
+
+
 def _stage_write(path: Path, value: bytes, work: Path) -> Path:
     _validate_managed_paths(work, (path.parent, path))
     temporary = path.with_name(
@@ -288,9 +308,12 @@ def _stage_write(path: Path, value: bytes, work: Path) -> Path:
         if temporary.read_bytes() != value:
             raise NativeNavigationPatchError("staged file verification failed")
         return temporary
-    except Exception:
-        temporary.unlink(missing_ok=True)
-        raise
+    except BaseException as exc:
+        if _unlink_paths((temporary,)):
+            raise NativeNavigationPatchError("NATIVE_NAV_CLEANUP_FAILED") from None
+        if isinstance(exc, NativeNavigationPatchError):
+            raise
+        raise NativeNavigationPatchError("NATIVE_NAV_STAGE_FAILED") from None
 
 
 def _restore_published(
@@ -308,7 +331,7 @@ def _restore_published(
             failures.append(exc)
         finally:
             if temporary is not None:
-                temporary.unlink(missing_ok=True)
+                failures.extend(_unlink_paths((temporary,)))
     return failures
 
 
@@ -379,18 +402,37 @@ def patch_native_navigation(
     for _, path in paths:
         if not path.is_file():
             raise NativeNavigationPatchError("NATIVE_NAV_INPUT_MISSING")
-    backup_states = [backup.is_file() for backup in backups.values()]
-    if any(backup_states) and not all(backup_states):
-        raise NativeNavigationPatchError("NATIVE_NAV_BACKUPS_INCOMPLETE")
+    backup_states = {path: backups[path].is_file() for _, path in paths}
+    has_any_backup = any(backup_states.values())
+    has_all_backups = all(backup_states.values())
     live = {
         path: _read_bytes(path, "NATIVE_NAV_INPUT_READ_FAILED")
         for _, path in paths
     }
     live_by_name = {name: live[path] for name, path in paths}
-    live_is_original = _matches_registered_state(live_by_name, "original")
-    live_is_patched = _matches_registered_state(live_by_name, "patched")
-    if not all(backup_states) and not live_is_original:
+    live_states = {
+        name: _registered_file_state(name, value)
+        for name, value in live_by_name.items()
+    }
+    live_is_original = all(state == "original" for state in live_states.values())
+    live_is_patched = all(state == "patched" for state in live_states.values())
+    if not has_any_backup and not live_is_original:
         raise NativeNavigationPatchError("NATIVE_NAV_UNSUPPORTED_INPUT")
+    # Recovery invariant: every backup is published before the first target.
+    # A partial backup set is therefore safe only with all-original live files;
+    # complete trusted backups can resume any original/patched live-file mix.
+    if has_any_backup and not has_all_backups:
+        for name, path in paths:
+            if backup_states[path] and not _matches_registered_file(
+                name,
+                _read_bytes(
+                    backups[path], "NATIVE_NAV_BACKUP_READ_FAILED"
+                ),
+                "original",
+            ):
+                raise NativeNavigationPatchError("NATIVE_NAV_BACKUP_TAMPERED")
+        if not live_is_original:
+            raise NativeNavigationPatchError("NATIVE_NAV_RECOVERY_UNSAFE")
     originals = (
         {
             path: _read_bytes(
@@ -398,14 +440,14 @@ def patch_native_navigation(
             )
             for _, path in paths
         }
-        if all(backup_states)
+        if has_all_backups
         else dict(live)
     )
-    if all(backup_states) and not _matches_registered_state(
+    if has_all_backups and not _matches_registered_state(
         {name: originals[path] for name, path in paths}, "original"
     ):
         raise NativeNavigationPatchError("NATIVE_NAV_BACKUP_TAMPERED")
-    if all(backup_states) and not (live_is_original or live_is_patched):
+    if has_all_backups and any(state is None for state in live_states.values()):
         raise NativeNavigationPatchError("NATIVE_NAV_LIVE_TAMPERED")
     patched = {
         feapp: _patched_feapp(originals[feapp]),
@@ -426,7 +468,7 @@ def patch_native_navigation(
         {name: patched[path] for name, path in paths}, "patched"
     ):
         raise NativeNavigationPatchError("NATIVE_NAV_PATCH_MISMATCH")
-    if all(backup_states):
+    if has_all_backups:
         if live_is_patched:
             return _result(paths, originals, patched, "ALREADY_PATCHED")
 
@@ -437,15 +479,17 @@ def patch_native_navigation(
     published: list[tuple[Path, bytes]] = []
     created_backups: list[Path] = []
     try:
-        if not all(backup_states):
+        if not has_all_backups:
             for _, path in paths:
-                temporary = _stage_write(backups[path], originals[path], work)
+                if not backup_states[path]:
+                    temporary = _stage_write(backups[path], originals[path], work)
+                    staged.append(temporary)
+                    staged_backups.append((temporary, backups[path]))
+        for name, path in paths:
+            if live_states[name] != "patched":
+                temporary = _stage_write(path, patched[path], work)
                 staged.append(temporary)
-                staged_backups.append((temporary, backups[path]))
-        for _, path in paths:
-            temporary = _stage_write(path, patched[path], work)
-            staged.append(temporary)
-            staged_targets.append((temporary, path))
+                staged_targets.append((temporary, path))
 
         for temporary, backup in staged_backups:
             _validate_managed_paths(work, (temporary, backup.parent, backup))
@@ -472,18 +516,23 @@ def patch_native_navigation(
             "original",
         ):
             raise NativeNavigationPatchError("NATIVE_NAV_PUBLISHED_TAMPERED")
-    except Exception as exc:
+    except BaseException as exc:
         rollback_failures = _restore_published(published, work)
+        cleanup_failures: list[BaseException] = []
         if not rollback_failures:
-            for backup in created_backups:
-                backup.unlink(missing_ok=True)
+            cleanup_failures.extend(_unlink_paths(created_backups))
+        cleanup_failures.extend(_unlink_paths(staged))
         if rollback_failures:
-            raise NativeNavigationPatchError("NATIVE_NAV_ROLLBACK_FAILED") from exc
+            raise NativeNavigationPatchError("NATIVE_NAV_ROLLBACK_FAILED") from None
+        if cleanup_failures:
+            raise NativeNavigationPatchError("NATIVE_NAV_CLEANUP_FAILED") from None
         if isinstance(exc, NativeNavigationPatchError):
             raise
-        raise NativeNavigationPatchError("NATIVE_NAV_PUBLICATION_FAILED") from exc
-    finally:
-        for temporary in staged:
-            temporary.unlink(missing_ok=True)
+        if not isinstance(exc, Exception):
+            raise
+        raise NativeNavigationPatchError("NATIVE_NAV_PUBLICATION_FAILED") from None
+
+    if _unlink_paths(staged):
+        raise NativeNavigationPatchError("NATIVE_NAV_CLEANUP_FAILED")
 
     return _result(paths, originals, patched, "PATCHED")

--- a/installer/patch_native_navigation.py
+++ b/installer/patch_native_navigation.py
@@ -1,0 +1,158 @@
+"""Restore the native Olivia 0.0.9.627 navigation in a private client copy."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+from pathlib import Path
+import zipfile
+
+
+CLIENT_VERSION = "0.0.9.627"
+MAIN_MEMBER = "assets/main-31595bd3.js"
+MAILBOX_DISABLED = "N3=!1,Ss=!1,wa=({onComplete"
+MAILBOX_ENABLED = "N3=!0,Ss=!1,wa=({onComplete"
+OFFLINE_WIDGETS_DISABLED = (
+    "e.isOfflineMode&&(l.value.mailWidget!==!1&&(l.value.mailWidget=!1),"
+    "l.value.musicWidget!==!1&&(l.value.musicWidget=!1))"
+)
+OFFLINE_WIDGETS_ENABLED = "l.value.mailWidget=!0,l.value.musicWidget=!0"
+
+
+class NativeNavigationPatchError(ValueError):
+    """The private client is not an exact supported 0.0.9.627 input."""
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _replace_unique(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise NativeNavigationPatchError(
+            f"{label} signature must occur exactly once; found {count}"
+        )
+    return text.replace(old, new, 1)
+
+
+def _patched_feapp(source: bytes) -> bytes:
+    try:
+        with zipfile.ZipFile(io.BytesIO(source)) as archive:
+            infos = archive.infolist()
+            if sum(info.filename == MAIN_MEMBER for info in infos) != 1:
+                raise NativeNavigationPatchError(
+                    "supported frontend bundle must occur exactly once"
+                )
+            members = [(info, archive.read(info)) for info in infos]
+            comment = archive.comment
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise NativeNavigationPatchError("feapp.dat is not a valid archive") from exc
+
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        archive.comment = comment
+        for info, payload in members:
+            if info.filename == MAIN_MEMBER:
+                try:
+                    javascript = payload.decode("utf-8")
+                except UnicodeError as exc:
+                    raise NativeNavigationPatchError(
+                        "supported frontend bundle is not UTF-8"
+                    ) from exc
+                javascript = _replace_unique(
+                    javascript,
+                    MAILBOX_DISABLED,
+                    MAILBOX_ENABLED,
+                    "mailbox entry",
+                )
+                javascript = _replace_unique(
+                    javascript,
+                    OFFLINE_WIDGETS_DISABLED,
+                    OFFLINE_WIDGETS_ENABLED,
+                    "offline widgets",
+                )
+                payload = javascript.encode("utf-8")
+            archive.writestr(info, payload)
+
+    patched = output.getvalue()
+    try:
+        with zipfile.ZipFile(io.BytesIO(patched)) as archive:
+            javascript = archive.read(MAIN_MEMBER).decode("utf-8")
+    except (OSError, UnicodeError, zipfile.BadZipFile, KeyError) as exc:
+        raise NativeNavigationPatchError(
+            "patched frontend archive verification failed"
+        ) from exc
+    if (
+        MAILBOX_ENABLED not in javascript
+        or MAILBOX_DISABLED in javascript
+        or OFFLINE_WIDGETS_ENABLED not in javascript
+        or OFFLINE_WIDGETS_DISABLED in javascript
+    ):
+        raise NativeNavigationPatchError(
+            "patched frontend archive verification failed"
+        )
+    return patched
+
+
+def _atomic_write(path: Path, value: bytes) -> None:
+    temporary = path.with_name(path.name + ".native-nav.tmp")
+    try:
+        with temporary.open("wb") as stream:
+            stream.write(value)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def patch_native_navigation(
+    client_version_root: str | os.PathLike[str],
+    *,
+    work_root: str | os.PathLike[str] | None = None,
+) -> dict[str, object]:
+    """Patch native widget visibility without changing the startup route."""
+
+    root = Path(client_version_root).expanduser().resolve()
+    if root.name != CLIENT_VERSION:
+        raise NativeNavigationPatchError("unsupported client version")
+    if work_root is not None and not Path(work_root).expanduser().resolve().is_dir():
+        raise FileNotFoundError(work_root)
+    feapp = root / "resources" / "feapp.dat"
+    if not feapp.is_file():
+        raise FileNotFoundError(feapp)
+
+    source = feapp.read_bytes()
+    patched = _patched_feapp(source)
+    backup = feapp.with_name(feapp.name + ".native-nav.orig")
+    created_backup = False
+    try:
+        if backup.exists():
+            if backup.read_bytes() != source:
+                raise NativeNavigationPatchError(
+                    "frontend backup does not match the original input"
+                )
+        else:
+            _atomic_write(backup, source)
+            created_backup = True
+        _atomic_write(feapp, patched)
+    except Exception:
+        if created_backup:
+            backup.unlink(missing_ok=True)
+        raise
+
+    return {
+        "status": "PATCHED",
+        "client_version": CLIENT_VERSION,
+        "files": {
+            "feapp": {
+                "path": str(feapp),
+                "backup_path": str(backup),
+                "source_sha256": _sha256(source),
+                "backup_sha256": _sha256(backup.read_bytes()),
+                "patched_sha256": _sha256(patched),
+            }
+        },
+    }

--- a/installer/patch_native_navigation.py
+++ b/installer/patch_native_navigation.py
@@ -19,6 +19,19 @@ OFFLINE_WIDGETS_DISABLED = (
     "l.value.musicWidget!==!1&&(l.value.musicWidget=!1))"
 )
 OFFLINE_WIDGETS_ENABLED = "l.value.mailWidget=!0,l.value.musicWidget=!0"
+OFFLINE_REQUEST_BLOCKED = "if(t.isOfflineMode)throw new Ol(e)"
+OFFLINE_REQUEST_ALLOWED = "if(!1)throw new Ol(e)"
+MAIL_FETCH_SKIPPED = "He(()=>{p.value||d.fetchMailList(!0)})"
+MAIL_FETCH_ALLOWED = "He(()=>{d.fetchMailList(!0)})"
+OFFLINE_POLL_SKIPPED = (
+    "s.isOfflineMode||(s.appMode===Se.PRO?Lt().proRestoreFromApi():"
+    "s.appMode===Se.LITE&&(Lt().liteStartPoll(),uo().startPolling()))"
+)
+OFFLINE_POLL_ALLOWED = (
+    "s.appMode===Se.PRO?Lt().proRestoreFromApi():"
+    "s.appMode===Se.LITE&&(s.isOfflineMode?uo().startPolling():"
+    "(Lt().liteStartPoll(),uo().startPolling()))"
+)
 OFFLINE_CALL_PATCH = bytes((0x33, 0xC0, 0x90, 0x90, 0x90, 0x90))
 STUDIO_SIGNATURES = (
     bytes.fromhex("CB E8 D2 37 08 00 EB 1E FF 15 B2 EC 08 00 48 8D 8F A8"),
@@ -83,6 +96,24 @@ def _patched_feapp(source: bytes) -> bytes:
                     OFFLINE_WIDGETS_DISABLED,
                     OFFLINE_WIDGETS_ENABLED,
                     "offline widgets",
+                )
+                javascript = _replace_unique(
+                    javascript,
+                    OFFLINE_REQUEST_BLOCKED,
+                    OFFLINE_REQUEST_ALLOWED,
+                    "offline request",
+                )
+                javascript = _replace_unique(
+                    javascript,
+                    MAIL_FETCH_SKIPPED,
+                    MAIL_FETCH_ALLOWED,
+                    "offline mail fetch",
+                )
+                javascript = _replace_unique(
+                    javascript,
+                    OFFLINE_POLL_SKIPPED,
+                    OFFLINE_POLL_ALLOWED,
+                    "offline mail polling",
                 )
                 payload = javascript.encode("utf-8")
             archive.writestr(info, payload)

--- a/installer/patch_native_navigation.py
+++ b/installer/patch_native_navigation.py
@@ -6,6 +6,7 @@ import hashlib
 import io
 import os
 from pathlib import Path
+import stat
 import uuid
 import zipfile
 
@@ -43,6 +44,43 @@ CONTAINER_SIGNATURE = bytes.fromhex(
     "48 8B DA 48 8B F9 FF 15 61 A4 04 00 84 C0 0F 85"
 )
 
+# The only managed 0.0.9.627 inputs this patcher may mutate.  The frontend
+# "original" is the deterministic endpoint/settings-patched staging input;
+# the DLL originals are the byte-exact client copies.  Sizes reject truncation
+# before archive/signature inspection.  No private client bytes are distributed.
+_SUPPORTED_INPUT_FINGERPRINTS = {
+    "feapp": {
+        "original": (
+            27_769_992,
+            "2abf4bc1208d3f7f39fbd2b4556c980ce5d641c75cee8863c3ca69e6029f7dcf",
+        ),
+        "patched": (
+            27_769_978,
+            "71c30b40dbbbf9d6949828425d5b093ad32aaf2d7b3c53b3f1c5a4a42643cc42",
+        ),
+    },
+    "studio_ui": {
+        "original": (
+            1_297_376,
+            "3756767fc01c2a1c034a56c1ae2920651f13021a1b4cc0c3ed291fc92a9728e1",
+        ),
+        "patched": (
+            1_297_376,
+            "294dcfe023c84bc83bdd531d8431bf76b2b7a1fbc0941a250ae8f4cf2ed8fa99",
+        ),
+    },
+    "container_plugin": {
+        "original": (
+            498_144,
+            "53b61d8e9766c5b1cf2af29ed1a4ac7985052db65c37aa1829c71416050e31d1",
+        ),
+        "patched": (
+            498_144,
+            "d78112ca218f805d437d2b03fe4c772c7cb279848dccce16570cbd466fe66ab4",
+        ),
+    },
+}
+
 
 class NativeNavigationPatchError(ValueError):
     """The private client is not an exact supported 0.0.9.627 input."""
@@ -50,6 +88,58 @@ class NativeNavigationPatchError(ValueError):
 
 def _sha256(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
+
+
+def _fingerprint(value: bytes) -> tuple[int, str]:
+    return len(value), _sha256(value)
+
+
+def _read_bytes(path: Path, error_code: str) -> bytes:
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        raise NativeNavigationPatchError(error_code) from exc
+
+
+def _matches_registered_state(
+    values: dict[str, bytes], state: str
+) -> bool:
+    return all(
+        _fingerprint(values[name])
+        == _SUPPORTED_INPUT_FINGERPRINTS[name][state]
+        for name in values
+    )
+
+
+def _absolute(path: str | os.PathLike[str]) -> Path:
+    return Path(os.path.abspath(os.fspath(Path(path).expanduser())))
+
+
+def _is_reparse_point(path: Path) -> bool:
+    try:
+        value = os.lstat(path)
+    except FileNotFoundError:
+        return False
+    attributes = getattr(value, "st_file_attributes", 0)
+    return stat.S_ISLNK(value.st_mode) or bool(
+        attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    )
+
+
+def _validate_managed_paths(work: Path, candidates: tuple[Path, ...]) -> None:
+    try:
+        for component in (*reversed(work.parents), work):
+            if _is_reparse_point(component):
+                raise NativeNavigationPatchError("NATIVE_NAV_UNSAFE_PATH")
+        for candidate in (work, *candidates):
+            relative = candidate.relative_to(work)
+            current = work
+            for part in relative.parts:
+                current = current / part
+                if _is_reparse_point(current):
+                    raise NativeNavigationPatchError("NATIVE_NAV_UNSAFE_PATH")
+    except (OSError, ValueError) as exc:
+        raise NativeNavigationPatchError("NATIVE_NAV_UNSAFE_PATH") from exc
 
 
 def _replace_unique(text: str, old: str, new: str, label: str) -> str:
@@ -185,7 +275,8 @@ def _patched_dll(
     return value
 
 
-def _stage_write(path: Path, value: bytes) -> Path:
+def _stage_write(path: Path, value: bytes, work: Path) -> Path:
+    _validate_managed_paths(work, (path.parent, path))
     temporary = path.with_name(
         path.name + f".native-nav-{uuid.uuid4().hex}.tmp"
     )
@@ -204,12 +295,14 @@ def _stage_write(path: Path, value: bytes) -> Path:
 
 def _restore_published(
     published: list[tuple[Path, bytes]],
+    work: Path,
 ) -> list[BaseException]:
     failures: list[BaseException] = []
     for path, original in reversed(published):
         temporary: Path | None = None
         try:
-            temporary = _stage_write(path, original)
+            temporary = _stage_write(path, original, work)
+            _validate_managed_paths(work, (temporary, path.parent, path))
             os.replace(temporary, path)
         except BaseException as exc:
             failures.append(exc)
@@ -230,12 +323,11 @@ def _result(
         "client_version": CLIENT_VERSION,
         "files": {
             name: {
-                "path": str(path),
-                "backup_path": str(
-                    path.with_name(path.name + ".native-nav.orig")
-                ),
+                "source_size": len(originals[path]),
                 "source_sha256": _sha256(originals[path]),
+                "backup_size": len(originals[path]),
                 "backup_sha256": _sha256(originals[path]),
+                "patched_size": len(patched[path]),
                 "patched_sha256": _sha256(patched[path]),
             }
             for name, path in paths
@@ -250,11 +342,16 @@ def patch_native_navigation(
 ) -> dict[str, object]:
     """Patch native widget visibility without changing the startup route."""
 
-    root = Path(client_version_root).expanduser().resolve()
-    if root.name != CLIENT_VERSION:
-        raise NativeNavigationPatchError("unsupported client version")
-    if work_root is not None and not Path(work_root).expanduser().resolve().is_dir():
-        raise FileNotFoundError(work_root)
+    if work_root is None:
+        raise NativeNavigationPatchError("NATIVE_NAV_UNMANAGED_ROOT")
+    work = _absolute(work_root)
+    root = _absolute(client_version_root)
+    if (
+        not work.is_dir()
+        or root != work / "app" / CLIENT_VERSION
+        or root.name != CLIENT_VERSION
+    ):
+        raise NativeNavigationPatchError("NATIVE_NAV_UNMANAGED_ROOT")
     feapp = root / "resources" / "feapp.dat"
     studio = root / "plugins" / "Studio" / "NutStudioUI.dll"
     container = (
@@ -265,25 +362,51 @@ def patch_native_navigation(
         ("studio_ui", studio),
         ("container_plugin", container),
     )
-    for _, path in paths:
-        if not path.is_file():
-            raise FileNotFoundError(path)
-
     backups = {
         path: path.with_name(path.name + ".native-nav.orig")
         for _, path in paths
     }
+    managed_paths = (
+        root,
+        root / "resources",
+        root / "plugins",
+        studio.parent,
+        container.parent,
+        *(path for _, path in paths),
+        *backups.values(),
+    )
+    _validate_managed_paths(work, managed_paths)
+    for _, path in paths:
+        if not path.is_file():
+            raise NativeNavigationPatchError("NATIVE_NAV_INPUT_MISSING")
     backup_states = [backup.is_file() for backup in backups.values()]
     if any(backup_states) and not all(backup_states):
-        raise NativeNavigationPatchError(
-            "native navigation backups are incomplete"
-        )
-    live = {path: path.read_bytes() for _, path in paths}
+        raise NativeNavigationPatchError("NATIVE_NAV_BACKUPS_INCOMPLETE")
+    live = {
+        path: _read_bytes(path, "NATIVE_NAV_INPUT_READ_FAILED")
+        for _, path in paths
+    }
+    live_by_name = {name: live[path] for name, path in paths}
+    live_is_original = _matches_registered_state(live_by_name, "original")
+    live_is_patched = _matches_registered_state(live_by_name, "patched")
+    if not all(backup_states) and not live_is_original:
+        raise NativeNavigationPatchError("NATIVE_NAV_UNSUPPORTED_INPUT")
     originals = (
-        {path: backups[path].read_bytes() for _, path in paths}
+        {
+            path: _read_bytes(
+                backups[path], "NATIVE_NAV_BACKUP_READ_FAILED"
+            )
+            for _, path in paths
+        }
         if all(backup_states)
         else dict(live)
     )
+    if all(backup_states) and not _matches_registered_state(
+        {name: originals[path] for name, path in paths}, "original"
+    ):
+        raise NativeNavigationPatchError("NATIVE_NAV_BACKUP_TAMPERED")
+    if all(backup_states) and not (live_is_original or live_is_patched):
+        raise NativeNavigationPatchError("NATIVE_NAV_LIVE_TAMPERED")
     patched = {
         feapp: _patched_feapp(originals[feapp]),
         studio: _patched_dll(
@@ -299,14 +422,15 @@ def patch_native_navigation(
             "NutContainerPlugin.dll lite-bar call",
         ),
     }
+    if not _matches_registered_state(
+        {name: patched[path] for name, path in paths}, "patched"
+    ):
+        raise NativeNavigationPatchError("NATIVE_NAV_PATCH_MISMATCH")
     if all(backup_states):
-        if all(live[path] == patched[path] for _, path in paths):
+        if live_is_patched:
             return _result(paths, originals, patched, "ALREADY_PATCHED")
-        if not all(live[path] == originals[path] for _, path in paths):
-            raise NativeNavigationPatchError(
-                "private client files do not match original backups"
-            )
 
+    _validate_managed_paths(work, managed_paths)
     staged: list[Path] = []
     staged_backups: list[tuple[Path, Path]] = []
     staged_targets: list[tuple[Path, Path]] = []
@@ -315,32 +439,49 @@ def patch_native_navigation(
     try:
         if not all(backup_states):
             for _, path in paths:
-                temporary = _stage_write(backups[path], originals[path])
+                temporary = _stage_write(backups[path], originals[path], work)
                 staged.append(temporary)
                 staged_backups.append((temporary, backups[path]))
         for _, path in paths:
-            temporary = _stage_write(path, patched[path])
+            temporary = _stage_write(path, patched[path], work)
             staged.append(temporary)
             staged_targets.append((temporary, path))
 
         for temporary, backup in staged_backups:
+            _validate_managed_paths(work, (temporary, backup.parent, backup))
             os.replace(temporary, backup)
             created_backups.append(backup)
         for temporary, path in staged_targets:
+            _validate_managed_paths(work, (temporary, path.parent, path))
             os.replace(temporary, path)
             published.append((path, originals[path]))
+        _validate_managed_paths(work, managed_paths)
+        if not _matches_registered_state(
+            {
+                name: _read_bytes(path, "NATIVE_NAV_PUBLISHED_READ_FAILED")
+                for name, path in paths
+            },
+            "patched",
+        ) or not _matches_registered_state(
+            {
+                name: _read_bytes(
+                    backups[path], "NATIVE_NAV_BACKUP_READ_FAILED"
+                )
+                for name, path in paths
+            },
+            "original",
+        ):
+            raise NativeNavigationPatchError("NATIVE_NAV_PUBLISHED_TAMPERED")
     except Exception as exc:
-        rollback_failures = _restore_published(published)
+        rollback_failures = _restore_published(published, work)
         if not rollback_failures:
             for backup in created_backups:
                 backup.unlink(missing_ok=True)
         if rollback_failures:
-            raise NativeNavigationPatchError(
-                "native navigation rollback failed"
-            ) from exc
-        raise NativeNavigationPatchError(
-            "native navigation publication failed"
-        ) from exc
+            raise NativeNavigationPatchError("NATIVE_NAV_ROLLBACK_FAILED") from exc
+        if isinstance(exc, NativeNavigationPatchError):
+            raise
+        raise NativeNavigationPatchError("NATIVE_NAV_PUBLICATION_FAILED") from exc
     finally:
         for temporary in staged:
             temporary.unlink(missing_ok=True)

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -23,6 +23,11 @@ from patch_companion_settings import (
     patch_companion_settings,
 )
 from installer.native_window_layout import LayoutStatus, guard_native_window_layout
+from installer.patch_native_navigation import (
+    COMPATIBILITY_MANIFEST_NAME,
+    NativeNavigationPatchError,
+    patch_native_navigation,
+)
 from video_capability_install import (
     VideoCapabilityError,
     load_video_runtime_environment,
@@ -465,6 +470,16 @@ def _repair_client_frontend(root: Path, port: int) -> str:
     return result["status"]
 
 
+def _repair_native_navigation(root: Path) -> str:
+    """Apply an installed private compatibility manifest to the managed copy."""
+
+    manifest = root / "local_backend" / "installer" / COMPATIBILITY_MANIFEST_NAME
+    if not manifest.is_file():
+        return "NOT_CONFIGURED"
+    result = patch_native_navigation(_client_executable(root).parent, work_root=root)
+    return str(result["status"])
+
+
 def _client_command(client: Path, local: Path) -> list[str]:
     """Match the first-party launcher's only client argument."""
 
@@ -777,6 +792,11 @@ def main(argv: list[str] | None = None) -> int:
             _repair_client_frontend(root, args.port)
         except (CompanionSettingsPatchError, OSError):
             print("CLIENT_FRONTEND_REPAIR_FAILED")
+            return 2
+        try:
+            _repair_native_navigation(root)
+        except (NativeNavigationPatchError, OSError):
+            print("CLIENT_NATIVE_NAVIGATION_REPAIR_FAILED")
             return 2
         owned_ready = (
             server is not None

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -114,6 +114,38 @@ def test_launcher_rejects_missing_frontend_archive(tmp_path: Path) -> None:
     assert error.value.code == "COMPANION_ARCHIVE_NOT_FOUND"
 
 
+def test_launcher_applies_installed_native_navigation_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _installation(tmp_path, client_version="0.0.9.627")
+    manifest = (
+        root
+        / "local_backend"
+        / "installer"
+        / start_local.COMPATIBILITY_MANIFEST_NAME
+    )
+    manifest.write_text("{}", encoding="utf-8")
+    calls: list[tuple[Path, Path]] = []
+
+    monkeypatch.setattr(
+        start_local,
+        "patch_native_navigation",
+        lambda client, *, work_root: calls.append((client, work_root))
+        or {"status": "PATCHED"},
+    )
+
+    assert start_local._repair_native_navigation(root) == "PATCHED"
+    assert calls == [(root / "app" / "0.0.9.627", root)]
+
+
+def test_launcher_skips_native_navigation_without_private_manifest(
+    tmp_path: Path,
+) -> None:
+    root = _installation(tmp_path, client_version="0.0.9.627")
+
+    assert start_local._repair_native_navigation(root) == "NOT_CONFIGURED"
+
+
 def test_launcher_loads_user_managed_llm_config_without_exposing_key(tmp_path: Path) -> None:
     data_root = tmp_path / "data"
     config_root = data_root / "config"
@@ -362,6 +394,7 @@ def test_launcher_starts_combined_server_before_original_client(
     client_commands: list[list[str]] = []
     client_working_directories: list[Path] = []
     frontend_repairs: list[tuple[Path, int]] = []
+    native_repairs: list[Path] = []
 
     class Process:
         @staticmethod
@@ -397,6 +430,11 @@ def test_launcher_starts_combined_server_before_original_client(
         lambda installation, port: frontend_repairs.append((installation, port))
         or "PATCHED",
     )
+    monkeypatch.setattr(
+        start_local,
+        "_repair_native_navigation",
+        lambda installation: native_repairs.append(installation) or "PATCHED",
+    )
 
     result = start_local.main(["--install-root", str(root), "--port", "8899"])
 
@@ -415,6 +453,7 @@ def test_launcher_starts_combined_server_before_original_client(
     ]
     assert not backend_command[-1].endswith("local_server.py")
     assert frontend_repairs == [(root.resolve(), 8899)]
+    assert native_repairs == [root.resolve()]
     launcher_log = (root / "data" / "logs" / "launcher.jsonl").read_text(
         encoding="utf-8"
     )

--- a/tests/installer/test_patch_native_navigation.py
+++ b/tests/installer/test_patch_native_navigation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import json
 from pathlib import Path
 import zipfile
 
@@ -14,49 +15,27 @@ from installer.patch_native_navigation import (
 )
 
 
-MAIN_MEMBER = "assets/main-31595bd3.js"
-HOME_ROUTE = (
-    '!z.isNew||$?(await t.replace({name:ve.Home}),' 
-    'await h(z.uid.toString(),z.modelGatewayToken||"",!1))'
-)
-MAILBOX_DISABLED = "N3=!1,Ss=!1,wa=({onComplete"
-MAILBOX_ENABLED = "N3=!0,Ss=!1,wa=({onComplete"
-OFFLINE_WIDGETS_DISABLED = (
-    "e.isOfflineMode&&(l.value.mailWidget!==!1&&(l.value.mailWidget=!1),"
-    "l.value.musicWidget!==!1&&(l.value.musicWidget=!1))"
-)
-OFFLINE_WIDGETS_ENABLED = "l.value.mailWidget=!0,l.value.musicWidget=!0"
-OFFLINE_REQUEST_BLOCKED = "if(t.isOfflineMode)throw new Ol(e)"
-OFFLINE_REQUEST_ALLOWED = "if(!1)throw new Ol(e)"
-MAIL_FETCH_SKIPPED = "He(()=>{p.value||d.fetchMailList(!0)})"
-MAIL_FETCH_ALLOWED = "He(()=>{d.fetchMailList(!0)})"
-OFFLINE_POLL_SKIPPED = (
-    "s.isOfflineMode||(s.appMode===Se.PRO?Lt().proRestoreFromApi():"
-    "s.appMode===Se.LITE&&(Lt().liteStartPoll(),uo().startPolling()))"
-)
-OFFLINE_POLL_ALLOWED = (
-    "s.appMode===Se.PRO?Lt().proRestoreFromApi():"
-    "s.appMode===Se.LITE&&(s.isOfflineMode?uo().startPolling():"
-    "(Lt().liteStartPoll(),uo().startPolling()))"
-)
-LOCAL_BRIDGE = (
-    'c.appConf.toyWsUrl="ws://127.0.0.1:8899/ws",'
-    'c.appConf.toyApiUrl="http://127.0.0.1:8899"'
-)
-OFFLINE_CALL_PATCH = bytes((0x33, 0xC0, 0x90, 0x90, 0x90, 0x90))
+MAIN_MEMBER = "assets/synthetic-main.js"
+HOME_ROUTE = "fixture-home-route;"
+MAILBOX_DISABLED = "fixture-mailbox-disabled;"
+MAILBOX_ENABLED = "fixture-mailbox-enabled;"
+OFFLINE_WIDGETS_DISABLED = "fixture-widgets-disabled;"
+OFFLINE_WIDGETS_ENABLED = "fixture-widgets-enabled;"
+OFFLINE_REQUEST_BLOCKED = "fixture-request-blocked;"
+OFFLINE_REQUEST_ALLOWED = "fixture-request-allowed;"
+MAIL_FETCH_SKIPPED = "fixture-fetch-skipped;"
+MAIL_FETCH_ALLOWED = "fixture-fetch-allowed;"
+OFFLINE_POLL_SKIPPED = "fixture-poll-skipped;"
+OFFLINE_POLL_ALLOWED = "fixture-poll-allowed;"
+LOCAL_BRIDGE = "fixture-local-bridge;"
+OFFLINE_CALL_PATCH = b"ALLOW!"
 STUDIO_SIGNATURES = (
-    bytes.fromhex("CB E8 D2 37 08 00 EB 1E FF 15 B2 EC 08 00 48 8D 8F A8"),
-    bytes.fromhex("CB E8 72 34 08 00 EB 1E FF 15 52 E9 08 00 48 8D 8F A8"),
-    bytes.fromhex("CB E8 B2 1F 08 00 EB 2B FF 15 92 D4 08 00 84 C0 75 14"),
-    bytes.fromhex("CB E8 FF 1D 08 00 EB 1C FF 15 DF D2 08 00 48 8D 4F 38"),
+    b"studio01BLOCKED-tail",
+    b"studio02BLOCKED-tail",
+    b"studio03BLOCKED-tail",
+    b"studio04BLOCKED-tail",
 )
-CONTAINER_SIGNATURE = bytes.fromhex(
-    "48 8B DA 48 8B F9 FF 15 61 A4 04 00 84 C0 0F 85"
-)
-_PRODUCTION_SUPPORTED_FINGERPRINTS = {
-    name: dict(states)
-    for name, states in native_navigation._SUPPORTED_INPUT_FINGERPRINTS.items()
-}
+CONTAINER_SIGNATURE = b"cont01BLOCKED-tail"
 
 
 def _write_feapp(path: Path, javascript: str) -> bytes:
@@ -99,6 +78,7 @@ def _write_supported_client(root: Path) -> dict[Path, bytes]:
     container.parent.mkdir(parents=True)
     container.write_bytes(b"container-prefix" + CONTAINER_SIGNATURE + b"container-suffix")
     originals[container] = container.read_bytes()
+    _write_compatibility_manifest(root, originals)
     return originals
 
 
@@ -110,52 +90,111 @@ def _managed_client_root(work_root: Path) -> Path:
     return work_root / "app" / "0.0.9.627"
 
 
-@pytest.fixture(autouse=True)
-def _trust_synthetic_supported_build(monkeypatch: pytest.MonkeyPatch) -> None:
-    root = Path("synthetic") / "0.0.9.627"
-    feapp_buffer = io.BytesIO()
-    with zipfile.ZipFile(feapp_buffer, "w", zipfile.ZIP_DEFLATED) as archive:
-        for name, payload in (
-            (
-                MAIN_MEMBER,
-                HOME_ROUTE
-                + MAILBOX_DISABLED
-                + OFFLINE_WIDGETS_DISABLED
-                + OFFLINE_REQUEST_BLOCKED
-                + MAIL_FETCH_SKIPPED
-                + OFFLINE_POLL_SKIPPED
-                + LOCAL_BRIDGE,
-            ),
-            ("assets/index.css", "body{display:block}"),
-        ):
-            info = zipfile.ZipInfo(name, date_time=(2026, 1, 1, 0, 0, 0))
-            info.compress_type = zipfile.ZIP_DEFLATED
+def _patched_feapp_fixture(source: bytes) -> bytes:
+    with zipfile.ZipFile(io.BytesIO(source)) as archive:
+        members = [(info, archive.read(info)) for info in archive.infolist()]
+        comment = archive.comment
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        archive.comment = comment
+        for info, payload in members:
+            if info.filename == MAIN_MEMBER:
+                text = payload.decode("utf-8")
+                for before, after in (
+                    (MAILBOX_DISABLED, MAILBOX_ENABLED),
+                    (OFFLINE_WIDGETS_DISABLED, OFFLINE_WIDGETS_ENABLED),
+                    (OFFLINE_REQUEST_BLOCKED, OFFLINE_REQUEST_ALLOWED),
+                    (MAIL_FETCH_SKIPPED, MAIL_FETCH_ALLOWED),
+                    (OFFLINE_POLL_SKIPPED, OFFLINE_POLL_ALLOWED),
+                ):
+                    text = text.replace(before, after, 1)
+                payload = text.encode("utf-8")
             archive.writestr(info, payload)
-    originals = {
-        "feapp": feapp_buffer.getvalue(),
-        "studio_ui": b"studio-prefix" + b"gap".join(STUDIO_SIGNATURES) + b"studio-suffix",
-        "container_plugin": b"container-prefix" + CONTAINER_SIGNATURE + b"container-suffix",
-    }
+    return output.getvalue()
+
+
+def _patched_binary_fixture(
+    source: bytes, signatures: tuple[bytes, ...], offset: int
+) -> bytes:
+    patched = bytearray(source)
+    for signature in signatures:
+        start = source.index(signature) + offset
+        patched[start : start + len(OFFLINE_CALL_PATCH)] = OFFLINE_CALL_PATCH
+    return bytes(patched)
+
+
+def _file_state(value: bytes) -> dict[str, object]:
+    size, digest = _fingerprint(value)
+    return {"size_bytes": size, "sha256": digest}
+
+
+def _write_compatibility_manifest(
+    client_root: Path, originals: dict[Path, bytes]
+) -> Path:
+    feapp = client_root / "resources" / "feapp.dat"
+    studio = client_root / "plugins" / "Studio" / "NutStudioUI.dll"
+    container = client_root / "plugins" / "Container" / "NutContainerPlugin.dll"
     patched = {
-        "feapp": native_navigation._patched_feapp(originals["feapp"]),
-        "studio_ui": native_navigation._patched_dll(
-            originals["studio_ui"], STUDIO_SIGNATURES, 8, "studio"
-        ),
-        "container_plugin": native_navigation._patched_dll(
-            originals["container_plugin"], (CONTAINER_SIGNATURE,), 6, "container"
-        ),
+        feapp: _patched_feapp_fixture(originals[feapp]),
+        studio: _patched_binary_fixture(originals[studio], STUDIO_SIGNATURES, 8),
+        container: _patched_binary_fixture(originals[container], (CONTAINER_SIGNATURE,), 6),
     }
-    monkeypatch.setattr(
-        native_navigation,
-        "_SUPPORTED_INPUT_FINGERPRINTS",
-        {
-            name: {
-                "original": _fingerprint(originals[name]),
-                "patched": _fingerprint(patched[name]),
-            }
-            for name in originals
-        },
-    )
+    manifest = {
+        "schema_version": "olivia.native-navigation-compatibility.v1",
+        "client_version": "0.0.9.627",
+        "files": [
+            {
+                "id": "feapp",
+                "relative_path": "resources/feapp.dat",
+                "original": _file_state(originals[feapp]),
+                "patched": _file_state(patched[feapp]),
+                "archive_member": MAIN_MEMBER,
+                "text_replacements": [
+                    {"id": name, "before": before, "after": after}
+                    for name, before, after in (
+                        ("mailbox", MAILBOX_DISABLED, MAILBOX_ENABLED),
+                        ("widgets", OFFLINE_WIDGETS_DISABLED, OFFLINE_WIDGETS_ENABLED),
+                        ("request", OFFLINE_REQUEST_BLOCKED, OFFLINE_REQUEST_ALLOWED),
+                        ("fetch", MAIL_FETCH_SKIPPED, MAIL_FETCH_ALLOWED),
+                        ("poll", OFFLINE_POLL_SKIPPED, OFFLINE_POLL_ALLOWED),
+                    )
+                ],
+            },
+            {
+                "id": "studio_ui",
+                "relative_path": "plugins/Studio/NutStudioUI.dll",
+                "original": _file_state(originals[studio]),
+                "patched": _file_state(patched[studio]),
+                "binary_replacements": [
+                    {
+                        "id": f"studio-{index}",
+                        "signature_hex": signature.hex(),
+                        "patch_offset": 8,
+                        "replacement_hex": OFFLINE_CALL_PATCH.hex(),
+                    }
+                    for index, signature in enumerate(STUDIO_SIGNATURES, start=1)
+                ],
+            },
+            {
+                "id": "container_plugin",
+                "relative_path": "plugins/Container/NutContainerPlugin.dll",
+                "original": _file_state(originals[container]),
+                "patched": _file_state(patched[container]),
+                "binary_replacements": [
+                    {
+                        "id": "container-1",
+                        "signature_hex": CONTAINER_SIGNATURE.hex(),
+                        "patch_offset": 6,
+                        "replacement_hex": OFFLINE_CALL_PATCH.hex(),
+                    }
+                ],
+            },
+        ],
+    }
+    path = client_root.parents[1] / "local_backend" / "installer" / native_navigation.COMPATIBILITY_MANIFEST_NAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    return path
 
 
 def _patched_signature(signature: bytes, call_offset: int) -> bytes:
@@ -166,21 +205,49 @@ def _patched_signature(signature: bytes, call_offset: int) -> bytes:
     )
 
 
-@pytest.mark.parametrize(
-    ("name", "state", "expected"),
-    (
-        ("feapp", "original", (27_769_992, "2abf4bc1208d3f7f39fbd2b4556c980ce5d641c75cee8863c3ca69e6029f7dcf")),
-        ("feapp", "patched", (27_769_978, "71c30b40dbbbf9d6949828425d5b093ad32aaf2d7b3c53b3f1c5a4a42643cc42")),
-        ("studio_ui", "original", (1_297_376, "3756767fc01c2a1c034a56c1ae2920651f13021a1b4cc0c3ed291fc92a9728e1")),
-        ("studio_ui", "patched", (1_297_376, "294dcfe023c84bc83bdd531d8431bf76b2b7a1fbc0941a250ae8f4cf2ed8fa99")),
-        ("container_plugin", "original", (498_144, "53b61d8e9766c5b1cf2af29ed1a4ac7985052db65c37aa1829c71416050e31d1")),
-        ("container_plugin", "patched", (498_144, "d78112ca218f805d437d2b03fe4c772c7cb279848dccce16570cbd466fe66ab4")),
-    ),
-)
-def test_supported_build_fingerprints_are_frozen(
-    name: str, state: str, expected: tuple[int, str]
+def test_public_patcher_contains_no_private_build_signatures() -> None:
+    assert not hasattr(native_navigation, "_SUPPORTED_INPUT_FINGERPRINTS")
+    assert not hasattr(native_navigation, "STUDIO_SIGNATURES")
+    assert not hasattr(native_navigation, "CONTAINER_SIGNATURE")
+
+
+def test_patch_native_navigation_requires_install_private_manifest(
+    tmp_path: Path,
 ) -> None:
-    assert _PRODUCTION_SUPPORTED_FINGERPRINTS[name][state] == expected
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    manifest = (
+        tmp_path
+        / "local_backend"
+        / "installer"
+        / native_navigation.COMPATIBILITY_MANIFEST_NAME
+    )
+    manifest.unlink()
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match="NATIVE_NAV_MANIFEST_REQUIRED",
+    ):
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert {path: path.read_bytes() for path in originals} == originals
+
+
+def test_patch_native_navigation_removes_orphan_staging_files_before_recovery(
+    tmp_path: Path,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    orphans = []
+    for path in originals:
+        orphan = path.with_name(path.name + ".native-nav-interrupted.tmp")
+        orphan.write_bytes(b"partial")
+        orphans.append(orphan)
+
+    result = patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert result["status"] == "PATCHED"
+    assert not any(path.exists() for path in orphans)
 
 
 def _assert_transaction_rolled_back(originals: dict[Path, bytes]) -> None:
@@ -852,21 +919,18 @@ def test_patch_native_navigation_rejects_tampered_live_files_with_backups(
 
 def test_patch_native_navigation_rejects_unregistered_patch_output_before_writes(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client_root = _managed_client_root(tmp_path)
     originals = _write_supported_client(client_root)
-    registered = {
-        name: dict(states)
-        for name, states in native_navigation._SUPPORTED_INPUT_FINGERPRINTS.items()
-    }
-    size, _ = registered["feapp"]["patched"]
-    registered["feapp"]["patched"] = (size, "0" * 64)
-    monkeypatch.setattr(
-        native_navigation,
-        "_SUPPORTED_INPUT_FINGERPRINTS",
-        registered,
+    manifest_path = (
+        tmp_path
+        / "local_backend"
+        / "installer"
+        / native_navigation.COMPATIBILITY_MANIFEST_NAME
     )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["files"][0]["patched"]["sha256"] = "0" * 64
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
     with pytest.raises(
         NativeNavigationPatchError,

--- a/tests/installer/test_patch_native_navigation.py
+++ b/tests/installer/test_patch_native_navigation.py
@@ -18,6 +18,16 @@ OFFLINE_WIDGETS_DISABLED = (
     "l.value.musicWidget!==!1&&(l.value.musicWidget=!1))"
 )
 OFFLINE_WIDGETS_ENABLED = "l.value.mailWidget=!0,l.value.musicWidget=!0"
+OFFLINE_CALL_PATCH = bytes((0x33, 0xC0, 0x90, 0x90, 0x90, 0x90))
+STUDIO_SIGNATURES = (
+    bytes.fromhex("CB E8 D2 37 08 00 EB 1E FF 15 B2 EC 08 00 48 8D 8F A8"),
+    bytes.fromhex("CB E8 72 34 08 00 EB 1E FF 15 52 E9 08 00 48 8D 8F A8"),
+    bytes.fromhex("CB E8 B2 1F 08 00 EB 2B FF 15 92 D4 08 00 84 C0 75 14"),
+    bytes.fromhex("CB E8 FF 1D 08 00 EB 1C FF 15 DF D2 08 00 48 8D 4F 38"),
+)
+CONTAINER_SIGNATURE = bytes.fromhex(
+    "48 8B DA 48 8B F9 FF 15 61 A4 04 00 84 C0 0F 85"
+)
 
 
 def _write_feapp(path: Path, javascript: str) -> bytes:
@@ -33,15 +43,39 @@ def _read_main(path: Path) -> str:
         return archive.read(MAIN_MEMBER).decode("utf-8")
 
 
+def _write_supported_client(root: Path) -> dict[Path, bytes]:
+    feapp = root / "resources" / "feapp.dat"
+    originals = {
+        feapp: _write_feapp(
+            feapp,
+            HOME_ROUTE + MAILBOX_DISABLED + OFFLINE_WIDGETS_DISABLED,
+        )
+    }
+    studio = root / "plugins" / "Studio" / "NutStudioUI.dll"
+    studio.parent.mkdir(parents=True)
+    studio.write_bytes(b"studio-prefix" + b"gap".join(STUDIO_SIGNATURES) + b"studio-suffix")
+    originals[studio] = studio.read_bytes()
+    container = root / "plugins" / "Container" / "NutContainerPlugin.dll"
+    container.parent.mkdir(parents=True)
+    container.write_bytes(b"container-prefix" + CONTAINER_SIGNATURE + b"container-suffix")
+    originals[container] = container.read_bytes()
+    return originals
+
+
+def _patched_signature(signature: bytes, call_offset: int) -> bytes:
+    return (
+        signature[:call_offset]
+        + OFFLINE_CALL_PATCH
+        + signature[call_offset + len(OFFLINE_CALL_PATCH) :]
+    )
+
+
 def test_patch_native_navigation_enables_widgets_without_changing_home_route(
     tmp_path: Path,
 ) -> None:
     client_root = tmp_path / "0.0.9.627"
     feapp = client_root / "resources" / "feapp.dat"
-    original = _write_feapp(
-        feapp,
-        HOME_ROUTE + MAILBOX_DISABLED + OFFLINE_WIDGETS_DISABLED,
-    )
+    originals = _write_supported_client(client_root)
 
     result = patch_native_navigation(client_root, work_root=tmp_path)
 
@@ -49,7 +83,7 @@ def test_patch_native_navigation_enables_widgets_without_changing_home_route(
     backup = feapp.with_name("feapp.dat.native-nav.orig")
     assert result["status"] == "PATCHED"
     assert result["client_version"] == "0.0.9.627"
-    assert backup.read_bytes() == original
+    assert backup.read_bytes() == originals[feapp]
     assert MAILBOX_ENABLED in patched
     assert MAILBOX_DISABLED not in patched
     assert OFFLINE_WIDGETS_ENABLED in patched
@@ -57,3 +91,29 @@ def test_patch_native_navigation_enables_widgets_without_changing_home_route(
     assert HOME_ROUTE in patched
     assert 'localStorage.setItem("appMode","lite")' not in patched
     assert "await t.replace({name:ve.Collection})" not in patched
+
+
+def test_patch_native_navigation_patches_both_native_dlls_with_original_backups(
+    tmp_path: Path,
+) -> None:
+    client_root = tmp_path / "0.0.9.627"
+    originals = _write_supported_client(client_root)
+
+    result = patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert set(result["files"]) == {"feapp", "studio_ui", "container_plugin"}
+    for path, original in originals.items():
+        assert path.with_name(path.name + ".native-nav.orig").read_bytes() == original
+
+    studio = client_root / "plugins" / "Studio" / "NutStudioUI.dll"
+    studio_patched = studio.read_bytes()
+    for signature in STUDIO_SIGNATURES:
+        assert signature not in studio_patched
+        assert _patched_signature(signature, 8) in studio_patched
+
+    container = (
+        client_root / "plugins" / "Container" / "NutContainerPlugin.dll"
+    )
+    container_patched = container.read_bytes()
+    assert CONTAINER_SIGNATURE not in container_patched
+    assert _patched_signature(CONTAINER_SIGNATURE, 6) in container_patched

--- a/tests/installer/test_patch_native_navigation.py
+++ b/tests/installer/test_patch_native_navigation.py
@@ -384,6 +384,7 @@ def test_patch_native_navigation_reports_input_read_failure_without_a_path(
 
     assert str(raised.value) == "NATIVE_NAV_INPUT_READ_FAILED"
     assert str(tmp_path) not in str(raised.value)
+    assert raised.value.__cause__ is None
     for path in originals:
         assert not path.with_name(path.name + ".native-nav.orig").exists()
 
@@ -669,6 +670,88 @@ def test_patch_native_navigation_rolls_back_a_tampered_published_target(
     _assert_transaction_rolled_back(originals)
 
 
+def test_patch_native_navigation_aggregates_cleanup_failure_and_recovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    feapp = client_root / "resources" / "feapp.dat"
+    studio = client_root / "plugins" / "Studio" / "NutStudioUI.dll"
+    failed_backup = feapp.with_name(feapp.name + ".native-nav.orig")
+    real_replace = native_navigation.os.replace
+    real_unlink = Path.unlink
+    publish_failed = False
+    cleanup_attempts: list[Path] = []
+
+    def fail_publication_once(source: Path, destination: Path) -> None:
+        nonlocal publish_failed
+        if Path(destination) == studio and not publish_failed:
+            publish_failed = True
+            raise OSError("synthetic publication failure")
+        real_replace(source, destination)
+
+    def fail_one_backup_cleanup(path: Path, *args: object, **kwargs: object) -> None:
+        if path.name.endswith(".native-nav.orig"):
+            cleanup_attempts.append(path)
+        if path == failed_backup:
+            raise OSError(f"synthetic cleanup failure: {path}")
+        real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(native_navigation.os, "replace", fail_publication_once)
+    monkeypatch.setattr(Path, "unlink", fail_one_backup_cleanup)
+
+    with pytest.raises(NativeNavigationPatchError) as raised:
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert str(raised.value) == "NATIVE_NAV_CLEANUP_FAILED"
+    assert str(tmp_path) not in str(raised.value)
+    assert len(cleanup_attempts) == 3
+    assert patch_native_navigation(client_root, work_root=tmp_path)["status"] == "PATCHED"
+
+
+def test_patch_native_navigation_attempts_every_rollback_and_recovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    targets = set(originals)
+    real_replace = native_navigation.os.replace
+    real_read = native_navigation._read_bytes
+    target_replaces = {path: 0 for path in targets}
+    rollback_attempts: list[Path] = []
+    verification_failed = False
+
+    def fail_one_rollback(source: Path, destination: Path) -> None:
+        destination = Path(destination)
+        if destination in targets:
+            target_replaces[destination] += 1
+            if target_replaces[destination] == 2:
+                rollback_attempts.append(destination)
+                if destination.name == "NutContainerPlugin.dll":
+                    raise OSError(f"synthetic rollback failure: {destination}")
+        real_replace(source, destination)
+
+    def fail_first_verification(path: Path, error_code: str) -> bytes:
+        nonlocal verification_failed
+        if error_code == "NATIVE_NAV_PUBLISHED_READ_FAILED" and not verification_failed:
+            verification_failed = True
+            raise NativeNavigationPatchError(error_code)
+        return real_read(path, error_code)
+
+    monkeypatch.setattr(native_navigation.os, "replace", fail_one_rollback)
+    monkeypatch.setattr(native_navigation, "_read_bytes", fail_first_verification)
+
+    with pytest.raises(NativeNavigationPatchError) as raised:
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert str(raised.value) == "NATIVE_NAV_ROLLBACK_FAILED"
+    assert str(tmp_path) not in str(raised.value)
+    assert set(rollback_attempts) == targets
+    assert patch_native_navigation(client_root, work_root=tmp_path)["status"] == "PATCHED"
+
+
 def test_patch_native_navigation_is_idempotent_with_complete_backups(
     tmp_path: Path,
 ) -> None:
@@ -685,6 +768,24 @@ def test_patch_native_navigation_is_idempotent_with_complete_backups(
     for path, original in originals.items():
         assert path.read_bytes() == first_patched[path]
         assert path.with_name(path.name + ".native-nav.orig").read_bytes() == original
+
+
+def test_patch_native_navigation_recovers_partial_live_publication(
+    tmp_path: Path,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    patch_native_navigation(client_root, work_root=tmp_path)
+    studio = client_root / "plugins" / "Studio" / "NutStudioUI.dll"
+    container = client_root / "plugins" / "Container" / "NutContainerPlugin.dll"
+    studio.write_bytes(originals[studio])
+    container.write_bytes(originals[container])
+
+    recovered = patch_native_navigation(client_root, work_root=tmp_path)
+    repeated = patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert recovered["status"] == "PATCHED"
+    assert repeated["status"] == "ALREADY_PATCHED"
 
 
 def test_patch_native_navigation_rejects_tampered_complete_backups(
@@ -707,7 +808,7 @@ def test_patch_native_navigation_rejects_tampered_complete_backups(
     assert {path: path.read_bytes() for path in originals} == live_before
 
 
-def test_patch_native_navigation_rejects_partial_backups_with_stable_error(
+def test_patch_native_navigation_recovers_partial_backup_publication(
     tmp_path: Path,
 ) -> None:
     client_root = _managed_client_root(tmp_path)
@@ -715,11 +816,13 @@ def test_patch_native_navigation_rejects_partial_backups_with_stable_error(
     feapp = client_root / "resources" / "feapp.dat"
     feapp.with_name(feapp.name + ".native-nav.orig").write_bytes(originals[feapp])
 
-    with pytest.raises(NativeNavigationPatchError) as raised:
-        patch_native_navigation(client_root, work_root=tmp_path)
+    recovered = patch_native_navigation(client_root, work_root=tmp_path)
+    repeated = patch_native_navigation(client_root, work_root=tmp_path)
 
-    assert str(raised.value) == "NATIVE_NAV_BACKUPS_INCOMPLETE"
-    assert str(tmp_path) not in str(raised.value)
+    assert recovered["status"] == "PATCHED"
+    assert repeated["status"] == "ALREADY_PATCHED"
+    for path, original in originals.items():
+        assert path.with_name(path.name + ".native-nav.orig").read_bytes() == original
 
 
 def test_patch_native_navigation_rejects_tampered_live_files_with_backups(

--- a/tests/installer/test_patch_native_navigation.py
+++ b/tests/installer/test_patch_native_navigation.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+import zipfile
+
+from installer.patch_native_navigation import patch_native_navigation
+
+
+MAIN_MEMBER = "assets/main-31595bd3.js"
+HOME_ROUTE = (
+    '!z.isNew||$?(await t.replace({name:ve.Home}),' 
+    'await h(z.uid.toString(),z.modelGatewayToken||"",!1))'
+)
+MAILBOX_DISABLED = "N3=!1,Ss=!1,wa=({onComplete"
+MAILBOX_ENABLED = "N3=!0,Ss=!1,wa=({onComplete"
+OFFLINE_WIDGETS_DISABLED = (
+    "e.isOfflineMode&&(l.value.mailWidget!==!1&&(l.value.mailWidget=!1),"
+    "l.value.musicWidget!==!1&&(l.value.musicWidget=!1))"
+)
+OFFLINE_WIDGETS_ENABLED = "l.value.mailWidget=!0,l.value.musicWidget=!0"
+
+
+def _write_feapp(path: Path, javascript: str) -> bytes:
+    path.parent.mkdir(parents=True)
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(MAIN_MEMBER, javascript)
+        archive.writestr("assets/index.css", "body{display:block}")
+    return path.read_bytes()
+
+
+def _read_main(path: Path) -> str:
+    with zipfile.ZipFile(path) as archive:
+        return archive.read(MAIN_MEMBER).decode("utf-8")
+
+
+def test_patch_native_navigation_enables_widgets_without_changing_home_route(
+    tmp_path: Path,
+) -> None:
+    client_root = tmp_path / "0.0.9.627"
+    feapp = client_root / "resources" / "feapp.dat"
+    original = _write_feapp(
+        feapp,
+        HOME_ROUTE + MAILBOX_DISABLED + OFFLINE_WIDGETS_DISABLED,
+    )
+
+    result = patch_native_navigation(client_root, work_root=tmp_path)
+
+    patched = _read_main(feapp)
+    backup = feapp.with_name("feapp.dat.native-nav.orig")
+    assert result["status"] == "PATCHED"
+    assert result["client_version"] == "0.0.9.627"
+    assert backup.read_bytes() == original
+    assert MAILBOX_ENABLED in patched
+    assert MAILBOX_DISABLED not in patched
+    assert OFFLINE_WIDGETS_ENABLED in patched
+    assert OFFLINE_WIDGETS_DISABLED not in patched
+    assert HOME_ROUTE in patched
+    assert 'localStorage.setItem("appMode","lite")' not in patched
+    assert "await t.replace({name:ve.Collection})" not in patched

--- a/tests/installer/test_patch_native_navigation.py
+++ b/tests/installer/test_patch_native_navigation.py
@@ -24,6 +24,23 @@ OFFLINE_WIDGETS_DISABLED = (
     "l.value.musicWidget!==!1&&(l.value.musicWidget=!1))"
 )
 OFFLINE_WIDGETS_ENABLED = "l.value.mailWidget=!0,l.value.musicWidget=!0"
+OFFLINE_REQUEST_BLOCKED = "if(t.isOfflineMode)throw new Ol(e)"
+OFFLINE_REQUEST_ALLOWED = "if(!1)throw new Ol(e)"
+MAIL_FETCH_SKIPPED = "He(()=>{p.value||d.fetchMailList(!0)})"
+MAIL_FETCH_ALLOWED = "He(()=>{d.fetchMailList(!0)})"
+OFFLINE_POLL_SKIPPED = (
+    "s.isOfflineMode||(s.appMode===Se.PRO?Lt().proRestoreFromApi():"
+    "s.appMode===Se.LITE&&(Lt().liteStartPoll(),uo().startPolling()))"
+)
+OFFLINE_POLL_ALLOWED = (
+    "s.appMode===Se.PRO?Lt().proRestoreFromApi():"
+    "s.appMode===Se.LITE&&(s.isOfflineMode?uo().startPolling():"
+    "(Lt().liteStartPoll(),uo().startPolling()))"
+)
+LOCAL_BRIDGE = (
+    'c.appConf.toyWsUrl="ws://127.0.0.1:8899/ws",'
+    'c.appConf.toyApiUrl="http://127.0.0.1:8899"'
+)
 OFFLINE_CALL_PATCH = bytes((0x33, 0xC0, 0x90, 0x90, 0x90, 0x90))
 STUDIO_SIGNATURES = (
     bytes.fromhex("CB E8 D2 37 08 00 EB 1E FF 15 B2 EC 08 00 48 8D 8F A8"),
@@ -54,7 +71,13 @@ def _write_supported_client(root: Path) -> dict[Path, bytes]:
     originals = {
         feapp: _write_feapp(
             feapp,
-            HOME_ROUTE + MAILBOX_DISABLED + OFFLINE_WIDGETS_DISABLED,
+            HOME_ROUTE
+            + MAILBOX_DISABLED
+            + OFFLINE_WIDGETS_DISABLED
+            + OFFLINE_REQUEST_BLOCKED
+            + MAIL_FETCH_SKIPPED
+            + OFFLINE_POLL_SKIPPED
+            + LOCAL_BRIDGE,
         )
     }
     studio = root / "plugins" / "Studio" / "NutStudioUI.dll"
@@ -103,6 +126,7 @@ def test_patch_native_navigation_enables_widgets_without_changing_home_route(
     assert OFFLINE_WIDGETS_ENABLED in patched
     assert OFFLINE_WIDGETS_DISABLED not in patched
     assert HOME_ROUTE in patched
+    assert LOCAL_BRIDGE in patched
     assert 'localStorage.setItem("appMode","lite")' not in patched
     assert "await t.replace({name:ve.Collection})" not in patched
 
@@ -131,6 +155,46 @@ def test_patch_native_navigation_patches_both_native_dlls_with_original_backups(
     container_patched = container.read_bytes()
     assert CONTAINER_SIGNATURE not in container_patched
     assert _patched_signature(CONTAINER_SIGNATURE, 6) in container_patched
+
+
+def test_patch_native_navigation_allows_mail_requests_through_local_bridge(
+    tmp_path: Path,
+) -> None:
+    client_root = tmp_path / "0.0.9.627"
+    _write_supported_client(client_root)
+
+    patch_native_navigation(client_root, work_root=tmp_path)
+
+    patched = _read_main(client_root / "resources" / "feapp.dat")
+    assert OFFLINE_REQUEST_ALLOWED in patched
+    assert OFFLINE_REQUEST_BLOCKED not in patched
+    assert LOCAL_BRIDGE in patched
+
+
+def test_patch_native_navigation_fetches_mail_while_client_is_offline(
+    tmp_path: Path,
+) -> None:
+    client_root = tmp_path / "0.0.9.627"
+    _write_supported_client(client_root)
+
+    patch_native_navigation(client_root, work_root=tmp_path)
+
+    patched = _read_main(client_root / "resources" / "feapp.dat")
+    assert MAIL_FETCH_ALLOWED in patched
+    assert MAIL_FETCH_SKIPPED not in patched
+
+
+def test_patch_native_navigation_starts_lite_mail_polling_while_offline(
+    tmp_path: Path,
+) -> None:
+    client_root = tmp_path / "0.0.9.627"
+    _write_supported_client(client_root)
+
+    patch_native_navigation(client_root, work_root=tmp_path)
+
+    patched = _read_main(client_root / "resources" / "feapp.dat")
+    assert OFFLINE_POLL_ALLOWED in patched
+    assert OFFLINE_POLL_SKIPPED not in patched
 
 
 def test_patch_native_navigation_rejects_a_missing_signature_before_writes(

--- a/tests/installer/test_patch_native_navigation.py
+++ b/tests/installer/test_patch_native_navigation.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 import zipfile
 
-from installer.patch_native_navigation import patch_native_navigation
+import pytest
+
+import installer.patch_native_navigation as native_navigation
+from installer.patch_native_navigation import (
+    NativeNavigationPatchError,
+    patch_native_navigation,
+)
 
 
 MAIN_MEMBER = "assets/main-31595bd3.js"
@@ -70,6 +76,14 @@ def _patched_signature(signature: bytes, call_offset: int) -> bytes:
     )
 
 
+def _assert_transaction_rolled_back(originals: dict[Path, bytes]) -> None:
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+        assert not path.with_name(path.name + ".native-nav.orig").exists()
+    roots = {path.parents[2] for path in originals}
+    assert not [temporary for root in roots for temporary in root.rglob("*.tmp")]
+
+
 def test_patch_native_navigation_enables_widgets_without_changing_home_route(
     tmp_path: Path,
 ) -> None:
@@ -117,3 +131,131 @@ def test_patch_native_navigation_patches_both_native_dlls_with_original_backups(
     container_patched = container.read_bytes()
     assert CONTAINER_SIGNATURE not in container_patched
     assert _patched_signature(CONTAINER_SIGNATURE, 6) in container_patched
+
+
+def test_patch_native_navigation_rejects_a_missing_signature_before_writes(
+    tmp_path: Path,
+) -> None:
+    client_root = tmp_path / "0.0.9.627"
+    originals = _write_supported_client(client_root)
+    studio = client_root / "plugins" / "Studio" / "NutStudioUI.dll"
+    studio.write_bytes(
+        studio.read_bytes().replace(
+            STUDIO_SIGNATURES[2],
+            b"\x7f" * len(STUDIO_SIGNATURES[2]),
+            1,
+        )
+    )
+    originals[studio] = studio.read_bytes()
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match=r"NutStudioUI\.dll offline call #3 signature.*found 0",
+    ):
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+        assert not path.with_name(path.name + ".native-nav.orig").exists()
+    assert not list(client_root.rglob("*.tmp"))
+
+
+def test_patch_native_navigation_rejects_a_repeated_signature_before_writes(
+    tmp_path: Path,
+) -> None:
+    client_root = tmp_path / "0.0.9.627"
+    originals = _write_supported_client(client_root)
+    container = (
+        client_root / "plugins" / "Container" / "NutContainerPlugin.dll"
+    )
+    container.write_bytes(container.read_bytes() + b"duplicate" + CONTAINER_SIGNATURE)
+    originals[container] = container.read_bytes()
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match=r"NutContainerPlugin\.dll lite-bar call #1 signature.*found 2",
+    ):
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+        assert not path.with_name(path.name + ".native-nav.orig").exists()
+    assert not list(client_root.rglob("*.tmp"))
+
+
+def test_patch_native_navigation_rolls_back_when_second_target_publish_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client_root = tmp_path / "0.0.9.627"
+    originals = _write_supported_client(client_root)
+    studio = client_root / "plugins" / "Studio" / "NutStudioUI.dll"
+    real_replace = native_navigation.os.replace
+    failed = False
+
+    def fail_once_on_studio(source: Path, destination: Path) -> None:
+        nonlocal failed
+        if Path(destination) == studio and not failed:
+            failed = True
+            raise OSError("synthetic second-target publication failure")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(native_navigation.os, "replace", fail_once_on_studio)
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match="native navigation publication failed",
+    ):
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert failed is True
+    _assert_transaction_rolled_back(originals)
+
+
+def test_patch_native_navigation_rolls_back_when_third_target_publish_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client_root = tmp_path / "0.0.9.627"
+    originals = _write_supported_client(client_root)
+    container = (
+        client_root / "plugins" / "Container" / "NutContainerPlugin.dll"
+    )
+    real_replace = native_navigation.os.replace
+    failed = False
+
+    def fail_once_on_container(source: Path, destination: Path) -> None:
+        nonlocal failed
+        if Path(destination) == container and not failed:
+            failed = True
+            raise OSError("synthetic third-target publication failure")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(native_navigation.os, "replace", fail_once_on_container)
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match="native navigation publication failed",
+    ):
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert failed is True
+    _assert_transaction_rolled_back(originals)
+
+
+def test_patch_native_navigation_is_idempotent_with_complete_backups(
+    tmp_path: Path,
+) -> None:
+    client_root = tmp_path / "0.0.9.627"
+    originals = _write_supported_client(client_root)
+
+    first = patch_native_navigation(client_root, work_root=tmp_path)
+    first_patched = {path: path.read_bytes() for path in originals}
+    repeated = patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert first["status"] == "PATCHED"
+    assert repeated["status"] == "ALREADY_PATCHED"
+    assert repeated["files"] == first["files"]
+    for path, original in originals.items():
+        assert path.read_bytes() == first_patched[path]
+        assert path.with_name(path.name + ".native-nav.orig").read_bytes() == original

--- a/tests/installer/test_patch_native_navigation.py
+++ b/tests/installer/test_patch_native_navigation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import io
 from pathlib import Path
 import zipfile
 
@@ -51,13 +53,22 @@ STUDIO_SIGNATURES = (
 CONTAINER_SIGNATURE = bytes.fromhex(
     "48 8B DA 48 8B F9 FF 15 61 A4 04 00 84 C0 0F 85"
 )
+_PRODUCTION_SUPPORTED_FINGERPRINTS = {
+    name: dict(states)
+    for name, states in native_navigation._SUPPORTED_INPUT_FINGERPRINTS.items()
+}
 
 
 def _write_feapp(path: Path, javascript: str) -> bytes:
     path.parent.mkdir(parents=True)
     with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
-        archive.writestr(MAIN_MEMBER, javascript)
-        archive.writestr("assets/index.css", "body{display:block}")
+        for name, payload in (
+            (MAIN_MEMBER, javascript),
+            ("assets/index.css", "body{display:block}"),
+        ):
+            info = zipfile.ZipInfo(name, date_time=(2026, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_DEFLATED
+            archive.writestr(info, payload)
     return path.read_bytes()
 
 
@@ -91,12 +102,85 @@ def _write_supported_client(root: Path) -> dict[Path, bytes]:
     return originals
 
 
+def _fingerprint(value: bytes) -> tuple[int, str]:
+    return len(value), hashlib.sha256(value).hexdigest()
+
+
+def _managed_client_root(work_root: Path) -> Path:
+    return work_root / "app" / "0.0.9.627"
+
+
+@pytest.fixture(autouse=True)
+def _trust_synthetic_supported_build(monkeypatch: pytest.MonkeyPatch) -> None:
+    root = Path("synthetic") / "0.0.9.627"
+    feapp_buffer = io.BytesIO()
+    with zipfile.ZipFile(feapp_buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, payload in (
+            (
+                MAIN_MEMBER,
+                HOME_ROUTE
+                + MAILBOX_DISABLED
+                + OFFLINE_WIDGETS_DISABLED
+                + OFFLINE_REQUEST_BLOCKED
+                + MAIL_FETCH_SKIPPED
+                + OFFLINE_POLL_SKIPPED
+                + LOCAL_BRIDGE,
+            ),
+            ("assets/index.css", "body{display:block}"),
+        ):
+            info = zipfile.ZipInfo(name, date_time=(2026, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_DEFLATED
+            archive.writestr(info, payload)
+    originals = {
+        "feapp": feapp_buffer.getvalue(),
+        "studio_ui": b"studio-prefix" + b"gap".join(STUDIO_SIGNATURES) + b"studio-suffix",
+        "container_plugin": b"container-prefix" + CONTAINER_SIGNATURE + b"container-suffix",
+    }
+    patched = {
+        "feapp": native_navigation._patched_feapp(originals["feapp"]),
+        "studio_ui": native_navigation._patched_dll(
+            originals["studio_ui"], STUDIO_SIGNATURES, 8, "studio"
+        ),
+        "container_plugin": native_navigation._patched_dll(
+            originals["container_plugin"], (CONTAINER_SIGNATURE,), 6, "container"
+        ),
+    }
+    monkeypatch.setattr(
+        native_navigation,
+        "_SUPPORTED_INPUT_FINGERPRINTS",
+        {
+            name: {
+                "original": _fingerprint(originals[name]),
+                "patched": _fingerprint(patched[name]),
+            }
+            for name in originals
+        },
+    )
+
+
 def _patched_signature(signature: bytes, call_offset: int) -> bytes:
     return (
         signature[:call_offset]
         + OFFLINE_CALL_PATCH
         + signature[call_offset + len(OFFLINE_CALL_PATCH) :]
     )
+
+
+@pytest.mark.parametrize(
+    ("name", "state", "expected"),
+    (
+        ("feapp", "original", (27_769_992, "2abf4bc1208d3f7f39fbd2b4556c980ce5d641c75cee8863c3ca69e6029f7dcf")),
+        ("feapp", "patched", (27_769_978, "71c30b40dbbbf9d6949828425d5b093ad32aaf2d7b3c53b3f1c5a4a42643cc42")),
+        ("studio_ui", "original", (1_297_376, "3756767fc01c2a1c034a56c1ae2920651f13021a1b4cc0c3ed291fc92a9728e1")),
+        ("studio_ui", "patched", (1_297_376, "294dcfe023c84bc83bdd531d8431bf76b2b7a1fbc0941a250ae8f4cf2ed8fa99")),
+        ("container_plugin", "original", (498_144, "53b61d8e9766c5b1cf2af29ed1a4ac7985052db65c37aa1829c71416050e31d1")),
+        ("container_plugin", "patched", (498_144, "d78112ca218f805d437d2b03fe4c772c7cb279848dccce16570cbd466fe66ab4")),
+    ),
+)
+def test_supported_build_fingerprints_are_frozen(
+    name: str, state: str, expected: tuple[int, str]
+) -> None:
+    assert _PRODUCTION_SUPPORTED_FINGERPRINTS[name][state] == expected
 
 
 def _assert_transaction_rolled_back(originals: dict[Path, bytes]) -> None:
@@ -110,7 +194,7 @@ def _assert_transaction_rolled_back(originals: dict[Path, bytes]) -> None:
 def test_patch_native_navigation_enables_widgets_without_changing_home_route(
     tmp_path: Path,
 ) -> None:
-    client_root = tmp_path / "0.0.9.627"
+    client_root = _managed_client_root(tmp_path)
     feapp = client_root / "resources" / "feapp.dat"
     originals = _write_supported_client(client_root)
 
@@ -129,12 +213,28 @@ def test_patch_native_navigation_enables_widgets_without_changing_home_route(
     assert LOCAL_BRIDGE in patched
     assert 'localStorage.setItem("appMode","lite")' not in patched
     assert "await t.replace({name:ve.Collection})" not in patched
+    with zipfile.ZipFile(io.BytesIO(originals[feapp])) as before, zipfile.ZipFile(
+        feapp
+    ) as after:
+        assert before.namelist() == after.namelist()
+        assert before.comment == after.comment
+        assert after.read("assets/index.css") == before.read("assets/index.css")
+        expected_main = before.read(MAIN_MEMBER).decode("utf-8")
+    for old, new in (
+        (MAILBOX_DISABLED, MAILBOX_ENABLED),
+        (OFFLINE_WIDGETS_DISABLED, OFFLINE_WIDGETS_ENABLED),
+        (OFFLINE_REQUEST_BLOCKED, OFFLINE_REQUEST_ALLOWED),
+        (MAIL_FETCH_SKIPPED, MAIL_FETCH_ALLOWED),
+        (OFFLINE_POLL_SKIPPED, OFFLINE_POLL_ALLOWED),
+    ):
+        expected_main = expected_main.replace(old, new, 1)
+    assert patched == expected_main
 
 
 def test_patch_native_navigation_patches_both_native_dlls_with_original_backups(
     tmp_path: Path,
 ) -> None:
-    client_root = tmp_path / "0.0.9.627"
+    client_root = _managed_client_root(tmp_path)
     originals = _write_supported_client(client_root)
 
     result = patch_native_navigation(client_root, work_root=tmp_path)
@@ -145,6 +245,19 @@ def test_patch_native_navigation_patches_both_native_dlls_with_original_backups(
 
     studio = client_root / "plugins" / "Studio" / "NutStudioUI.dll"
     studio_patched = studio.read_bytes()
+    studio_changed = {
+        index
+        for index, (before, after) in enumerate(
+            zip(originals[studio], studio_patched, strict=True)
+        )
+        if before != after
+    }
+    assert studio_changed == {
+        originals[studio].find(signature) + 8 + byte_offset
+        for signature in STUDIO_SIGNATURES
+        for byte_offset in range(len(OFFLINE_CALL_PATCH))
+        if signature[8 + byte_offset] != OFFLINE_CALL_PATCH[byte_offset]
+    }
     for signature in STUDIO_SIGNATURES:
         assert signature not in studio_patched
         assert _patched_signature(signature, 8) in studio_patched
@@ -153,14 +266,48 @@ def test_patch_native_navigation_patches_both_native_dlls_with_original_backups(
         client_root / "plugins" / "Container" / "NutContainerPlugin.dll"
     )
     container_patched = container.read_bytes()
+    assert {
+        index
+        for index, (before, after) in enumerate(
+            zip(originals[container], container_patched, strict=True)
+        )
+        if before != after
+    } == {
+        originals[container].find(CONTAINER_SIGNATURE) + 6 + byte_offset
+        for byte_offset in range(len(OFFLINE_CALL_PATCH))
+        if CONTAINER_SIGNATURE[6 + byte_offset] != OFFLINE_CALL_PATCH[byte_offset]
+    }
     assert CONTAINER_SIGNATURE not in container_patched
     assert _patched_signature(CONTAINER_SIGNATURE, 6) in container_patched
+
+
+def test_patch_result_contains_only_logical_ids_hashes_and_sizes(
+    tmp_path: Path,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    _write_supported_client(client_root)
+
+    result = patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert str(tmp_path) not in repr(result)
+    for name, evidence in result["files"].items():
+        assert name in {"feapp", "studio_ui", "container_plugin"}
+        assert set(evidence) == {
+            "source_size",
+            "source_sha256",
+            "backup_size",
+            "backup_sha256",
+            "patched_size",
+            "patched_sha256",
+        }
+        assert evidence["source_size"] == evidence["backup_size"]
+        assert evidence["source_sha256"] == evidence["backup_sha256"]
 
 
 def test_patch_native_navigation_allows_mail_requests_through_local_bridge(
     tmp_path: Path,
 ) -> None:
-    client_root = tmp_path / "0.0.9.627"
+    client_root = _managed_client_root(tmp_path)
     _write_supported_client(client_root)
 
     patch_native_navigation(client_root, work_root=tmp_path)
@@ -174,7 +321,7 @@ def test_patch_native_navigation_allows_mail_requests_through_local_bridge(
 def test_patch_native_navigation_fetches_mail_while_client_is_offline(
     tmp_path: Path,
 ) -> None:
-    client_root = tmp_path / "0.0.9.627"
+    client_root = _managed_client_root(tmp_path)
     _write_supported_client(client_root)
 
     patch_native_navigation(client_root, work_root=tmp_path)
@@ -187,7 +334,7 @@ def test_patch_native_navigation_fetches_mail_while_client_is_offline(
 def test_patch_native_navigation_starts_lite_mail_polling_while_offline(
     tmp_path: Path,
 ) -> None:
-    client_root = tmp_path / "0.0.9.627"
+    client_root = _managed_client_root(tmp_path)
     _write_supported_client(client_root)
 
     patch_native_navigation(client_root, work_root=tmp_path)
@@ -197,10 +344,190 @@ def test_patch_native_navigation_starts_lite_mail_polling_while_offline(
     assert OFFLINE_POLL_SKIPPED not in patched
 
 
+def test_patch_native_navigation_rejects_unknown_build_with_all_anchors(
+    tmp_path: Path,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    studio = client_root / "plugins" / "Studio" / "NutStudioUI.dll"
+    studio.write_bytes(b"unknown-build" + studio.read_bytes())
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match="NATIVE_NAV_UNSUPPORTED_INPUT",
+    ):
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert studio.read_bytes().startswith(b"unknown-build")
+    for path in originals:
+        assert not path.with_name(path.name + ".native-nav.orig").exists()
+
+
+def test_patch_native_navigation_reports_input_read_failure_without_a_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    studio = client_root / "plugins" / "Studio" / "NutStudioUI.dll"
+    original_read_bytes = Path.read_bytes
+
+    def deny_studio(path: Path) -> bytes:
+        if path == studio:
+            raise PermissionError(f"denied: {path}")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", deny_studio)
+
+    with pytest.raises(NativeNavigationPatchError) as raised:
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert str(raised.value) == "NATIVE_NAV_INPUT_READ_FAILED"
+    assert str(tmp_path) not in str(raised.value)
+    for path in originals:
+        assert not path.with_name(path.name + ".native-nav.orig").exists()
+
+
+def test_patch_native_navigation_rejects_unmanaged_version_root(
+    tmp_path: Path,
+) -> None:
+    official_root = tmp_path / "0.0.9.627"
+    originals = _write_supported_client(official_root)
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match="NATIVE_NAV_UNMANAGED_ROOT",
+    ):
+        patch_native_navigation(official_root, work_root=tmp_path)
+
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+        assert not path.with_name(path.name + ".native-nav.orig").exists()
+
+
+def test_patch_native_navigation_rejects_reparse_component_before_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    monkeypatch.setattr(
+        native_navigation,
+        "_is_reparse_point",
+        lambda path: Path(path).name == "Studio",
+    )
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match="NATIVE_NAV_UNSAFE_PATH",
+    ):
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+        assert not path.with_name(path.name + ".native-nav.orig").exists()
+
+
+def test_patch_native_navigation_rejects_reparse_ancestor_of_work_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    work_root = tmp_path / "managed"
+    client_root = _managed_client_root(work_root)
+    originals = _write_supported_client(client_root)
+    unsafe_ancestor = tmp_path
+    monkeypatch.setattr(
+        native_navigation,
+        "_is_reparse_point",
+        lambda path: Path(path) == unsafe_ancestor,
+    )
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match="NATIVE_NAV_UNSAFE_PATH",
+    ):
+        patch_native_navigation(client_root, work_root=work_root)
+
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+        assert not path.with_name(path.name + ".native-nav.orig").exists()
+
+
+def test_patch_native_navigation_rechecks_reparse_points_immediately_before_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    studio_parent = client_root / "plugins" / "Studio"
+    original_read_bytes = Path.read_bytes
+    target_reads = 0
+    unsafe = False
+
+    def mark_unsafe_after_inputs_are_read(path: Path) -> bytes:
+        nonlocal target_reads, unsafe
+        value = original_read_bytes(path)
+        if path in originals:
+            target_reads += 1
+            if target_reads == len(originals):
+                unsafe = True
+        return value
+
+    monkeypatch.setattr(Path, "read_bytes", mark_unsafe_after_inputs_are_read)
+    monkeypatch.setattr(
+        native_navigation,
+        "_is_reparse_point",
+        lambda path: unsafe and Path(path) == studio_parent,
+    )
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match="NATIVE_NAV_UNSAFE_PATH",
+    ):
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    for path, original in originals.items():
+        assert original_read_bytes(path) == original
+        assert not path.with_name(path.name + ".native-nav.orig").exists()
+
+
+def test_patch_native_navigation_rechecks_each_managed_write_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    studio_parent = client_root / "plugins" / "Studio"
+    original_open = Path.open
+    unsafe = False
+
+    def flip_after_first_staging_open(path: Path, *args: object, **kwargs: object):
+        nonlocal unsafe
+        stream = original_open(path, *args, **kwargs)
+        if ".native-nav-" in path.name and path.suffix == ".tmp":
+            unsafe = True
+        return stream
+
+    monkeypatch.setattr(Path, "open", flip_after_first_staging_open)
+    monkeypatch.setattr(
+        native_navigation,
+        "_is_reparse_point",
+        lambda path: unsafe and Path(path) == studio_parent,
+    )
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match="NATIVE_NAV_UNSAFE_PATH",
+    ):
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    _assert_transaction_rolled_back(originals)
+
+
 def test_patch_native_navigation_rejects_a_missing_signature_before_writes(
     tmp_path: Path,
 ) -> None:
-    client_root = tmp_path / "0.0.9.627"
+    client_root = _managed_client_root(tmp_path)
     originals = _write_supported_client(client_root)
     studio = client_root / "plugins" / "Studio" / "NutStudioUI.dll"
     studio.write_bytes(
@@ -214,7 +541,7 @@ def test_patch_native_navigation_rejects_a_missing_signature_before_writes(
 
     with pytest.raises(
         NativeNavigationPatchError,
-        match=r"NutStudioUI\.dll offline call #3 signature.*found 0",
+        match="NATIVE_NAV_UNSUPPORTED_INPUT",
     ):
         patch_native_navigation(client_root, work_root=tmp_path)
 
@@ -227,7 +554,7 @@ def test_patch_native_navigation_rejects_a_missing_signature_before_writes(
 def test_patch_native_navigation_rejects_a_repeated_signature_before_writes(
     tmp_path: Path,
 ) -> None:
-    client_root = tmp_path / "0.0.9.627"
+    client_root = _managed_client_root(tmp_path)
     originals = _write_supported_client(client_root)
     container = (
         client_root / "plugins" / "Container" / "NutContainerPlugin.dll"
@@ -237,7 +564,7 @@ def test_patch_native_navigation_rejects_a_repeated_signature_before_writes(
 
     with pytest.raises(
         NativeNavigationPatchError,
-        match=r"NutContainerPlugin\.dll lite-bar call #1 signature.*found 2",
+        match="NATIVE_NAV_UNSUPPORTED_INPUT",
     ):
         patch_native_navigation(client_root, work_root=tmp_path)
 
@@ -251,7 +578,7 @@ def test_patch_native_navigation_rolls_back_when_second_target_publish_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    client_root = tmp_path / "0.0.9.627"
+    client_root = _managed_client_root(tmp_path)
     originals = _write_supported_client(client_root)
     studio = client_root / "plugins" / "Studio" / "NutStudioUI.dll"
     real_replace = native_navigation.os.replace
@@ -268,7 +595,7 @@ def test_patch_native_navigation_rolls_back_when_second_target_publish_fails(
 
     with pytest.raises(
         NativeNavigationPatchError,
-        match="native navigation publication failed",
+        match="NATIVE_NAV_PUBLICATION_FAILED",
     ):
         patch_native_navigation(client_root, work_root=tmp_path)
 
@@ -280,7 +607,7 @@ def test_patch_native_navigation_rolls_back_when_third_target_publish_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    client_root = tmp_path / "0.0.9.627"
+    client_root = _managed_client_root(tmp_path)
     originals = _write_supported_client(client_root)
     container = (
         client_root / "plugins" / "Container" / "NutContainerPlugin.dll"
@@ -299,7 +626,7 @@ def test_patch_native_navigation_rolls_back_when_third_target_publish_fails(
 
     with pytest.raises(
         NativeNavigationPatchError,
-        match="native navigation publication failed",
+        match="NATIVE_NAV_PUBLICATION_FAILED",
     ):
         patch_native_navigation(client_root, work_root=tmp_path)
 
@@ -307,10 +634,45 @@ def test_patch_native_navigation_rolls_back_when_third_target_publish_fails(
     _assert_transaction_rolled_back(originals)
 
 
+def test_patch_native_navigation_rolls_back_a_tampered_published_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    container = (
+        client_root / "plugins" / "Container" / "NutContainerPlugin.dll"
+    )
+    real_replace = native_navigation.os.replace
+    corrupted = False
+
+    def corrupt_first_container_publication(source: Path, destination: Path) -> None:
+        nonlocal corrupted
+        real_replace(source, destination)
+        if Path(destination) == container and not corrupted:
+            corrupted = True
+            container.write_bytes(container.read_bytes() + b"tampered")
+
+    monkeypatch.setattr(
+        native_navigation.os,
+        "replace",
+        corrupt_first_container_publication,
+    )
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match="NATIVE_NAV_PUBLISHED_TAMPERED",
+    ):
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert corrupted is True
+    _assert_transaction_rolled_back(originals)
+
+
 def test_patch_native_navigation_is_idempotent_with_complete_backups(
     tmp_path: Path,
 ) -> None:
-    client_root = tmp_path / "0.0.9.627"
+    client_root = _managed_client_root(tmp_path)
     originals = _write_supported_client(client_root)
 
     first = patch_native_navigation(client_root, work_root=tmp_path)
@@ -323,3 +685,90 @@ def test_patch_native_navigation_is_idempotent_with_complete_backups(
     for path, original in originals.items():
         assert path.read_bytes() == first_patched[path]
         assert path.with_name(path.name + ".native-nav.orig").read_bytes() == original
+
+
+def test_patch_native_navigation_rejects_tampered_complete_backups(
+    tmp_path: Path,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    patch_native_navigation(client_root, work_root=tmp_path)
+    studio = client_root / "plugins" / "Studio" / "NutStudioUI.dll"
+    backup = studio.with_name(studio.name + ".native-nav.orig")
+    backup.write_bytes(backup.read_bytes() + b"tampered")
+    live_before = {path: path.read_bytes() for path in originals}
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match="NATIVE_NAV_BACKUP_TAMPERED",
+    ):
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert {path: path.read_bytes() for path in originals} == live_before
+
+
+def test_patch_native_navigation_rejects_partial_backups_with_stable_error(
+    tmp_path: Path,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    feapp = client_root / "resources" / "feapp.dat"
+    feapp.with_name(feapp.name + ".native-nav.orig").write_bytes(originals[feapp])
+
+    with pytest.raises(NativeNavigationPatchError) as raised:
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    assert str(raised.value) == "NATIVE_NAV_BACKUPS_INCOMPLETE"
+    assert str(tmp_path) not in str(raised.value)
+
+
+def test_patch_native_navigation_rejects_tampered_live_files_with_backups(
+    tmp_path: Path,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    patch_native_navigation(client_root, work_root=tmp_path)
+    container = (
+        client_root / "plugins" / "Container" / "NutContainerPlugin.dll"
+    )
+    container.write_bytes(container.read_bytes() + b"tampered")
+    backups_before = {
+        path: path.with_name(path.name + ".native-nav.orig").read_bytes()
+        for path in originals
+    }
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match="NATIVE_NAV_LIVE_TAMPERED",
+    ):
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    for path, backup_value in backups_before.items():
+        assert path.with_name(path.name + ".native-nav.orig").read_bytes() == backup_value
+
+
+def test_patch_native_navigation_rejects_unregistered_patch_output_before_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client_root = _managed_client_root(tmp_path)
+    originals = _write_supported_client(client_root)
+    registered = {
+        name: dict(states)
+        for name, states in native_navigation._SUPPORTED_INPUT_FINGERPRINTS.items()
+    }
+    size, _ = registered["feapp"]["patched"]
+    registered["feapp"]["patched"] = (size, "0" * 64)
+    monkeypatch.setattr(
+        native_navigation,
+        "_SUPPORTED_INPUT_FINGERPRINTS",
+        registered,
+    )
+
+    with pytest.raises(
+        NativeNavigationPatchError,
+        match="NATIVE_NAV_PATCH_MISMATCH",
+    ):
+        patch_native_navigation(client_root, work_root=tmp_path)
+
+    _assert_transaction_rolled_back(originals)

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -59,6 +59,56 @@ def _write_voice_reference(path: Path) -> None:
         target.writeframes(b"\x00\x00" * 160)
 
 
+def _write_native_navigation_manifest(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    original_state = {"size_bytes": 1, "sha256": "0" * 64}
+    patched_state = {"size_bytes": 2, "sha256": "1" * 64}
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "olivia.native-navigation-compatibility.v1",
+                "client_version": "0.0.9.627",
+                "files": [
+                    {
+                        "id": "feapp",
+                        "relative_path": "resources/feapp.dat",
+                        "original": original_state,
+                        "patched": patched_state,
+                        "archive_member": "assets/synthetic-main.js",
+                        "text_replacements": [
+                            {"id": "fixture", "before": "old", "after": "new"}
+                        ],
+                    },
+                    *[
+                        {
+                            "id": file_id,
+                            "relative_path": relative,
+                            "original": original_state,
+                            "patched": patched_state,
+                            "binary_replacements": [
+                                {
+                                    "id": "fixture",
+                                    "signature_hex": "00112233445566",
+                                    "patch_offset": 1,
+                                    "replacement_hex": "aabb",
+                                }
+                            ],
+                        }
+                        for file_id, relative in (
+                            ("studio_ui", "plugins/Studio/NutStudioUI.dll"),
+                            (
+                                "container_plugin",
+                                "plugins/Container/NutContainerPlugin.dll",
+                            ),
+                        )
+                    ],
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def _write_video_runtime(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     environment = {
@@ -272,6 +322,9 @@ def _voice_setup_fixture(tmp_path: Path, monkeypatch) -> tuple[Path, Path, Path]
     (installer / "runtime-requirements.txt").write_bytes(requirements)
     reference = tmp_path / "distributor" / "olivia-reference.wav"
     _write_voice_reference(reference)
+    _write_native_navigation_manifest(
+        reference.parent / "native-navigation-compatibility.json"
+    )
     _video_offline_fixture(
         source, tmp_path / "distributor" / "Olivia-video-offline-fixture"
     )
@@ -407,6 +460,11 @@ def test_prepare_setup_payload_injects_hash_locked_voice_reference(tmp_path: Pat
     assert (
         destination / "installer/activate_private_video.py"
     ).read_text(encoding="utf-8") == "# private video activation entrypoint\n"
+    assert (
+        destination / "installer/native-navigation-compatibility.json"
+    ).read_text(encoding="utf-8") == (
+        reference.parent / "native-navigation-compatibility.json"
+    ).read_text(encoding="utf-8")
     input_manifest_path = offline / "offline-core-assets.json"
     input_manifest = json.loads(input_manifest_path.read_text())
     input_manifest.update(
@@ -469,6 +527,27 @@ def test_prepare_private_payload_requires_video_activation_entrypoint(
     with pytest.raises(SetupBuildError, match="SETUP_REQUIRED_PAYLOAD_MISSING"):
         _prepare_private_runtime(
             source, offline, reference, runtime, tmp_path / "missing-activation"
+        )
+
+
+def test_prepare_private_payload_requires_native_navigation_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    runtime = tmp_path / "distributor/Olivia-video-runtime-fixture.zip"
+    _write_video_runtime(runtime)
+    (reference.parent / "native-navigation-compatibility.json").unlink()
+
+    with pytest.raises(
+        SetupBuildError,
+        match="SETUP_PRIVATE_NATIVE_NAVIGATION_MANIFEST_REQUIRED",
+    ):
+        _prepare_private_runtime(
+            source,
+            offline,
+            reference,
+            runtime,
+            tmp_path / "missing-native-navigation",
         )
 
 
@@ -753,6 +832,7 @@ def test_setup_build_cli_forwards_distributor_voice_reference(tmp_path: Path, mo
     runtime = tmp_path / "Olivia-video-runtime-fixture.zip"
     runtime.write_bytes(b"runtime")
     video_offline = tmp_path / "Olivia-video-offline-private"
+    native_navigation = tmp_path / "native-navigation-compatibility.json"
     captured: dict[str, object] = {}
     monkeypatch.setattr(
         "installer.build_windows_setup.build_windows_setup",
@@ -763,6 +843,7 @@ def test_setup_build_cli_forwards_distributor_voice_reference(tmp_path: Path, mo
         "--offline", str(tmp_path / "offline"), "--output", str(tmp_path / "output"),
         "--version", "0.1.test", "--distribution", "private", "--voice-reference", str(reference),
         "--video-runtime", str(runtime), "--video-offline-root", str(video_offline),
+        "--native-navigation-manifest", str(native_navigation),
     ])
 
     assert result == 0
@@ -770,6 +851,7 @@ def test_setup_build_cli_forwards_distributor_voice_reference(tmp_path: Path, mo
     assert captured["voice_reference"] == reference
     assert captured["video_runtime"] == runtime
     assert captured["video_offline_root"] == video_offline
+    assert captured["native_navigation_manifest"] == native_navigation
 
 
 def test_failed_private_setup_compile_removes_partial_final_artifacts(
@@ -882,6 +964,7 @@ def test_windows_setup_docs_separate_public_and_private_voice_artifacts() -> Non
     assert "--voice-reference" in documentation
     assert "--video-runtime" in documentation
     assert "--video-offline-root" in documentation
+    assert "--native-navigation-manifest" in documentation
     assert "dist-private" in documentation
     assert "Olivia-video-runtime-private.zip" in documentation
     assert "Olivia-video-offline-private" in documentation
@@ -893,6 +976,8 @@ def test_windows_setup_docs_separate_public_and_private_voice_artifacts() -> Non
     assert "music_video" in documentation
     assert "因而没有自引用" in documentation
     assert "GitHub Actions 只生成公开安装器 artifact" in documentation
+    assert "会修改隔离副本中的业务 bundle 与两个原生 DLL" in documentation
+    assert "公开仓库不保存这些官方字节签名" in documentation
 
 
 def test_prepare_setup_payload_rejects_truncated_voice_reference(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- restore the original mailbox navigation in the isolated client copy
- keep official signatures and compatibility bytes out of the public repository
- package the private compatibility manifest only in authorized private builds
- apply the patch from the real launcher and recover managed temporary files

## Verification
- 191 focused tests passed
- installer compileall passed
- git diff check passed

## Boundary
- Steam originals remain untouched
- no official asset bytes or private letters are committed
- real installed-client validation follows in the final private installer E2E