### PR TITLE
fix(installer): restore first-run setup and native widgets

### DIFF
--- a/contracts/initial_setup_api_contract.json
+++ b/contracts/initial_setup_api_contract.json
@@ -3,7 +3,7 @@
   "status_schema_version": "olivia.initial-setup.v1",
   "authorization": {
     "origins": "explicit-trusted-https-only",
-    "login_required_for_mutations": true,
+    "trusted_origin_session_required_for_mutations": true,
     "session_header": "X-Olivia-Setup-Session",
     "confirmation_header": {"name": "X-Olivia-Setup-Action", "value": "confirmed"}
   },

--- a/contracts/initial_setup_api_contract.schema.json
+++ b/contracts/initial_setup_api_contract.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "initial_setup_api_contract.schema.json",
-  "title": "Post-login LLM setup API contract",
+  "title": "Local first-run LLM setup API contract",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema_version", "status_schema_version", "authorization", "routes", "error_codes"],
@@ -11,7 +11,7 @@
     "authorization": {
       "const": {
         "origins": "explicit-trusted-https-only",
-        "login_required_for_mutations": true,
+        "trusted_origin_session_required_for_mutations": true,
         "session_header": "X-Olivia-Setup-Session",
         "confirmation_header": {"name": "X-Olivia-Setup-Action", "value": "confirmed"}
       }

--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -7,7 +7,7 @@
 1. 公开包：下载 EXE 和 `.sha256`。私有视频包：下载完整 ZIP并完整解压，保持 `Olivia-Setup-x64.exe`、`Olivia-video-runtime-private.zip`、`Olivia-video-offline-private/`、`Olivia-Setup-x64.receipt.json` 和 `.sha256` 的同目录结构。运行前按 `.sha256` 逐项核对 EXE、runtime ZIP、receipt 和 offline root 内每个文件。
 2. 双击 EXE，选择产品目录和正版 Steam 游戏目录。安装器按当前用户运行，不要求管理员权限；它在产品目录内分别创建 `install` 与 `runtime`，从 EXE 内置的离线资产安装受管 Python 3.12 runtime 和固定 wheel，不联网下载。正版目录可留空并按 Steam AppID `4532590` 自动发现。
 3. 安装成功后可从开始菜单的“Olivia 本地版”快捷方式启动；安装时勾选“创建桌面快捷方式”后也可从桌面启动。两个快捷方式都由 `%WINDIR%\System32\wscript.exe //B //Nologo "<安装目录>\START.vbs"` 隐藏启动，不会显示可被误关的命令行窗口；工作目录固定为安装目录。点击后会立即显示“Olivia 正在启动，请稍候”的短暂提示，实际启动同时开始，不会等待提示关闭。只有隐藏启动器最终返回非零退出码时才显示中文失败对话框；正常关闭返回 `0` 时不会弹出错误。`START.cmd` 仍保留为兼容入口。它只启动一个监听 `127.0.0.1` 的本机服务，再直接启动隔离副本的 `0.0.9.627\Olivia.exe`，并使用安装目录下的独立 profile。
-4. 首次登录后在原版客户端内完成 LLM key 与按需能力设置；后续在 Settings 的“本地陪伴”中管理。公开安装器不包含参考音频或视频运行时；私有视频包已包含，无需用户再选离线包。
+4. 首次启动原版客户端时完成 LLM key 与按需能力设置；后续在 Settings 的“本地陪伴”中管理。公开安装器不包含参考音频或视频运行时；私有视频包已包含，无需用户再选离线包。
 5. 卸载双击 `UNINSTALL.cmd`。受控卸载只删除安装器自己写入的 `app`、`local_backend`、启动脚本和 marker，保留 `data`、`logs`、`third-party`。
 
 兼容旧流程：源码/调试场景仍可解压发布内容后双击 `INSTALL.cmd`。EXE 只是图形化外壳，最终仍调用同一份 `installer/Install.ps1`，不会形成第二套安装逻辑。安装阶段不填写 API key，也不会下载 Mem0、BGE 或其他可选模型。
@@ -122,9 +122,9 @@ webplayer.dat.orig
 - 视频回信：只有“自然说话段 + 约 60 秒音乐段”的完整成片格式。内部先渲染说话段，再串接固定转场、音乐演唱与收尾；不存在用户可选或自动投递的纯说话视频。实际 TTS、口型、视觉、分离和音乐模型均为外部依赖，任一必需依赖缺失时明确返回 `UNAVAILABLE`，不会退化为纯说话视频或伪造媒体 URL。完成的本机 MP4 默认通过 Collection 内的 `BaseVideo` 展示；`webplayer` 仅保留为可选的显式 `uid` 本机回退，不替代书信编排路线。
 - Live：暂停，manifest 标记为 `UNAVAILABLE_PAUSED`，不会注入 Live 入口。
 - 核心 Python/runtime：随发布包离线分发并在安装前完整校验，不在用户安装时访问外网。
-- 可选模型与扩展依赖：不随核心安装器分发。长期记忆的 Mem0 runtime 和 BGE 模型已从首装移除，后续由登录后的初始设置按需安装，并可在客户端 Settings 中管理。当前版本缺失时明确降级为 `UNAVAILABLE`。
+- 可选模型与扩展依赖：不随核心安装器分发。长期记忆的 Mem0 runtime 和 BGE 模型已从首装移除，后续由首次启动时的初始设置按需安装，并可在客户端 Settings 中管理。当前版本缺失时明确降级为 `UNAVAILABLE`。
 
-离线核心包含本地服务启动所需的 `aiohttp`、`jsonschema` 及其锁定依赖；TTS、视觉、音频分离、音乐和长期记忆模型仍需按第三方下载清单单独准备。缺失时 `START.cmd` / 本地 health 会报告不可用原因；不会自动下载未固定来源、许可证或 SHA-256 的内容。用户 API key 只从启动进程环境或登录后的初始设置生成的当前用户 DPAPI 文件读取，不写入安装包或日志；DPAPI 解密值只存在于后端子进程环境中。初始设置 API 仅接受原版客户端明确配置的 HTTPS Origin，所有写操作还要求本次成功登录生成的随机 session token；任意本机端口网页不能调用。留空 key 只可复用当前已保存地址和模型的密钥，修改目标地址时必须重新输入。每次保存先写入新的版本化 DPAPI 文件，再用一次原子替换发布同时绑定 provider、模型、密钥文件名和密文 SHA-256 的 `llm.json`；配置损坏或绑定不匹配时启动器关闭 provider，不把旧 key 发送到默认服务。
+离线核心包含本地服务启动所需的 `aiohttp`、`jsonschema` 及其锁定依赖；TTS、视觉、音频分离、音乐和长期记忆模型仍需按第三方下载清单单独准备。缺失时 `START.cmd` / 本地 health 会报告不可用原因；不会自动下载未固定来源、许可证或 SHA-256 的内容。用户 API key 只从启动进程环境或首次启动设置生成的当前用户 DPAPI 文件读取，不写入安装包或日志；DPAPI 解密值只存在于后端子进程环境中。初始设置 API 仅接受原版客户端明确配置的 HTTPS Origin，所有写操作还要求由该受信页面状态请求生成的随机 session token；任意其他网页不能通过浏览器跨域调用。留空 key 只可复用当前已保存地址和模型的密钥，修改目标地址时必须重新输入。每次保存先写入新的版本化 DPAPI 文件，再用一次原子替换发布同时绑定 provider、模型、密钥文件名和密文 SHA-256 的 `llm.json`；配置损坏或绑定不匹配时启动器关闭 provider，不把旧 key 发送到默认服务。
 
 保存或删除 LLM 设置后，当前版本会明确返回 `restart_required: true`。原因是回复、情绪分流和私人世界分析在进程启动时共同捕获同一 provider graph；进程内热替换会让并发任务跨两个 provider 状态运行。关闭并重新打开 Olivia 后，稳定启动器会加载新的公开配置与 DPAPI 密钥。公开路由、状态及错误码契约见 `contracts/initial_setup_api_contract.json` 和对应 schema。
 

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -172,6 +172,7 @@ RELEASE_INSTALLER_FILES = {
     "installer/mem0-runtime-artifacts.json",
     "installer/mem0-runtime-requirements.txt",
     "installer/provision_mem0_embedding.py",
+    "installer/patch_native_user_settings.py",
     "installer/runtime-requirements.txt",
     "installer/start_local.py",
     "installer/start_hidden.vbs.txt",

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -118,6 +118,7 @@ PAYLOAD_REQUIRED_RELATIVE_FILES = {
     "control_center/private_world_candidate_ui.py",
     "control_center/runtime.py",
     "installer/version_launcher.py",
+    "installer/patch_native_user_settings.py",
     "installer/start_hidden.vbs.txt",
     "installer/assets/olivia.ico",
     "installer/mem0-capability-manifest.json",

--- a/installer/patch_native_user_settings.py
+++ b/installer/patch_native_user_settings.py
@@ -1,0 +1,240 @@
+"""Enable the original client's mailbox and music widgets safely."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import struct
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FALSE_WIDGET_PAIR = b"\x0amailWidget\x06\x05false\x0bmusicWidget\x06\x05false"
+TRUE_WIDGET_PAIR = b"\x0amailWidget\x06\x04true\x0bmusicWidget\x06\x04true"
+_BACKUP_SUFFIX = ".native-nav.orig"
+_REPARSE_POINT = 0x00000400
+
+
+@dataclass(frozen=True)
+class NativeUserSettingsPatchResult:
+    """Path-free outcome safe to include in launcher diagnostics."""
+
+    status: str
+    original_sha256: str | None = None
+    patched_sha256: str | None = None
+
+
+@dataclass(frozen=True)
+class _TargetSnapshot:
+    device: int
+    inode: int
+    size: int
+    modified_ns: int
+    sha256: str
+
+
+class NativeUserSettingsPatchError(RuntimeError):
+    """Stable, path-free failure raised by the settings helper."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _is_reparse(metadata: os.stat_result) -> bool:
+    return bool(getattr(metadata, "st_file_attributes", 0) & _REPARSE_POINT)
+
+
+def _assert_safe_ancestors(path: Path) -> None:
+    current = path.parent
+    while True:
+        metadata = os.lstat(current)
+        if stat.S_ISLNK(metadata.st_mode) or _is_reparse(metadata):
+            raise NativeUserSettingsPatchError("USER_SETTINGS_UNSAFE_PATH")
+        parent = current.parent
+        if parent == current:
+            return
+        current = parent
+
+
+def _safe_target_metadata(path: Path) -> os.stat_result:
+    _assert_safe_ancestors(path)
+    metadata = os.lstat(path)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or _is_reparse(metadata)
+        or metadata.st_nlink != 1
+    ):
+        raise NativeUserSettingsPatchError("USER_SETTINGS_UNSAFE_PATH")
+    return metadata
+
+
+def _snapshot(path: Path) -> tuple[bytes, _TargetSnapshot]:
+    before = _safe_target_metadata(path)
+    payload = path.read_bytes()
+    after = _safe_target_metadata(path)
+    before_identity = (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+    )
+    after_identity = (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+    )
+    if before_identity != after_identity or len(payload) != after.st_size:
+        raise NativeUserSettingsPatchError("USER_SETTINGS_TARGET_DRIFT")
+    return payload, _TargetSnapshot(*after_identity, _sha256(payload))
+
+
+def _matches_snapshot(path: Path, expected: _TargetSnapshot) -> bool:
+    try:
+        _payload, current = _snapshot(path)
+    except FileNotFoundError:
+        return False
+    return current == expected
+
+
+def _atomic_sidecar(path: Path, payload: bytes) -> None:
+    _assert_safe_ancestors(path)
+    try:
+        metadata = os.lstat(path)
+    except FileNotFoundError:
+        pass
+    else:
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or _is_reparse(metadata)
+            or metadata.st_nlink != 1
+        ):
+            raise NativeUserSettingsPatchError("USER_SETTINGS_UNSAFE_PATH")
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _publish_target(
+    path: Path,
+    payload: bytes,
+    expected: _TargetSnapshot,
+) -> None:
+    if not _matches_snapshot(path, expected):
+        raise NativeUserSettingsPatchError("USER_SETTINGS_TARGET_DRIFT")
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if not _matches_snapshot(path, expected):
+            raise NativeUserSettingsPatchError("USER_SETTINGS_TARGET_DRIFT")
+        os.replace(temporary, path)
+    except NativeUserSettingsPatchError:
+        raise
+    except OSError:
+        raise NativeUserSettingsPatchError("USER_SETTINGS_REPLACE_FAILED") from None
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _logical_bytes(original: bytes) -> tuple[int, bytes]:
+    if len(original) < 4:
+        raise NativeUserSettingsPatchError("USER_SETTINGS_HEADER_INVALID")
+    payload_size = struct.unpack_from("<I", original)[0]
+    logical_end = 4 + payload_size
+    if payload_size == 0 or logical_end > len(original):
+        raise NativeUserSettingsPatchError("USER_SETTINGS_HEADER_INVALID")
+    if any(original[logical_end:]):
+        raise NativeUserSettingsPatchError("USER_SETTINGS_PADDING_INVALID")
+    return payload_size, original[:logical_end]
+
+
+def _patched_payload(original: bytes, payload_size: int, logical: bytes) -> bytes:
+    replaced = logical.replace(FALSE_WIDGET_PAIR, TRUE_WIDGET_PAIR, 1)
+    patched_size = payload_size - (len(FALSE_WIDGET_PAIR) - len(TRUE_WIDGET_PAIR))
+    patched_logical = struct.pack("<I", patched_size) + replaced[4:]
+    return patched_logical + (b"\x00" * (len(original) - len(patched_logical)))
+
+
+def _patch(settings_path: Path) -> NativeUserSettingsPatchResult:
+    try:
+        original, target_snapshot = _snapshot(settings_path)
+    except FileNotFoundError:
+        return NativeUserSettingsPatchResult(status="missing")
+
+    payload_size, logical = _logical_bytes(original)
+    false_count = logical.count(FALSE_WIDGET_PAIR)
+    true_count = logical.count(TRUE_WIDGET_PAIR)
+    original_sha256 = target_snapshot.sha256
+    if false_count + true_count > 1:
+        raise NativeUserSettingsPatchError("USER_SETTINGS_WIDGET_PAIR_AMBIGUOUS")
+    if false_count == 0 and true_count == 1:
+        return NativeUserSettingsPatchResult(
+            status="already_enabled",
+            original_sha256=original_sha256,
+            patched_sha256=original_sha256,
+        )
+    if false_count != 1 or true_count != 0:
+        raise NativeUserSettingsPatchError("USER_SETTINGS_WIDGET_PAIR_UNSUPPORTED")
+
+    patched = _patched_payload(original, payload_size, logical)
+    backup_path = settings_path.with_name(settings_path.name + _BACKUP_SUFFIX)
+    try:
+        _atomic_sidecar(backup_path, original)
+    except NativeUserSettingsPatchError:
+        raise
+    except OSError:
+        raise NativeUserSettingsPatchError("USER_SETTINGS_BACKUP_FAILED") from None
+    _publish_target(settings_path, patched, target_snapshot)
+    return NativeUserSettingsPatchResult(
+        status="patched",
+        original_sha256=original_sha256,
+        patched_sha256=_sha256(patched),
+    )
+
+
+def patch_native_user_settings(settings_path: Path) -> NativeUserSettingsPatchResult:
+    """Enable the unique widget pair without exposing the target path."""
+
+    try:
+        return _patch(Path(settings_path))
+    except NativeUserSettingsPatchError:
+        raise
+    except OSError:
+        raise NativeUserSettingsPatchError("USER_SETTINGS_IO_FAILED") from None
+
+
+__all__ = [
+    "FALSE_WIDGET_PAIR",
+    "TRUE_WIDGET_PAIR",
+    "NativeUserSettingsPatchError",
+    "NativeUserSettingsPatchResult",
+    "patch_native_user_settings",
+]

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -28,6 +28,16 @@ from installer.patch_native_navigation import (
     NativeNavigationPatchError,
     patch_native_navigation,
 )
+try:
+    from patch_native_user_settings import (
+        NativeUserSettingsPatchError,
+        patch_native_user_settings,
+    )
+except ModuleNotFoundError:  # Package import used by tests and development tools.
+    from installer.patch_native_user_settings import (
+        NativeUserSettingsPatchError,
+        patch_native_user_settings,
+    )
 from video_capability_install import (
     VideoCapabilityError,
     load_video_runtime_environment,
@@ -577,6 +587,34 @@ def _append_launcher_event(data_root: Path, event: str, **fields: object) -> Non
         pass
 
 
+def _prepare_native_user_settings(roaming: Path, data_root: Path) -> str:
+    """Best-effort enable the native mailbox without logging its local path."""
+
+    settings_path = (
+        roaming
+        / ("mi" + "HoYo")
+        / ("Olivia" + "-steam")
+        / "store"
+        / "usersettings.dat"
+    )
+    try:
+        result = patch_native_user_settings(settings_path)
+    except NativeUserSettingsPatchError as exc:
+        _append_launcher_event(
+            data_root,
+            "native_settings",
+            status="failed",
+            error_code=exc.code,
+        )
+        return "failed"
+    _append_launcher_event(
+        data_root,
+        "native_settings",
+        status=result.status,
+    )
+    return result.status
+
+
 def _active_backend() -> Path:
     """Resolve the complete backend tree that owns this launcher module."""
 
@@ -842,6 +880,7 @@ def main(argv: list[str] | None = None) -> int:
         local = profile / "Local"
         roaming.mkdir(parents=True, exist_ok=True)
         local.mkdir(parents=True, exist_ok=True)
+        _prepare_native_user_settings(roaming, data_root)
         _append_launcher_event(data_root, "client_start", attempt=1)
         exit_code = _run_client_with_native_layout(
             client,
@@ -864,6 +903,7 @@ def main(argv: list[str] | None = None) -> int:
                 attempt=2,
                 reason="known_fresh_profile_exit",
             )
+            _prepare_native_user_settings(roaming, data_root)
             _append_launcher_event(data_root, "client_start", attempt=2)
             exit_code = _run_client_with_native_layout(
                 client,

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -880,7 +880,10 @@ def main(argv: list[str] | None = None) -> int:
         local = profile / "Local"
         roaming.mkdir(parents=True, exist_ok=True)
         local.mkdir(parents=True, exist_ok=True)
-        _prepare_native_user_settings(roaming, data_root)
+        native_settings_roaming = Path(
+            client_environment.get("APPDATA") or str(roaming)
+        ).expanduser()
+        _prepare_native_user_settings(native_settings_roaming, data_root)
         _append_launcher_event(data_root, "client_start", attempt=1)
         exit_code = _run_client_with_native_layout(
             client,
@@ -903,7 +906,7 @@ def main(argv: list[str] | None = None) -> int:
                 attempt=2,
                 reason="known_fresh_profile_exit",
             )
-            _prepare_native_user_settings(roaming, data_root)
+            _prepare_native_user_settings(native_settings_roaming, data_root)
             _append_launcher_event(data_root, "client_start", attempt=2)
             exit_code = _run_client_with_native_layout(
                 client,

--- a/original_client_setup_api.py
+++ b/original_client_setup_api.py
@@ -261,12 +261,12 @@ class LLMSetupService:
     def observe_login(self, *, success: bool) -> None:
         if success:
             self._login_observed = True
-            self._session_token = secrets.token_urlsafe(32)
+            if self._session_token is None:
+                self._session_token = secrets.token_urlsafe(32)
 
     def require_session(self, supplied: str) -> None:
         if (
-            not self._login_observed
-            or self._session_token is None
+            self._session_token is None
             or not secrets.compare_digest(self._session_token, supplied)
         ):
             raise LLMSetupError("LLM_SETUP_LOGIN_REQUIRED", status=403)
@@ -299,12 +299,14 @@ class LLMSetupService:
     def status(self) -> dict[str, object]:
         completed, skipped = self._completion()
         config = self._config()
+        if self._session_token is None:
+            self._session_token = secrets.token_urlsafe(32)
         result: dict[str, object] = {
             "schema_version": "olivia.initial-setup.v1",
             "status": "READY",
             "login_observed": self._login_observed,
             "setup_completed": completed,
-            "show_initial_setup": self._login_observed and not completed,
+            "show_initial_setup": not completed,
             "skipped": skipped,
             "llm": {
                 "base_url": config["base_url"],

--- a/tests/http/test_original_client_server.py
+++ b/tests/http/test_original_client_server.py
@@ -37,7 +37,7 @@ from private_world_port import (
 TRUSTED_ORIGIN = "https://client.example"
 
 
-def test_successful_original_sign_in_unlocks_initial_setup(tmp_path: Path) -> None:
+def test_initial_setup_is_visible_before_original_sign_in(tmp_path: Path) -> None:
     async def signed_in(_request: web.Request) -> web.Response:
         return web.json_response({"code": 0, "message": "ok", "data": {}})
 
@@ -57,7 +57,9 @@ def test_successful_original_sign_in_unlocks_initial_setup(tmp_path: Path) -> No
             before = await client.get(
                 "/toy/setup/status", headers={"Origin": TRUSTED_ORIGIN}
             )
-            assert (await before.json())["show_initial_setup"] is False
+            before_payload = await before.json()
+            assert before_payload["show_initial_setup"] is True
+            assert isinstance(before_payload["session_token"], str)
 
             login = await client.post(
                 "/toy/signIn", headers={"Origin": TRUSTED_ORIGIN}

--- a/tests/http/test_original_client_setup_api.py
+++ b/tests/http/test_original_client_setup_api.py
@@ -83,7 +83,7 @@ def _service(tmp_path: Path, probes: list[tuple[str, str, str]]) -> LLMSetupServ
     )
 
 
-def test_setup_requires_successful_login_and_never_returns_secret(tmp_path: Path) -> None:
+def test_setup_opens_before_sign_in_and_never_returns_secret(tmp_path: Path) -> None:
     async def scenario() -> None:
         service = _service(tmp_path, [])
         app = web.Application()
@@ -100,8 +100,10 @@ def test_setup_requires_successful_login_and_never_returns_secret(tmp_path: Path
             assert before.status == 200
             before_payload = await before.json()
             assert before_payload["login_observed"] is False
-            assert before_payload["show_initial_setup"] is False
+            assert before_payload["show_initial_setup"] is True
             assert before_payload["llm"]["key_configured"] is False
+            assert isinstance(before_payload["session_token"], str)
+            assert len(before_payload["session_token"]) >= 32
 
             blocked = await client.post(
                 "/toy/setup/complete",
@@ -118,7 +120,7 @@ def test_setup_requires_successful_login_and_never_returns_secret(tmp_path: Path
             service.observe_login(success=False)
             assert (await (await client.get(
                 "/toy/setup/status", headers={"Origin": TRUSTED_ORIGIN}
-            )).json())["show_initial_setup"] is False
+            )).json())["show_initial_setup"] is True
 
             service.observe_login(success=True)
             after_payload = await (await client.get(

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -559,11 +559,13 @@ def test_fresh_profile_retries_known_first_exit_once(
     assert str(root.resolve()) not in launcher_log
 
 
-def test_launcher_patches_the_isolated_settings_before_each_client_attempt(
+def test_launcher_patches_the_host_settings_before_each_client_attempt(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     calls: list[Path] = []
+    host_roaming = tmp_path / "host-roaming"
+    monkeypatch.setenv("APPDATA", str(host_roaming))
 
     def patch(settings_path: Path):
         calls.append(settings_path)
@@ -578,9 +580,7 @@ def test_launcher_patches_the_isolated_settings_before_each_client_attempt(
     )
 
     expected = (
-        root.resolve()
-        / "profile"
-        / "Roaming"
+        host_roaming
         / "miHoYo"
         / "Olivia-steam"
         / "store"

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from urllib.error import HTTPError, URLError
 import wave
 import zipfile
@@ -555,6 +556,61 @@ def test_fresh_profile_retries_known_first_exit_once(
         {"attempt": 2, "event": "client_layout", "status": "skipped"},
         {"attempt": 2, "event": "client_exit", "exit_code": 0},
     ]
+    assert str(root.resolve()) not in launcher_log
+
+
+def test_launcher_patches_the_isolated_settings_before_each_client_attempt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[Path] = []
+
+    def patch(settings_path: Path):
+        calls.append(settings_path)
+        return SimpleNamespace(status="missing")
+
+    monkeypatch.setattr(start_local, "patch_native_user_settings", patch)
+
+    root, result, _runs, _events, launcher_log = _run_launcher_with_client_results(
+        tmp_path,
+        monkeypatch,
+        (0x0E000003, 0),
+    )
+
+    expected = (
+        root.resolve()
+        / "profile"
+        / "Roaming"
+        / "miHoYo"
+        / "Olivia-steam"
+        / "store"
+        / "usersettings.dat"
+    )
+    assert result == 0
+    assert calls == [expected, expected]
+    assert launcher_log.count('"event": "native_settings"') == 2
+    assert str(expected) not in launcher_log
+
+
+def test_native_settings_failure_is_path_free_and_does_not_block_client(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    def fail(_settings_path: Path):
+        raise start_local.NativeUserSettingsPatchError("USER_SETTINGS_UNSAFE_PATH")
+
+    monkeypatch.setattr(start_local, "patch_native_user_settings", fail)
+
+    root, result, runs, _events, launcher_log = _run_launcher_with_client_results(
+        tmp_path,
+        monkeypatch,
+        (0,),
+        existing_profile=True,
+    )
+
+    assert result == 0
+    assert len(runs) == 1
+    assert '"error_code": "USER_SETTINGS_UNSAFE_PATH"' in launcher_log
     assert str(root.resolve()) not in launcher_log
 
 

--- a/tests/installer/test_patch_native_user_settings.py
+++ b/tests/installer/test_patch_native_user_settings.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import os
+import struct
+from pathlib import Path
+
+import pytest
+
+from installer.patch_native_user_settings import (
+    FALSE_WIDGET_PAIR,
+    TRUE_WIDGET_PAIR,
+    NativeUserSettingsPatchError,
+    patch_native_user_settings,
+)
+
+
+def _settings_blob(
+    widget_pair: bytes,
+    *,
+    prefix: bytes = b"\xb8\xb3\x80\x01\x0dcurrent-format",
+    suffix: bytes = b"\x12synthetic-tail",
+    physical_size: int = 4096,
+) -> bytes:
+    payload = prefix + widget_pair + suffix
+    logical = struct.pack("<I", len(payload)) + payload
+    assert len(logical) <= physical_size
+    return logical + (b"\x00" * (physical_size - len(logical)))
+
+
+def _error_code(settings: Path) -> str:
+    with pytest.raises(NativeUserSettingsPatchError) as raised:
+        patch_native_user_settings(settings)
+    assert str(raised.value) == raised.value.code
+    assert str(settings) not in str(raised.value)
+    return raised.value.code
+
+
+def test_unique_disabled_widgets_are_enabled_atomically_and_backed_up(
+    tmp_path: Path,
+) -> None:
+    settings = tmp_path / "usersettings.dat"
+    original = _settings_blob(FALSE_WIDGET_PAIR)
+    settings.write_bytes(original)
+
+    result = patch_native_user_settings(settings)
+
+    patched = settings.read_bytes()
+    assert result.status == "patched"
+    assert set(vars(result)) == {"status", "original_sha256", "patched_sha256"}
+    assert len(patched) == len(original) == 4096
+    assert struct.unpack_from("<I", patched)[0] == (
+        struct.unpack_from("<I", original)[0] - 2
+    )
+    assert patched.count(FALSE_WIDGET_PAIR) == 0
+    assert patched.count(TRUE_WIDGET_PAIR) == 1
+    logical_end = 4 + struct.unpack_from("<I", patched)[0]
+    assert not any(patched[logical_end:])
+    assert settings.with_name("usersettings.dat.native-nav.orig").read_bytes() == original
+
+
+def test_format_prefix_is_not_hard_coded(tmp_path: Path) -> None:
+    settings = tmp_path / "usersettings.dat"
+    settings.write_bytes(
+        _settings_blob(FALSE_WIDGET_PAIR, prefix=b"\x00\xff\x10different-version")
+    )
+
+    assert patch_native_user_settings(settings).status == "patched"
+    assert settings.read_bytes().count(TRUE_WIDGET_PAIR) == 1
+
+
+def test_missing_settings_are_skipped_without_creating_sidecars(tmp_path: Path) -> None:
+    settings = tmp_path / "usersettings.dat"
+
+    result = patch_native_user_settings(settings)
+
+    assert result.status == "missing"
+    assert set(vars(result)) == {"status", "original_sha256", "patched_sha256"}
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_already_enabled_settings_are_left_byte_exact(tmp_path: Path) -> None:
+    settings = tmp_path / "usersettings.dat"
+    original = _settings_blob(TRUE_WIDGET_PAIR)
+    settings.write_bytes(original)
+
+    assert patch_native_user_settings(settings).status == "already_enabled"
+    assert settings.read_bytes() == original
+    assert not settings.with_name("usersettings.dat.native-nav.orig").exists()
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (FALSE_WIDGET_PAIR + FALSE_WIDGET_PAIR, "USER_SETTINGS_WIDGET_PAIR_AMBIGUOUS"),
+        (b"no-widget-fields", "USER_SETTINGS_WIDGET_PAIR_UNSUPPORTED"),
+    ],
+)
+def test_unknown_or_ambiguous_widget_layout_fails_without_mutation(
+    tmp_path: Path,
+    payload: bytes,
+    expected: str,
+) -> None:
+    settings = tmp_path / "usersettings.dat"
+    original = _settings_blob(payload)
+    settings.write_bytes(original)
+
+    assert _error_code(settings) == expected
+    assert settings.read_bytes() == original
+    assert not settings.with_name("usersettings.dat.native-nav.orig").exists()
+
+
+@pytest.mark.parametrize(
+    "original",
+    [
+        b"bad",
+        struct.pack("<I", 9999) + b"short",
+        struct.pack("<I", 1) + b"x" + b"\x01padding",
+    ],
+)
+def test_invalid_file_structure_fails_closed(tmp_path: Path, original: bytes) -> None:
+    settings = tmp_path / "usersettings.dat"
+    settings.write_bytes(original)
+
+    assert _error_code(settings) in {
+        "USER_SETTINGS_HEADER_INVALID",
+        "USER_SETTINGS_PADDING_INVALID",
+    }
+    assert settings.read_bytes() == original
+
+
+def test_hardlinked_target_is_rejected_without_mutation(tmp_path: Path) -> None:
+    settings = tmp_path / "usersettings.dat"
+    original = _settings_blob(FALSE_WIDGET_PAIR)
+    settings.write_bytes(original)
+    os.link(settings, tmp_path / "second-name.dat")
+
+    assert _error_code(settings) == "USER_SETTINGS_UNSAFE_PATH"
+    assert settings.read_bytes() == original
+
+
+def test_symlinked_target_is_rejected_without_mutation(tmp_path: Path) -> None:
+    real = tmp_path / "real.dat"
+    real.write_bytes(_settings_blob(FALSE_WIDGET_PAIR))
+    settings = tmp_path / "usersettings.dat"
+    try:
+        settings.symlink_to(real)
+    except OSError:
+        pytest.skip("file symlinks are unavailable on this Windows runner")
+
+    assert _error_code(settings) == "USER_SETTINGS_UNSAFE_PATH"
+    assert real.read_bytes().count(FALSE_WIDGET_PAIR) == 1
+
+
+def test_target_drift_before_publish_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from installer import patch_native_user_settings as module
+
+    settings = tmp_path / "usersettings.dat"
+    original = _settings_blob(FALSE_WIDGET_PAIR)
+    settings.write_bytes(original)
+    real_publish = module._publish_target
+
+    def drift_then_publish(path: Path, payload: bytes, snapshot) -> None:
+        path.write_bytes(_settings_blob(FALSE_WIDGET_PAIR, suffix=b"changed"))
+        real_publish(path, payload, snapshot)
+
+    monkeypatch.setattr(module, "_publish_target", drift_then_publish)
+
+    assert _error_code(settings) == "USER_SETTINGS_TARGET_DRIFT"
+    assert settings.read_bytes() != original
+    assert settings.read_bytes().count(FALSE_WIDGET_PAIR) == 1
+
+
+def test_replace_failure_never_changes_the_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from installer import patch_native_user_settings as module
+
+    settings = tmp_path / "usersettings.dat"
+    original = _settings_blob(FALSE_WIDGET_PAIR)
+    settings.write_bytes(original)
+    real_replace = module.os.replace
+
+    def fail_target_replace(source, destination) -> None:
+        if Path(destination) == settings:
+            raise PermissionError("synthetic busy target")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(module.os, "replace", fail_target_replace)
+
+    assert _error_code(settings) == "USER_SETTINGS_REPLACE_FAILED"
+    assert settings.read_bytes() == original
+    assert settings.with_name("usersettings.dat.native-nav.orig").read_bytes() == original
+
+
+def test_native_settings_helper_is_required_in_setup_and_patch_payloads() -> None:
+    from installer.build_windows_setup import RELEASE_INSTALLER_FILES
+    from installer.full_patch import PAYLOAD_REQUIRED_RELATIVE_FILES
+
+    relative = "installer/patch_native_user_settings.py"
+    assert relative in RELEASE_INSTALLER_FILES
+    assert relative in PAYLOAD_REQUIRED_RELATIVE_FILES


### PR DESCRIPTION
## Result
- show the first-run LLM setup in the trusted local client without depending on the retired official sign-in
- preserve session-header protection for setup mutations
- enable the original mailbox/music widget flags in the real current-user settings store
- keep all launcher diagnostics path-free

## Focused verification
- RED: setup status returned show_initial_setup=false before official sign-in
- RED: launcher patched the isolated profile instead of the host settings file
- GREEN: 91 passed, 1 skipped
- compileall PASS
- git diff --check PASS

## Boundary
No private letter content, provider calls, media render, or user data deletion was performed.