### PR TITLE
fix(installer): reinstall over preserved user data

### DIFF
--- a/docs/WINDOWS_FULL_PATCH.md
+++ b/docs/WINDOWS_FULL_PATCH.md
@@ -8,7 +8,7 @@
 2. 双击 EXE，选择产品目录和正版 Steam 游戏目录。安装器按当前用户运行，不要求管理员权限；它在产品目录内分别创建 `install` 与 `runtime`，从 EXE 内置的离线资产安装受管 Python 3.12 runtime 和固定 wheel，不联网下载。正版目录可留空并按 Steam AppID `4532590` 自动发现。
 3. 安装成功后可从开始菜单的“Olivia 本地版”快捷方式启动；安装时勾选“创建桌面快捷方式”后也可从桌面启动。两个快捷方式都由 `%WINDIR%\System32\wscript.exe //B //Nologo "<安装目录>\START.vbs"` 隐藏启动，不会显示可被误关的命令行窗口；工作目录固定为安装目录。点击后会立即显示“Olivia 正在启动，请稍候”的短暂提示，实际启动同时开始，不会等待提示关闭。只有隐藏启动器最终返回非零退出码时才显示中文失败对话框；正常关闭返回 `0` 时不会弹出错误。`START.cmd` 仍保留为兼容入口。它只启动一个监听 `127.0.0.1` 的本机服务，再直接启动隔离副本的 `0.0.9.627\Olivia.exe`，并使用安装目录下的独立 profile。
 4. 首次启动原版客户端时完成 LLM key 与按需能力设置；后续在 Settings 的“本地陪伴”中管理。公开安装器不包含参考音频或视频运行时；私有视频包已包含，无需用户再选离线包。
-5. 卸载双击 `UNINSTALL.cmd`。受控卸载只删除安装器自己写入的 `app`、`local_backend`、启动脚本和 marker，保留 `data`、`logs`、`third-party`。
+5. 卸载双击 `UNINSTALL.cmd`。受控卸载只删除安装器自己写入的 `app`、`local_backend`、启动脚本和 marker，保留 `data`、`logs`、`third-party`、`downloads` 与 `profile`；之后可直接重装并继续使用这些本地数据。
 
 兼容旧流程：源码/调试场景仍可解压发布内容后双击 `INSTALL.cmd`。EXE 只是图形化外壳，最终仍调用同一份 `installer/Install.ps1`，不会形成第二套安装逻辑。安装阶段不填写 API key，也不会下载 Mem0、BGE 或其他可选模型。
 

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -560,6 +560,33 @@ def _managed_entry_is_reparse(metadata: os.stat_result) -> bool:
     )
 
 
+def _preserved_only_install_root(target: Path) -> bool:
+    """Accept an uninstalled root only when every entry is preserved user state."""
+
+    metadata = _managed_entry_metadata(target)
+    if (
+        metadata is None
+        or not stat.S_ISDIR(metadata.st_mode)
+        or _managed_entry_is_reparse(metadata)
+    ):
+        return False
+    allowed = set(PRESERVED_PATHS)
+    try:
+        entries = tuple(target.iterdir())
+    except OSError:
+        return False
+    for entry in entries:
+        entry_metadata = _managed_entry_metadata(entry)
+        if (
+            entry.name not in allowed
+            or entry_metadata is None
+            or not stat.S_ISDIR(entry_metadata.st_mode)
+            or _managed_entry_is_reparse(entry_metadata)
+        ):
+            return False
+    return True
+
+
 def _refresh_existing_install(
     target: Path,
     payload: Path,
@@ -677,6 +704,7 @@ def install_full_patch(
     if target == source or target in source.parents or source in target.parents:
         raise PatchInstallError("INSTALL_ROOT_OVERLAPS_OFFICIAL")
     marker_path = target / MARKER_NAME
+    reusing_preserved_root = False
     if target.exists():
         if marker_path.is_file():
             marker = _read_marker(marker_path)
@@ -687,8 +715,12 @@ def install_full_patch(
             ):
                 refreshed = _refresh_existing_install(target, payload, marker, port)
                 return {"status": "ALREADY_INSTALLED", **refreshed}
-        raise PatchInstallError("INSTALL_ROOT_ALREADY_EXISTS")
-    target.parent.mkdir(parents=True, exist_ok=True)
+        if not marker_path.exists() and _preserved_only_install_root(target):
+            reusing_preserved_root = True
+        else:
+            raise PatchInstallError("INSTALL_ROOT_ALREADY_EXISTS")
+    else:
+        target.parent.mkdir(parents=True, exist_ok=True)
     staging = target
     try:
         copied_runtime = copy_official_runtime(
@@ -734,7 +766,7 @@ def install_full_patch(
             raise PatchInstallError("UNSUPPORTED_OFFICIAL_VERSION") from exc
 
         _write_start_scripts(staging, port)
-        (staging / "data").mkdir()
+        (staging / "data").mkdir(exist_ok=True)
         marker = {
             "schema_version": "olivia.full-patch.install.v2",
             "steam_app_id": APP_ID,
@@ -775,7 +807,13 @@ def install_full_patch(
         )
     except Exception:
         if staging.exists():
-            shutil.rmtree(staging)
+            if reusing_preserved_root:
+                try:
+                    remove_owned_targets(staging)
+                except ValueError as rollback_exc:
+                    raise PatchInstallError("PATCH_ROLLBACK_FAILED") from rollback_exc
+            else:
+                shutil.rmtree(staging)
         raise
     return {"status": "INSTALLED", **marker}
 

--- a/installer/uninstall_safety.py
+++ b/installer/uninstall_safety.py
@@ -24,7 +24,7 @@ OWNED_PATHS = (
     ".olivia-update-state.json",
     MARKER_NAME,
 )
-PRESERVED_PATHS = ("data", "logs", "third-party")
+PRESERVED_PATHS = ("data", "logs", "third-party", "downloads", "profile")
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
 

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1978,6 +1978,50 @@ def test_install_is_idempotent_and_unknown_target_is_not_overwritten(
     ).read_text(encoding="utf-8") == "keep"
 
 
+def test_reinstall_after_uninstall_reuses_only_preserved_directories(
+    fixture_inputs,
+    tmp_path: Path,
+) -> None:
+    official, payload, manifest, _feapp, _webplayer = fixture_inputs
+    target = tmp_path / "installed"
+    install_full_patch(official, target, payload, manifest)
+    preserved = ("data", "logs", "third-party", "downloads", "profile")
+    for name in preserved:
+        directory = target / name
+        directory.mkdir(exist_ok=True)
+        (directory / "preserve.txt").write_text(name, encoding="utf-8")
+
+    uninstall_full_patch(target, apply=True)
+    reinstalled = install_full_patch(official, target, payload, manifest)
+
+    assert reinstalled["status"] == "INSTALLED"
+    for name in preserved:
+        assert (target / name / "preserve.txt").read_text(encoding="utf-8") == name
+
+
+def test_failed_reinstall_keeps_preserved_data(
+    fixture_inputs,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    official, payload, manifest, _feapp, _webplayer = fixture_inputs
+    target = tmp_path / "installed"
+    sentinel = target / "data" / "letter-state.db"
+    sentinel.parent.mkdir(parents=True)
+    sentinel.write_bytes(b"preserved-user-data")
+    monkeypatch.setattr(
+        full_patch,
+        "patch_feapp",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("fixture")),
+    )
+
+    with pytest.raises(PatchInstallError, match="UNSUPPORTED_OFFICIAL_VERSION"):
+        install_full_patch(official, target, payload, manifest)
+
+    assert sentinel.read_bytes() == b"preserved-user-data"
+    assert {entry.name for entry in target.iterdir()} == {"data"}
+
+
 def test_repeat_install_retires_unsigned_component_state_to_stable_backend(
     fixture_inputs,
     tmp_path: Path,


### PR DESCRIPTION
Fix reinstall after managed uninstall when only preserved local user directories remain. Preserve data, logs, third-party, downloads, and profile on failed or successful reinstall.\n\nValidation: 61 passed, 1 skipped in tests/installer/test_windows_full_patch.py; installer compileall; git diff --check.