### PR TITLE
fix(installer): ship small personal setup with on-demand models

### DIFF
--- a/installer/Create-Shortcut.ps1
+++ b/installer/Create-Shortcut.ps1
@@ -3,7 +3,8 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$InstallRoot,
     [string]$ShortcutPath,
-    [switch]$RefreshExisting
+    [switch]$RefreshExisting,
+    [switch]$RemoveExisting
 )
 
 $ErrorActionPreference = 'Stop'
@@ -13,6 +14,50 @@ $startHidden = Join-Path $root 'START.vbs'
 $startHiddenTemplate = Join-Path $PSScriptRoot 'start_hidden.vbs.txt'
 $wscript = Join-Path $env:WINDIR 'System32\wscript.exe'
 $hiddenArguments = '//B //Nologo "' + $startHidden + '"'
+
+if ($RemoveExisting) {
+    $shortcutPaths = if ($ShortcutPath) { @($ShortcutPath) } else {
+        @(foreach ($folderName in @('Desktop', 'Programs')) {
+            try {
+                $folder = [Environment]::GetFolderPath($folderName)
+                if ($folder) {
+                    $candidate = Join-Path $folder 'Olivia 本地版.lnk'
+                    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+                        $candidate
+                    }
+                }
+            }
+            catch {
+                # One unavailable shell folder must not suppress the other.
+            }
+        })
+    }
+    $shell = New-Object -ComObject WScript.Shell
+    foreach ($path in $shortcutPaths) {
+        try {
+            if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { continue }
+            $shortcut = $shell.CreateShortcut($path)
+            $target = [IO.Path]::GetFullPath([string]$shortcut.TargetPath)
+            $isLegacyShortcut = [string]::Equals(
+                $target, [IO.Path]::GetFullPath($start), [StringComparison]::OrdinalIgnoreCase
+            )
+            $isHiddenShortcut = [string]::Equals(
+                $target, [IO.Path]::GetFullPath($wscript), [StringComparison]::OrdinalIgnoreCase
+            ) -and [string]::Equals(
+                [string]$shortcut.Arguments, $hiddenArguments, [StringComparison]::OrdinalIgnoreCase
+            )
+            if ($isLegacyShortcut -or $isHiddenShortcut) {
+                Remove-Item -LiteralPath $path -Force
+            }
+        }
+        catch {
+            # Shortcut cleanup is best-effort and must not block safe uninstall.
+        }
+    }
+    [pscustomobject]@{ status = 'SHORTCUTS_REMOVED' }
+    return
+}
+
 $markerPath = Join-Path $root '.olivia-full-patch.json'
 if (-not (Test-Path -LiteralPath $start -PathType Leaf)) {
     throw 'LOCAL_START_ENTRYPOINT_NOT_FOUND'

--- a/installer/Install.ps1
+++ b/installer/Install.ps1
@@ -1451,16 +1451,28 @@ function Get-OfflineCoreAssets {
     $hasVideoRuntime = $manifest.PSObject.Properties.Name -ccontains 'video_runtime'
     $hasVideoOffline = $manifest.PSObject.Properties.Name -ccontains 'video_offline'
     $hasDistribution = $manifest.PSObject.Properties.Name -ccontains 'distribution'
-    if (
-        $hasVideoRuntime -ne $hasVoiceReference -or $hasVideoOffline -ne $hasVoiceReference -or
-        $hasVoiceReference -ne $hasDistribution -or
-        ($hasDistribution -and $manifest.distribution -cne 'private')
-    ) {
+    if ($hasVideoOffline -and -not $hasVideoRuntime) {
         throw 'VOICE_REFERENCE_PRIVATE_MANIFEST_REQUIRED'
+    }
+    if ($hasVoiceReference -ne $hasDistribution) {
+        throw 'VOICE_REFERENCE_PRIVATE_MANIFEST_REQUIRED'
+    }
+    if ($hasDistribution) {
+        if ($manifest.distribution -cnotin @('personal', 'private')) {
+            throw 'VOICE_REFERENCE_PRIVATE_MANIFEST_REQUIRED'
+        }
+        if (
+            ($manifest.distribution -ceq 'private' -and (-not $hasVideoRuntime -or -not $hasVideoOffline)) -or
+            ($manifest.distribution -ceq 'personal' -and $hasVideoOffline)
+        ) {
+            throw 'VOICE_REFERENCE_PRIVATE_MANIFEST_REQUIRED'
+        }
     }
     if (-not $hasVideoRuntime -and $VideoRuntimePath) { throw 'VIDEO_RUNTIME_INVALID' }
     if (-not $hasVideoOffline -and $VideoOfflineRoot) { throw 'VIDEO_PRIVATE_OFFLINE_INVALID' }
-    if ($hasVoiceReference) { $manifestNames += @('distribution', 'voice_reference', 'video_runtime', 'video_offline') }
+    if ($hasVoiceReference) { $manifestNames += @('distribution', 'voice_reference') }
+    if ($hasVideoRuntime) { $manifestNames += @('video_runtime') }
+    if ($hasVideoOffline) { $manifestNames += @('video_offline') }
     Assert-OfflineObjectShape -Value $manifest -Names $manifestNames
     Assert-OfflineObjectShape -Value $manifest.python_runtime -Names @('path', 'size_bytes', 'sha256', 'source_url')
     Assert-OfflineObjectShape -Value $manifest.pip_bootstrap -Names @('path', 'size_bytes', 'sha256', 'package', 'version')
@@ -1520,6 +1532,8 @@ function Get-OfflineCoreAssets {
         }
         $voiceReference = $manifest.voice_reference
         $voiceReference.path = $voiceReferencePath
+    }
+    if ($hasVideoRuntime) {
         Assert-OfflineObjectShape -Value $manifest.video_runtime -Names @('path', 'size_bytes', 'sha256')
         if ($manifest.video_runtime.path -cne 'Olivia-video-runtime-private.zip') {
             throw 'OFFLINE_CORE_MANIFEST_INVALID'
@@ -1541,6 +1555,8 @@ function Get-OfflineCoreAssets {
             sha256 = [string]$manifest.video_runtime.sha256
             verified = [bool]$true
         }
+    }
+    if ($hasVideoOffline) {
         Assert-OfflineObjectShape -Value $manifest.video_offline -Names @('path', 'manifest_version', 'manifest_sha256', 'file_count', 'size_bytes')
         if (
             $manifest.video_offline.path -cne 'Olivia-video-offline-private' -or

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -1232,7 +1232,9 @@ def build_windows_setup(
             os.fspath(source / "installer" / "windows_setup.iss"),
         ]
         if video_runtime is not None:
-            command.insert(-1, "/DPrivatePayload=1")
+            command.insert(-1, "/DVideoRuntimePayload=1")
+        if video_offline_root is not None:
+            command.insert(-1, "/DVideoOfflinePayload=1")
         result = subprocess.run(command, check=False, timeout=900)
         if result.returncode != 0 or not setup.is_file():
             raise SetupBuildError("SETUP_COMPILE_FAILED")

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -1018,13 +1018,14 @@ def prepare_setup_payload(
     source = source.expanduser().resolve()
     offline = offline.expanduser().resolve()
     destination = destination.expanduser().resolve()
-    if distribution not in {"public", "private"}:
+    if distribution not in {"public", "personal", "private"}:
         raise SetupBuildError("SETUP_DISTRIBUTION_INVALID")
-    if voice_reference is not None and distribution != "private":
+    private_distribution = distribution in {"personal", "private"}
+    if voice_reference is not None and not private_distribution:
         raise SetupBuildError("SETUP_VOICE_REFERENCE_PRIVATE_ONLY")
-    if distribution == "private" and voice_reference is None:
+    if private_distribution and voice_reference is None:
         raise SetupBuildError("SETUP_PRIVATE_VOICE_REFERENCE_REQUIRED")
-    if video_runtime is not None and distribution != "private":
+    if video_runtime is not None and not private_distribution:
         raise SetupBuildError("SETUP_VIDEO_RUNTIME_PRIVATE_ONLY")
     if distribution == "private" and video_runtime is None:
         raise SetupBuildError("SETUP_PRIVATE_VIDEO_RUNTIME_REQUIRED")
@@ -1032,9 +1033,11 @@ def prepare_setup_payload(
         raise SetupBuildError("SETUP_VIDEO_OFFLINE_PRIVATE_ONLY")
     if distribution == "private" and video_offline_root is None:
         raise SetupBuildError("SETUP_PRIVATE_VIDEO_OFFLINE_REQUIRED")
-    if native_navigation_manifest is not None and distribution != "private":
+    if distribution == "personal" and video_offline_root is not None:
+        raise SetupBuildError("SETUP_VIDEO_OFFLINE_PRIVATE_ONLY")
+    if native_navigation_manifest is not None and not private_distribution:
         raise SetupBuildError("SETUP_NATIVE_NAVIGATION_MANIFEST_PRIVATE_ONLY")
-    if distribution == "private" and native_navigation_manifest is None:
+    if private_distribution and native_navigation_manifest is None:
         assert voice_reference is not None
         native_navigation_manifest = (
             voice_reference.parent / NATIVE_NAVIGATION_MANIFEST_NAME
@@ -1050,7 +1053,7 @@ def prepare_setup_payload(
     if not REQUIRED_PAYLOAD_FILES.issubset(tracked):
         raise SetupBuildError("SETUP_REQUIRED_PAYLOAD_MISSING")
     if (
-        distribution == "private"
+        private_distribution
         and not PRIVATE_REQUIRED_PAYLOAD_FILES.issubset(tracked)
     ):
         raise SetupBuildError("SETUP_REQUIRED_PAYLOAD_MISSING")
@@ -1082,11 +1085,7 @@ def prepare_setup_payload(
                 staging / "installer" / NATIVE_NAVIGATION_MANIFEST_NAME,
             )
         shutil.copytree(offline, staging / "offline")
-        if (
-            voice_reference is not None
-            and video_runtime is not None
-            and video_offline_root is not None
-        ):
+        if voice_reference is not None:
             reference = _absolute_sidecar_source(
                 voice_reference,
                 directory=False,
@@ -1097,35 +1096,35 @@ def prepare_setup_payload(
             target = staging / "offline" / Path(*VOICE_REFERENCE_PATH.split("/"))
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(reference, target)
-            runtime_source = _absolute_sidecar_source(
-                video_runtime,
-                directory=False,
-                error_code="SETUP_VIDEO_RUNTIME_INVALID",
-            )
-            if runtime_source.stat().st_size < 1:
-                raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
-            runtime_metadata = _video_runtime_metadata(runtime_source)
-            video_offline_metadata = _video_offline_metadata(
-                staging / "installer" / "video-capability-manifest.json",
-                video_offline_root,
-            )
             manifest_path = staging / "offline" / MANIFEST_NAME
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-            manifest["distribution"] = "private"
+            manifest["distribution"] = distribution
             manifest["voice_reference"] = {
                 "path": VOICE_REFERENCE_PATH,
                 "size_bytes": target.stat().st_size,
                 "sha256": _sha256(target),
                 "wave": _voice_reference_metadata(target),
             }
-            manifest["video_runtime"] = {
-                "path": VIDEO_RUNTIME_PATH,
-                **runtime_metadata,
-            }
-            manifest["video_offline"] = {
-                "path": VIDEO_OFFLINE_SIDECAR_NAME,
-                **video_offline_metadata,
-            }
+            if video_runtime is not None:
+                runtime_source = _absolute_sidecar_source(
+                    video_runtime,
+                    directory=False,
+                    error_code="SETUP_VIDEO_RUNTIME_INVALID",
+                )
+                if runtime_source.stat().st_size < 1:
+                    raise SetupBuildError("SETUP_VIDEO_RUNTIME_INVALID")
+                manifest["video_runtime"] = {
+                    "path": VIDEO_RUNTIME_PATH,
+                    **_video_runtime_metadata(runtime_source),
+                }
+            if video_offline_root is not None:
+                manifest["video_offline"] = {
+                    "path": VIDEO_OFFLINE_SIDECAR_NAME,
+                    **_video_offline_metadata(
+                        staging / "installer" / "video-capability-manifest.json",
+                        video_offline_root,
+                    ),
+                }
             manifest_path.write_text(
                 json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True)
                 + "\n",
@@ -1372,7 +1371,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--iscc", type=Path)
-    parser.add_argument("--distribution", choices=("public", "private"), default="public")
+    parser.add_argument(
+        "--distribution", choices=("public", "personal", "private"), default="public"
+    )
     parser.add_argument("--voice-reference", type=Path)
     parser.add_argument("--video-runtime", type=Path)
     parser.add_argument("--video-offline-root", type=Path)

--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -171,6 +171,7 @@ RELEASE_INSTALLER_FILES = {
     "installer/mem0-capability-manifest.json",
     "installer/mem0-runtime-artifacts.json",
     "installer/mem0-runtime-requirements.txt",
+    "installer/native_window_layout.py",
     "installer/provision_mem0_embedding.py",
     "installer/patch_native_user_settings.py",
     "installer/runtime-requirements.txt",

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -19,6 +19,11 @@ from patch_companion_settings import (
 )
 from patch_feapp import patch_feapp
 from patch_webplayer import WebPlayerPatchError, patch_webplayer
+from installer.patch_native_navigation import (
+    COMPATIBILITY_MANIFEST_NAME,
+    NativeNavigationPatchError,
+    patch_native_navigation,
+)
 from installer.uninstall_safety import (
     MARKER_NAME,
     OWNED_PATHS,
@@ -749,6 +754,11 @@ def install_full_patch(
                 f"ws://127.0.0.1:{port}/ws",
                 work_root=resources,
             )
+            navigation_manifest = (
+                staging / "local_backend" / "installer" / COMPATIBILITY_MANIFEST_NAME
+            )
+            if navigation_manifest.is_file():
+                patch_native_navigation(staging / "app" / version, work_root=staging)
             settings_patch = patch_companion_settings(
                 feapp,
                 base_http,
@@ -761,6 +771,7 @@ def install_full_patch(
         except (
             ValueError,
             CompanionSettingsPatchError,
+            NativeNavigationPatchError,
             WebPlayerPatchError,
         ) as exc:
             raise PatchInstallError("UNSUPPORTED_OFFICIAL_VERSION") from exc

--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -749,16 +749,16 @@ def install_full_patch(
 
         base_http = f"http://127.0.0.1:{port}"
         try:
-            endpoint_patch = patch_feapp(
-                feapp,
-                f"ws://127.0.0.1:{port}/ws",
-                work_root=resources,
-            )
             navigation_manifest = (
                 staging / "local_backend" / "installer" / COMPATIBILITY_MANIFEST_NAME
             )
             if navigation_manifest.is_file():
                 patch_native_navigation(staging / "app" / version, work_root=staging)
+            endpoint_patch = patch_feapp(
+                feapp,
+                f"ws://127.0.0.1:{port}/ws",
+                work_root=resources,
+            )
             settings_patch = patch_companion_settings(
                 feapp,
                 base_http,

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -486,7 +486,15 @@ def _repair_native_navigation(root: Path) -> str:
     manifest = root / "local_backend" / "installer" / COMPATIBILITY_MANIFEST_NAME
     if not manifest.is_file():
         return "NOT_CONFIGURED"
-    result = patch_native_navigation(_client_executable(root).parent, work_root=root)
+    client_root = _client_executable(root).parent
+    managed = (
+        client_root / "resources" / "feapp.dat",
+        client_root / "plugins" / "Studio" / "NutStudioUI.dll",
+        client_root / "plugins" / "Container" / "NutContainerPlugin.dll",
+    )
+    if all(path.with_name(path.name + ".native-nav.orig").is_file() for path in managed):
+        return "ALREADY_PATCHED"
+    result = patch_native_navigation(client_root, work_root=root)
     return str(result["status"])
 
 
@@ -827,14 +835,14 @@ def main(argv: list[str] | None = None) -> int:
             print("ISOLATED_CLIENT_NOT_FOUND")
             return 2
         try:
-            _repair_client_frontend(root, args.port)
-        except (CompanionSettingsPatchError, OSError):
-            print("CLIENT_FRONTEND_REPAIR_FAILED")
-            return 2
-        try:
             _repair_native_navigation(root)
         except (NativeNavigationPatchError, OSError):
             print("CLIENT_NATIVE_NAVIGATION_REPAIR_FAILED")
+            return 2
+        try:
+            _repair_client_frontend(root, args.port)
+        except (CompanionSettingsPatchError, OSError):
+            print("CLIENT_FRONTEND_REPAIR_FAILED")
             return 2
         owned_ready = (
             server is not None

--- a/installer/uninstall.py
+++ b/installer/uninstall.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
+import subprocess
 import sys
 
 try:
@@ -24,6 +26,43 @@ except ImportError:  # Support direct execution and the stable runpy launcher.
         remove_owned_targets,
         safe_owned_targets,
     )
+
+
+def _remove_launch_shortcuts(root: Path) -> None:
+    if os.name != "nt":
+        return
+    script = Path(__file__).resolve().parent / "Create-Shortcut.ps1"
+    try:
+        powershell = (
+            Path(os.environ["WINDIR"])
+            / "System32"
+            / "WindowsPowerShell"
+            / "v1.0"
+            / "powershell.exe"
+        )
+        if not powershell.is_file() or not script.is_file():
+            raise OSError
+        subprocess.run(
+            [
+                os.fspath(powershell),
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                os.fspath(script),
+                "-InstallRoot",
+                os.fspath(root),
+                "-RemoveExisting",
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=15,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+    except (KeyError, OSError, subprocess.SubprocessError):
+        print("SHORTCUT_CLEANUP_FAILED")
 
 
 def main() -> int:
@@ -47,6 +86,7 @@ def main() -> int:
         return 2
     print(json.dumps({"status": "UNINSTALLED" if args.apply else "DRY_RUN", "owned_paths": list(OWNED_PATHS), "preserved_paths": list(PRESERVED_PATHS)}, ensure_ascii=False))
     if args.apply:
+        _remove_launch_shortcuts(root)
         try:
             remove_owned_targets(root)
         except ValueError:

--- a/installer/windows_setup.iss
+++ b/installer/windows_setup.iss
@@ -292,11 +292,14 @@ begin
       ' -SetupResultPath ' + AddQuotes(SetupResultPath) +
       ' -NonInteractive' +
       ' -SkipShortcut';
-#ifdef PrivatePayload
+#ifdef VideoRuntimePayload
     Params := Params +
       ' -VideoRuntimePath ' + AddQuotes(
         ExpandConstant('{src}\Olivia-video-runtime-private.zip')
-      ) +
+      );
+#endif
+#ifdef VideoOfflinePayload
+    Params := Params +
       ' -VideoOfflineRoot ' + AddQuotes(
         ExpandConstant('{src}\Olivia-video-offline-private')
       );

--- a/tests/installer/test_offline_core_assets.py
+++ b/tests/installer/test_offline_core_assets.py
@@ -88,8 +88,12 @@ def test_installer_accepts_only_complete_private_video_runtime_manifest() -> Non
     assert "[string]$VideoOfflineRoot = ''" in script
     assert "$hasVideoRuntime = $manifest.PSObject.Properties.Name -ccontains 'video_runtime'" in script
     assert "$hasVideoOffline = $manifest.PSObject.Properties.Name -ccontains 'video_offline'" in script
-    assert "$hasVideoRuntime -ne $hasVoiceReference -or $hasVideoOffline -ne $hasVoiceReference" in script
-    assert "$manifestNames += @('distribution', 'voice_reference', 'video_runtime', 'video_offline')" in script
+    assert "$hasVideoOffline -and -not $hasVideoRuntime" in script
+    assert "$manifest.distribution -ceq 'private' -and (-not $hasVideoRuntime -or -not $hasVideoOffline)" in script
+    assert "$manifest.distribution -ceq 'personal' -and $hasVideoOffline" in script
+    assert "$manifestNames += @('distribution', 'voice_reference')" in script
+    assert "$manifestNames += @('video_runtime')" in script
+    assert "$manifestNames += @('video_offline')" in script
     assert "Assert-OfflineObjectShape -Value $manifest.video_runtime -Names @('path', 'size_bytes', 'sha256')" in script
     assert "Assert-OfflineObjectShape -Value $manifest.video_offline -Names @('path', 'manifest_version', 'manifest_sha256', 'file_count', 'size_bytes')" in script
     assert "$manifest.video_runtime.path -cne 'Olivia-video-runtime-private.zip'" in script

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -1001,7 +1001,8 @@ def test_prepare_setup_payload_rejects_truncated_voice_reference(tmp_path: Path,
 
 def test_private_inno_payload_reads_large_runtime_beside_setup_without_tmp_extract() -> None:
     script = (ROOT / "installer/windows_setup.iss").read_text(encoding="utf-8")
-    assert "#ifdef PrivatePayload" in script
+    assert "#ifdef VideoRuntimePayload" in script
+    assert "#ifdef VideoOfflinePayload" in script
     assert "DiskSpanning=yes" not in script
     assert "DiskSliceSize=" not in script
     assert 'Source: "{#PayloadRoot}\\offline\\video-runtime\\*"' not in script
@@ -1048,7 +1049,8 @@ def test_private_build_publishes_hash_locked_video_runtime_sidecar(
         video_offline_root=video_offline,
     )
 
-    assert "/DPrivatePayload=1" in observed
+    assert "/DVideoRuntimePayload=1" in observed
+    assert "/DVideoOfflinePayload=1" in observed
     assert [Path(item["path"]).name for item in result["artifacts"]] == [
         "Olivia-Setup-x64.exe",
         "Olivia-video-runtime-private.zip",


### PR DESCRIPTION
## Summary
- add personal setup mode: small EXE plus reusable runtime sidecar; model bundles remain online/on-demand
- separate runtime and model payload flags
- package native layout support and apply 0.0.9.627 navigation before frontend overlays
- remove only owned shortcuts during uninstall

## Direct smoke
- Inno build succeeded for v0.1.380
- real uninstall preserved data/downloads/profile
- real install exited 0 and created desktop/start-menu shortcuts
- hidden launch reached backend READY and client_start; Olivia/CEF processes remain running
- health HEALTHY; video capability READY; both required bundles and runtime ready

No full pytest/TDD campaign was run for this delivery-speed pass.