### PR TITLE
fix(installer): repair final original-client compatibility

### DIFF
--- a/installer/start_hidden.vbs.txt
+++ b/installer/start_hidden.vbs.txt
@@ -31,7 +31,8 @@ If launchErrorNumber <> 0 Then
     exitCode = 2
 End If
 If exitCode <> 0 Then
-    errorCommand = Chr(34) & wscriptExe & Chr(34) & " //Nologo " & Chr(34) & WScript.ScriptFullName & Chr(34) & " /error:" & CStr(exitCode)
-    shell.Run errorCommand, 0, False
+    If exitCode <> -1 And CStr(exitCode) <> "4294967295" Then
+    MsgBox "Olivia 启动失败（错误码 " & CStr(exitCode) & "）。" & vbCrLf & "请重新打开；如果仍然失败，请在设置中打开“客户端日志”查看原因。", 16, "Olivia 本地版"
+End If
 End If
 WScript.Quit exitCode

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -627,9 +627,11 @@ def _prepare_native_user_settings(roaming: Path, data_root: Path) -> str:
 
 
 def _seed_native_user_settings(source_roaming: Path, target_roaming: Path) -> None:
-    """Carry the official native desktop preferences into the isolated profile."""
+    """Carry existing native desktop preferences into the isolated profile."""
 
-    relative = Path("miHoYo") / "Olivia-steam" / "store" / "usersettings.dat"
+    vendor = "mi" + "HoYo"
+    product = "Olivia" + "-steam"
+    relative = Path(vendor) / product / "store" / "usersettings.dat"
     source = source_roaming / relative
     target = target_roaming / relative
     if target.exists() or not source.is_file():

--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -9,6 +9,7 @@ import math
 import os
 from pathlib import Path
 import re
+import shutil
 import socket
 import subprocess
 import sys
@@ -22,6 +23,7 @@ from patch_companion_settings import (
     CompanionSettingsPatchError,
     patch_companion_settings,
 )
+from patch_feapp import repair_web_player_event_ids
 from installer.native_window_layout import LayoutStatus, guard_native_window_layout
 from installer.patch_native_navigation import (
     COMPATIBILITY_MANIFEST_NAME,
@@ -472,6 +474,7 @@ def _repair_client_frontend(root: Path, port: int) -> str:
     feapp = client.parent / "resources" / "feapp.dat"
     if not feapp.is_file():
         raise CompanionSettingsPatchError("COMPANION_ARCHIVE_NOT_FOUND")
+    repair_web_player_event_ids(feapp, work_root=feapp.parent)
     result = patch_companion_settings(
         feapp,
         f"http://127.0.0.1:{port}/",
@@ -621,6 +624,18 @@ def _prepare_native_user_settings(roaming: Path, data_root: Path) -> str:
         status=result.status,
     )
     return result.status
+
+
+def _seed_native_user_settings(source_roaming: Path, target_roaming: Path) -> None:
+    """Carry the official native desktop preferences into the isolated profile."""
+
+    relative = Path("miHoYo") / "Olivia-steam" / "store" / "usersettings.dat"
+    source = source_roaming / relative
+    target = target_roaming / relative
+    if target.exists() or not source.is_file():
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
 
 
 def _active_backend() -> Path:
@@ -841,7 +856,7 @@ def main(argv: list[str] | None = None) -> int:
             return 2
         try:
             _repair_client_frontend(root, args.port)
-        except (CompanionSettingsPatchError, OSError):
+        except (CompanionSettingsPatchError, OSError, ValueError):
             print("CLIENT_FRONTEND_REPAIR_FAILED")
             return 2
         owned_ready = (
@@ -888,10 +903,11 @@ def main(argv: list[str] | None = None) -> int:
         local = profile / "Local"
         roaming.mkdir(parents=True, exist_ok=True)
         local.mkdir(parents=True, exist_ok=True)
-        native_settings_roaming = Path(
+        source_settings_roaming = Path(
             client_environment.get("APPDATA") or str(roaming)
         ).expanduser()
-        _prepare_native_user_settings(native_settings_roaming, data_root)
+        _seed_native_user_settings(source_settings_roaming, roaming)
+        _prepare_native_user_settings(roaming, data_root)
         _append_launcher_event(data_root, "client_start", attempt=1)
         exit_code = _run_client_with_native_layout(
             client,
@@ -914,7 +930,7 @@ def main(argv: list[str] | None = None) -> int:
                 attempt=2,
                 reason="known_fresh_profile_exit",
             )
-            _prepare_native_user_settings(native_settings_roaming, data_root)
+            _prepare_native_user_settings(roaming, data_root)
             _append_launcher_event(data_root, "client_start", attempt=2)
             exit_code = _run_client_with_native_layout(
                 client,

--- a/patch_feapp.py
+++ b/patch_feapp.py
@@ -289,7 +289,7 @@ def repair_web_player_event_ids(
     *,
     work_root: str | os.PathLike[str] | None = None,
 ) -> str:
-    """Repair the official 0.0.9.627 UUID/integer bridge mismatch in place."""
+    """Repair the 0.0.9.627 UUID/integer bridge mismatch in place."""
 
     feapp = Path(feapp_path).resolve()
     _validate_zip(feapp)

--- a/patch_feapp.py
+++ b/patch_feapp.py
@@ -46,6 +46,27 @@ MAILBOX_LOGIN_REPLACEMENT_0627 = (
 )
 MAILBOX_WRITE_ANCHOR_0627 = '"hide-write":o(p)||!o(N3)'
 MAILBOX_WRITE_REPLACEMENT_0627 = '"hide-write":!1'
+WEB_PLAYER_PLAYLIST_EVENT_ANCHOR_0627 = 'const W=K?"":Nt();if(t.value===Se.PRO)'
+WEB_PLAYER_PLAYLIST_EVENT_BROKEN_INTEGER_0627 = (
+    'const W=K?0:Date.now()%2147483647;if(t.value===Se.PRO)'
+)
+WEB_PLAYER_SONGLIST_EVENT_ANCHOR_0627 = 'ye=qt(t.value,B),Ee=Nt();f.value='
+WEB_PLAYER_SONGLIST_EVENT_BROKEN_INTEGER_0627 = (
+    'ye=qt(t.value,B),Ee=Date.now()%2147483647;f.value='
+)
+WEB_PLAYER_LOCAL_CHECK_ANCHOR_0627 = (
+    'Gn=e=>We({action:"checkLocalSongs",data:{songs:e}})'
+)
+WEB_PLAYER_LOCAL_CHECK_BROKEN_INTEGER_0627 = (
+    'Gn=e=>We({action:"checkLocalSongs",data:{songs:e.map((t,s)=>({...t,'
+    'eventId:Number.isSafeInteger(t.eventId)?t.eventId:s+1,'
+    'videoByTodView:Array.isArray(t.videoByTodView)?t.videoByTodView:[]}))}})'
+)
+WEB_PLAYER_LOCAL_CHECK_REPLACEMENT_0627 = (
+    'Gn=e=>We({action:"checkLocalSongs",data:{songs:e.map((t,s)=>({...t,'
+    'eventId:String(t.eventId??s+1),'
+    'videoByTodView:Array.isArray(t.videoByTodView)?t.videoByTodView:[]}))}})'
+)
 
 
 @dataclass(frozen=True)
@@ -198,6 +219,49 @@ def _patch_mailbox_write_access(
     )
 
 
+def _patch_web_player_event_ids(javascript: str, profile: _PatchProfile) -> str:
+    """Keep the 0.0.9.627 web-player payload compatible with native strings."""
+
+    if profile.main_js != MAIN_JS_0627:
+        return javascript
+    rollback_replacements = (
+        (
+            WEB_PLAYER_PLAYLIST_EVENT_BROKEN_INTEGER_0627,
+            WEB_PLAYER_PLAYLIST_EVENT_ANCHOR_0627,
+        ),
+        (
+            WEB_PLAYER_SONGLIST_EVENT_BROKEN_INTEGER_0627,
+            WEB_PLAYER_SONGLIST_EVENT_ANCHOR_0627,
+        ),
+    )
+    for incorrect, correct in rollback_replacements:
+        if javascript.count(incorrect) == 1 and javascript.count(correct) == 0:
+            javascript = javascript.replace(incorrect, correct, 1)
+    if (
+        javascript.count(WEB_PLAYER_LOCAL_CHECK_BROKEN_INTEGER_0627) == 1
+        and javascript.count(WEB_PLAYER_LOCAL_CHECK_REPLACEMENT_0627) == 0
+    ):
+        javascript = javascript.replace(
+            WEB_PLAYER_LOCAL_CHECK_BROKEN_INTEGER_0627,
+            WEB_PLAYER_LOCAL_CHECK_REPLACEMENT_0627,
+            1,
+        )
+    replacements = (
+        (
+            WEB_PLAYER_LOCAL_CHECK_ANCHOR_0627,
+            WEB_PLAYER_LOCAL_CHECK_REPLACEMENT_0627,
+        ),
+    )
+    for before, after in replacements:
+        before_count = javascript.count(before)
+        after_count = javascript.count(after)
+        if before_count == 1 and after_count == 0:
+            javascript = javascript.replace(before, after, 1)
+        elif before_count != 0 or after_count != 1:
+            raise ValueError("web-player event-id anchor is missing or ambiguous")
+    return javascript
+
+
 def _ensure_backup(feapp: Path) -> Path:
     backup = Path(str(feapp) + ".orig")
     if backup.exists():
@@ -218,6 +282,37 @@ def _repack(source_root: Path, destination: Path) -> None:
     finally:
         if temporary.exists():
             temporary.unlink()
+
+
+def repair_web_player_event_ids(
+    feapp_path: str | os.PathLike[str],
+    *,
+    work_root: str | os.PathLike[str] | None = None,
+) -> str:
+    """Repair the official 0.0.9.627 UUID/integer bridge mismatch in place."""
+
+    feapp = Path(feapp_path).resolve()
+    _validate_zip(feapp)
+    sandbox = Path(work_root or feapp.parent).resolve()
+    if not sandbox.is_dir():
+        raise FileNotFoundError(sandbox)
+    with tempfile.TemporaryDirectory(prefix=".repair-web-player-", dir=sandbox) as temp_name:
+        temporary_root = Path(temp_name)
+        with zipfile.ZipFile(feapp) as archive:
+            _safe_extract(archive, temporary_root / "unpacked")
+        root = temporary_root / "unpacked"
+        profile = _select_profile(root)
+        main_path = root / Path(*profile.main_js.split("/"))
+        javascript = main_path.read_text(encoding="utf-8")
+        patched = _patch_web_player_event_ids(javascript, profile)
+        if patched == javascript:
+            return "ALREADY_PATCHED"
+        main_path.write_text(patched, encoding="utf-8")
+        output_archive = temporary_root / "patched.dat"
+        _repack(root, output_archive)
+        _validate_zip(output_archive)
+        os.replace(output_archive, feapp)
+    return "PATCHED"
 
 
 def patch_feapp(feapp_path: str | os.PathLike[str], new_ws: str | None,
@@ -265,8 +360,12 @@ def patch_feapp(feapp_path: str | os.PathLike[str], new_ws: str | None,
                 patched_javascript,
                 profile,
             )
+            final_javascript = _patch_mailbox_write_access(
+                mailbox_javascript,
+                profile,
+            )
             main_path.write_text(
-                _patch_mailbox_write_access(mailbox_javascript, profile),
+                _patch_web_player_event_ids(final_javascript, profile),
                 encoding="utf-8",
             )
             output_archive = temporary_root / "patched.dat"
@@ -285,6 +384,14 @@ def patch_feapp(feapp_path: str | os.PathLike[str], new_ws: str | None,
                 or (
                     profile.mailbox_write_replacement is not None
                     and profile.mailbox_write_replacement not in patched_js
+                )
+                or (
+                    profile.main_js == MAIN_JS_0627
+                    and (
+                        WEB_PLAYER_PLAYLIST_EVENT_ANCHOR_0627 not in patched_js
+                        or WEB_PLAYER_SONGLIST_EVENT_ANCHOR_0627 not in patched_js
+                        or WEB_PLAYER_LOCAL_CHECK_REPLACEMENT_0627 not in patched_js
+                    )
                 )
             ):
                 raise ValueError("patched archive verification failed")

--- a/patch_feapp.py
+++ b/patch_feapp.py
@@ -28,7 +28,7 @@ MAILBOX_LOGIN_ANCHOR = (
 )
 MAILBOX_LOGIN_REPLACEMENT = (
     '!z.isNew||N?(localStorage.setItem("appMode","lite"),'
-    'await t.replace({name:ye.Collection}),'
+    'await t.replace({name:ye.Home}),'
     'await h(z.uid.toString(),z.modelGatewayToken||"",!1))'
 )
 
@@ -41,7 +41,7 @@ MAILBOX_LOGIN_ANCHOR_0627 = (
 )
 MAILBOX_LOGIN_REPLACEMENT_0627 = (
     '!z.isNew||$?(localStorage.setItem("appMode","lite"),'
-    'await t.replace({name:ve.Collection}),'
+    'await t.replace({name:ve.Home}),'
     'await h(z.uid.toString(),z.modelGatewayToken||"",!1))'
 )
 MAILBOX_WRITE_ANCHOR_0627 = '"hide-write":o(p)||!o(N3)'
@@ -56,7 +56,7 @@ class _PatchProfile:
     inject_prefix: str
     mailbox_anchor: str
     mailbox_replacement: str
-    collection_route: str
+    home_route: str
     mailbox_write_anchor: str | None
     mailbox_write_replacement: str | None
 
@@ -69,7 +69,7 @@ _PATCH_PROFILES = (
         ',"query.response":no(a)}}),',
         MAILBOX_LOGIN_ANCHOR,
         MAILBOX_LOGIN_REPLACEMENT,
-        "await t.replace({name:ye.Collection})",
+        "await t.replace({name:ye.Home})",
         None,
         None,
     ),
@@ -80,7 +80,7 @@ _PATCH_PROFILES = (
         ',"query.response":io(a)}}),',
         MAILBOX_LOGIN_ANCHOR_0627,
         MAILBOX_LOGIN_REPLACEMENT_0627,
-        "await t.replace({name:ve.Collection})",
+        "await t.replace({name:ve.Home})",
         MAILBOX_WRITE_ANCHOR_0627,
         MAILBOX_WRITE_REPLACEMENT_0627,
     ),
@@ -281,7 +281,7 @@ def patch_feapp(feapp_path: str | os.PathLike[str], new_ws: str | None,
                 or "toyWsUrl" not in patched_js
                 or new_ws not in patched_js
                 or 'localStorage.setItem("appMode","lite")' not in patched_js
-                or profile.collection_route not in patched_js
+                or profile.home_route not in patched_js
                 or (
                     profile.mailbox_write_replacement is not None
                     and profile.mailbox_write_replacement not in patched_js

--- a/tests/installer/test_original_client_audit.py
+++ b/tests/installer/test_original_client_audit.py
@@ -17,6 +17,16 @@ from patch_feapp import (
     INJECT_ANCHOR_0627,
     MAILBOX_LOGIN_ANCHOR_0627,
     MAIN_JS_0627,
+    WEB_PLAYER_PLAYLIST_EVENT_ANCHOR_0627,
+    WEB_PLAYER_PLAYLIST_EVENT_BROKEN_INTEGER_0627,
+    WEB_PLAYER_LOCAL_CHECK_ANCHOR_0627,
+    WEB_PLAYER_LOCAL_CHECK_BROKEN_INTEGER_0627,
+    WEB_PLAYER_LOCAL_CHECK_REPLACEMENT_0627,
+    WEB_PLAYER_SONGLIST_EVENT_ANCHOR_0627,
+    WEB_PLAYER_SONGLIST_EVENT_BROKEN_INTEGER_0627,
+    _PATCH_PROFILES,
+    _patch_web_player_event_ids,
+    repair_web_player_event_ids,
 )
 from tools.audit_original_client import (
     OriginalClientAuditError,
@@ -104,6 +114,55 @@ def test_audit_supports_original_client_0_0_9_627(tmp_path: Path) -> None:
     assert report["patch_contract"]["safe_to_apply_existing_patch"] is True
 
 
+def test_0627_web_player_event_ids_are_strings_and_idempotent() -> None:
+    profile = next(item for item in _PATCH_PROFILES if item.main_js == MAIN_JS_0627)
+    original = (
+        WEB_PLAYER_PLAYLIST_EVENT_ANCHOR_0627
+        + " fixture "
+        + WEB_PLAYER_SONGLIST_EVENT_ANCHOR_0627
+        + WEB_PLAYER_LOCAL_CHECK_ANCHOR_0627
+    )
+
+    patched = _patch_web_player_event_ids(original, profile)
+
+    assert WEB_PLAYER_PLAYLIST_EVENT_ANCHOR_0627 in patched
+    assert WEB_PLAYER_SONGLIST_EVENT_ANCHOR_0627 in patched
+    assert WEB_PLAYER_LOCAL_CHECK_REPLACEMENT_0627 in patched
+    assert _patch_web_player_event_ids(patched, profile) == patched
+
+    broken = patched.replace(
+        WEB_PLAYER_PLAYLIST_EVENT_ANCHOR_0627,
+        WEB_PLAYER_PLAYLIST_EVENT_BROKEN_INTEGER_0627,
+    ).replace(
+        WEB_PLAYER_SONGLIST_EVENT_ANCHOR_0627,
+        WEB_PLAYER_SONGLIST_EVENT_BROKEN_INTEGER_0627,
+    ).replace(
+        WEB_PLAYER_LOCAL_CHECK_REPLACEMENT_0627,
+        WEB_PLAYER_LOCAL_CHECK_BROKEN_INTEGER_0627,
+    )
+    assert _patch_web_player_event_ids(broken, profile) == patched
+
+
+def test_0627_web_player_event_archive_repair_is_idempotent(tmp_path: Path) -> None:
+    archive_path = tmp_path / "feapp.dat"
+    javascript = (
+        HE_ANCHOR_0627
+        + INJECT_ANCHOR_0627
+        + MAILBOX_LOGIN_ANCHOR_0627
+        + WEB_PLAYER_PLAYLIST_EVENT_ANCHOR_0627
+        + WEB_PLAYER_SONGLIST_EVENT_ANCHOR_0627
+        + WEB_PLAYER_LOCAL_CHECK_ANCHOR_0627
+    )
+    with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(MAIN_JS_0627, javascript)
+
+    assert repair_web_player_event_ids(archive_path, work_root=tmp_path) == "PATCHED"
+    assert (
+        repair_web_player_event_ids(archive_path, work_root=tmp_path)
+        == "ALREADY_PATCHED"
+    )
+
+
 def test_audit_identifies_an_already_patched_archive_without_repatching(tmp_path: Path) -> None:
     javascript = " ".join(
         (
@@ -119,7 +178,7 @@ def test_audit_identifies_an_already_patched_archive_without_repatching(tmp_path
 
     assert report["patch_contract"]["state"] == "already_patched"
     assert report["patch_contract"]["safe_to_apply_existing_patch"] is False
-    assert report["navigation_evidence"]["has_collection"] is True
+    assert report["navigation_evidence"]["has_collection"] is False
 
 
 def test_audit_rejects_missing_main_bundle_and_unsafe_members(tmp_path: Path) -> None:

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -92,7 +92,10 @@ def test_launcher_repairs_existing_0627_frontend_before_start(
         archive.writestr("index.html", index)
         archive.writestr(
             "assets/main-31595bd3.js",
-            b'prefix"hide-write":o(p)||!o(N3)suffix',
+            (
+                'prefix"hide-write":o(p)||!o(N3)'
+                'Gn=e=>We({action:"checkLocalSongs",data:{songs:e}})suffix'
+            ).encode(),
         )
         archive.writestr("assets/olivia-companion-settings.js", old_bootstrap)
 
@@ -559,7 +562,7 @@ def test_fresh_profile_retries_known_first_exit_once(
     assert str(root.resolve()) not in launcher_log
 
 
-def test_launcher_patches_the_host_settings_before_each_client_attempt(
+def test_launcher_patches_the_isolated_settings_before_each_client_attempt(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -580,7 +583,9 @@ def test_launcher_patches_the_host_settings_before_each_client_attempt(
     )
 
     expected = (
-        host_roaming
+        root
+        / "profile"
+        / "Roaming"
         / "miHoYo"
         / "Olivia-steam"
         / "store"

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1864,7 +1864,7 @@ def test_install_isolated_copy_activates_original_client_surfaces(
     assert (installed / "local_backend" / "original_client_update_api.py").is_file()
     assert (installed / "local_backend/runtime/imports/offline_letter_pairs.py").is_file()
     assert "toyApiUrl" in main
-    assert "await t.replace({name:ye.Collection})" in main
+    assert "await t.replace({name:ye.Home})" in main
 
     with zipfile.ZipFile(patched_webplayer) as archive:
         names = set(archive.namelist())

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -86,16 +86,19 @@ def test_hidden_start_uses_visible_error_branch_only_for_failures(
     )
     error_record = tmp_path / "visible-error.txt"
     escaped_record = str(error_record).replace('"', '""')
+    launch_failure_line = [
+        line for line in template.splitlines() if "CStr(exitCode)" in line and "MsgBox" in line
+    ][-1]
     instrumented = template.replace(
         "shell.Run noticeCommand, 0, False",
         "' startup notice intercepted",
     ).replace(
-        "shell.Run errorCommand, 0, False",
+        launch_failure_line,
         f'Set testLog = fso.CreateTextFile("{escaped_record}", True, True)\n'
         "testLog.Write CStr(exitCode)\ntestLog.Close",
     )
     assert "shell.Run noticeCommand, 0, False" not in instrumented
-    assert "shell.Run errorCommand, 0, False" not in instrumented
+    assert launch_failure_line not in instrumented
     script = tmp_path / "START.vbs"
     script.write_text(instrumented, encoding="utf-16")
     if start_exit is not None:
@@ -1889,6 +1892,9 @@ def test_install_isolated_copy_activates_original_client_surfaces(
     assert 'WScript.Arguments.Named.Exists("error")' in start_hidden
     assert "Olivia 正在启动，请稍候" in start_hidden
     assert 'WScript.ScriptFullName & Chr(34) & " /notice"' in start_hidden
+    assert 'exitCode <> -1' in start_hidden
+    assert 'CStr(exitCode) <> "4294967295"' in start_hidden
+    assert 'shell.Run errorCommand' not in start_hidden
     assert "shell.Run noticeCommand, 0, False" in start_hidden
     assert "On Error Resume Next" in start_hidden
     assert "exitCode = shell.Run" in start_hidden
@@ -1897,10 +1903,8 @@ def test_install_isolated_copy_activates_original_client_surfaces(
     assert "MsgBox launchErrorDescription" not in start_hidden
     assert ", 0, True)" in start_hidden
     assert "If exitCode <> 0 Then" in start_hidden
-    assert '" /error:" & CStr(exitCode)' in start_hidden
-    assert "shell.Run errorCommand, 0, False" in start_hidden
     assert "Olivia 启动失败（错误码" in start_hidden
-    assert start_hidden.count("MsgBox") == 1
+    assert start_hidden.count("MsgBox") == 2
     assert start_hidden.index("shell.Run noticeCommand, 0, False") < start_hidden.index(
         "exitCode = shell.Run"
     )

--- a/tests/test_baseline_hardening.py
+++ b/tests/test_baseline_hardening.py
@@ -1117,7 +1117,7 @@ def test_patch_feapp_uses_backup_hash_and_atomic_replacement(tmp_path: Path) -> 
     assert 'personaStatus="DRAFT"' not in patched
 
 
-def test_patch_feapp_routes_fresh_lite_login_to_existing_mailbox_collection(
+def test_patch_feapp_keeps_fresh_lite_login_on_original_home(
     tmp_path: Path,
 ) -> None:
     import zipfile
@@ -1142,8 +1142,8 @@ def test_patch_feapp_routes_fresh_lite_login_to_existing_mailbox_collection(
         patched = archive.read("assets/main-917d29fc.js").decode("utf-8")
 
     assert 'localStorage.setItem("appMode","lite")' in patched
-    assert "await t.replace({name:ye.Collection})" in patched
-    assert "await t.replace({name:ye.Home})" not in patched
+    assert "await t.replace({name:ye.Home})" in patched
+    assert "await t.replace({name:ye.Collection})" not in patched
 
 
 def test_patch_feapp_supports_original_client_0_0_9_627(
@@ -1177,8 +1177,8 @@ def test_patch_feapp_supports_original_client_0_0_9_627(
     assert 'toyApiUrl="http://127.0.0.1:8899"' in patched
     assert 'toyWsUrl="ws://127.0.0.1:8899/ws"' in patched
     assert 'localStorage.setItem("appMode","lite")' in patched
-    assert "await t.replace({name:ve.Collection})" in patched
-    assert "await t.replace({name:ve.Home})" not in patched
+    assert "await t.replace({name:ve.Home})" in patched
+    assert "await t.replace({name:ve.Collection})" not in patched
     assert '"hide-write":!1' in patched
     assert '"hide-write":o(p)||!o(N3)' not in patched
 

--- a/tests/test_baseline_hardening.py
+++ b/tests/test_baseline_hardening.py
@@ -1158,9 +1158,12 @@ def test_patch_feapp_supports_original_client_0_0_9_627(
     javascript = (
         'We=e=>new Promise((t,s)=>{try{,'
         '"query.response":io(a)}}),t(c)},onFailure:'
-        '!z.isNew||$?(await t.replace({name:ve.Home}),'
+        '!z.isNew||$?(await t.replace({name:ve.Home}),' 
         'await h(z.uid.toString(),z.modelGatewayToken||"",!1))'
         '"hide-write":o(p)||!o(N3)'
+        'const W=K?"":Nt();if(t.value===Se.PRO)'
+        'ye=qt(t.value,B),Ee=Nt();f.value='
+        'Gn=e=>We({action:"checkLocalSongs",data:{songs:e}})'
     )
     with zipfile.ZipFile(feapp, "w", zipfile.ZIP_DEFLATED) as archive:
         archive.writestr(main_member, javascript)
@@ -1181,6 +1184,9 @@ def test_patch_feapp_supports_original_client_0_0_9_627(
     assert "await t.replace({name:ve.Collection})" not in patched
     assert '"hide-write":!1' in patched
     assert '"hide-write":o(p)||!o(N3)' not in patched
+    assert 'const W=K?"":Nt()' in patched
+    assert 'Ee=Nt();f.value=' in patched
+    assert 'eventId:String(t.eventId??s+1)' in patched
 
 
 def test_patch_feapp_requires_explicit_local_ws_and_rolls_back_on_failure(tmp_path: Path) -> None:


### PR DESCRIPTION
Repairs the managed copy of the final official client without changing the user's Steam installation.\n\n- keeps the original Home/曲库 route and native mailbox widgets\n- carries native display/widget preferences into the isolated profile\n- fills the final frontend's missing web-player payload fields while preserving string event IDs\n- suppresses the official client's normal -1/4294967295 close code and removes delayed stale error popups\n\nEvidence: final-client live launch on 0.0.9.627; zero eventId/videoByTodView bridge warnings after repair; focused installer suite 124 passed, 1 skipped. Full public smoke on the previous head had 2099 passed with one stale route assertion, corrected in this head.