### PR TITLE
fix(diagnostics): export live launcher status

### DIFF
--- a/runtime/diagnostics/support_bundle.py
+++ b/runtime/diagnostics/support_bundle.py
@@ -186,9 +186,14 @@ def _project_tail_record(value: object, *, runtime: bool) -> dict[str, object]:
             if type(exit_code) is not int or not -(1 << 31) <= exit_code <= 0xFFFFFFFF:
                 raise _invalid()
             record["exit_code"] = exit_code
-    for name in ("status", "error_code", "health"):
+    for name in ("status", "health"):
         if name in source:
-            record[name] = _code(source[name])
+            value = source[name]
+            if not isinstance(value, str):
+                raise _invalid()
+            record[name] = _status(value.strip().lower())
+    if "error_code" in source:
+        record["error_code"] = _code(source["error_code"])
     if runtime:
         if "reply_mode" in source:
             reply_mode = source["reply_mode"]

--- a/tests/http/test_original_client_diagnostics_api.py
+++ b/tests/http/test_original_client_diagnostics_api.py
@@ -39,7 +39,14 @@ def _source() -> dict[str, object]:
 def test_diagnostics_export_is_loopback_safe_and_downloadable() -> None:
     async def scenario() -> None:
         app = web.Application()
-        mount_original_client_diagnostics_api(app, lambda: _source())
+        source = _source()
+        source["launcher_tail"] = [
+            {"event": "native_settings", "status": "already_enabled"}
+        ]
+        source["runtime_tail"] = [
+            {"event": "health_probe", "health": "HEALTHY"}
+        ]
+        mount_original_client_diagnostics_api(app, lambda: source)
         client = await _client(app)
         try:
             response = await client.get(
@@ -54,6 +61,10 @@ def test_diagnostics_export_is_loopback_safe_and_downloadable() -> None:
             bundle = await response.read()
             with zipfile.ZipFile(io.BytesIO(bundle)) as archive:
                 manifest = json.loads(archive.read("manifest.json"))
+                launcher_tail = archive.read("launcher-tail.jsonl")
+                runtime_tail = archive.read("runtime-tail.jsonl")
+            assert b'"status":"already_enabled"' in launcher_tail
+            assert b'"health":"healthy"' in runtime_tail
             manifest_schema = json.loads(
                 Path("contracts/diagnostic_bundle_manifest.schema.json").read_text(
                     encoding="utf-8"


### PR DESCRIPTION
Fixes the installed diagnostic export returning DIAGNOSTIC_EXPORT_UNAVAILABLE when real launcher events contain lowercase status tokens or uppercase health tokens. Status/health fields are normalized as status values; error_code remains strict uppercase. Focused: 10 passed; hardening and diff check pass.