### PR TITLE
fix(media): keep video settings responsive

### DIFF
--- a/local_server.py
+++ b/local_server.py
@@ -2660,6 +2660,7 @@ async def route(
                     video_reply_dependency_status,
                     environment,
                     performance_video_path=_current_music_performance(environment),
+                    probe_runtime=False,
                 )
             except Exception:
                 return ok({
@@ -2697,6 +2698,7 @@ async def route(
                     video_reply_dependency_status,
                     environment,
                     performance_video_path=_current_music_performance(environment),
+                    probe_runtime=False,
                 )
             except Exception:
                 return err(503, "VIDEO_REPLY_SETTING_UNAVAILABLE", {

--- a/runtime/media/music_reply.py
+++ b/runtime/media/music_reply.py
@@ -289,6 +289,7 @@ def video_reply_dependency_status(
     env: Mapping[str, str],
     *,
     performance_video_path: Path | None,
+    probe_runtime: bool = True,
 ) -> dict[str, object]:
     """Describe the complete speech-plus-music closure without exposing local paths."""
 
@@ -314,7 +315,7 @@ def video_reply_dependency_status(
             external_python = Path(
                 str(delivery.tts.provider_options.get("external_python", ""))
             )
-            cosyvoice_runtime_ready = _python_runtime_ready(
+            cosyvoice_runtime_ready = not probe_runtime or _python_runtime_ready(
                 external_python,
                 cwd=Path(delivery.tts.runtime_root),
                 imports=("torch", "torchaudio", "cosyvoice.cli.cosyvoice"),
@@ -338,11 +339,14 @@ def video_reply_dependency_status(
                 minimax_root / "models" / "vae" / "minimax_music3_dav.safetensors",
             )
         )
-        and _python_runtime_ready(
-            configured("OLIVIA_MINIMAX_COMFY_PYTHON"),
-            cwd=minimax_root,
-            imports=("torch", "comfy", "comfy_extras.nodes_minimax_music"),
-            accepted_torch_versions=("2.13.0+cu130",),
+        and (
+            not probe_runtime
+            or _python_runtime_ready(
+                configured("OLIVIA_MINIMAX_COMFY_PYTHON"),
+                cwd=minimax_root,
+                imports=("torch", "comfy", "comfy_extras.nodes_minimax_music"),
+                accepted_torch_versions=("2.13.0+cu130",),
+            )
         )
     )
     latentsync_root = configured("OLIVIA_LATENTSYNC_ROOT")
@@ -358,11 +362,14 @@ def video_reply_dependency_status(
                 latentsync_root / "checkpoints" / "latentsync_unet.pt",
             )
         )
-        and _python_runtime_ready(
-            configured("OLIVIA_LATENTSYNC_PYTHON"),
-            cwd=latentsync_root,
-            imports=("torch", "diffusers", "latentsync"),
-            accepted_torch_versions=("2.5.1+cu121", "2.9.1+cu128"),
+        and (
+            not probe_runtime
+            or _python_runtime_ready(
+                configured("OLIVIA_LATENTSYNC_PYTHON"),
+                cwd=latentsync_root,
+                imports=("torch", "diffusers", "latentsync"),
+                accepted_torch_versions=("2.5.1+cu121", "2.9.1+cu128"),
+            )
         )
     )
     roformer_python = configured("OLIVIA_ROFORMER_PYTHON")
@@ -373,14 +380,17 @@ def video_reply_dependency_status(
         and file("OLIVIA_ROFORMER_MODEL_PATH")
         and file("OLIVIA_ROFORMER_CONFIG_PATH")
         and (
-            _python_runtime_ready(
-                roformer_python,
-                cwd=roformer_python.parent if roformer_python else None,
-                imports=("torch", "mel_band_roformer.inference"),
-                accepted_torch_versions=("2.11.0+cu128", "2.13.0+cu130"),
+            not probe_runtime
+            or (
+                _python_runtime_ready(
+                    roformer_python,
+                    cwd=roformer_python.parent if roformer_python else None,
+                    imports=("torch", "mel_band_roformer.inference"),
+                    accepted_torch_versions=("2.11.0+cu128", "2.13.0+cu130"),
+                )
+                if roformer_python is not None
+                else _executable_runtime_ready(roformer_executable)
             )
-            if roformer_python is not None
-            else _executable_runtime_ready(roformer_executable)
         )
     )
     ordinary_assets_ready = file("OLIVIA_ORDINARY_ACTION_BASE")

--- a/tests/http/test_video_reply_settings.py
+++ b/tests/http/test_video_reply_settings.py
@@ -223,8 +223,9 @@ def test_video_reply_settings_requests_keep_http_responsive_during_probe(
     release = threading.Event()
     preflight_complete = threading.Event()
 
-    def slow_probe(_environment, *, performance_video_path):
+    def slow_probe(_environment, *, performance_video_path, probe_runtime=True):
         assert performance_video_path is None
+        assert probe_runtime is False
         started.set()
         assert release.wait(2)
         return {"ready": True, "dependencies": []}
@@ -368,7 +369,8 @@ def test_letter_send_does_not_wait_for_the_full_video_runtime_probe(
         raising=False,
     )
 
-    def slow_full_probe(_environment, *, performance_video_path):
+    def slow_full_probe(_environment, *, performance_video_path, probe_runtime=True):
+        assert probe_runtime is True
         time.sleep(0.3)
         return {"ready": False, "dependencies": []}
 
@@ -413,7 +415,7 @@ def test_video_reply_enable_is_blocked_and_receive_fails_closed_when_dependencie
     monkeypatch.setattr(
         local_server,
         "video_reply_dependency_status",
-        lambda _environment, *, performance_video_path: {
+        lambda _environment, *, performance_video_path, probe_runtime=True: {
             "ready": False,
             "dependencies": [
                 {


### PR DESCRIPTION
## Result
- video settings GET and enable POST now inspect the installed dependency closure without importing Torch or probing CUDA
- render/install verification keeps the existing full runtime probes
- installed E2E improved from >10s timeout to 13ms, all dependencies ready, setting enabled/effective

## Verification
- 48 focused tests passed
- baseline hardening PASS
- py_compile and diff-check PASS