### PR TITLE
fix(installer): stop running app before uninstall

### DIFF
--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -542,7 +542,7 @@ def _write_start_scripts(root: Path, port: int) -> None:
         encoding="utf-16",
     )
     (root / "UNINSTALL.cmd").write_text(
-        "@echo off\nsetlocal EnableDelayedExpansion\nset ROOT=%~dp0\nset PYTHON_EXE=%ROOT%..\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" uninstall --apply & exit /b !ERRORLEVEL!\n",
+        "@echo off\nsetlocal EnableDelayedExpansion\nset ROOT=%~dp0\nset PYTHON_EXE=%ROOT%..\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" uninstall --apply\nset EXIT_CODE=!ERRORLEVEL!\nif !EXIT_CODE! EQU 0 start \"\" /b cmd.exe /d /c \"ping.exe 127.0.0.1 -n 2 ^>nul ^& del /f /q \\\"%~f0\\\"\"\nexit /b !EXIT_CODE!\n",
         encoding="utf-8",
     )
     (root / "CONFIGURE.cmd").write_text(

--- a/installer/uninstall.py
+++ b/installer/uninstall.py
@@ -28,6 +28,73 @@ except ImportError:  # Support direct execution and the stable runpy launcher.
     )
 
 
+_STOP_MANAGED_PROCESSES = r"""
+$ErrorActionPreference = 'Stop'
+$root = [IO.Path]::GetFullPath($env:OLIVIA_UNINSTALL_TARGET)
+$appPrefix = [IO.Path]::GetFullPath((Join-Path $root 'app')) + [IO.Path]::DirectorySeparatorChar
+$backendToken = [IO.Path]::GetFullPath((Join-Path $root 'local_backend'))
+$taskkill = Join-Path $env:WINDIR 'System32\taskkill.exe'
+$targets = @(Get-CimInstance Win32_Process | Where-Object {
+    $executable = [string]$_.ExecutablePath
+    $command = [string]$_.CommandLine
+    ($executable -and $executable.StartsWith($appPrefix, [StringComparison]::OrdinalIgnoreCase)) -or
+    (($_.Name -in @('python.exe', 'pythonw.exe')) -and
+        $command.IndexOf($backendToken, [StringComparison]::OrdinalIgnoreCase) -ge 0)
+})
+foreach ($target in $targets) {
+    & $taskkill /PID $target.ProcessId /T /F *> $null
+}
+for ($attempt = 0; $attempt -lt 50; $attempt += 1) {
+    $remaining = @(Get-CimInstance Win32_Process | Where-Object {
+        $executable = [string]$_.ExecutablePath
+        $command = [string]$_.CommandLine
+        ($executable -and $executable.StartsWith($appPrefix, [StringComparison]::OrdinalIgnoreCase)) -or
+        (($_.Name -in @('python.exe', 'pythonw.exe')) -and
+            $command.IndexOf($backendToken, [StringComparison]::OrdinalIgnoreCase) -ge 0)
+    })
+    if ($remaining.Count -eq 0) { exit 0 }
+    Start-Sleep -Milliseconds 100
+}
+exit 1
+"""
+
+
+def _stop_managed_processes(root: Path) -> None:
+    if os.name != "nt":
+        return
+    powershell = (
+        Path(os.environ["WINDIR"])
+        / "System32"
+        / "WindowsPowerShell"
+        / "v1.0"
+        / "powershell.exe"
+    )
+    if not powershell.is_file():
+        raise OSError("MANAGED_PROCESS_STOP_FAILED")
+    environment = dict(os.environ)
+    environment["OLIVIA_UNINSTALL_TARGET"] = os.fspath(root)
+    command = [
+        os.fspath(powershell),
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        _STOP_MANAGED_PROCESSES,
+    ]
+    for _attempt in range(2):
+        result = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=15,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            env=environment,
+        )
+        if result.returncode == 0:
+            return
+    raise OSError("MANAGED_PROCESS_STOP_FAILED")
+
+
 def _remove_launch_shortcuts(root: Path) -> None:
     if os.name != "nt":
         return
@@ -86,9 +153,14 @@ def main() -> int:
         return 2
     print(json.dumps({"status": "UNINSTALLED" if args.apply else "DRY_RUN", "owned_paths": list(OWNED_PATHS), "preserved_paths": list(PRESERVED_PATHS)}, ensure_ascii=False))
     if args.apply:
+        try:
+            _stop_managed_processes(root)
+        except (KeyError, OSError, subprocess.SubprocessError):
+            print("MANAGED_PROCESS_STOP_FAILED")
+            return 2
         _remove_launch_shortcuts(root)
         try:
-            remove_owned_targets(root)
+            remove_owned_targets(root, deferred_paths=("UNINSTALL.cmd",))
         except ValueError:
             print("PATCH_MARKER_INVALID")
             return 2

--- a/installer/uninstall_safety.py
+++ b/installer/uninstall_safety.py
@@ -121,15 +121,23 @@ def _remove_managed_python_path_registration(root: Path) -> None:
                 temporary.unlink(missing_ok=True)
 
 
-def remove_owned_targets(root: Path) -> None:
+def remove_owned_targets(
+    root: Path, *, deferred_paths: tuple[str, ...] = ()
+) -> None:
     """Remove only validated compiled targets; marker contents are untrusted."""
 
+    deferred = set(deferred_paths)
+    if not deferred.issubset(OWNED_PATHS):
+        raise ValueError("PATCH_MARKER_INVALID")
     targets = safe_owned_targets(root)
     _remove_managed_python_path_registration(root.resolve())
     for target in targets:
+        relative = target.relative_to(root.resolve()).as_posix()
+        if relative in deferred:
+            continue
         # Re-check each target immediately before deletion to avoid following a
         # path component that was replaced after the initial validation.
-        _safe_target(root.resolve(), target.relative_to(root.resolve()).as_posix())
+        _safe_target(root.resolve(), relative)
         if target.is_dir():
             shutil.rmtree(target)
         elif target.is_file():

--- a/tests/installer/test_uninstall_runtime.py
+++ b/tests/installer/test_uninstall_runtime.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from installer import uninstall
+from installer.uninstall_safety import remove_owned_targets
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows process ownership is required")
+def test_uninstall_stops_only_the_managed_process_tree_before_deleting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    windows = tmp_path / "Windows"
+    powershell = (
+        windows / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
+    )
+    powershell.parent.mkdir(parents=True)
+    powershell.touch()
+    install = tmp_path / "Olivia Local" / "install"
+    install.mkdir(parents=True)
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def run(command: list[str], **kwargs: object) -> object:
+        calls.append((command, kwargs))
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setenv("WINDIR", os.fspath(windows))
+    monkeypatch.setattr(uninstall.subprocess, "run", run)
+
+    uninstall._stop_managed_processes(install)
+
+    assert len(calls) == 1
+    command, options = calls[0]
+    assert command[:4] == [
+        os.fspath(powershell),
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+    ]
+    assert options["env"]["OLIVIA_UNINSTALL_TARGET"] == os.fspath(install)
+    assert "Get-CimInstance Win32_Process" in command[4]
+    assert "local_backend" in command[4]
+    assert "Olivia.exe" not in command[4]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows process ownership is required")
+def test_uninstall_rechecks_after_a_process_exits_during_tree_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    windows = tmp_path / "Windows"
+    powershell = (
+        windows / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
+    )
+    powershell.parent.mkdir(parents=True)
+    powershell.touch()
+    install = tmp_path / "install"
+    install.mkdir()
+    returncodes = iter((1, 0))
+
+    monkeypatch.setenv("WINDIR", os.fspath(windows))
+    monkeypatch.setattr(
+        uninstall.subprocess,
+        "run",
+        lambda *_args, **_kwargs: type(
+            "Result", (), {"returncode": next(returncodes)}
+        )(),
+    )
+
+    uninstall._stop_managed_processes(install)
+
+
+def test_standalone_uninstall_defers_only_its_running_batch_file(
+    tmp_path: Path,
+) -> None:
+    app = tmp_path / "app"
+    app.mkdir()
+    (app / "managed.txt").write_text("managed", encoding="utf-8")
+    command = tmp_path / "UNINSTALL.cmd"
+    command.write_text("managed", encoding="utf-8")
+
+    remove_owned_targets(tmp_path, deferred_paths=("UNINSTALL.cmd",))
+
+    assert not app.exists()
+    assert command.read_text(encoding="utf-8") == "managed"

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1916,7 +1916,11 @@ def test_install_isolated_copy_activates_original_client_surfaces(
     assert "launcher\\version_launcher.py" in uninstall
     assert "installer_main" not in uninstall
     assert "setlocal EnableDelayedExpansion" in uninstall
-    assert "uninstall --apply & exit /b !ERRORLEVEL!" in uninstall
+    assert "uninstall --apply" in uninstall
+    assert "set EXIT_CODE=!ERRORLEVEL!" in uninstall
+    assert "start \"\" /b cmd.exe" in uninstall
+    assert "del /f /q" in uninstall
+    assert "exit /b !EXIT_CODE!" in uninstall
     for script in (
         installed / "START.cmd",
         installed / "CONFIGURE.cmd",


### PR DESCRIPTION
## Result
- uninstall now stops only this install's app/backend process tree before deleting managed files
- prevents locked wallpaper audio and Mem0 installer processes from breaking removal
- user data/profile/downloads remain preserved

## Verification
- installed repro captured WinError 32 before repair
- 4 focused tests passed
- hardening, py_compile and diff-check PASS