### PR TITLE
fix(installer): complete deferred uninstall cleanup

### DIFF
--- a/installer/full_patch.py
+++ b/installer/full_patch.py
@@ -542,7 +542,7 @@ def _write_start_scripts(root: Path, port: int) -> None:
         encoding="utf-16",
     )
     (root / "UNINSTALL.cmd").write_text(
-        "@echo off\nsetlocal EnableDelayedExpansion\nset ROOT=%~dp0\nset PYTHON_EXE=%ROOT%..\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" uninstall --apply\nset EXIT_CODE=!ERRORLEVEL!\nif !EXIT_CODE! EQU 0 start \"\" /b cmd.exe /d /c \"ping.exe 127.0.0.1 -n 2 ^>nul ^& del /f /q \\\"%~f0\\\"\"\nexit /b !EXIT_CODE!\n",
+        "@echo off\nsetlocal EnableDelayedExpansion\nset ROOT=%~dp0\nset PYTHON_EXE=%ROOT%..\\runtime\\python-3.12.10-embed-amd64\\python.exe\nif not exist \"%PYTHON_EXE%\" (echo PYTHON_UNAVAILABLE & exit /b 2)\n\"%PYTHON_EXE%\" \"%ROOT%launcher\\version_launcher.py\" --install-root \"%ROOT%.\" uninstall --apply\nset EXIT_CODE=!ERRORLEVEL!\nif not !EXIT_CODE! EQU 0 exit /b !EXIT_CODE!\nstart \"\" /b \"%ComSpec%\" /d /c \"ping.exe 127.0.0.1 -n 2 >nul & del /f /q ^\"%~f0^\"\"\nexit /b 0\n",
         encoding="utf-8",
     )
     (root / "CONFIGURE.cmd").write_text(

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1918,9 +1918,11 @@ def test_install_isolated_copy_activates_original_client_surfaces(
     assert "setlocal EnableDelayedExpansion" in uninstall
     assert "uninstall --apply" in uninstall
     assert "set EXIT_CODE=!ERRORLEVEL!" in uninstall
-    assert "start \"\" /b cmd.exe" in uninstall
+    assert "if not !EXIT_CODE! EQU 0 exit /b !EXIT_CODE!" in uninstall
+    assert 'start "" /b "%ComSpec%"' in uninstall
+    assert "ping.exe 127.0.0.1 -n 2 >nul & del /f /q" in uninstall
     assert "del /f /q" in uninstall
-    assert "exit /b !EXIT_CODE!" in uninstall
+    assert "exit /b 0" in uninstall
     for script in (
         installed / "START.cmd",
         installed / "CONFIGURE.cmd",

--- a/tests/media/test_managed_subprocess.py
+++ b/tests/media/test_managed_subprocess.py
@@ -186,7 +186,9 @@ def test_windows_resume_failure_terminates_assigned_job_once(monkeypatch) -> Non
     with pytest.raises(OSError, match="resume"):
         managed_subprocess.run_managed_process(["worker"], timeout_seconds=1)
 
-    assert observed == ["assign", "terminate", "reap:15.0", "close"]
+    assert observed[:2] == ["assign", "terminate"]
+    assert float(observed[2].removeprefix("reap:")) == pytest.approx(15.0)
+    assert observed[3:] == ["close"]
 
 
 def test_windows_cleanup_failures_do_not_swallow_resume_error(monkeypatch) -> None:
@@ -234,7 +236,8 @@ def test_windows_job_close_failure_warns_after_tree_exit(monkeypatch) -> None:
             ["worker"], timeout_seconds=1,
         )
     assert result.returncode == 0
-    assert observed == ["reap:1", "terminate", "reap:15.0"]
+    assert observed[:2] == ["reap:1", "terminate"]
+    assert float(observed[2].removeprefix("reap:")) == pytest.approx(15.0)
 
 
 def test_windows_terminate_failure_warns_after_tree_exit(monkeypatch) -> None:
@@ -351,10 +354,11 @@ def test_posix_success_terminates_process_group_and_reaps(monkeypatch) -> None:
     result = managed_subprocess.run_managed_process(["worker"], timeout_seconds=12)
 
     assert result.stdout == b"out"
-    assert observed == [
-        "reap:12", f"kill:4242:{managed_subprocess.signal.SIGKILL}", "reap:15.0",
-        "kill:4242:0", "kill:4242:0",
+    assert observed[:2] == [
+        "reap:12", f"kill:4242:{managed_subprocess.signal.SIGKILL}",
     ]
+    assert float(observed[2].removeprefix("reap:")) == pytest.approx(15.0)
+    assert observed[3:] == ["kill:4242:0", "kill:4242:0"]
 
 
 def test_posix_kill_failure_warns_after_group_exit(monkeypatch) -> None:


### PR DESCRIPTION
Fix Windows cmd quoting for the deferred UNINSTALL.cmd self-delete. The previous quoting returned success but left the batch file behind. Verified with a disposable real Windows batch self-delete, focused installer tests (4 passed), py_compile, and git diff --check.