### PR TITLE
fix(import): prefer local letter backups

### DIFF
--- a/contracts/http_contract.example.json
+++ b/contracts/http_contract.example.json
@@ -19,6 +19,14 @@
       "error_code": null,
       "evidence": "local-extension"
     },
+    "/toy/letter/legacy/local-import": {
+      "methods": ["GET", "POST"],
+      "capability": "letters.legacy_import",
+      "state": "available",
+      "read_only": false,
+      "error_code": null,
+      "evidence": "local-extension"
+    },
     "/toy/letter/legacy/official-import": {
       "methods": ["GET", "POST"],
       "capability": "letters.official_import",

--- a/docs/B02_HTTP_CONTRACT.md
+++ b/docs/B02_HTTP_CONTRACT.md
@@ -40,7 +40,7 @@ B01 的私有 manifest/state matrix 只允许存在于 ignored `.evidence/`。�
 | 音乐写操作 | `/toy/addPerformance` 等 | unavailable | 501 `MUSIC_WRITE_NOT_IMPLEMENTED` |
 | MIDI | `/toy/midi/*` | terminal/partial | 任务状态兼容现有原型；生成/上传/分享码导入明确 501 |
 | legacy import | `/toy/letter/legacy/import` | available | SQLite 本地扩展；仅接受 `mode=read_only`，以单事务原子导入旧信并按内容哈希去重；导入后旧信域只读且不与新聊天合并 |
-| 官方文字信件导入 | `/toy/letter/legacy/official-import` | available/degraded | 用户在设置页明确确认后，先要求 Mem0 与 PrivateWorld 可用；首次初始化关系状态时还要求大模型已配置。随后临时读取官方客户端登录日志并从官方接口导入原信与文字回信；严格按时间写入 Mem0、初始化 PrivateWorld，最后才原子发布到信箱；忽略视频，不保存或回显凭证 |
+| 本地历史信件恢复 | `/toy/letter/legacy/local-import` | available/degraded | 设置页只读取安装时选定的原版游戏目录中的 `letter_pairs.json`；用户确认后把成对文字记录作为只读历史原子写入本地信箱。官方服务器已关闭，本入口不读取登录日志、不访问官方接口，也不调用 LLM、Mem0、PrivateWorld 或媒体 |
 | 长期记忆重试 | `/toy/companion/memory/retry` | available/degraded | 仅接受带确认头的 `POST`；返回 `INITIALIZING`、`AVAILABLE`、`DEGRADED`、`UNAVAILABLE` 或 `DISABLED`，其中显式禁用的 `DISABLED` 不可重试；重试真实 Mem0 factory，并在 delegate 已就绪时重新启动 durable outbox，不要求退出重进 |
 | 诊断包导出 | `/toy/diagnostics/export` | available | 设置页显式触发，只在本机生成并下载严格白名单 ZIP；不上传，不包含密钥、正文、记忆、真实 ID、绝对路径、完整 URL 或原始日志 |
 
@@ -55,10 +55,7 @@ CORS 仅允许 loopback Origin，或精确命中原生客户端固定信任源
 - 缺少 `letter_id`/`content`：400 `MISSING_FIELD`。
 - `content` 为空、`material` 非 object、JSON 非法或请求体非 object：400 稳定错误。
 - legacy import 的 body、`mode` 或 `letters` 不合法：400 `INVALID_BODY`；SQLite 存储不可用：503 `MEMORY_UNAVAILABLE`。两类错误都不回显旧信正文、路径或密钥。
-- 官方文字信件导入无法读取登录日志、官方接口或有效账户时：503 `OFFICIAL_LETTER_IMPORT_UNAVAILABLE`；用户可先启动官方客户端并登录后重试。
-- Mem0 或 PrivateWorld 在采集前不可用时，分别返回 503 `OFFICIAL_HISTORY_MEMORY_UNAVAILABLE` 或 `PRIVATE_WORLD_HISTORY_UNAVAILABLE`，不会读取官方历史。预检无法在读取私人历史前识别本次 corpus，因此大模型未配置时保守返回 503 `OFFICIAL_HISTORY_LLM_UNAVAILABLE`，即使 PrivateWorld 已有其他状态也不会读取官方历史或写入 Mem0。迁移取得 corpus 后仍会在调用 provider 前查询匹配的稳定 command audit；归档失败后的同 corpus 重试在大模型已就绪时不会重复调用 provider。迁移中断时返回 503 `OFFICIAL_HISTORY_MEMORY_WRITE_FAILED` 或 `PRIVATE_WORLD_HISTORY_UNAVAILABLE`，不会把本批历史信件发布到信箱；已写入 Mem0 的记录由稳定 source id 判重，重试不会重复生成。SQLite 只读归档是最后一步可见性提交，成功后官方历史信件按原时间出现在默认信箱中，但保持 `scope=legacy`、`read_only=true`、`is_read=true`，不增加未读数，也不生成新回信或视频。
-
-`GET /toy/letter/legacy/official-import` 返回当前导入进度，响应遵循 `contracts/official_history_import_progress.schema.json`。带 `preflight=1` 时响应遵循 `contracts/official_history_import_preflight.schema.json`，只检查本地 Mem0、PrivateWorld 和必要的大模型配置，不读取信件、不调用 provider，也不启动或重试导入。成功返回 `READY` 和布尔值 `llm_required`；不可用时返回稳定错误 envelope。客户端使用 `stage`、`processed` 和 `total` 显示读取、记忆整理、关系恢复与信箱写入进度。
+- 本地历史恢复找不到 `letter_pairs.json` 时返回 404 `OFFLINE_LETTER_BACKUP_REQUIRED`，设置页明确提示官方服务器已关闭并要求准备本地备份；格式不合法时返回 400 `OFFLINE_LETTER_BACKUP_INVALID`。两种情况都不会发起网络请求或写入部分记录。
 - 找不到信件或 MIDI job：404，不返回空的成功对象。
 - 空信箱、无匹配歌曲、空 playlist：200，但 `source=local-memory|empty`、列表和计数明确为空。
 - LLM timeout/error：发信确认保持 200/PENDING，detail 随后标记 `FAILED` 并带错误码；不得写入 `reply_text` 占位符。

--- a/docs/B04_LOCAL_MEMORY.md
+++ b/docs/B04_LOCAL_MEMORY.md
@@ -19,7 +19,7 @@ SQLite 表、FTS 索引和配置都属于本机数据，位于被 `.gitignore` �
 
 `tools.memory_import.LegacyLetterImporter` 支持 JSON、JSONL、CSV 和逐行文本。支持显式映射、BOM/UTF-8/常见本地编码、路径根限制、dry-run 和 checkpoint；格式、编码、JSON 行和字段错误返回稳定代码，不把正文或路径放入报告。默认 `atomic=true`，坏行或存储失败整批回滚；内容 SHA-256 用于幂等重复检测。
 
-本机已有成对文字备份时，`python -m runtime.imports.offline_letter_pairs --source <json> --memory-root <memory-root>` 默认只 dry-run；用户确认后附加 `--apply` 才会原子写入。输入必须是只含非空 `content`/`reply` 的 JSON 数组，输出仅含计数、状态和源文件 SHA-256。恢复记录使用独立的 typed provenance 与 `offline_mailbox_publish_status=validated_pair_v1`，可作为 `scope=legacy`、`read_only=true`、已读历史显示在默认信箱；它不会调用 LLM、Mem0、PrivateWorld 或媒体，也不会写 `history.evidence.v1`、`official_history_publish_status` 或官方历史记忆语义。通用 HTTP legacy import 会剥离这些本机发布字段，不能伪造默认信箱可见性；原始备份仍不进入仓库或安装包。
+本机已有成对文字备份时，设置页优先通过 `/toy/letter/legacy/local-import` 查找安装时选定的原版游戏目录中的 `letter_pairs.json`；用户确认后原子写入。找不到时明确提示官方服务器已关闭并要求用户准备本地备份，不回退到官方接口。命令行 `python -m runtime.imports.offline_letter_pairs --source <json> --memory-root <memory-root>` 仍可用于显式 dry-run，附加 `--apply` 后写入。输入必须是只含非空 `content`/`reply` 的 JSON 数组，输出仅含计数、状态和源文件 SHA-256。恢复记录使用独立的 typed provenance 与 `offline_mailbox_publish_status=validated_pair_v1`，可作为 `scope=legacy`、`read_only=true`、已读历史显示在默认信箱；它不会调用 LLM、Mem0、PrivateWorld 或媒体，也不会写 `history.evidence.v1`、`official_history_publish_status` 或官方历史记忆语义。通用 HTTP legacy import 会剥离这些本机发布字段，不能伪造默认信箱可见性；原始备份仍不进入仓库或安装包。
 
 metadata 先规范化为 JSON 数据模型，再作为完整 JSON 文本存储；超过安全上限会拒绝整条记录，绝不会截断序列化后的 JSON。`export_records(domains=...)` 要求调用方显式选择域，并在返回前校验可以生成有效 JSON；未选择域会拒绝。
 
@@ -27,11 +27,7 @@ metadata 先规范化为 JSON 数据模型，再作为完整 JSON 文本存储�
 
 检索内容只作为 `<MEMORY_CONTEXT_UNTRUSTED_DATA>` 内的引用资料。正文在渲染时转义 `<`、`>`、方括号、下划线和反斜杠；角色伪装、命令、重复 delimiter 都不会成为 system 指令。资料区分 `CONVERSATION_MEMORY_CURRENT` 与 `LEGACY_LETTERS_REFERENCE_ONLY`，并携带有限 provenance。
 
-聊天清空只调用 `clear_conversation()`，不会触碰 `legacy_letters`。旧信件没有单条删除 API；显式 `uninstall(delete_legacy=true)` 才会在一个事务中整库删除，并返回实际删除计数和 `whole_library` 范围。HTTP `/toy/letter/legacy/import` 只接受显式 `mode=read_only` 的内存 JSON 记录；它把原文、来源和 metadata 原样交给现有 SQLite adapter 的原子导入和 SHA-256 去重逻辑，响应只返回计数而不回显正文或本地路径。`/toy/letter/legacy/official-import` 由设置页用户确认触发，复用同一只读导入边界，只导入用户原信和官方文字回信，忽略视频；官方凭证只在本次请求内存中使用。一个本地 data-root 只对应一个用户档案：首个含文字回信的官方账号写入稳定账号标记，后续不同账号会在任何归档或记忆写入前被拒绝；需要切换账号时必须使用独立 data-root。导入前必须确认真实 Mem0 与 PrivateWorld 可用，否则在采集官方历史前失败。采集并校验后，系统按 `occurred_at` 从早到晚逐封执行 `remember_exchange`；只有写入或稳定判重成功才会继续，`SKIPPED` 视为失败。
-
-Mem0 完成后，PrivateWorld 以完整、规范排序的 `source_record_id` 集合生成稳定命令 ID，并在调用评估 provider 前查询命令审计。已有审计直接复用，不再调用 provider；没有审计时，即使 Mem0 全部判重或 PrivateWorld 已有状态，也只评估一次完整语料，并通过 `ApplyHistoricalRelationshipEvidence` 对 `familiarity` / `closeness` 做逐轴 `max`。该命令不改变阶段、trust、comfort、tension、增长配额、亲密授权或其他私人状态。最后一步才把完成标记与记录一起原子写入 SQLite 只读归档，并发布到默认信箱时间线；旧版本留下且没有完成标记的官方归档不会被发布。历史信件保持 `scope=legacy`、`read_only=true`、`is_read=true`，因此可在真实信箱查看，但不增加未读数，也不会生成新回信或视频。
-
-`official_history_publish_status` 是服务端保留 metadata；通用 legacy import 会丢弃调用方提交的同名字段。官方历史成功重试若命中旧版同内容归档，会在同一 SQLite 事务内升级该归档的来源、原时间和完成标记，并在事务结束前恢复只读 update trigger。
+聊天清空只调用 `clear_conversation()`，不会触碰 `legacy_letters`。旧信件没有单条删除 API；显式 `uninstall(delete_legacy=true)` 才会在一个事务中整库删除，并返回实际删除计数和 `whole_library` 范围。HTTP `/toy/letter/legacy/import` 只接受显式 `mode=read_only` 的内存 JSON 记录；它把原文、来源和 metadata 原样交给现有 SQLite adapter 的原子导入和 SHA-256 去重逻辑，响应只返回计数而不回显正文或本地路径。本地 `letter_pairs.json` 不含可信时间戳，因此恢复信件的时间保持未知，不伪造原时间，也不自动改变关系状态或写入长期语义记忆。
 
 `official_history_memory_semantics` 也是服务端保留 metadata。只有值为 `actor_split_first_person_v2` 的官方历史才可跳过记忆重建；旧记录会先删除，再按 actor 分别提取来信用户事实与林离事实，只有林离事实必须使用第一人称“我”。首次导入时 SQLite 尚未创建 `legacy_letters` 表属于空库引导状态，可安全回退到进程内空归档；其他 SQLite 错误继续失败关闭。
 

--- a/http_contract.py
+++ b/http_contract.py
@@ -65,6 +65,8 @@ ERROR_CODES: dict[str, dict[str, Any]] = {
     "FEEDBACK_NOT_IMPLEMENTED": {"http_status": 501, "retryable": False},
     "SHARE_TOKEN_NOT_IMPLEMENTED": {"http_status": 501, "retryable": False},
     "MEMORY_UNAVAILABLE": {"http_status": 503, "retryable": True},
+    "OFFLINE_LETTER_BACKUP_REQUIRED": {"http_status": 404, "retryable": True},
+    "OFFLINE_LETTER_BACKUP_INVALID": {"http_status": 400, "retryable": True},
     "OFFICIAL_LETTER_IMPORT_UNAVAILABLE": {"http_status": 503, "retryable": True},
     "OFFICIAL_HISTORY_MEMORY_UNAVAILABLE": {"http_status": 503, "retryable": True},
     "OFFICIAL_HISTORY_LLM_UNAVAILABLE": {"http_status": 503, "retryable": True},
@@ -214,6 +216,11 @@ ROUTES: dict[str, dict[str, Any]] = {
     ),
     "/toy/letter/legacy/import": _route(
         ["POST"],
+        "letters.legacy_import",
+        evidence="local-extension",
+    ),
+    "/toy/letter/legacy/local-import": _route(
+        ["GET", "POST"],
         "letters.legacy_import",
         evidence="local-extension",
     ),

--- a/local_server.py
+++ b/local_server.py
@@ -20,7 +20,7 @@ import inspect
 import threading
 import tempfile as _tempfile
 import webbrowser as _webbrowser
-from dataclasses import replace
+from dataclasses import asdict, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from types import MappingProxyType
@@ -127,7 +127,9 @@ from runtime.imports.official_letters import collect_default_official_text_repli
 from runtime.imports.offline_letter_pairs import (
     OFFLINE_LETTER_PAIR_PROVENANCE_KEY,
     OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY,
+    apply_offline_letter_pair_recovery_to_adapter,
     is_published_offline_letter_pair,
+    plan_offline_letter_pair_recovery_with_adapter,
 )
 from runtime.imports.historical_memory import (
     HistoricalMigrationResult,
@@ -817,6 +819,29 @@ def _local_data_root(environment: Mapping[str, str] | None = None) -> Path | Non
         "OLIVIA_LOCAL_DATA_ROOT",
     )
     return configured.resolve(strict=False) if configured is not None else None
+
+
+def _default_offline_letter_pair_source() -> Path | None:
+    """Find the local backup beside the original client selected at install time."""
+
+    data_root = _local_data_root()
+    if data_root is None:
+        return None
+    marker_path = data_root.parent / ".olivia-full-patch.json"
+    try:
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        official_source = marker.get("official_source")
+        if not isinstance(official_source, str) or not official_source.strip():
+            return None
+        official_root = Path(official_source).expanduser()
+        if not official_root.is_absolute():
+            return None
+        official_root = official_root.resolve(strict=True)
+        source = (official_root / "letter_pairs.json").resolve(strict=True)
+        source.relative_to(official_root)
+        return source if source.is_file() else None
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        return None
 
 
 def _conversation_state_root() -> Path | None:
@@ -2521,6 +2546,73 @@ async def route(
         })
     if spec["state"] == "not_implemented" and p != "/toy/midi/generate":
         return not_implemented(spec["error_code"] or "ROUTE_NOT_IMPLEMENTED")
+
+    if p == "/toy/letter/legacy/local-import":
+        source = _default_offline_letter_pair_source()
+        if source is None:
+            return err(404, "OFFLINE_LETTER_BACKUP_REQUIRED", {
+                "status": "UNAVAILABLE",
+                "error_code": "OFFLINE_LETTER_BACKUP_REQUIRED",
+                "retryable": True,
+                "source": "local_backup",
+            })
+        adapter = _legacy_import_adapter()
+        if not getattr(adapter, "enabled", False):
+            return err(503, "MEMORY_UNAVAILABLE", {
+                "status": "UNAVAILABLE",
+                "error_code": "MEMORY_UNAVAILABLE",
+                "retryable": True,
+                "source": "local_backup",
+            })
+        try:
+            if method == "GET":
+                report = await asyncio.to_thread(
+                    plan_offline_letter_pair_recovery_with_adapter,
+                    source,
+                    adapter=adapter,
+                )
+                return ok({
+                    **asdict(report),
+                    "status": "READY",
+                    "source": "local_backup",
+                })
+            if companion_confirmed is not True:
+                return err(403, "COMPANION_CONFIRMATION_REQUIRED", {
+                    "status": "FAILED",
+                    "error_code": "COMPANION_CONFIRMATION_REQUIRED",
+                    "retryable": False,
+                })
+            report = await asyncio.to_thread(
+                apply_offline_letter_pair_recovery_to_adapter,
+                source,
+                adapter=adapter,
+            )
+        except ValueError:
+            return err(400, "OFFLINE_LETTER_BACKUP_INVALID", {
+                "status": "FAILED",
+                "error_code": "OFFLINE_LETTER_BACKUP_INVALID",
+                "retryable": True,
+                "source": "local_backup",
+            })
+        except (OSError, sqlite3.Error):
+            return err(503, "MEMORY_UNAVAILABLE", {
+                "status": "UNAVAILABLE",
+                "error_code": "MEMORY_UNAVAILABLE",
+                "retryable": True,
+                "source": "local_backup",
+            })
+        if report.status != "committed" or report.rejected:
+            return err(503, "MEMORY_UNAVAILABLE", {
+                "status": "FAILED",
+                "error_code": "MEMORY_UNAVAILABLE",
+                "retryable": True,
+                "source": "local_backup",
+            })
+        return ok({
+            **asdict(report),
+            "status": "APPLIED",
+            "source": "local_backup",
+        })
 
     if p == "/toy/letter/legacy/official-import":
         if method == "GET":

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-SETTINGS_UI_VERSION = "p03.original-settings-manage.v14"
+SETTINGS_UI_VERSION = "p03.original-settings-manage.v15"
 
 BOOTSTRAP_JAVASCRIPT = r'''(() => {
   "use strict";
@@ -19,7 +19,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const VIDEO_CAPABILITY_PATH = "/toy/capabilities/video";
   const VIDEO_CAPABILITY_ACTION_PATH = "/toy/capabilities/video/action";
   const DIAGNOSTIC_EXPORT_PATH = "/toy/diagnostics/export";
-  const OFFICIAL_LETTER_IMPORT_PATH = "/toy/letter/legacy/official-import";
+  const LOCAL_LETTER_IMPORT_PATH = "/toy/letter/legacy/local-import";
   const OFFICIAL_IMPORT_CONFIRM_ATTR = "data-olivia-companion-official-import-confirm";
   const MEMORY_CORRECT_PATH = "/toy/companion/memory/correct";
   const MEMORY_DELETE_PATH = "/toy/companion/memory/delete";
@@ -286,23 +286,16 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         signal: controller.signal,
       });
       const responseBody = await response.json();
-      const officialPreflight = path === OFFICIAL_LETTER_IMPORT_PATH
-        && params.preflight === "1";
-      const payload = (path === VIDEO_REPLY_SETTINGS_PATH || path === OFFICIAL_LETTER_IMPORT_PATH)
+      const payload = (path === VIDEO_REPLY_SETTINGS_PATH
+          || path === LOCAL_LETTER_IMPORT_PATH)
         && responseBody && responseBody.data
         ? responseBody.data
         : responseBody;
-      const valid = officialPreflight
+      const valid = path === LOCAL_LETTER_IMPORT_PATH
         ? payload && payload.status === "READY"
-          && typeof payload.llm_required === "boolean"
-        : path === OFFICIAL_LETTER_IMPORT_PATH
-        ? payload && ["IDLE", "RUNNING", "COMPLETED", "FAILED"].includes(payload.status)
-          && typeof payload.stage === "string"
-          && Number.isInteger(payload.total)
-          && Number.isInteger(payload.processed)
-          && Number.isInteger(payload.imported)
-          && Number.isInteger(payload.skipped)
-          && typeof payload.last_updated_at === "string"
+          && Number.isInteger(payload.seen)
+          && Number.isInteger(payload.would_insert)
+          && Number.isInteger(payload.duplicates)
         : path === VIDEO_REPLY_SETTINGS_PATH
         ? payload && (payload.state === "available" && typeof payload.enabled === "boolean"
           || payload.state === "unavailable" && typeof payload.reason_code === "string")
@@ -360,12 +353,10 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
   const requestMutation = async (path, body) => {
     const endpoint = new URL(path, apiBase);
     const controller = new AbortController();
-    const timeoutMs = path === OFFICIAL_LETTER_IMPORT_PATH
-      ? null
-      : path === VIDEO_REPLY_SETTINGS_PATH
+    const timeoutMs = path === VIDEO_REPLY_SETTINGS_PATH
       ? 300000
       : 8000;
-    const timeout = timeoutMs === null ? null : window.setTimeout(() => controller.abort(), timeoutMs);
+    const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
     try {
       const response = await fetch(endpoint, {
         method: "POST",
@@ -386,7 +377,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         responseBody = null;
       }
       const payload = (path === VIDEO_REPLY_SETTINGS_PATH
-          || path === OFFICIAL_LETTER_IMPORT_PATH
+          || path === LOCAL_LETTER_IMPORT_PATH
           || path === MEMORY_RETRY_PATH)
         && responseBody && responseBody.data && typeof responseBody.data === "object"
         ? responseBody.data
@@ -403,7 +394,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       }
       return payload;
     } finally {
-      if (timeout !== null) window.clearTimeout(timeout);
+      window.clearTimeout(timeout);
     }
   };
 
@@ -2012,7 +2003,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     section.append(text("div", "诊断与反馈", "text-text-body text-title-m"), row);
   };
 
-  const mountOfficialLetterImport = (section) => {
+  const mountLocalLetterImport = (section) => {
     const importRow = document.createElement("div");
     importRow.className = "flex items-center justify-between px-0 py-3 rounded-3";
     const importCopy = document.createElement("div");
@@ -2020,109 +2011,52 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     const importState = text("div", "", "text-text-secondary text-caption-m font-regular");
     importState.setAttribute("aria-live", "polite");
     importCopy.append(
-      text("div", "导入官方文字信件", "text-text-body text-label-l"),
-      text("div", "原信和林离的文字回信会按原时间进入信箱；双方内容会形成长期语义记忆，历史往来会初始化关系状态。不导入视频，重复信件自动跳过。", "text-text-secondary text-body-m font-regular"),
+      text("div", "导入本地历史信件", "text-text-body text-label-l"),
+      text("div", "官方服务器已关闭；这里只读取安装时选择的原版游戏目录中的 letter_pairs.json。本地原信和林离的文字回信会作为只读历史进入信箱，不联网、不导入视频，重复记录自动跳过。", "text-text-secondary text-body-m font-regular"),
       importState
     );
     let importPending = false;
-    let progressTimer = null;
-    let lastProgressSignature = "";
-    let lastProgressAt = Date.now();
-    const officialProgressText = (payload) => {
-      const total = Math.max(0, payload.total || 0);
-      const processed = Math.max(0, payload.processed || 0);
-      if (payload.stage === "listing") return `正在获取信件列表：已发现 ${total} 封。`;
-      if (payload.stage === "reading") return `正在读取信件内容：${processed} / ${total} 封。`;
-      if (payload.stage === "memory") return `正在整理长期记忆：${processed} / ${total} 封。`;
-      if (payload.stage === "relationship") return "信件记忆已整理，正在恢复你和林离的关系状态……";
-      if (payload.stage === "importing") return `正在写入信箱：${processed} / ${total} 封。`;
-      if (payload.stage === "completed") return `已导入 ${payload.imported || 0} 封，跳过 ${payload.skipped || 0} 封重复信件。`;
-      if (payload.stage === "failed") return "导入中断，可点击重试导入。";
-      return "正在准备导入……";
-    };
-    const refreshOfficialImportProgress = async () => {
+    const missingBackupText = "未在原版游戏目录找到 letter_pairs.json。官方服务器已关闭，请先准备本地备份并放回该目录。";
+    const refreshLocalBackup = async () => {
       try {
-        const progress = await requestJson(OFFICIAL_LETTER_IMPORT_PATH);
-        const signature = `${progress.stage}:${progress.total}:${progress.processed}:${progress.imported}:${progress.skipped}:${progress.last_updated_at}`;
-        if (signature !== lastProgressSignature) {
-          lastProgressSignature = signature;
-          lastProgressAt = Date.now();
-        }
-        if (Date.now() - lastProgressAt >= 20000 && progress.status === "RUNNING") {
-          importState.textContent = "20 秒没有新进度，可能卡住了。可点击“重新检查进度”；如果导入失败，可直接重试导入。";
-          importButton.textContent = "重新检查进度";
-          setButtonsBusy([importButton], false);
-        } else {
-          importState.textContent = officialProgressText(progress);
-        }
-      } catch (_error) {
-        importState.textContent = "暂时读取不到导入进度，正在等待导入结果……";
-      }
-    };
-    const pollOfficialImport = async () => {
-      if (!importPending) return;
-      await refreshOfficialImportProgress();
-      if (importPending) {
-        progressTimer = window.setTimeout(pollOfficialImport, 1000);
-      }
-    };
-    const importButton = button("导入", async () => {
-      if (importPending) {
-        await refreshOfficialImportProgress();
-        return;
-      }
-      try {
-        await requestJson(OFFICIAL_LETTER_IMPORT_PATH, { preflight: "1" });
+        const payload = await requestJson(LOCAL_LETTER_IMPORT_PATH);
+        importState.textContent = `已找到本地备份，共 ${payload.seen} 封；可导入 ${payload.would_insert} 封，重复 ${payload.duplicates} 封。`;
+        return payload;
       } catch (error) {
-        importState.textContent = error && error.code === "OFFICIAL_HISTORY_LLM_UNAVAILABLE"
-          ? "请先在“大模型”中完成连接测试并保存，再导入。"
-          : error && [
-            "OFFICIAL_HISTORY_MEMORY_UNAVAILABLE",
-            "PRIVATE_WORLD_HISTORY_UNAVAILABLE",
-          ].includes(error.code)
-            ? "请先安装并启用长期记忆组件，确认私人世界可用并重启客户端后再导入。"
-            : "无法确认导入条件，请重启客户端后再试。";
-        return;
+        importState.textContent = error && error.code === "OFFLINE_LETTER_BACKUP_REQUIRED"
+          ? missingBackupText
+          : error && error.code === "OFFLINE_LETTER_BACKUP_INVALID"
+            ? "本地 letter_pairs.json 格式无效，请更换完整备份后重试。"
+            : "暂时无法检查本地备份，请重启 Olivia 后重试。";
+        return null;
       }
-      if (!await confirmAction("确认从这台电脑上的官方 Olivia 账户导入文字信件？")) {
+    };
+    const importButton = button("导入本地备份", async () => {
+      if (importPending) return;
+      const preflight = await refreshLocalBackup();
+      if (!preflight) return;
+      if (!await confirmAction(`确认从本地 letter_pairs.json 导入 ${preflight.would_insert} 封只读历史信件？`)) {
         return;
       }
       setButtonsBusy([importButton], true);
       importButton.textContent = "正在导入";
       importPending = true;
-      lastProgressSignature = "";
-      lastProgressAt = Date.now();
-      importState.textContent = "正在读取官方文字信件……";
-      void pollOfficialImport();
+      importState.textContent = "正在读取本地备份并写入信箱……";
       try {
-        const payload = await requestMutation(OFFICIAL_LETTER_IMPORT_PATH, {});
+        const payload = await requestMutation(LOCAL_LETTER_IMPORT_PATH, {});
         const inserted = Number.isInteger(payload.inserted) ? payload.inserted : 0;
         const duplicates = Number.isInteger(payload.duplicates) ? payload.duplicates : 0;
-        const migration = payload.memory_migration;
-        const memoryText = migration && migration.status === "completed"
-          ? `记忆已按时间顺序处理 ${migration.processed || 0} 封。`
-          : "长期记忆写入未完成，历史信件未发布。";
-        const relationText = migration && migration.private_world_status === "initialized"
-          ? "已根据历史信件恢复初始关系状态。"
-          : migration && migration.private_world_status === "already_initialized"
-            ? "已有关系状态已保留，历史信件已加入长期记忆。"
-            : "关系状态未更新。";
-        importState.textContent = `已导入 ${inserted} 封，跳过 ${duplicates} 封重复信件。${memoryText}${relationText}`;
-        importButton.textContent = "再次导入";
+        importState.textContent = `已导入 ${inserted} 封只读历史信件，跳过 ${duplicates} 封重复记录。`;
+        importButton.textContent = "再次检查并导入";
       } catch (error) {
-        importState.textContent = error && error.code === "OFFICIAL_HISTORY_LLM_UNAVAILABLE"
-          ? "请先在“大模型”中完成连接测试并保存，再导入。"
-          : error && [
-            "OFFICIAL_HISTORY_MEMORY_UNAVAILABLE",
-            "OFFICIAL_HISTORY_MEMORY_WRITE_FAILED",
-            "PRIVATE_WORLD_HISTORY_UNAVAILABLE",
-          ].includes(error.code)
-            ? "长期记忆未就绪或写入失败，未发布任何历史信件。请检查记忆组件后重试。"
-            : "导入失败。请先启动官方客户端并登录，再重试。";
+        importState.textContent = error && error.code === "OFFLINE_LETTER_BACKUP_REQUIRED"
+          ? missingBackupText
+          : error && error.code === "OFFLINE_LETTER_BACKUP_INVALID"
+            ? "本地 letter_pairs.json 格式无效，请更换完整备份后重试。"
+            : "本地信件导入失败，请重启 Olivia 后重试。";
         importButton.textContent = "重试导入";
       } finally {
         importPending = false;
-        if (progressTimer !== null) window.clearTimeout(progressTimer);
         setButtonsBusy([importButton], false);
       }
     });
@@ -2131,8 +2065,6 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       text("div", "历史信件", "text-text-body text-title-m"),
       importRow
     );
-    return;
-
   };
 
   const mountShell = () => {
@@ -2171,7 +2103,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     section.append(title, row);
     mountDiagnosticExport(section);
     mountVideoReplySetting(section);
-    mountOfficialLetterImport(section);
+    mountLocalLetterImport(section);
     container.append(section);
   };
 

--- a/patch_companion_settings.py
+++ b/patch_companion_settings.py
@@ -377,7 +377,7 @@ def _verify_archive(
     bootstrap_required = (
         'const STATUS_PATH = "/toy/companion/status";',
         'const MEMORY_PATH = "/toy/companion/memory";',
-        'const OFFICIAL_LETTER_IMPORT_PATH = "/toy/letter/legacy/official-import";',
+        'const LOCAL_LETTER_IMPORT_PATH = "/toy/letter/legacy/local-import";',
         'const MEMORY_CORRECT_PATH = "/toy/companion/memory/correct";',
         'const MEMORY_DELETE_PATH = "/toy/companion/memory/delete";',
         'const MEMORY_PAUSE_PATH = "/toy/companion/memory/pause";',
@@ -395,7 +395,7 @@ def _verify_archive(
         "删除",
         "暂停长期记忆",
         "恢复长期记忆",
-        "导入官方文字信件",
+        "导入本地历史信件",
         "new MutationObserver",
         "replaceChildren",
     )

--- a/runtime/imports/offline_letter_pairs.py
+++ b/runtime/imports/offline_letter_pairs.py
@@ -12,7 +12,7 @@ import sqlite3
 from typing import Mapping, Sequence
 
 from runtime.memory.local_memory import LocalMemoryAdapter
-from runtime.memory.memory_port import LegacyLetter
+from runtime.memory.memory_port import LegacyLetter, MemoryPort
 
 
 _MAX_SOURCE_BYTES = 16 * 1024 * 1024
@@ -160,12 +160,11 @@ def _read_existing_hashes(database_path: Path) -> set[str]:
         connection.close()
 
 
-def _recovery_plan(
+def _recovery_plan_from_hashes(
     raw: bytes,
     pairs: tuple[tuple[str, str], ...],
-    database_path: Path,
+    existing: set[str],
 ) -> OfflineLetterPairRecoveryReport:
-    existing = _read_existing_hashes(database_path)
     batch: set[str] = set()
     duplicates = 0
     for pair in pairs:
@@ -183,6 +182,18 @@ def _recovery_plan(
     )
 
 
+def _recovery_plan(
+    raw: bytes,
+    pairs: tuple[tuple[str, str], ...],
+    database_path: Path,
+) -> OfflineLetterPairRecoveryReport:
+    return _recovery_plan_from_hashes(
+        raw,
+        pairs,
+        _read_existing_hashes(database_path),
+    )
+
+
 def plan_offline_letter_pair_recovery(
     source_path: str | Path,
     *,
@@ -190,6 +201,21 @@ def plan_offline_letter_pair_recovery(
 ) -> OfflineLetterPairRecoveryReport:
     raw, pairs = _parse_source(Path(source_path))
     return _recovery_plan(raw, pairs, Path(database_path))
+
+
+def plan_offline_letter_pair_recovery_with_adapter(
+    source_path: str | Path,
+    *,
+    adapter: MemoryPort,
+) -> OfflineLetterPairRecoveryReport:
+    """Inspect a paired backup against the active Archive adapter."""
+
+    raw, pairs = _parse_source(Path(source_path))
+    return _recovery_plan_from_hashes(
+        raw,
+        pairs,
+        adapter.legacy_content_hashes(),
+    )
 
 
 def apply_offline_letter_pair_recovery(
@@ -208,6 +234,32 @@ def apply_offline_letter_pair_recovery(
         )
     finally:
         archive.close()
+    return replace(
+        plan,
+        status="rolled_back" if result.rolled_back else "committed",
+        inserted=result.inserted,
+        duplicates=result.duplicates,
+        rejected=result.rejected,
+    )
+
+
+def apply_offline_letter_pair_recovery_to_adapter(
+    source_path: str | Path,
+    *,
+    adapter: MemoryPort,
+) -> OfflineLetterPairRecoveryReport:
+    """Import a local paired backup through the active Archive adapter."""
+
+    raw, pairs = _parse_source(Path(source_path))
+    plan = _recovery_plan_from_hashes(
+        raw,
+        pairs,
+        adapter.legacy_content_hashes(),
+    )
+    result = adapter.import_legacy_records(
+        _build_records(raw, pairs),
+        atomic=True,
+    )
     return replace(
         plan,
         status="rolled_back" if result.rolled_back else "committed",

--- a/tests/imports/test_offline_letter_pairs.py
+++ b/tests/imports/test_offline_letter_pairs.py
@@ -210,3 +210,75 @@ def test_generic_legacy_http_import_cannot_forge_offline_mailbox_publication(mon
     assert OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY not in metadata
     assert OFFLINE_LETTER_PAIR_PROVENANCE_KEY not in metadata
     assert metadata["reply_text"] == "synthetic reply"
+
+
+def test_local_history_route_discovers_installed_official_backup_and_imports(
+    tmp_path, monkeypatch
+):
+    import local_server
+
+    install_root = tmp_path / "installed"
+    data_root = install_root / "data"
+    official_root = tmp_path / "official-client"
+    data_root.mkdir(parents=True)
+    official_root.mkdir()
+    source = official_root / "letter_pairs.json"
+    _write_pairs(source)
+    (install_root / ".olivia-full-patch.json").write_text(
+        json.dumps({"official_source": str(official_root)}),
+        encoding="utf-8",
+    )
+    archive = LocalMemoryAdapter(tmp_path / "memory.sqlite3")
+    monkeypatch.setattr(local_server, "_local_data_root", lambda: data_root)
+    monkeypatch.setattr(local_server, "_legacy_import_adapter", lambda: archive)
+    try:
+        ready = asyncio.run(local_server.route(
+            "GET", "/toy/letter/legacy/local-import", {}, {}
+        ))
+        unconfirmed = asyncio.run(local_server.route(
+            "POST", "/toy/letter/legacy/local-import", {}, {}
+        ))
+        applied = asyncio.run(local_server.route(
+            "POST", "/toy/letter/legacy/local-import", {}, {},
+            companion_confirmed=True,
+        ))
+        repeated = asyncio.run(local_server.route(
+            "POST", "/toy/letter/legacy/local-import", {}, {},
+            companion_confirmed=True,
+        ))
+    finally:
+        archive.close()
+
+    assert ready["data"]["source"] == "local_backup"
+    assert (ready["data"]["status"], ready["data"]["seen"]) == ("READY", 2)
+    assert (ready["data"]["would_insert"], ready["data"]["duplicates"]) == (2, 0)
+    assert unconfirmed["code"] == 403
+    assert (applied["data"]["status"], applied["data"]["inserted"]) == ("APPLIED", 2)
+    assert (repeated["data"]["inserted"], repeated["data"]["duplicates"]) == (0, 2)
+
+
+def test_local_history_route_prompts_when_backup_is_absent(tmp_path, monkeypatch):
+    import local_server
+
+    install_root = tmp_path / "installed"
+    data_root = install_root / "data"
+    official_root = tmp_path / "official-client"
+    data_root.mkdir(parents=True)
+    official_root.mkdir()
+    (install_root / ".olivia-full-patch.json").write_text(
+        json.dumps({"official_source": str(official_root)}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(local_server, "_local_data_root", lambda: data_root)
+
+    result = asyncio.run(local_server.route(
+        "GET", "/toy/letter/legacy/local-import", {}, {}
+    ))
+
+    assert result["code"] == 404
+    assert result["data"] == {
+        "status": "UNAVAILABLE",
+        "error_code": "OFFLINE_LETTER_BACKUP_REQUIRED",
+        "retryable": True,
+        "source": "local_backup",
+    }

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -152,7 +152,7 @@ const run = async () => { const [id, fn] = timers.entries().next().value; timers
 
 # The shipped CEF surface needs explicit no-drag/pointer and display-state guards.
 def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
-    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v14"
+    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v15"
     for declaration in (
             'const STATUS_PATH = "/toy/companion/status";',
             'const MEMORY_PATH = "/toy/companion/memory";',
@@ -229,38 +229,25 @@ def test_original_settings_does_not_render_manual_patch_import_controls() -> Non
     assert "关闭并重新打开 Olivia 后生效" in source
 
 
-def test_original_settings_can_import_official_text_reply_history() -> None:
+def test_original_settings_imports_local_history_without_official_server() -> None:
     assert BOOTSTRAP_JAVASCRIPT.count(
-        'const OFFICIAL_LETTER_IMPORT_PATH = "/toy/letter/legacy/official-import";'
+        'const LOCAL_LETTER_IMPORT_PATH = "/toy/letter/legacy/local-import";'
     ) == 1
-    assert "导入官方文字信件" in BOOTSTRAP_JAVASCRIPT
-    assert "原信和林离的文字回信会按原时间进入信箱" in BOOTSTRAP_JAVASCRIPT
-    assert "双方内容会形成长期语义记忆" in BOOTSTRAP_JAVASCRIPT
-    assert "历史往来会初始化关系状态" in BOOTSTRAP_JAVASCRIPT
-    assert "requestMutation(OFFICIAL_LETTER_IMPORT_PATH, {})" in BOOTSTRAP_JAVASCRIPT
-    assert "path === OFFICIAL_LETTER_IMPORT_PATH\n      ? null" in BOOTSTRAP_JAVASCRIPT
-    assert "timeoutMs === null ? null" in BOOTSTRAP_JAVASCRIPT
-    assert ": 8000;" in BOOTSTRAP_JAVASCRIPT
+    assert "导入本地历史信件" in BOOTSTRAP_JAVASCRIPT
+    assert "官方服务器已关闭" in BOOTSTRAP_JAVASCRIPT
+    assert "letter_pairs.json" in BOOTSTRAP_JAVASCRIPT
+    assert "作为只读历史进入信箱" in BOOTSTRAP_JAVASCRIPT
+    assert "不联网" in BOOTSTRAP_JAVASCRIPT
+    assert "requestMutation(LOCAL_LETTER_IMPORT_PATH, {})" in BOOTSTRAP_JAVASCRIPT
+    assert "requestJson(LOCAL_LETTER_IMPORT_PATH)" in BOOTSTRAP_JAVASCRIPT
     assert "payload.inserted" in BOOTSTRAP_JAVASCRIPT
-    assert "payload.memory_migration" in BOOTSTRAP_JAVASCRIPT
-    assert "记忆已按时间顺序处理" in BOOTSTRAP_JAVASCRIPT
-    assert "requestJson(OFFICIAL_LETTER_IMPORT_PATH)" in BOOTSTRAP_JAVASCRIPT
-    assert (
-        'requestJson(OFFICIAL_LETTER_IMPORT_PATH, { preflight: "1" })'
-        in BOOTSTRAP_JAVASCRIPT
-    )
-    assert "请先在“大模型”中完成连接测试并保存，再导入。" in BOOTSTRAP_JAVASCRIPT
-    assert "正在获取信件列表" in BOOTSTRAP_JAVASCRIPT
-    assert "正在读取信件内容" in BOOTSTRAP_JAVASCRIPT
-    assert "正在整理长期记忆" in BOOTSTRAP_JAVASCRIPT
-    assert "正在写入信箱" in BOOTSTRAP_JAVASCRIPT
-    assert "20 秒没有新进度，可能卡住了" in BOOTSTRAP_JAVASCRIPT
-    assert 'importButton.textContent = "重新检查进度"' in BOOTSTRAP_JAVASCRIPT
+    assert "payload.would_insert" in BOOTSTRAP_JAVASCRIPT
+    assert "未在原版游戏目录找到 letter_pairs.json" in BOOTSTRAP_JAVASCRIPT
     assert 'importButton.textContent = "重试导入"' in BOOTSTRAP_JAVASCRIPT
-    assert "已导入历史信件（只读）" not in BOOTSTRAP_JAVASCRIPT
+    assert "mountOfficialLetterImport(section)" not in BOOTSTRAP_JAVASCRIPT
 
 
-def test_official_import_uses_visible_confirmation_without_settings_history_list() -> None:
+def test_local_import_prompts_for_missing_backup_and_uses_visible_confirmation() -> None:
     node = shutil.which("node")
     if node is None:
         pytest.skip("Node.js is not installed")
@@ -341,7 +328,7 @@ const document = {
   querySelector: (selector) => body.querySelector(selector),
 };
 let nativeConfirmCalls = 0;
-let memoryAvailable = false;
+let backupAvailable = false;
 const calls = [];
 const fetch = async (endpoint, options) => {
   calls.push({ path: endpoint.pathname, method: options.method, headers: options.headers });
@@ -355,7 +342,7 @@ const fetch = async (endpoint, options) => {
     return { ok: true, json: async () => ({
       status: "READY",
       capabilities: {
-        memory: { state: memoryAvailable ? "available" : "missing" },
+        memory: { state: "available" },
         private_world: { state: "available" },
         candidates: { state: "available" },
       },
@@ -367,29 +354,23 @@ const fetch = async (endpoint, options) => {
       total: 1, scope: "legacy", read_only: true,
     } }) };
   }
-  if (endpoint.pathname === "/toy/letter/legacy/official-import") {
+  if (endpoint.pathname === "/toy/letter/legacy/local-import") {
     if (options.method === "GET") {
-      if (endpoint.searchParams.get("preflight") === "1") {
-        return memoryAvailable
-          ? { ok: true, json: async () => ({ code: 0, data: {
-              status: "READY", llm_required: true,
-            } }) }
-          : { ok: false, json: async () => ({ code: 503, data: {
-              status: "UNAVAILABLE",
-              error_code: "OFFICIAL_HISTORY_LLM_UNAVAILABLE",
-              retryable: true,
-            } }) };
-      }
-      return { ok: true, json: async () => ({ code: 0, data: {
-        status: "RUNNING", stage: "reading", total: 2, processed: 1,
-        imported: 0, skipped: 0, last_updated_at: "2026-08-29T00:00:00+00:00",
-        retryable: false,
-      } }) };
+      return backupAvailable
+        ? { ok: true, json: async () => ({ code: 0, data: {
+            status: "READY", seen: 2, would_insert: 2, duplicates: 0,
+            source: "local_backup",
+          } }) }
+        : { ok: false, json: async () => ({ code: 404, data: {
+            status: "UNAVAILABLE",
+            error_code: "OFFLINE_LETTER_BACKUP_REQUIRED",
+            retryable: true,
+            source: "local_backup",
+          } }) };
     }
-    return { ok: false, json: async () => ({ code: 503, data: {
-      status: "UNAVAILABLE",
-      error_code: "OFFICIAL_HISTORY_LLM_UNAVAILABLE",
-      retryable: true,
+    return { ok: true, json: async () => ({ code: 0, data: {
+      status: "APPLIED", inserted: 2, duplicates: 0,
+      source: "local_backup",
     } }) };
   }
   throw new Error(`unexpected request: ${endpoint.pathname}`);
@@ -412,43 +393,45 @@ const flush = async () => { for (let index = 0; index < 8; index += 1) await Pro
   await flush();
   const buttons = body.querySelectorAll("button");
   const importButton = buttons[buttons.length - 1];
-  if (!importButton) throw new Error("official import button missing");
+  if (!importButton) throw new Error("local import button missing");
   if (body.querySelectorAll("span").some((item) => item.textContent === "legacy-summary")) {
     throw new Error("history must be rendered in the mailbox, not settings");
   }
   await importButton.click();
   await flush();
   if (body.querySelector("[data-olivia-companion-official-import-confirm]")) {
-    throw new Error("confirmation opened while memory was unavailable");
+    throw new Error("confirmation opened while backup was unavailable");
   }
-  if (calls.some((item) => item.path === "/toy/letter/legacy/official-import" && item.method === "POST")) {
-    throw new Error("official import wrote while LLM was unavailable");
+  if (calls.some((item) => item.path === "/toy/letter/legacy/local-import" && item.method === "POST")) {
+    throw new Error("local import wrote while backup was unavailable");
   }
-  memoryAvailable = true;
+  if (!body.querySelectorAll("div").some((item) => item.textContent.includes("官方服务器已关闭，请先准备本地备份"))) {
+    throw new Error("missing backup prompt was not shown");
+  }
+  backupAvailable = true;
   const importPending = importButton.click();
   await flush();
   const confirmDialog = body.querySelector("[data-olivia-companion-official-import-confirm]");
-  if (!confirmDialog) throw new Error("visible official import confirmation missing");
+  if (!confirmDialog) throw new Error("visible local import confirmation missing");
   const confirmButton = confirmDialog.querySelectorAll("button")[1];
   if (!confirmButton || confirmButton.style.pointerEvents !== "auto") throw new Error("confirmation button is not actionable");
   await confirmButton.click();
   await importPending;
   await flush();
-  const importCall = calls.find((item) => item.path === "/toy/letter/legacy/official-import" && item.method === "POST");
-  const preflightIndex = calls.findIndex((item) => item.path === "/toy/letter/legacy/official-import" && item.method === "GET");
-  const importIndex = calls.findIndex((item) => item.path === "/toy/letter/legacy/official-import" && item.method === "POST");
-  if (!importCall || importCall.headers["X-Olivia-Companion-Action"] !== "confirmed") throw new Error("official import confirmation header missing");
-  if (!calls.some((item) => item.path === "/toy/letter/legacy/official-import" && item.method === "GET")) throw new Error("official import progress was not polled");
-  if (preflightIndex < 0 || preflightIndex >= importIndex) throw new Error("import preflight did not run before official import");
-  if (!body.querySelectorAll("div").some((item) => item.textContent === "请先在“大模型”中完成连接测试并保存，再导入。")) {
-    throw new Error("LLM mutation failure did not show the actionable model setup message");
+  const importCall = calls.find((item) => item.path === "/toy/letter/legacy/local-import" && item.method === "POST");
+  const preflightIndex = calls.findIndex((item) => item.path === "/toy/letter/legacy/local-import" && item.method === "GET");
+  const importIndex = calls.findIndex((item) => item.path === "/toy/letter/legacy/local-import" && item.method === "POST");
+  if (!importCall || importCall.headers["X-Olivia-Companion-Action"] !== "confirmed") throw new Error("local import confirmation header missing");
+  if (preflightIndex < 0 || preflightIndex >= importIndex) throw new Error("local import preflight did not run before import");
+  if (!body.querySelectorAll("div").some((item) => item.textContent.includes("已导入 2 封只读历史信件"))) {
+    throw new Error("local import completion was not shown");
   }
   if (nativeConfirmCalls !== 0) throw new Error("native confirmation was used");
   process.stdout.write(JSON.stringify({
     legacyListRequests: calls.filter((item) => item.path === "/toy/letter/list").length,
-    llmBlocked: true,
+    missingBackupPrompt: true,
     importPreflight: true,
-    llmMutationMapped: true,
+    localImportCompleted: true,
   }));
 })().catch((error) => { console.error(error.stack); process.exitCode = 1; });
 '''
@@ -463,9 +446,9 @@ const flush = async () => { for (let index = 0; index < 8; index += 1) await Pro
     assert result.returncode == 0, output
     assert json.loads(result.stdout.decode("utf-8")) == {
         "legacyListRequests": 0,
-        "llmBlocked": True,
+        "missingBackupPrompt": True,
         "importPreflight": True,
-        "llmMutationMapped": True,
+        "localImportCompleted": True,
     }
 
 

--- a/tests/installer/test_patch_companion_settings.py
+++ b/tests/installer/test_patch_companion_settings.py
@@ -94,7 +94,7 @@ def test_patch_adds_original_settings_management_and_preserves_existing_assets(
         "/toy/companion/memory/delete",
         "/toy/companion/memory/pause",
         "/toy/companion/memory/resume",
-        "/toy/letter/legacy/official-import",
+        "/toy/letter/legacy/local-import",
     ):
         assert path_value in bootstrap
     for visible_text in (
@@ -105,7 +105,7 @@ def test_patch_adds_original_settings_management_and_preserves_existing_assets(
         "删除",
         "暂停长期记忆",
         "恢复长期记忆",
-        "导入官方文字信件",
+        "导入本地历史信件",
     ):
         assert visible_text in bootstrap
     for hidden_artifact in (

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1861,7 +1861,7 @@ def test_install_isolated_copy_activates_original_client_surfaces(
         main = archive.read("assets/main-917d29fc.js").decode("utf-8")
     assert "assets/olivia-companion-settings.js" in names
     assert "data-olivia-companion-settings" in index
-    assert "data-ui-version=\"p03.original-settings-manage.v14\"" in index
+    assert "data-ui-version=\"p03.original-settings-manage.v15\"" in index
     assert (installed / "local_backend" / "original_client_setup_api.py").is_file()
     assert (installed / "local_backend" / "original_client_capability_api.py").is_file()
     assert (installed / "local_backend" / "original_client_update_api.py").is_file()


### PR DESCRIPTION
## Summary
- add a local-only history import route that discovers letter_pairs.json beside the installed official client
- show an actionable missing-backup message because the official server is closed
- remove the official online import flow from the settings UI and keep recovered records read-only

## Verification
- tests/imports: 61 passed
- settings/patch/launcher: 94 passed
- HTTP contract: 64 passed, 1 deselected
- baseline hardening: 42 passed
- compileall and git diff --check: pass

## Boundary
No official API, LLM, Mem0, PrivateWorld, or media calls are made by the local recovery route.