### PR TITLE
fix(import): repair mojibake in local letter backups

### DIFF
--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-SETTINGS_UI_VERSION = "p03.original-settings-manage.v15"
+SETTINGS_UI_VERSION = "p03.original-settings-manage.v16"
 
 BOOTSTRAP_JAVASCRIPT = r'''(() => {
   "use strict";
@@ -295,6 +295,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         ? payload && payload.status === "READY"
           && Number.isInteger(payload.seen)
           && Number.isInteger(payload.would_insert)
+          && Number.isInteger(payload.would_update)
           && Number.isInteger(payload.duplicates)
         : path === VIDEO_REPLY_SETTINGS_PATH
         ? payload && (payload.state === "available" && typeof payload.enabled === "boolean"
@@ -2020,7 +2021,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     const refreshLocalBackup = async () => {
       try {
         const payload = await requestJson(LOCAL_LETTER_IMPORT_PATH);
-        importState.textContent = `已找到本地备份，共 ${payload.seen} 封；可导入 ${payload.would_insert} 封，重复 ${payload.duplicates} 封。`;
+        importState.textContent = `已找到本地备份，共 ${payload.seen} 封；可新增 ${payload.would_insert} 封，需修复 ${payload.would_update} 封，重复 ${payload.duplicates} 封。`;
         return payload;
       } catch (error) {
         importState.textContent = error && error.code === "OFFLINE_LETTER_BACKUP_REQUIRED"
@@ -2035,7 +2036,8 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       if (importPending) return;
       const preflight = await refreshLocalBackup();
       if (!preflight) return;
-      if (!await confirmAction(`确认从本地 letter_pairs.json 导入 ${preflight.would_insert} 封只读历史信件？`)) {
+      const changeCount = preflight.would_insert + preflight.would_update;
+      if (!await confirmAction(`确认从本地 letter_pairs.json 写入或修复 ${changeCount} 封只读历史信件？`)) {
         return;
       }
       setButtonsBusy([importButton], true);
@@ -2045,8 +2047,9 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       try {
         const payload = await requestMutation(LOCAL_LETTER_IMPORT_PATH, {});
         const inserted = Number.isInteger(payload.inserted) ? payload.inserted : 0;
+        const updated = Number.isInteger(payload.updated) ? payload.updated : 0;
         const duplicates = Number.isInteger(payload.duplicates) ? payload.duplicates : 0;
-        importState.textContent = `已导入 ${inserted} 封只读历史信件，跳过 ${duplicates} 封重复记录。`;
+        importState.textContent = `已导入 ${inserted} 封、修复 ${updated} 封只读历史信件，跳过 ${duplicates} 封重复记录。`;
         importButton.textContent = "再次检查并导入";
       } catch (error) {
         importState.textContent = error && error.code === "OFFLINE_LETTER_BACKUP_REQUIRED"

--- a/runtime/imports/offline_letter_pairs.py
+++ b/runtime/imports/offline_letter_pairs.py
@@ -63,6 +63,8 @@ class OfflineLetterPairRecoveryReport:
     read_only: bool = True
     history_audit: str = "not_written"
     provider_calls: int = 0
+    would_update: int = 0
+    updated: int = 0
 
 
 def is_published_offline_letter_pair(metadata: object) -> bool:
@@ -90,6 +92,24 @@ def _pair_archive_content(pair: tuple[str, str]) -> str:
         separators=(",", ":"),
         sort_keys=True,
     )
+
+
+def _repair_reversible_utf8_latin1_mojibake(value: str) -> str:
+    """Undo the legacy backup's lossless UTF-8-as-Latin-1 decode mistake."""
+
+    if any(ord(character) > 0xFF for character in value):
+        return value
+    try:
+        repaired = value.encode("latin-1").decode("utf-8")
+    except UnicodeError:
+        return value
+    original_c1 = sum(0x80 <= ord(character) <= 0x9F for character in value)
+    repaired_c1 = sum(0x80 <= ord(character) <= 0x9F for character in repaired)
+    original_cjk = sum("\u3400" <= character <= "\u9fff" for character in value)
+    repaired_cjk = sum("\u3400" <= character <= "\u9fff" for character in repaired)
+    if original_c1 and repaired_c1 < original_c1 and repaired_cjk > original_cjk:
+        return repaired
+    return value
 
 
 def _build_records(
@@ -137,25 +157,37 @@ def _parse_source(path: Path) -> tuple[bytes, tuple[tuple[str, str], ...]]:
         reply = value.get("reply")
         if not all(isinstance(item, str) and item.strip() for item in (content, reply)):
             raise ValueError("OFFLINE_LETTER_PAIR_INVALID")
-        pair = (content, reply)
+        pair = (
+            _repair_reversible_utf8_latin1_mojibake(content),
+            _repair_reversible_utf8_latin1_mojibake(reply),
+        )
         if len(_pair_archive_content(pair)) > _MAX_PAIR_CHARS:
             raise ValueError("OFFLINE_LETTER_PAIR_TOO_LARGE")
         pairs.append(pair)
     return raw, tuple(pairs)
 
 
-def _read_existing_hashes(database_path: Path) -> set[str]:
+def _read_existing_state(database_path: Path) -> tuple[set[str], dict[str, str]]:
     if not database_path.is_file():
-        return set()
+        return set(), {}
     connection = sqlite3.connect(f"file:{database_path.as_posix()}?mode=ro", uri=True)
     try:
         try:
-            rows = connection.execute("SELECT content_hash FROM legacy_letters").fetchall()
+            rows = connection.execute(
+                "SELECT content_hash, source_record_id, source FROM legacy_letters"
+            ).fetchall()
         except sqlite3.OperationalError as exc:
             if "no such table" not in str(exc):
                 raise
-            return set()
-        return {str(row[0]) for row in rows}
+            return set(), {}
+        return (
+            {str(row[0]) for row in rows},
+            {
+                str(row[1]): str(row[0])
+                for row in rows
+                if str(row[2]) == "offline-letter-pairs"
+            },
+        )
     finally:
         connection.close()
 
@@ -164,20 +196,35 @@ def _recovery_plan_from_hashes(
     raw: bytes,
     pairs: tuple[tuple[str, str], ...],
     existing: set[str],
+    existing_by_source: Mapping[str, str] | None = None,
 ) -> OfflineLetterPairRecoveryReport:
     batch: set[str] = set()
     duplicates = 0
-    for pair in pairs:
+    would_insert = 0
+    would_update = 0
+    source_sha256 = hashlib.sha256(raw).hexdigest()
+    source_hashes = existing_by_source or {}
+    for index, pair in enumerate(pairs, start=1):
         digest = hashlib.sha256(_pair_archive_content(pair).encode()).hexdigest()
-        if digest in existing or digest in batch:
+        source_record_id = f"offline-letter-pairs:{source_sha256}:{index:06d}"
+        old_digest = source_hashes.get(source_record_id)
+        if old_digest is not None:
+            if old_digest == digest:
+                duplicates += 1
+            else:
+                would_update += 1
+        elif digest in existing or digest in batch:
             duplicates += 1
+        else:
+            would_insert += 1
         batch.add(digest)
     return OfflineLetterPairRecoveryReport(
         status="dry_run",
-        source_sha256=hashlib.sha256(raw).hexdigest(),
+        source_sha256=source_sha256,
         seen=len(pairs),
         accepted=len(pairs),
-        would_insert=len(pairs) - duplicates,
+        would_insert=would_insert,
+        would_update=would_update,
         duplicates=duplicates,
     )
 
@@ -187,10 +234,12 @@ def _recovery_plan(
     pairs: tuple[tuple[str, str], ...],
     database_path: Path,
 ) -> OfflineLetterPairRecoveryReport:
+    existing, existing_by_source = _read_existing_state(database_path)
     return _recovery_plan_from_hashes(
         raw,
         pairs,
-        _read_existing_hashes(database_path),
+        existing,
+        existing_by_source,
     )
 
 
@@ -215,6 +264,7 @@ def plan_offline_letter_pair_recovery_with_adapter(
         raw,
         pairs,
         adapter.legacy_content_hashes(),
+        adapter.legacy_source_hashes("offline-letter-pairs"),
     )
 
 
@@ -231,6 +281,7 @@ def apply_offline_letter_pair_recovery(
         result = archive.import_legacy_records(
             _build_records(raw, pairs),
             atomic=True,
+            replace_matching_source_records=True,
         )
     finally:
         archive.close()
@@ -238,6 +289,7 @@ def apply_offline_letter_pair_recovery(
         plan,
         status="rolled_back" if result.rolled_back else "committed",
         inserted=result.inserted,
+        updated=result.updated,
         duplicates=result.duplicates,
         rejected=result.rejected,
     )
@@ -255,15 +307,18 @@ def apply_offline_letter_pair_recovery_to_adapter(
         raw,
         pairs,
         adapter.legacy_content_hashes(),
+        adapter.legacy_source_hashes("offline-letter-pairs"),
     )
     result = adapter.import_legacy_records(
         _build_records(raw, pairs),
         atomic=True,
+        replace_matching_source_records=True,
     )
     return replace(
         plan,
         status="rolled_back" if result.rolled_back else "committed",
         inserted=result.inserted,
+        updated=result.updated,
         duplicates=result.duplicates,
         rejected=result.rejected,
     )

--- a/runtime/memory/local_memory.py
+++ b/runtime/memory/local_memory.py
@@ -257,14 +257,19 @@ class UnavailableMemoryPort(NullMemoryPort):
     def legacy_content_hashes(self) -> set[str]:
         raise MemoryUnavailable(self.reason)
 
+    def legacy_source_hashes(self, source: str) -> Mapping[str, str]:
+        del source
+        raise MemoryUnavailable(self.reason)
+
     def import_legacy_records(
         self,
         records: Iterable[LegacyLetter],
         *,
         atomic: bool = True,
         promote_duplicate_metadata: bool = False,
+        replace_matching_source_records: bool = False,
     ) -> LegacyImportResult:
-        del promote_duplicate_metadata
+        del promote_duplicate_metadata, replace_matching_source_records
         raise MemoryUnavailable(self.reason)
 
 
@@ -616,6 +621,15 @@ class LocalMemoryAdapter:
             rows = self.connection.execute("SELECT content_hash FROM legacy_letters").fetchall()
             return {str(row[0]) for row in rows}
 
+    def legacy_source_hashes(self, source: str) -> Mapping[str, str]:
+        source_name = _label(source, default="local-import")
+        with self._lock:
+            rows = self.connection.execute(
+                "SELECT source_record_id, content_hash FROM legacy_letters WHERE source = ?",
+                (source_name,),
+            ).fetchall()
+        return {str(row[0]): str(row[1]) for row in rows}
+
     def _promote_legacy_duplicate(
         self,
         conn: sqlite3.Connection,
@@ -654,12 +668,61 @@ class LocalMemoryAdapter:
                 "BEGIN SELECT RAISE(ABORT, 'legacy_letters are read-only'); END"
             )
 
+    def _replace_legacy_source_record(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        content: str,
+        source_record_id: str,
+        source: str,
+        occurred_at: str | None,
+        digest: str,
+        metadata: str,
+    ) -> str | None:
+        rows = conn.execute(
+            "SELECT memory_id, content_hash FROM legacy_letters "
+            "WHERE source_record_id = ? AND source = ?",
+            (source_record_id, source),
+        ).fetchall()
+        if not rows:
+            return None
+        if len(rows) != 1:
+            raise sqlite3.IntegrityError("legacy source record is ambiguous")
+        memory_id, old_digest = str(rows[0][0]), str(rows[0][1])
+        if old_digest == digest:
+            return old_digest
+        collision = conn.execute(
+            "SELECT 1 FROM legacy_letters WHERE content_hash = ? AND memory_id <> ?",
+            (digest, memory_id),
+        ).fetchone()
+        if collision is not None:
+            raise sqlite3.IntegrityError("legacy replacement content already exists")
+        conn.execute("DROP TRIGGER IF EXISTS legacy_letters_no_update")
+        try:
+            conn.execute(
+                "UPDATE legacy_letters SET content = ?, content_hash = ?, occurred_at = ?, "
+                "metadata_json = ? WHERE memory_id = ?",
+                (content, digest, occurred_at, metadata, memory_id),
+            )
+            if self._fts5:
+                conn.execute(
+                    "UPDATE legacy_letters_fts SET content = ?, source = ? WHERE memory_id = ?",
+                    (content, source, memory_id),
+                )
+        finally:
+            conn.execute(
+                "CREATE TRIGGER legacy_letters_no_update BEFORE UPDATE ON legacy_letters "
+                "BEGIN SELECT RAISE(ABORT, 'legacy_letters are read-only'); END"
+            )
+        return old_digest
+
     def import_legacy_records(
         self,
         records: Iterable[LegacyLetter],
         *,
         atomic: bool = True,
         promote_duplicate_metadata: bool = False,
+        replace_matching_source_records: bool = False,
     ) -> LegacyImportResult:
         self._require_writable()
         materialized = list(records)
@@ -677,6 +740,7 @@ class LocalMemoryAdapter:
                 rolled_back=True,
             )
         inserted = 0
+        updated = 0
         duplicates = 0
         try:
             with self._transaction() as conn:
@@ -686,6 +750,25 @@ class LocalMemoryAdapter:
                 }
                 batch: set[str] = set()
                 for content, source_record_id, source, occurred_at, digest, metadata in normalized:
+                    if replace_matching_source_records:
+                        old_digest = self._replace_legacy_source_record(
+                            conn,
+                            content=content,
+                            source_record_id=source_record_id,
+                            source=source,
+                            occurred_at=occurred_at,
+                            digest=digest,
+                            metadata=metadata,
+                        )
+                        if old_digest is not None:
+                            if old_digest == digest:
+                                duplicates += 1
+                            else:
+                                existing.discard(old_digest)
+                                existing.add(digest)
+                                updated += 1
+                            batch.add(digest)
+                            continue
                     if digest in existing or digest in batch:
                         if promote_duplicate_metadata and digest in existing:
                             self._promote_legacy_duplicate(
@@ -715,6 +798,7 @@ class LocalMemoryAdapter:
             return LegacyImportResult(
                 seen=len(materialized),
                 inserted=0,
+                updated=0,
                 duplicates=duplicates,
                 rejected=rejected,
                 rolled_back=True,
@@ -722,6 +806,7 @@ class LocalMemoryAdapter:
         return LegacyImportResult(
             seen=len(materialized),
             inserted=inserted,
+            updated=updated,
             duplicates=duplicates,
             rejected=rejected,
         )

--- a/runtime/memory/memory_port.py
+++ b/runtime/memory/memory_port.py
@@ -68,11 +68,13 @@ class LegacyImportResult:
     duplicates: int = 0
     rejected: int = 0
     rolled_back: bool = False
+    updated: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "seen": self.seen,
             "inserted": self.inserted,
+            "updated": self.updated,
             "duplicates": self.duplicates,
             "rejected": self.rejected,
             "rolled_back": self.rolled_back,
@@ -111,9 +113,12 @@ class MemoryPort(Protocol):
         *,
         atomic: bool = True,
         promote_duplicate_metadata: bool = False,
+        replace_matching_source_records: bool = False,
     ) -> LegacyImportResult: ...
 
     def legacy_content_hashes(self) -> set[str]: ...
+
+    def legacy_source_hashes(self, source: str) -> Mapping[str, str]: ...
 
     def unload_legacy(self) -> int: ...
 
@@ -177,8 +182,9 @@ class NullMemoryPort:
         *,
         atomic: bool = True,
         promote_duplicate_metadata: bool = False,
+        replace_matching_source_records: bool = False,
     ) -> LegacyImportResult:
-        del promote_duplicate_metadata
+        del promote_duplicate_metadata, replace_matching_source_records
         materialized = list(records)
         return LegacyImportResult(
             seen=len(materialized),
@@ -188,6 +194,10 @@ class NullMemoryPort:
 
     def legacy_content_hashes(self) -> set[str]:
         return set()
+
+    def legacy_source_hashes(self, source: str) -> Mapping[str, str]:
+        del source
+        return {}
 
     def unload_legacy(self) -> int:
         return 0

--- a/tests/imports/test_offline_letter_pairs.py
+++ b/tests/imports/test_offline_letter_pairs.py
@@ -10,10 +10,11 @@ from runtime.imports.offline_letter_pairs import (
     OFFLINE_LETTER_PAIR_PROVENANCE_KEY,
     OFFLINE_LETTER_PAIR_PUBLISH_STATUS,
     OFFLINE_LETTER_PAIR_PUBLISH_STATUS_KEY,
+    apply_offline_letter_pair_recovery_to_adapter,
     main,
 )
 from runtime.memory.local_memory import LocalMemoryAdapter
-from runtime.memory.memory_port import LegacyImportResult
+from runtime.memory.memory_port import LegacyImportResult, LegacyLetter
 
 
 def _write_pairs(path: Path) -> bytes:
@@ -39,6 +40,86 @@ def _offline_metadata(digest: str) -> dict[str, object]:
         OFFLINE_LETTER_PAIR_PROVENANCE_KEY: dict(schema_version=1, source_index=1,
             source_sha256=digest, timestamp_status="unknown"),
     }
+
+
+def _latin1_mojibake(value: str) -> str:
+    return value.encode("utf-8").decode("latin-1")
+
+
+def _write_mojibake_pair(path: Path) -> tuple[bytes, str, str]:
+    content = "合成测试旧信"
+    reply = "合成测试回信"
+    raw = json.dumps([{
+        "content": _latin1_mojibake(content),
+        "reply": _latin1_mojibake(reply),
+    }], ensure_ascii=False).encode("utf-8")
+    path.write_bytes(raw)
+    return raw, content, reply
+
+
+def test_offline_recovery_repairs_reversible_utf8_latin1_mojibake(tmp_path, capsys):
+    source = tmp_path / "letter-pairs.json"
+    _raw, content, reply = _write_mojibake_pair(source)
+    memory_root = tmp_path / "memory"
+
+    exit_code, _output, report = _run_cli(source, memory_root, capsys, apply=True)
+
+    archive = LocalMemoryAdapter(memory_root / "memory.sqlite3")
+    try:
+        stored = archive.list_legacy()
+    finally:
+        archive.close()
+    assert exit_code == 0
+    assert report["inserted"] == 1
+    assert stored[0]["content"] == content
+    assert stored[0]["reply_text"] == reply
+
+
+def test_offline_recovery_updates_same_source_record_imported_by_old_decoder(tmp_path):
+    source = tmp_path / "letter-pairs.json"
+    raw, content, reply = _write_mojibake_pair(source)
+    digest = hashlib.sha256(raw).hexdigest()
+    source_record_id = f"offline-letter-pairs:{digest}:000001"
+    broken_content = _latin1_mojibake(content)
+    broken_reply = _latin1_mojibake(reply)
+    archive = LocalMemoryAdapter(tmp_path / "memory.sqlite3")
+    try:
+        seeded = archive.import_legacy_records([LegacyLetter(
+            content=json.dumps(
+                {"content": broken_content, "reply": broken_reply},
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            source_record_id=source_record_id,
+            source="offline-letter-pairs",
+            metadata={
+                **_offline_metadata(digest),
+                "user_content": broken_content,
+                "reply_text": broken_reply,
+            },
+        )])
+        report = apply_offline_letter_pair_recovery_to_adapter(source, adapter=archive)
+        stored = archive.list_legacy()
+        search_matches = archive.search(content, domains=("legacy_letters",))
+    finally:
+        archive.close()
+
+    assert seeded.inserted == 1
+    assert (report.would_insert, report.would_update) == (0, 1)
+    assert (report.inserted, report.updated, report.duplicates) == (0, 1, 0)
+    assert len(stored) == 1
+    assert stored[0]["source_record_id"] == source_record_id
+    assert stored[0]["content"] == content
+    assert stored[0]["reply_text"] == reply
+    assert [match.text for match in search_matches] == [
+        json.dumps(
+            {"content": content, "reply": reply},
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    ]
 
 
 def test_offline_letter_pair_cli_dry_run_is_content_free_and_side_effect_free(tmp_path, capsys):

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -152,7 +152,7 @@ const run = async () => { const [id, fn] = timers.entries().next().value; timers
 
 # The shipped CEF surface needs explicit no-drag/pointer and display-state guards.
 def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
-    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v15"
+    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v16"
     for declaration in (
             'const STATUS_PATH = "/toy/companion/status";',
             'const MEMORY_PATH = "/toy/companion/memory";',
@@ -241,7 +241,9 @@ def test_original_settings_imports_local_history_without_official_server() -> No
     assert "requestMutation(LOCAL_LETTER_IMPORT_PATH, {})" in BOOTSTRAP_JAVASCRIPT
     assert "requestJson(LOCAL_LETTER_IMPORT_PATH)" in BOOTSTRAP_JAVASCRIPT
     assert "payload.inserted" in BOOTSTRAP_JAVASCRIPT
+    assert "payload.updated" in BOOTSTRAP_JAVASCRIPT
     assert "payload.would_insert" in BOOTSTRAP_JAVASCRIPT
+    assert "payload.would_update" in BOOTSTRAP_JAVASCRIPT
     assert "未在原版游戏目录找到 letter_pairs.json" in BOOTSTRAP_JAVASCRIPT
     assert 'importButton.textContent = "重试导入"' in BOOTSTRAP_JAVASCRIPT
     assert "mountOfficialLetterImport(section)" not in BOOTSTRAP_JAVASCRIPT
@@ -358,7 +360,7 @@ const fetch = async (endpoint, options) => {
     if (options.method === "GET") {
       return backupAvailable
         ? { ok: true, json: async () => ({ code: 0, data: {
-            status: "READY", seen: 2, would_insert: 2, duplicates: 0,
+            status: "READY", seen: 2, would_insert: 2, would_update: 0, duplicates: 0,
             source: "local_backup",
           } }) }
         : { ok: false, json: async () => ({ code: 404, data: {
@@ -369,7 +371,7 @@ const fetch = async (endpoint, options) => {
           } }) };
     }
     return { ok: true, json: async () => ({ code: 0, data: {
-      status: "APPLIED", inserted: 2, duplicates: 0,
+      status: "APPLIED", inserted: 2, updated: 0, duplicates: 0,
       source: "local_backup",
     } }) };
   }
@@ -423,7 +425,7 @@ const flush = async () => { for (let index = 0; index < 8; index += 1) await Pro
   const importIndex = calls.findIndex((item) => item.path === "/toy/letter/legacy/local-import" && item.method === "POST");
   if (!importCall || importCall.headers["X-Olivia-Companion-Action"] !== "confirmed") throw new Error("local import confirmation header missing");
   if (preflightIndex < 0 || preflightIndex >= importIndex) throw new Error("local import preflight did not run before import");
-  if (!body.querySelectorAll("div").some((item) => item.textContent.includes("已导入 2 封只读历史信件"))) {
+  if (!body.querySelectorAll("div").some((item) => item.textContent.includes("已导入 2 封、修复 0 封只读历史信件"))) {
     throw new Error("local import completion was not shown");
   }
   if (nativeConfirmCalls !== 0) throw new Error("native confirmation was used");

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1861,7 +1861,7 @@ def test_install_isolated_copy_activates_original_client_surfaces(
         main = archive.read("assets/main-917d29fc.js").decode("utf-8")
     assert "assets/olivia-companion-settings.js" in names
     assert "data-olivia-companion-settings" in index
-    assert "data-ui-version=\"p03.original-settings-manage.v15\"" in index
+    assert "data-ui-version=\"p03.original-settings-manage.v16\"" in index
     assert (installed / "local_backend" / "original_client_setup_api.py").is_file()
     assert (installed / "local_backend" / "original_client_capability_api.py").is_file()
     assert (installed / "local_backend" / "original_client_update_api.py").is_file()


### PR DESCRIPTION
Repairs lossless UTF-8-as-Latin-1 mojibake while parsing local letter_pairs.json backups. Re-import now atomically updates matching offline source records in place, preserves letter IDs, refreshes FTS, and reports repaired counts in settings. Focused imports/memory/UI/HTTP tests pass; no private letter content is logged or committed.