### PR TITLE
feat: add Breeze TTS 2 provider adapter

### DIFF
--- a/tests/tts/test_breeze_provider.py
+++ b/tests/tts/test_breeze_provider.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import wave
+from array import array
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import tts.delivery as delivery
+from tts import TTSConfig, TTSProfileManager, TTSRequest, TTSService, default_registry
+from tts.contracts import TTSValidationError
+from tts import external_breeze_worker
+from tts.breeze import BreezeTTS2Provider
+from voice_direction import VoicePerformancePlan
+
+
+_BREEZE_LICENSE = "BreezeBlue-Research-and-Non-Commercial-1.0"
+
+
+def _breeze_config(tmp_path: Path) -> TTSConfig:
+    runtime = tmp_path / "ComfyUI-Breeze-TTS-2"
+    runtime.mkdir()
+    for name in ("__init__.py", "loader.py", "nodes.py", "int8.py", "LICENSE"):
+        (runtime / name).write_text("# pinned external runtime\n", encoding="utf-8")
+
+    model_root = tmp_path / "models"
+    model = model_root / "drbaph_Breeze-TTS-2-comfyui"
+    (model / "audio_tokenizer").mkdir(parents=True)
+    for name in (
+        "config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+        "generation_config.json",
+        "Breeze-TTS-2-int8-hybrid.safetensors",
+        "audio_tokenizer/config.json",
+        "audio_tokenizer/model.safetensors",
+    ):
+        (model / name).write_bytes(b"pinned external model")
+
+    model_license = tmp_path / "BREEZE_MODEL_LICENSE"
+    model_license.write_text(
+        "BREEZEBLUE RESEARCH AND NON-COMMERCIAL LICENSE AGREEMENT\nVersion 1.0\n",
+        encoding="utf-8",
+    )
+    reference = tmp_path / "reference.wav"
+    reference.write_bytes(b"private local reference")
+    return TTSConfig(
+        profile="breeze-tts2-int8-hybrid",
+        provider="breeze_tts2",
+        runtime_root=str(runtime),
+        model_dir=str(model_root),
+        reference_audio=str(reference),
+        reference_text="精确参考转写",
+        license_id=_BREEZE_LICENSE,
+        fallback="text",
+        provider_options={
+            "external_python": sys.executable,
+            "model_variant": "int8_hybrid",
+            "model_license_path": str(model_license),
+        },
+    )
+
+
+def _plan() -> VoicePerformancePlan:
+    return VoicePerformancePlan(
+        reply_text="林" * 190,
+        overall_emotion="声音柔软自然地承接，再缓缓托起给到力量",
+        global_speed=1.0,
+        energy=0.55,
+        breath_before_sentences=(),
+        emphasize_sentences=(),
+        short_instruction="声音柔软自然地承接，再缓缓托起给到力量",
+    )
+
+
+def test_breeze_provider_is_selectable_and_missing_assets_fall_back_before_generation(
+    tmp_path: Path,
+) -> None:
+    config = _breeze_config(tmp_path)
+    registry = default_registry()
+
+    provider = registry.create(config)
+    try:
+        health = provider.health()
+    finally:
+        provider.close()
+
+    assert registry.names() == ("breeze_tts2", "cosyvoice3")
+    assert health == {
+        "status": "available",
+        "provider": "breeze_tts2",
+        "license_id": _BREEZE_LICENSE,
+        "model": "Breeze-TTS-2-int8-hybrid",
+        "model_variant": "int8_hybrid",
+        "streaming": False,
+        "delivery_mode": "single_pass_voice_performance_plan",
+        "reference_audio_local_only": True,
+        "offline_only": True,
+        "execution": "external-process",
+    }
+
+    missing = TTSConfig.from_mapping(
+        {
+            **config.__dict__,
+            "model_dir": str(tmp_path / "missing-model"),
+        }
+    )
+    service = TTSService(missing)
+    try:
+        result = asyncio.run(service.synthesize(TTSRequest("保留这段回复。")))
+    finally:
+        service.close()
+
+    assert result.status == "text_fallback"
+    assert result.error_code == "TTS_ASSET_MISSING"
+    assert result.fallback_text == "保留这段回复。"
+
+    service = TTSService(config)
+    try:
+        result = asyncio.run(service.synthesize(TTSRequest("必须走完整语音编排。")))
+    finally:
+        service.close()
+    assert result.status == "text_fallback"
+    assert result.error_code == "TTS_PERFORMANCE_PLAN_REQUIRED"
+
+    model_license = Path(str(config.provider_options["model_license_path"]))
+    model_license.write_text("Apache License 2.0\n", encoding="utf-8")
+    invalid_license = BreezeTTS2Provider(config).health()
+    assert invalid_license["status"] == "unavailable"
+    assert invalid_license["reason_code"] == "TTS_LICENSE_UNVERIFIED"
+
+
+def test_breeze_performance_request_consumes_the_complete_llm_voice_plan(
+    tmp_path: Path,
+) -> None:
+    reply = "第一句保持温柔。第二句慢慢托起力量。"
+    plan = VoicePerformancePlan(
+        reply_text=reply,
+        overall_emotion="声音柔软自然地承接，再缓缓托起给到力量",
+        global_speed=1.06,
+        energy=0.72,
+        breath_before_sentences=(2,),
+        emphasize_sentences=(1,),
+        short_instruction="声音柔软自然地承接，再缓缓托起给到力量",
+    )
+
+    config = _breeze_config(tmp_path)
+    request = BreezeTTS2Provider(config).performance_request(plan)
+
+    assert request["text"] == reply
+    assert request["text"] == plan.spoken_text
+    assert request["instruction"] == (
+        "声音柔软自然地承接，再缓缓托起给到力量，"
+        "整体语速略快但保持自然对话感，能量饱满但不喊叫，"
+        "在第2句前自然换气，轻轻强调第1句"
+    )
+    assert request["voice_plan"] == {
+        "emotion": plan.overall_emotion,
+        "speed": 1.06,
+        "energy": 0.72,
+        "breath_before_sentences": [2],
+        "emphasize_sentences": [1],
+    }
+    assert request["cfg_scale"] == 4.0
+    assert request["model_variant"] == "int8_hybrid"
+    assert request["max_new_tokens"] == 650
+    assert request["quality_gate_required"] is True
+    assert request["quality_forbidden_text"] == request["instruction"]
+
+    limited = TTSConfig.from_mapping(
+        {
+            **config.__dict__,
+            "provider_options": {
+                **config.provider_options,
+                "max_new_tokens": -10,
+            },
+        }
+    )
+    assert BreezeTTS2Provider(limited).performance_request(plan)["max_new_tokens"] == 64
+
+
+def test_breeze_worker_marks_ready_before_generation_and_writes_pcm(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: dict[str, object] = {}
+
+    class Waveform:
+        def detach(self):
+            return self
+
+        def float(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def numpy(self):
+            import numpy
+
+            return numpy.asarray([[[0.25, -0.5, 0.75]]], dtype="float32")
+
+    class Loader:
+        HYBRID_LABEL = "int8 hybrid (recommended)"
+
+        @staticmethod
+        def load_breeze_bundle(*args):
+            calls["load"] = args
+            return SimpleNamespace(codec="codec")
+
+    class Runtime:
+        @staticmethod
+        def comfy_audio_to_tensor(audio):
+            calls["reference"] = audio
+            return "reference-waveform", 24000
+
+        @staticmethod
+        def encode_reference_audio(codec, waveform, sample_rate):
+            calls["encoded"] = (codec, waveform, sample_rate)
+            return "reference-codes"
+
+    class Nodes:
+        @staticmethod
+        def _generate_audio(bundle, **kwargs):
+            calls["status_before_generation"] = json.loads(
+                status.read_text(encoding="utf-8")
+            )
+            calls["generation"] = kwargs
+            return {"waveform": Waveform(), "sample_rate": 24000}
+
+    monkeypatch.setattr(
+        external_breeze_worker,
+        "_load_package",
+        lambda _runtime: (Loader, Nodes, Runtime),
+    )
+    monkeypatch.setattr(
+        external_breeze_worker,
+        "_read_reference_audio",
+        lambda _path: {"waveform": "private-reference", "sample_rate": 24000},
+    )
+    request = {
+        "runtime_root": str(tmp_path / "runtime"),
+        "model_dir": str(tmp_path / "model"),
+        "reference_audio": str(tmp_path / "reference.wav"),
+        "reference_text": "精确参考转写",
+        "text": "完整冻结回复。",
+        "instruction": "声音柔软自然地承接，保持自然语速，保持中等能量",
+        "model_variant": "int8_hybrid",
+        "dtype": "bf16",
+        "device": "cuda",
+        "attention": "eager",
+        "decode_mode": "eager",
+        "cfg_scale": 4.0,
+        "seed": 200717,
+        "max_new_tokens": 1500,
+        "temperature": 0.9,
+        "top_k": 50,
+        "top_p": 1.0,
+        "repetition_penalty": 1.1,
+        "depth_temperature": 0.9,
+        "depth_top_k": 50,
+        "depth_top_p": 1.0,
+        "gain_db": 0.0,
+    }
+    output = tmp_path / "speech.wav"
+    status = tmp_path / "status.json"
+
+    external_breeze_worker._synthesize(request, output, status)
+
+    assert calls["load"] == (
+        "int8 hybrid (recommended)",
+        "bf16",
+        "cuda",
+        "eager",
+        False,
+        "eager",
+    )
+    assert calls["status_before_generation"] == {
+        "status": "ready",
+        "phase": "generation",
+        "audio_started": False,
+    }
+    assert calls["generation"]["text"] == request["text"]
+    assert calls["generation"]["instruction"] == request["instruction"]
+    assert calls["generation"]["ref_text"] == request["reference_text"]
+    assert calls["generation"]["ref_codes"] == "reference-codes"
+    assert json.loads(status.read_text(encoding="utf-8")) == {
+        "status": "completed",
+        "phase": "completed",
+        "audio_started": True,
+    }
+    with wave.open(str(output), "rb") as rendered:
+        assert rendered.getnchannels() == 1
+        assert rendered.getframerate() == 24000
+        assert array("h", rendered.readframes(3)).tolist() == [8192, -16384, 24575]
+
+
+def test_breeze_delivery_renders_one_complete_plan_and_reports_the_real_provider(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    observed: list[tuple[str, dict[str, object]]] = []
+
+    def fake_run(command, **_kwargs):
+        command = [str(item) for item in command]
+        request_path = Path(command[command.index("--request") + 1])
+        output_path = Path(command[command.index("--output") + 1])
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+        worker = Path(command[1]).name
+        observed.append((worker, request))
+        if worker == "external_breeze_worker.py":
+            with wave.open(str(output_path), "wb") as target:
+                target.setnchannels(1)
+                target.setsampwidth(2)
+                target.setframerate(24000)
+                target.writeframes(b"\x00\x00" * (43 * 24000))
+        else:
+            output_path.write_text(
+                json.dumps(
+                    delivery.assess_transcript(
+                        str(request["expected_text"]),
+                        str(request["expected_text"]),
+                        str(request["forbidden_text"]),
+                    ),
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(delivery, "delivery_configured", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(delivery.subprocess, "run", fake_run)
+    output = tmp_path / "reply.wav"
+
+    result = delivery.render_delivery_wav(_breeze_config(tmp_path), _plan(), output)
+
+    assert result.provider == "breeze_tts2"
+    assert result.duration_seconds == 43.0
+    assert result.quality_report is not None
+    assert result.quality_report["passed"] is True
+    assert output.is_file()
+    assert [name for name, _request in observed] == [
+        "external_breeze_worker.py",
+        "external_audio_quality_worker.py",
+    ]
+    synthesis_request = observed[0][1]
+    assert synthesis_request["text"] == _plan().spoken_text
+    assert synthesis_request["voice_plan"]["emotion"] == _plan().overall_emotion
+    assert synthesis_request["max_attempts"] == 1
+
+
+@pytest.mark.parametrize("phase,audio_started", [("preflight", False), ("generation", True)])
+def test_breeze_failure_never_runs_a_second_tts_model(
+    tmp_path: Path,
+    monkeypatch,
+    phase: str,
+    audio_started: bool,
+) -> None:
+    calls: list[str] = []
+
+    def fake_run(command, **_kwargs):
+        command = [str(item) for item in command]
+        worker = Path(command[1]).name
+        calls.append(worker)
+        status = Path(command[command.index("--status") + 1])
+        status.write_text(
+            json.dumps(
+                {"status": "failed", "phase": phase, "audio_started": audio_started}
+            ),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=2)
+
+    monkeypatch.setattr(delivery, "delivery_configured", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(delivery.subprocess, "run", fake_run)
+
+    with pytest.raises(delivery.DeliveryAudioError, match="TTS_EXTERNAL_PROCESS_FAILED"):
+        delivery.render_delivery_wav(
+            _breeze_config(tmp_path),
+            _plan(),
+            tmp_path / "reply.wav",
+            enforce_content_gate=False,
+        )
+
+    assert calls == ["external_breeze_worker.py"]
+
+
+def test_breeze_profile_persists_selection_without_exposing_paths(
+    tmp_path: Path,
+) -> None:
+    config = _breeze_config(tmp_path)
+    manager = TTSProfileManager(tmp_path / "state")
+
+    installed = manager.install(config)
+    loaded = manager.config(config.profile)
+    public = loaded.public_dict()
+
+    assert installed["status"] == "INSTALLED"
+    assert public["provider"] == "breeze_tts2"
+    assert str(tmp_path) not in json.dumps(public, ensure_ascii=False)
+
+    missing = TTSConfig.from_mapping(
+        {**config.__dict__, "model_dir": str(tmp_path / "missing")}
+    )
+    with pytest.raises(TTSValidationError) as exc_info:
+        manager.install(missing)
+    assert exc_info.value.code == "TTS_EXTERNAL_ASSET_MISSING"

--- a/tts/breeze.py
+++ b/tts/breeze.py
@@ -1,0 +1,251 @@
+"""Thin external-process adapter for Breeze TTS 2.
+
+The product owns only configuration, health reporting, cancellation, and PCM
+transport.  Model loading and inference remain in the pinned upstream runtime.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+
+from .contracts import AudioChunk, TTSConfig, TTSRequest, TTSUnavailable
+
+
+BREEZE_LICENSE_ID = "BreezeBlue-Research-and-Non-Commercial-1.0"
+
+_VARIANT_WEIGHTS = {
+    "int8_hybrid": "Breeze-TTS-2-int8-hybrid.safetensors",
+    "bf16": "Breeze-TTS-2-bf16.safetensors",
+    "int8_convrot": "Breeze-TTS-2-int8-convrot.safetensors",
+    "int8_text_encoder": "Breeze-TTS-2-int8-text-encoder.safetensors",
+}
+_MODEL_REPOSITORY_DIR = "drbaph_Breeze-TTS-2-comfyui"
+_MODEL_LICENSE_HEADING = "BREEZEBLUE RESEARCH AND NON-COMMERCIAL LICENSE AGREEMENT"
+
+
+def _pace_direction(speed: float) -> str:
+    if speed <= 1.02:
+        return "保持自然语速"
+    if speed <= 1.08:
+        return "整体语速略快但保持自然对话感"
+    return "整体语速轻快但吐字清楚"
+
+
+def _energy_direction(energy: float) -> str:
+    if energy < 0.45:
+        return "能量轻柔克制"
+    if energy <= 0.65:
+        return "保持中等能量"
+    return "能量饱满但不喊叫"
+
+
+def _sentence_marks_direction(prefix: str, values: tuple[int, ...]) -> str | None:
+    if not values:
+        return None
+    numbers = "、".join(str(value) for value in values)
+    return f"{prefix}第{numbers}句"
+
+
+class BreezeTTS2Provider:
+    """Breeze TTS 2 voice-clone provider backed by an isolated runtime."""
+
+    name = "breeze_tts2"
+    license_id = BREEZE_LICENSE_ID
+
+    def __init__(self, config: TTSConfig) -> None:
+        self.config = config
+        self._closed = False
+
+    @property
+    def runtime_root(self) -> Path:
+        return Path(self.config.runtime_root)
+
+    @property
+    def model_root(self) -> Path:
+        return Path(self.config.model_dir)
+
+    @property
+    def model_variant(self) -> str:
+        return str(
+            self.config.provider_options.get("model_variant", "int8_hybrid")
+            or "int8_hybrid"
+        ).strip().lower()
+
+    @property
+    def model_repository(self) -> Path:
+        return self.model_root / _MODEL_REPOSITORY_DIR
+
+    @property
+    def external_python(self) -> Path:
+        return Path(str(self.config.provider_options.get("external_python", "") or ""))
+
+    @property
+    def model_license(self) -> Path:
+        return Path(
+            str(self.config.provider_options.get("model_license_path", "") or "")
+        )
+
+    def _model_license_verified(self) -> bool:
+        try:
+            heading = self.model_license.read_text(encoding="utf-8")[:512]
+        except (OSError, UnicodeDecodeError):
+            return False
+        return _MODEL_LICENSE_HEADING in heading and "Version 1.0" in heading
+
+    def _missing_files(self) -> list[str]:
+        missing: list[str] = []
+        for relative in ("__init__.py", "loader.py", "nodes.py", "int8.py", "LICENSE"):
+            if not (self.runtime_root / relative).is_file():
+                missing.append(f"runtime:{relative}")
+        weights = _VARIANT_WEIGHTS.get(self.model_variant)
+        if weights is None:
+            missing.append("model_variant")
+        else:
+            for relative in (
+                "config.json",
+                "tokenizer.json",
+                weights,
+                "audio_tokenizer/config.json",
+                "audio_tokenizer/model.safetensors",
+            ):
+                if not (self.model_repository / relative).is_file():
+                    missing.append(f"model:{relative}")
+        if not self.external_python.is_file():
+            missing.append("external_python")
+        if not Path(self.config.reference_audio).is_file():
+            missing.append("reference_audio")
+        if not self.config.reference_text:
+            missing.append("reference_text")
+        if not self.model_license.is_file():
+            missing.append("model_license")
+        return missing
+
+    def health(self) -> dict[str, Any]:
+        if self._closed:
+            return {
+                "status": "unavailable",
+                "provider": self.name,
+                "reason_code": "TTS_CLOSED",
+                "license_id": self.license_id,
+            }
+        if self.config.license_id != self.license_id:
+            return {
+                "status": "unavailable",
+                "provider": self.name,
+                "reason_code": "TTS_LICENSE_UNVERIFIED",
+                "license_id": self.config.license_id,
+            }
+        if self.model_license.is_file() and not self._model_license_verified():
+            return {
+                "status": "unavailable",
+                "provider": self.name,
+                "reason_code": "TTS_LICENSE_UNVERIFIED",
+                "license_id": self.config.license_id,
+            }
+        missing = self._missing_files()
+        if missing:
+            return {
+                "status": "unavailable",
+                "provider": self.name,
+                "reason_code": "TTS_ASSET_MISSING",
+                "missing": missing,
+                "license_id": self.license_id,
+            }
+        return {
+            "status": "available",
+            "provider": self.name,
+            "license_id": self.license_id,
+            "model": f"Breeze-TTS-2-{self.model_variant.replace('_', '-')}",
+            "model_variant": self.model_variant,
+            "streaming": False,
+            "delivery_mode": "single_pass_voice_performance_plan",
+            "reference_audio_local_only": True,
+            "offline_only": True,
+            "execution": "external-process",
+        }
+
+    def performance_request(self, plan: object) -> dict[str, object]:
+        """Map one persisted LLM plan into Breeze's non-spoken direction channel."""
+
+        text = str(getattr(plan, "spoken_text", "") or "")
+        emotion = str(
+            getattr(plan, "short_instruction", "")
+            or getattr(plan, "overall_emotion", "")
+            or ""
+        ).strip().rstrip("。")
+        speed = float(getattr(plan, "global_speed", 1.0))
+        energy = float(getattr(plan, "energy", 0.55))
+        breaths = tuple(getattr(plan, "breath_before_sentences", ()) or ())
+        emphasis = tuple(getattr(plan, "emphasize_sentences", ()) or ())
+        instruction_parts = [emotion, _pace_direction(speed), _energy_direction(energy)]
+        breath_direction = _sentence_marks_direction("在", breaths)
+        if breath_direction:
+            instruction_parts.append(breath_direction + "前自然换气")
+        emphasis_direction = _sentence_marks_direction("轻轻强调", emphasis)
+        if emphasis_direction:
+            instruction_parts.append(emphasis_direction)
+        instruction = "，".join(part for part in instruction_parts if part)
+        options = self.config.provider_options
+        units = tuple(getattr(plan, "speech_units")())
+        gain_db = float(getattr(units[0], "gain_db", 0.0)) if units else 0.0
+        return {
+            "runtime_root": str(self.runtime_root),
+            "model_dir": str(self.model_root),
+            "reference_audio": self.config.reference_audio,
+            "reference_text": self.config.reference_text,
+            "text": text,
+            "instruction": instruction,
+            "voice_plan": {
+                "emotion": str(getattr(plan, "overall_emotion", "") or ""),
+                "speed": speed,
+                "energy": energy,
+                "breath_before_sentences": list(breaths),
+                "emphasize_sentences": list(emphasis),
+            },
+            "model_variant": self.model_variant,
+            "dtype": str(options.get("dtype", "bf16") or "bf16"),
+            "device": str(options.get("device", "cuda") or "cuda"),
+            "attention": str(options.get("attention", "eager") or "eager"),
+            "decode_mode": str(options.get("decode_mode", "eager") or "eager"),
+            "cfg_scale": float(options.get("cfg_scale", 4.0)),
+            "seed": int(options.get("seed", 200717)),
+            # The ordinary-reply contract rejects audio over 52 seconds.
+            # Breeze emits 12.5 frames/s, so never spend GPU time beyond the
+            # longest candidate the product can accept.
+            "max_new_tokens": max(
+                64, min(650, int(options.get("max_new_tokens", 650)))
+            ),
+            "temperature": float(options.get("temperature", 0.9)),
+            "top_k": int(options.get("top_k", 50)),
+            "top_p": float(options.get("top_p", 1.0)),
+            "repetition_penalty": float(options.get("repetition_penalty", 1.1)),
+            "depth_temperature": float(options.get("depth_temperature", 0.9)),
+            "depth_top_k": int(options.get("depth_top_k", 50)),
+            "depth_top_p": float(options.get("depth_top_p", 1.0)),
+            "gain_db": max(-1.5, min(1.5, gain_db)),
+            "quality_gate_required": True,
+            "quality_forbidden_text": instruction,
+            "quality_gate_model": str(options.get("quality_gate_model", "base") or "base"),
+            "quality_gate_cache_root": str(options.get("quality_gate_cache_root", "") or ""),
+            "quality_max_cer": 0.18,
+            "duration_target_seconds": [40.0, 50.0],
+            "max_attempts": 3,
+            "performance_control_mode": "single_pass_llm_breeze_direction",
+        }
+
+    def stream_sentence(
+        self, text: str, request: TTSRequest, sentence_index: int
+    ) -> Iterator[AudioChunk]:
+        del text, request, sentence_index
+        health = self.health()
+        if health.get("status") != "available":
+            raise TTSUnavailable(str(health.get("reason_code", "TTS_UNAVAILABLE")))
+        raise TTSUnavailable("TTS_PERFORMANCE_PLAN_REQUIRED")
+        yield  # pragma: no cover - keeps this method an iterator
+
+    def close(self) -> None:
+        self._closed = True
+
+
+__all__ = ["BREEZE_LICENSE_ID", "BreezeTTS2Provider"]

--- a/tts/contracts.py
+++ b/tts/contracts.py
@@ -75,7 +75,9 @@ def _public_provider_options(options: Mapping[str, Any]) -> dict[str, Any]:
     """Expose provider switches without echoing private cache/model paths."""
 
     path_keys = {
+        "model_license_path",
         "numba_cache_dir",
+        "quality_gate_python",
         "quality_gate_cache_root",
         "temp_root",
         "wetext_fst_root",

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -1,4 +1,4 @@
-"""One-process CosyVoice rendering for a non-spoken reply delivery plan."""
+"""One-process TTS rendering for a non-spoken reply delivery plan."""
 
 from __future__ import annotations
 
@@ -19,6 +19,7 @@ from runtime.reply.reply_delivery import ReplyDeliveryPlan
 from voice_direction import VoiceDirectionError, validate_short_instruction
 
 from .contracts import TTSConfig
+from .breeze import BreezeTTS2Provider
 from .external_audio_quality_worker import assess_transcript
 
 
@@ -41,6 +42,7 @@ class DeliveryAudioResult:
     sample_rate: int
     segment_count: int
     quality_report: dict[str, object] | None = None
+    provider: str = ""
 
 
 def _validated_quality_report(
@@ -108,6 +110,9 @@ def build_external_delivery_request(
     plan: ReplyDeliveryPlan | object,
 ) -> dict[str, object]:
     """Render the frozen reply in one inference so the voice never resets."""
+
+    if str(getattr(config, "provider", "cosyvoice3")) == "breeze_tts2":
+        return BreezeTTS2Provider(config).performance_request(plan)
 
     units = tuple(plan.speech_units())
     spoken_text = str(getattr(plan, "spoken_text", "") or "".join(unit.text for unit in units))
@@ -323,6 +328,33 @@ def delivery_configured(
 
     options = config.provider_options or {}
     executable = Path(str(options.get("external_python", "") or ""))
+    if config.provider == "breeze_tts2":
+        provider = BreezeTTS2Provider(config)
+        base_checks = all((
+            provider.health().get("status") == "available",
+            Path(__file__).with_name("external_breeze_worker.py").is_file(),
+        ))
+        if not base_checks or not require_quality_gate:
+            return base_checks
+        cache_value = str(options.get("quality_gate_cache_root", "") or "").strip()
+        quality_python = Path(
+            str(options.get("quality_gate_python", executable) or executable)
+        )
+        checkpoint = Path(cache_value) / "base.pt"
+        try:
+            executable_stat = quality_python.stat()
+        except OSError:
+            return False
+        return all((
+            bool(cache_value),
+            Path(__file__).with_name("external_audio_quality_worker.py").is_file(),
+            _verified_file(checkpoint, _WHISPER_BASE_SHA256),
+            _quality_runtime_available(
+                str(quality_python.resolve()),
+                executable_stat.st_size,
+                executable_stat.st_mtime_ns,
+            ),
+        ))
     model_checkpoint = Path(config.model_dir) / "llm.pt"
     base_checks = all((
         executable.is_file(),
@@ -367,19 +399,40 @@ def render_delivery_wav(
     if not plan.cues:
         raise DeliveryAudioError("TTS_DELIVERY_UNAVAILABLE")
     request = build_external_delivery_request(config, plan)
-    require_quality_gate = bool(
-        enforce_content_gate
-        and request.get("voice_condition_mode") == "instruct2_single_pass"
+
+    def gate_required(payload: dict[str, object]) -> bool:
+        return bool(
+            enforce_content_gate
+            and (
+                payload.get("quality_gate_required") is True
+                or payload.get("voice_condition_mode") == "instruct2_single_pass"
+            )
+        )
+
+    require_quality_gate = gate_required(request)
+
+    if not delivery_configured(config, require_quality_gate=require_quality_gate):
+        code = (
+            "TTS_CONTENT_GATE_UNAVAILABLE"
+            if require_quality_gate
+            else "TTS_DELIVERY_UNAVAILABLE"
+        )
+        raise DeliveryAudioError(code)
+
+    request["verify_accepted_base_model"] = bool(
+        require_quality_gate and config.provider == "cosyvoice3"
     )
-    if not delivery_configured(config):
-        raise DeliveryAudioError("TTS_DELIVERY_UNAVAILABLE")
-    if require_quality_gate and not delivery_configured(
-        config, require_quality_gate=True
-    ):
-        raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE")
-    request["verify_accepted_base_model"] = require_quality_gate
-    executable = Path(str(config.provider_options.get("external_python", "") or ""))
-    worker = Path(__file__).with_name("external_cosyvoice_worker.py")
+    executable = Path(
+        str(config.provider_options.get("external_python", "") or "")
+    )
+    quality_executable = Path(
+        str(config.provider_options.get("quality_gate_python", executable) or executable)
+    )
+    worker = Path(__file__).with_name(
+        "external_breeze_worker.py"
+        if config.provider == "breeze_tts2"
+        else "external_cosyvoice_worker.py"
+    )
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     temp_parent = str(config.provider_options.get("temp_root", "") or "").strip()
@@ -390,6 +443,7 @@ def render_delivery_wav(
     request_path = work / "request.json"
     quality_request_path = work / "quality-request.json"
     quality_output_path = work / "quality-result.json"
+    worker_status_path = work / "worker-status.json"
     temporary_output = work / "speech.wav"
     try:
         environment = dict(os.environ)
@@ -402,10 +456,21 @@ def render_delivery_wav(
         )
         def run_worker(payload: dict[str, object]) -> None:
             temporary_output.unlink(missing_ok=True)
+            worker_status_path.unlink(missing_ok=True)
             request_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+            command = [
+                str(executable),
+                str(worker),
+                "--request",
+                str(request_path),
+                "--output",
+                str(temporary_output),
+            ]
+            if config.provider == "breeze_tts2":
+                command.extend(("--status", str(worker_status_path)))
             try:
                 completed = subprocess.run(
-                    [str(executable), str(worker), "--request", str(request_path), "--output", str(temporary_output)],
+                    command,
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
@@ -442,7 +507,7 @@ def render_delivery_wav(
                 raise DeliveryAudioError("TTS_CONTENT_GATE_UNAVAILABLE") from exc
             try:
                 completed = subprocess.run(
-                    [str(executable), str(quality_worker), "--request", str(quality_request_path), "--output", str(quality_output_path)],
+                    [str(quality_executable), str(quality_worker), "--request", str(quality_request_path), "--output", str(quality_output_path)],
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
@@ -510,6 +575,7 @@ def render_delivery_wav(
             sample_rate=sample_rate,
             segment_count=len(plan.speech_units()),
             quality_report=quality_report,
+            provider=config.provider,
         )
     finally:
         shutil.rmtree(work, ignore_errors=True)

--- a/tts/external_breeze_worker.py
+++ b/tts/external_breeze_worker.py
@@ -1,0 +1,178 @@
+"""Isolated Breeze TTS 2 worker using the pinned community runtime."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import wave
+from pathlib import Path
+from typing import Any
+
+
+_PACKAGE_NAME = "olivia_breeze_tts2_runtime"
+_VARIANT_LABEL_ATTR = {
+    "int8_hybrid": "HYBRID_LABEL",
+    "bf16": "BF16_LABEL",
+    "int8_convrot": "INT8_LABEL",
+    "int8_text_encoder": "TE_INT8_LABEL",
+}
+
+
+def _write_status(path: Path, value: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
+
+
+def _load_package(runtime_root: Path):
+    spec = importlib.util.spec_from_file_location(
+        _PACKAGE_NAME,
+        runtime_root / "__init__.py",
+        submodule_search_locations=[str(runtime_root)],
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("BREEZE_RUNTIME_INVALID")
+    package = importlib.util.module_from_spec(spec)
+    sys.modules[_PACKAGE_NAME] = package
+    spec.loader.exec_module(package)
+    try:
+        return (
+            sys.modules[f"{_PACKAGE_NAME}.loader"],
+            sys.modules[f"{_PACKAGE_NAME}.nodes"],
+            sys.modules[f"{_PACKAGE_NAME}.runtime"],
+        )
+    except KeyError as exc:
+        raise RuntimeError("BREEZE_RUNTIME_INVALID") from exc
+
+
+def _read_reference_audio(path: Path) -> dict[str, Any]:
+    import soundfile as sf
+    import torch
+
+    audio, sample_rate = sf.read(path, dtype="float32", always_2d=True)
+    mono = audio.mean(axis=1)
+    if mono.size == 0 or int(sample_rate) <= 0:
+        raise RuntimeError("BREEZE_REFERENCE_AUDIO_INVALID")
+    return {
+        "waveform": torch.from_numpy(mono).view(1, 1, -1),
+        "sample_rate": int(sample_rate),
+    }
+
+
+def _write_wav(path: Path, waveform: Any, sample_rate: int, gain_db: float) -> None:
+    import numpy
+
+    values = waveform.detach().float().cpu().numpy().reshape(-1)
+    gain = 10.0 ** (float(gain_db) / 20.0)
+    pcm = numpy.rint(numpy.clip(values * gain, -1.0, 1.0) * 32767.0).astype("<i2")
+    if pcm.size == 0 or int(sample_rate) <= 0:
+        raise RuntimeError("BREEZE_EMPTY_AUDIO")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as target:
+        target.setnchannels(1)
+        target.setsampwidth(2)
+        target.setframerate(int(sample_rate))
+        target.writeframes(pcm.tobytes())
+
+
+def _synthesize(request: dict[str, Any], output: Path, status: Path) -> None:
+    ready = False
+    try:
+        _write_status(
+            status,
+            {"status": "initializing", "phase": "preflight", "audio_started": False},
+        )
+        runtime_root = Path(str(request["runtime_root"]))
+        model_root = Path(str(request["model_dir"]))
+        loader, nodes, runtime = _load_package(runtime_root)
+        loader.model_dirs = lambda: [model_root]
+        variant = str(request.get("model_variant", "int8_hybrid") or "int8_hybrid")
+        try:
+            label = getattr(loader, _VARIANT_LABEL_ATTR[variant])
+        except (KeyError, AttributeError) as exc:
+            raise RuntimeError("BREEZE_MODEL_VARIANT_UNSUPPORTED") from exc
+        bundle = loader.load_breeze_bundle(
+            label,
+            str(request.get("dtype", "bf16") or "bf16"),
+            str(request.get("device", "cuda") or "cuda"),
+            str(request.get("attention", "eager") or "eager"),
+            False,
+            str(request.get("decode_mode", "eager") or "eager"),
+        )
+        reference = _read_reference_audio(Path(str(request["reference_audio"])))
+        reference_waveform, reference_rate = runtime.comfy_audio_to_tensor(reference)
+        reference_codes = runtime.encode_reference_audio(
+            bundle.codec, reference_waveform, reference_rate
+        )
+        ready = True
+        _write_status(
+            status,
+            {"status": "ready", "phase": "generation", "audio_started": False},
+        )
+        result = nodes._generate_audio(
+            bundle,
+            text=str(request["text"]),
+            instruction=str(request["instruction"]),
+            ref_audio=None,
+            ref_text=str(request["reference_text"]),
+            cfg_scale=float(request.get("cfg_scale", 4.0)),
+            max_new_tokens=int(request.get("max_new_tokens", 1500)),
+            temperature=float(request.get("temperature", 0.9)),
+            top_k=int(request.get("top_k", 50)),
+            top_p=float(request.get("top_p", 1.0)),
+            repetition_penalty=float(request.get("repetition_penalty", 1.1)),
+            depth_temperature=float(request.get("depth_temperature", 0.9)),
+            depth_top_k=int(request.get("depth_top_k", 50)),
+            depth_top_p=float(request.get("depth_top_p", 1.0)),
+            seed=int(request.get("seed", 200717)),
+            ref_codes=reference_codes,
+            progress_callback=None,
+            progress_label=None,
+        )
+        _write_wav(
+            output,
+            result["waveform"],
+            int(result["sample_rate"]),
+            float(request.get("gain_db", 0.0)),
+        )
+        _write_status(
+            status,
+            {"status": "completed", "phase": "completed", "audio_started": True},
+        )
+    except Exception:
+        _write_status(
+            status,
+            {
+                "status": "failed",
+                "phase": "generation" if ready else "preflight",
+                "audio_started": ready,
+            },
+        )
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--request", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--status", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        request = json.loads(args.request.read_text(encoding="utf-8"))
+        if not isinstance(request, dict):
+            raise ValueError("request must be an object")
+        _synthesize(request, args.output, args.status)
+    except Exception:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tts/profiles.py
+++ b/tts/profiles.py
@@ -81,6 +81,18 @@ class TTSProfileManager:
             if not all(health.values()):
                 missing = [key for key, present in health.items() if not present]
                 raise TTSValidationError("TTS_EXTERNAL_ASSET_MISSING", ",".join(missing))
+        elif config.provider == "breeze_tts2":
+            provider = self.registry.create(config)
+            try:
+                health = provider.health()
+            finally:
+                provider.close()
+            if health.get("status") != "available":
+                missing = health.get("missing", [health.get("reason_code", "TTS_UNAVAILABLE")])
+                raise TTSValidationError(
+                    "TTS_EXTERNAL_ASSET_MISSING",
+                    ",".join(str(item) for item in missing),
+                )
         existing = path.is_file()
         payload = {
             "schema_version": self.schema_version,

--- a/tts/registry.py
+++ b/tts/registry.py
@@ -59,8 +59,10 @@ class TTSProviderRegistry:
 
 
 def default_registry() -> TTSProviderRegistry:
+    from .breeze import BREEZE_LICENSE_ID, BreezeTTS2Provider
     from .providers import CosyVoice3Provider
 
     registry = TTSProviderRegistry()
+    registry.register("breeze_tts2", BreezeTTS2Provider, license_id=BREEZE_LICENSE_ID)
     registry.register("cosyvoice3", CosyVoice3Provider, license_id="Apache-2.0")
     return registry


### PR DESCRIPTION
Replaces the ordinary reply TTS provider boundary with a Breeze TTS 2 adapter that consumes the persisted VoicePerformancePlan in one pass. Adds pinned external worker selection, non-commercial license verification, content-gated delivery, truthful non-streaming health, and explicit failure without a second TTS model. Product download/default installation wiring remains in the immediately following PR. Verification: tests/tts (65 passed); reply media and HTTP chain (79 passed); real 43.36-second INT8 hybrid generation passed the content gate on the local 10GB GPU, with 9455 MiB peak nvidia-smi use. No model, reference audio, letter text, or generated audio is committed.