### PR TITLE
fix(installer): stop versioned backend during uninstall

### DIFF
--- a/installer/uninstall.py
+++ b/installer/uninstall.py
@@ -28,29 +28,45 @@ except ImportError:  # Support direct execution and the stable runpy launcher.
     )
 
 
-_STOP_MANAGED_PROCESSES = r"""
+_MANAGED_PROCESS_FILTER = r"""
 $ErrorActionPreference = 'Stop'
 $root = [IO.Path]::GetFullPath($env:OLIVIA_UNINSTALL_TARGET)
 $appPrefix = [IO.Path]::GetFullPath((Join-Path $root 'app')) + [IO.Path]::DirectorySeparatorChar
-$backendToken = [IO.Path]::GetFullPath((Join-Path $root 'local_backend'))
+$backendPrefixes = @(
+    [IO.Path]::GetFullPath((Join-Path $root 'local_backend')) + [IO.Path]::DirectorySeparatorChar
+    [IO.Path]::GetFullPath((Join-Path $root 'versions\local_backend')) + [IO.Path]::DirectorySeparatorChar
+)
+function Test-IsManagedOliviaProcess {
+    param([object]$Process)
+    $executable = [string]$Process.ExecutablePath
+    if ($executable -and $executable.StartsWith($appPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        return $true
+    }
+    if ($Process.Name -notin @('python.exe', 'pythonw.exe')) {
+        return $false
+    }
+    $command = [string]$Process.CommandLine
+    foreach ($backendPrefix in $backendPrefixes) {
+        if ($command.IndexOf($backendPrefix, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            return $true
+        }
+    }
+    return $false
+}
+"""
+
+
+_STOP_MANAGED_PROCESSES = _MANAGED_PROCESS_FILTER + r"""
 $taskkill = Join-Path $env:WINDIR 'System32\taskkill.exe'
 $targets = @(Get-CimInstance Win32_Process | Where-Object {
-    $executable = [string]$_.ExecutablePath
-    $command = [string]$_.CommandLine
-    ($executable -and $executable.StartsWith($appPrefix, [StringComparison]::OrdinalIgnoreCase)) -or
-    (($_.Name -in @('python.exe', 'pythonw.exe')) -and
-        $command.IndexOf($backendToken, [StringComparison]::OrdinalIgnoreCase) -ge 0)
+    Test-IsManagedOliviaProcess $_
 })
 foreach ($target in $targets) {
     & $taskkill /PID $target.ProcessId /T /F *> $null
 }
 for ($attempt = 0; $attempt -lt 50; $attempt += 1) {
     $remaining = @(Get-CimInstance Win32_Process | Where-Object {
-        $executable = [string]$_.ExecutablePath
-        $command = [string]$_.CommandLine
-        ($executable -and $executable.StartsWith($appPrefix, [StringComparison]::OrdinalIgnoreCase)) -or
-        (($_.Name -in @('python.exe', 'pythonw.exe')) -and
-            $command.IndexOf($backendToken, [StringComparison]::OrdinalIgnoreCase) -ge 0)
+        Test-IsManagedOliviaProcess $_
     })
     if ($remaining.Count -eq 0) { exit 0 }
     Start-Sleep -Milliseconds 100

--- a/tests/installer/test_uninstall_runtime.py
+++ b/tests/installer/test_uninstall_runtime.py
@@ -2,11 +2,59 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import subprocess
 
 import pytest
 
 from installer import uninstall
 from installer.uninstall_safety import remove_owned_targets
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows process ownership is required")
+def test_uninstall_process_filter_covers_versioned_backend_without_lookalikes(
+    tmp_path: Path,
+) -> None:
+    powershell = (
+        Path(os.environ["WINDIR"])
+        / "System32"
+        / "WindowsPowerShell"
+        / "v1.0"
+        / "powershell.exe"
+    )
+    environment = dict(os.environ)
+    environment["OLIVIA_UNINSTALL_TARGET"] = os.fspath(
+        tmp_path / "Olivia Local" / "install"
+    )
+    script = uninstall._MANAGED_PROCESS_FILTER + r"""
+$versioned = Join-Path $root 'versions\local_backend\0.1.2\local_server.py'
+$legacy = Join-Path $root 'local_backend\local_server.py'
+$outside = Join-Path (Split-Path $root -Parent) 'outside\versions\local_backend\0.1.2\local_server.py'
+$sibling = Join-Path $root 'versions\local_backend-copy\0.1.2\local_server.py'
+$actual = @(
+    Test-IsManagedOliviaProcess ([PSCustomObject]@{ Name = 'pythonw.exe'; ExecutablePath = ''; CommandLine = $versioned })
+    Test-IsManagedOliviaProcess ([PSCustomObject]@{ Name = 'python.exe'; ExecutablePath = ''; CommandLine = $legacy })
+    Test-IsManagedOliviaProcess ([PSCustomObject]@{ Name = 'pythonw.exe'; ExecutablePath = ''; CommandLine = $outside })
+    Test-IsManagedOliviaProcess ([PSCustomObject]@{ Name = 'pythonw.exe'; ExecutablePath = ''; CommandLine = $sibling })
+    Test-IsManagedOliviaProcess ([PSCustomObject]@{ Name = 'node.exe'; ExecutablePath = ''; CommandLine = $versioned })
+)
+if (($actual -join ',') -eq 'True,True,False,False,False') { exit 0 }
+Write-Error ($actual -join ',')
+exit 1
+"""
+    result = subprocess.run(
+        [
+            os.fspath(powershell),
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            script,
+        ],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=environment,
+    )
+    assert result.returncode == 0
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows process ownership is required")
@@ -42,7 +90,8 @@ def test_uninstall_stops_only_the_managed_process_tree_before_deleting(
     ]
     assert options["env"]["OLIVIA_UNINSTALL_TARGET"] == os.fspath(install)
     assert "Get-CimInstance Win32_Process" in command[4]
-    assert "local_backend" in command[4]
+    assert "versions\\local_backend" in command[4]
+    assert "/PID $target.ProcessId /T /F" in command[4]
     assert "Olivia.exe" not in command[4]
 
 


### PR DESCRIPTION
## Summary
- match managed Python backends under both the legacy local_backend root and versioned versions/local_backend root
- keep directory-boundary, executable-name, and exact PID tree-kill constraints
- cover versioned orphan detection and reject root-external or prefix-lookalike processes

## Verification
- python -m pytest -q tests/installer/test_uninstall_runtime.py (4 passed)
- python -m compileall -q installer/uninstall.py tests/installer/test_uninstall_runtime.py
- git diff --check

No real uninstall was executed and no user data path is changed.