### PR TITLE
fix(installer): allow reinstall after uninstall

### DIFF
--- a/installer/uninstall_safety.py
+++ b/installer/uninstall_safety.py
@@ -25,6 +25,7 @@ OWNED_PATHS = (
     MARKER_NAME,
 )
 PRESERVED_PATHS = ("data", "logs", "third-party", "downloads", "profile")
+EMPTY_OWNED_PARENT_PATHS = ("runtime",)
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
 
@@ -142,9 +143,19 @@ def remove_owned_targets(
             shutil.rmtree(target)
         elif target.is_file():
             target.unlink()
+    for relative in EMPTY_OWNED_PARENT_PATHS:
+        target = safe_managed_target(root, relative)
+        try:
+            target.rmdir()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            # Unknown or non-empty parents are outside the ownership list.
+            pass
 
 
 __all__ = [
+    "EMPTY_OWNED_PARENT_PATHS",
     "MARKER_NAME",
     "OWNED_PATHS",
     "PRESERVED_PATHS",

--- a/tests/installer/test_uninstall_runtime.py
+++ b/tests/installer/test_uninstall_runtime.py
@@ -134,3 +134,27 @@ def test_standalone_uninstall_defers_only_its_running_batch_file(
 
     assert not app.exists()
     assert command.read_text(encoding="utf-8") == "managed"
+
+
+def test_uninstall_removes_empty_runtime_parent_but_preserves_unknown_content(
+    tmp_path: Path,
+) -> None:
+    clean = tmp_path / "clean"
+    managed = clean / "runtime" / "mem0-site-packages"
+    managed.mkdir(parents=True)
+    (managed / "managed.txt").write_text("managed", encoding="utf-8")
+
+    remove_owned_targets(clean)
+
+    assert not (clean / "runtime").exists()
+
+    mixed = tmp_path / "mixed"
+    managed = mixed / "runtime" / "mem0-site-packages"
+    managed.mkdir(parents=True)
+    (managed / "managed.txt").write_text("managed", encoding="utf-8")
+    unknown = mixed / "runtime" / "user-owned.txt"
+    unknown.write_text("keep", encoding="utf-8")
+
+    remove_owned_targets(mixed)
+
+    assert unknown.read_text(encoding="utf-8") == "keep"


### PR DESCRIPTION
## Fix\n- remove the managed install/runtime parent only when it is empty after uninstall\n- preserve any unknown/non-empty runtime content\n- cover clean reinstall and unknown-content boundaries\n\n## Evidence\n- 11 passed, 1 skipped, 55 deselected for uninstall/reinstall focused tests\n- git diff --check PASS\n\n## Real failure\nA real 0.1.376 uninstall preserved user data but left an empty install/runtime directory, so 0.1.377 failed closed with INSTALL_ROOT_ALREADY_EXISTS.