### PR TITLE
fix(tts): fit Breeze generation to slow GPUs

### DIFF
--- a/tests/tts/test_breeze_provider.py
+++ b/tests/tts/test_breeze_provider.py
@@ -168,7 +168,7 @@ def test_breeze_performance_request_consumes_the_complete_llm_voice_plan(
     }
     assert request["cfg_scale"] == 4.0
     assert request["model_variant"] == "int8_hybrid"
-    assert request["max_new_tokens"] == 650
+    assert request["max_new_tokens"] == 600
     assert request["quality_gate_required"] is True
     assert request["quality_forbidden_text"] == request["instruction"]
 

--- a/tts/breeze.py
+++ b/tts/breeze.py
@@ -210,11 +210,11 @@ class BreezeTTS2Provider:
             "decode_mode": str(options.get("decode_mode", "eager") or "eager"),
             "cfg_scale": float(options.get("cfg_scale", 4.0)),
             "seed": int(options.get("seed", 200717)),
-            # The ordinary-reply contract rejects audio over 52 seconds.
-            # Breeze emits 12.5 frames/s, so never spend GPU time beyond the
-            # longest candidate the product can accept.
+            # Breeze emits 12.5 frames/s. Cap generation at 48 seconds so the
+            # result stays inside the 40-50 second delivery contract without
+            # spending another slow-GPU pass on an overlong candidate.
             "max_new_tokens": max(
-                64, min(650, int(options.get("max_new_tokens", 650)))
+                64, min(600, int(options.get("max_new_tokens", 600)))
             ),
             "temperature": float(options.get("temperature", 0.9)),
             "top_k": int(options.get("top_k", 50)),

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -391,7 +391,7 @@ def render_delivery_wav(
     plan: ReplyDeliveryPlan | object,
     output_path: Path,
     *,
-    timeout_seconds: float = 3600.0,
+    timeout_seconds: float = 7200.0,
     enforce_content_gate: bool = True,
 ) -> DeliveryAudioResult:
     """Render all delivery segments while loading the maintained model once."""


### PR DESCRIPTION
Real installed 40-50s Breeze synthesis was killed at the hard 3600s worker timeout on a 10GB GPU. Cap generation at 600 frames (48s at the fixed 12.5fps codec) and allow a 2h worker budget for slower supported hardware.\n\nValidation: 102 focused TTS/media tests passed; compileall and diff check passed.