### PR TITLE
fix(media): keep long MiniMax renders alive

### DIFF
--- a/runtime/media/music_reply.py
+++ b/runtime/media/music_reply.py
@@ -43,7 +43,7 @@ from runtime.media.song_content import plan_song_content
 from .voice_direction import VoicePerformancePlan
 
 
-_MINIMAX_WORKER_TIMEOUT_SECONDS = 7500.0
+_MINIMAX_WORKER_TIMEOUT_SECONDS = 14700.0
 _MUSIC_STAGE_MANIFEST_VERSION = 3
 _RUNTIME_PROBE_TIMEOUT_SECONDS = 120.0
 _RUNTIME_PROBE_REMOVED_ENVIRONMENT = (

--- a/tests/media/test_minimax_music3_worker.py
+++ b/tests/media/test_minimax_music3_worker.py
@@ -231,3 +231,47 @@ def test_118_second_generation_timeouts_cover_both_model_phases() -> None:
 
     assert worker._INFERENCE_TIMEOUT_SECONDS >= 7200.0
     assert adapter.timeout_seconds >= worker._INFERENCE_TIMEOUT_SECONDS + 300.0
+
+
+def test_history_poll_retries_transient_timeout_while_server_is_alive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = tmp_path / "generated" / "audio"
+    generated.mkdir(parents=True)
+    source = generated / "song.flac"
+    source.write_bytes(b"audio")
+    calls = 0
+
+    def request_json(_url: str) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise TimeoutError("busy GPU kernel")
+        return {
+            "prompt": {
+                "outputs": {"9": {"audio": [{"filename": source.name, "subfolder": "audio"}]}}
+            }
+        }
+
+    class AliveProcess:
+        @staticmethod
+        def poll() -> None:
+            return None
+
+    monkeypatch.setattr(worker, "_request_json", request_json)
+    monkeypatch.setattr(worker, "_gpu_sample", lambda: None)
+    monkeypatch.setattr(worker.time, "sleep", lambda _seconds: None)
+    output = tmp_path / "song.flac"
+
+    worker._copy_result(
+        base_url="http://127.0.0.1:1",
+        prompt_id="prompt",
+        generated_root=tmp_path / "generated",
+        output=output,
+        gpu_samples=[],
+        server_process=AliveProcess(),
+    )
+
+    assert calls == 2
+    assert output.read_bytes() == b"audio"

--- a/tools/minimax_music3_worker.py
+++ b/tools/minimax_music3_worker.py
@@ -26,7 +26,7 @@ from tools.minimax_profile import (  # noqa: E402
 
 
 _ALLOWED_DURATIONS = frozenset({40, 60})
-_INFERENCE_TIMEOUT_SECONDS = 7200.0
+_INFERENCE_TIMEOUT_SECONDS = 14400.0
 _EXPECTED_LYRIC_LINES = {40: 12, 60: 16}
 _SONG_TAGS = ("[Intro]", "[Verse]", "[Chorus]", "[Outro]")
 _TAG_LINE = re.compile(r"^\[[A-Za-z][A-Za-z0-9_-]{0,31}\]$")
@@ -236,6 +236,7 @@ def _copy_result(
     generated_root: Path,
     output: Path,
     gpu_samples: list[dict[str, float]],
+    server_process: subprocess.Popen,
 ) -> None:
     deadline = time.monotonic() + _INFERENCE_TIMEOUT_SECONDS
     next_gpu_sample = 0.0
@@ -246,7 +247,16 @@ def _copy_result(
             if sample is not None:
                 gpu_samples.append(sample)
             next_gpu_sample = now + 10.0
-        history = _request_json(f"{base_url}/history/{prompt_id}")
+        if server_process.poll() is not None:
+            raise RuntimeError("MINIMAX_MUSIC3_SERVER_EXITED")
+        try:
+            history = _request_json(f"{base_url}/history/{prompt_id}")
+        except (OSError, TimeoutError):
+            # Long GPU kernels can make ComfyUI's local HTTP loop temporarily
+            # unresponsive.  The inference is still healthy while its process
+            # remains alive, so keep polling until the overall deadline.
+            time.sleep(2.0)
+            continue
         item = history.get(prompt_id)
         if isinstance(item, dict):
             outputs = item.get("outputs")
@@ -401,6 +411,7 @@ def main(argv: list[str] | None = None) -> int:
                     generated_root=generated_root,
                     output=output,
                     gpu_samples=gpu_samples,
+                    server_process=process,
                 )
                 metrics["jobs"].append({
                     "request_json": str(request_path),


### PR DESCRIPTION
Fixes the real RTX 3080 10 GB music-video run: local Comfy history polling now tolerates transient HTTP timeouts while the server process is alive, and the 60-second MiniMax generation deadline covers slower supported GPUs (4h inner / 4h05 outer). The completed 48-second spoken stage remains resumable. Focused verification: 49 passed (MiniMax worker + musical concat pipeline); diff check passed. A full real 60-second product-chain rerun is in progress and will be reported separately.