### PR TITLE
fix(media): accept float RoFormer stems

### DIFF
--- a/runtime/media/music_reply.py
+++ b/runtime/media/music_reply.py
@@ -1052,14 +1052,23 @@ def separate_vocals(
         candidates = sorted(outputs.rglob("*vocals*.wav"))
         if not candidates:
             raise MusicReplyError("ROFORMER_OUTPUT_MISSING")
-        if not _valid_wave_audio(candidates[0]):
+        if not _valid_wave_audio(candidates[0], ffmpeg_path=ffmpeg_path):
             raise MusicReplyError("ROFORMER_OUTPUT_INVALID")
         vocals_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(candidates[0], vocals_path)
 
 
-def _valid_wave_audio(path: Path, *, minimum_duration_seconds: float = 0.1) -> bool:
-    duration = _media_duration_seconds(path, required_streams=("0:a:0",))
+def _valid_wave_audio(
+    path: Path,
+    *,
+    minimum_duration_seconds: float = 0.1,
+    ffmpeg_path: Path | None = None,
+) -> bool:
+    duration = _media_duration_seconds(
+        path,
+        required_streams=("0:a:0",),
+        ffmpeg_path=ffmpeg_path,
+    )
     return duration is not None and duration >= minimum_duration_seconds
 
 
@@ -1289,7 +1298,11 @@ def _media_duration_seconds(path: Path, *, required_streams: tuple[str, ...], ff
                 payload = stream.readframes(frame_count)
             if frame_rate <= 0 or expected_size <= 0 or len(payload) < expected_size: return None
             return frame_count / frame_rate
-        except (EOFError, OSError, wave.Error): return None
+        except (EOFError, OSError, wave.Error):
+            # RoFormer writes standards-compliant IEEE-float WAV (format tag 3),
+            # which Python's ``wave`` module cannot decode.  Fall through to the
+            # configured FFmpeg decoder instead of rejecting valid stem output.
+            pass
     def decode(stream: str) -> subprocess.CompletedProcess[bytes] | None:
         try:
             return subprocess.run([

--- a/tests/media/test_portable_media_boundaries.py
+++ b/tests/media/test_portable_media_boundaries.py
@@ -608,6 +608,43 @@ def test_roformer_zero_duration_wav_is_rejected_before_publication(
     assert not vocals.exists()
 
 
+def test_ieee_float_wav_falls_back_to_configured_ffmpeg(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import struct
+    import subprocess
+
+    audio = tmp_path / "float-vocals.wav"
+    payload = b"\0" * 16
+    fmt = struct.pack("<HHIIHH", 3, 2, 44100, 44100 * 8, 8, 32)
+    audio.write_bytes(
+        b"RIFF"
+        + struct.pack("<I", 4 + 8 + len(fmt) + 8 + len(payload))
+        + b"WAVEfmt "
+        + struct.pack("<I", len(fmt))
+        + fmt
+        + b"data"
+        + struct.pack("<I", len(payload))
+        + payload
+    )
+    configured_ffmpeg = tmp_path / "ffmpeg.exe"
+    configured_ffmpeg.write_bytes(b"synthetic")
+
+    def fake_run(command, **_kwargs):
+        assert command[0] == str(configured_ffmpeg)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=b"out_time=00:00:01.000000\nprogress=end\n",
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(music_reply.subprocess, "run", fake_run)
+
+    assert music_reply._valid_wave_audio(audio, ffmpeg_path=configured_ffmpeg)
+
+
 def test_official_voice_reference_is_bounded_for_cosyvoice(tmp_path, monkeypatch):
     reference = tmp_path / "official-reference.wav"
     with wave.open(str(reference), "wb") as target:


### PR DESCRIPTION
Fix the real MiniMax Music 3 product chain after a successful 60-second song render: MelBand-RoFormer writes valid IEEE-float WAV stems (format tag 3), which Python's wave module cannot decode. Fall back to the configured FFmpeg full-decode validator and thread the managed ffmpeg path through the stem gate.\n\nVerification:\n- 52 focused media tests passed\n- Real local separator output: 59.99s stereo PCM float WAV, full ffprobe/decode valid\n- No model or installer payload change