### PR TITLE
fix(media): restore official piano performance plate

### DIFF
--- a/installer/start_local.py
+++ b/installer/start_local.py
@@ -472,8 +472,6 @@ def _load_fixed_video_assets_environment(
     """Keep managed reply assets and never use wallpaper as music performance."""
 
     values = environment.copy()
-    managed_performance = values.get("OLIVIA_MUSIC_PERFORMANCE_BASE", "").strip()
-    managed_action = values.get("OLIVIA_ORDINARY_ACTION_BASE", "").strip()
     assets = _client_executable(root).parent / "assets" / "Wallpaper_Presence"
     scene = assets / "A_R1_2000.mp4"
     transition = assets / "A_Transition_2000_1200.mp4"
@@ -481,8 +479,6 @@ def _load_fixed_video_assets_environment(
         return values
     values.setdefault("OLIVIA_ORDINARY_ACTION_BASE", str(scene.resolve()))
     values.setdefault("OLIVIA_OFFICIAL_REPLY_REFERENCE", str(transition.resolve()))
-    if not managed_performance and managed_action and Path(managed_action).is_file():
-        values["OLIVIA_MUSIC_PERFORMANCE_BASE"] = str(Path(managed_action).resolve())
     return values
 
 

--- a/installer/video-capability-manifest.json
+++ b/installer/video-capability-manifest.json
@@ -113,7 +113,7 @@
                 "OLIVIA_LATENTSYNC_PYTHON": "latentsync/runtime/python/python.exe",
                 "OLIVIA_LATENTSYNC_ROOT": "latentsync/runtime",
                 "OLIVIA_ORDINARY_ACTION_BASE": "scenes/official-reply-action-base-v1.mp4",
-                "OLIVIA_MUSIC_PERFORMANCE_BASE": "scenes/official-reply-action-base-v1.mp4",
+                "OLIVIA_MUSIC_PERFORMANCE_BASE": "scenes/official-performance-lipsync-safe-2950f-v1.mp4",
                 "OLIVIA_OFFICIAL_REPLY_REFERENCE": "scenes/official-reply-reference-000-043s-v1.mp4"
             },
             "runtime_patches": [
@@ -410,6 +410,16 @@
                     "license": "Olivia original media preservation",
                     "sources": {
                         "official": "https://github.com/Ornn8/bside-olivia-community/releases/download/v0.1.2/official-reply-action-base-v1.mp4"
+                    }
+                },
+                {
+                    "id": "official-music-performance-base",
+                    "path": "scenes/official-performance-lipsync-safe-2950f-v1.mp4",
+                    "size_bytes": 19900636,
+                    "sha256": "ee6e513d772fe8c70d4fef3c2176a4e8e33f4e973bef2a6be55fce0dd6688efd",
+                    "license": "Olivia original media preservation",
+                    "sources": {
+                        "official": "https://github.com/Ornn8/bside-olivia-community/releases/download/v0.1.2/official-performance-lipsync-safe-2950f-v1.mp4"
                     }
                 },
                 {

--- a/runtime/media/music_reply.py
+++ b/runtime/media/music_reply.py
@@ -1500,6 +1500,15 @@ def _read_compatible_manifest(
             )
             if isinstance(normal, dict):
                 artifacts["normal_video"] = normal
+        if isinstance(loaded, dict) and _music_audio_stage_inputs_match(
+            loaded, expected
+        ):
+            loaded_artifacts = loaded.get("artifacts")
+            if isinstance(loaded_artifacts, dict):
+                for name in ("song_audio", "vocals"):
+                    record = loaded_artifacts.get(name)
+                    if isinstance(record, dict):
+                        artifacts[name] = record
         return {**expected, "artifacts": artifacts}
     artifacts = loaded.get("artifacts")
     return {**expected, "artifacts": artifacts if isinstance(artifacts, dict) else {}}
@@ -1526,6 +1535,35 @@ def _normal_stage_inputs_match(
             ),
         ),
         ("providers", ("face_sync",)),
+    ):
+        old_values = loaded.get(section)
+        new_values = expected.get(section)
+        if not isinstance(old_values, dict) or not isinstance(new_values, dict):
+            return False
+        if any(old_values.get(key) != new_values.get(key) for key in keys):
+            return False
+    return True
+
+
+def _music_audio_stage_inputs_match(
+    loaded: dict[str, object],
+    expected: dict[str, object],
+) -> bool:
+    """Keep generated music and vocals when only the visual plate changes."""
+
+    if loaded.get("schema_version") != expected.get("schema_version"):
+        return False
+    for section, keys in (
+        (
+            "inputs",
+            (
+                "canonical_reply_sha256",
+                "caption_sha256",
+                "duration_seconds",
+                "lyrics_sha256",
+            ),
+        ),
+        ("providers", ("music", "vocal_separator")),
     ):
         old_values = loaded.get(section)
         new_values = expected.get(section)

--- a/tests/installer/test_original_client_server_launcher.py
+++ b/tests/installer/test_original_client_server_launcher.py
@@ -477,7 +477,9 @@ def test_launcher_auto_uses_private_voice_but_keeps_public_absence_valid(
     assert "OLIVIA_REPLY_VOICE_REFERENCE" not in public
 
 
-def test_launcher_uses_registered_reply_motion_for_music_performance(tmp_path: Path) -> None:
+def test_launcher_never_reuses_registered_reply_motion_for_music_performance(
+    tmp_path: Path,
+) -> None:
     root = _installation(tmp_path, client_version="0.0.9.627")
     assets = root / "app" / "0.0.9.627" / "assets" / "Wallpaper_Presence"
     assets.mkdir(parents=True)
@@ -504,7 +506,6 @@ def test_launcher_uses_registered_reply_motion_for_music_performance(tmp_path: P
     assert environment == {
         "OLIVIA_ORDINARY_ACTION_BASE": str(accepted_scene.resolve()),
         "OLIVIA_OFFICIAL_REPLY_REFERENCE": str(accepted_reference.resolve()),
-        "OLIVIA_MUSIC_PERFORMANCE_BASE": str(accepted_scene.resolve()),
     }
 
 

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -146,7 +146,7 @@ def test_repository_bom_replaces_cosyvoice_with_fixed_breeze_and_license_boundar
         "OLIVIA_LATENTSYNC_ROOT": "latentsync/runtime",
         "OLIVIA_OFFICIAL_REPLY_REFERENCE": "scenes/official-reply-reference-000-043s-v1.mp4",
         "OLIVIA_ORDINARY_ACTION_BASE": "scenes/official-reply-action-base-v1.mp4",
-        "OLIVIA_MUSIC_PERFORMANCE_BASE": "scenes/official-reply-action-base-v1.mp4",
+        "OLIVIA_MUSIC_PERFORMANCE_BASE": "scenes/official-performance-lipsync-safe-2950f-v1.mp4",
     }
     assert ordinary.runtime_artifacts == (
         VideoRuntimeArtifact(
@@ -1512,6 +1512,7 @@ def test_production_manifest_persists_managed_worker_and_finishes_ready(
         "ordinary_video/breeze/runtime/nodes.py",
         "ordinary_video/breeze/model/LICENSE", "ordinary_video/ffmpeg/runtime/bin/ffmpeg.exe",
         "ordinary_video/scenes/official-reply-action-base-v1.mp4",
+        "ordinary_video/scenes/official-performance-lipsync-safe-2950f-v1.mp4",
         "ordinary_video/scenes/official-reply-reference-000-043s-v1.mp4",
         "music_video/roformer/models/MelBandRoformer.ckpt",
         "music_video/roformer/runtime/src/mel_band_roformer/configs/config_vocals_mel_band_roformer.yaml",
@@ -1664,6 +1665,7 @@ def test_split_production_bundles_reach_real_readiness_without_legacy_archive(
         ordinary / "latentsync/runtime/configs/unet/stage2_efficient.yaml",
         ordinary / "latentsync/runtime/checkpoints/latentsync_unet.pt",
         ordinary / "scenes/official-reply-action-base-v1.mp4",
+        ordinary / "scenes/official-performance-lipsync-safe-2950f-v1.mp4",
         ordinary / "scenes/official-reply-reference-000-043s-v1.mp4",
         music / "minimax/runtime/python/python.exe",
         music / "minimax/runtime/main.py",

--- a/tests/media/test_music_reply_concat_pipeline.py
+++ b/tests/media/test_music_reply_concat_pipeline.py
@@ -1193,12 +1193,60 @@ def test_render_musical_reply_resumes_from_persisted_spoken_and_song_stages(
     visual_config.write_bytes(b"visual-v2")
     music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
 
-    assert calls == {"spoken": 4, "minimax": 5, "separate": 6}
+    assert calls == {"spoken": 4, "minimax": 4, "separate": 5}
 
     visual_worker.write_bytes(b"worker-v2")
     music_reply.render_musical_reply("letter", "changed reply", output, **kwargs)
 
-    assert calls == {"spoken": 5, "minimax": 6, "separate": 7}
+    assert calls == {"spoken": 5, "minimax": 4, "separate": 5}
+
+
+def test_manifest_plate_change_reuses_audio_but_rebuilds_visual_stages(
+    tmp_path: Path,
+) -> None:
+    expected = {
+        "schema_version": 3,
+        "inputs": {
+            "canonical_reply_sha256": "reply",
+            "voice_performance_sha256": "voice",
+            "caption_sha256": "caption",
+            "duration_seconds": 60,
+            "lyrics_sha256": "lyrics",
+        },
+        "assets": {
+            "performance_video": {"sha256": "correct-plate"},
+            "official_reply_reference": {"sha256": "official"},
+            "spoken_action_base": {"sha256": "spoken"},
+            "tts_config": {"sha256": "tts"},
+            "visual_config": {"sha256": "visual"},
+            "visual_worker": {"sha256": "worker"},
+        },
+        "providers": {
+            "face_sync": {"sha256": "face"},
+            "music": {"sha256": "music"},
+            "vocal_separator": {"sha256": "separator"},
+        },
+        "artifacts": {},
+    }
+    loaded = json.loads(json.dumps(expected))
+    loaded["assets"]["performance_video"] = {"sha256": "wrong-plate"}
+    loaded["artifacts"] = {
+        "normal_video": {"fingerprint": "normal"},
+        "song_audio": {"fingerprint": "song"},
+        "vocals": {"fingerprint": "vocals"},
+        "song_video": {"fingerprint": "wrong-visual"},
+        "final_output": {"fingerprint": "wrong-final"},
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(loaded), encoding="utf-8")
+
+    compatible = music_reply._read_compatible_manifest(manifest_path, expected)
+
+    assert compatible["artifacts"] == {
+        "normal_video": loaded["artifacts"]["normal_video"],
+        "song_audio": loaded["artifacts"]["song_audio"],
+        "vocals": loaded["artifacts"]["vocals"],
+    }
 
 
 def test_render_musical_reply_invalidates_manifest_cached_short_song_audio(
@@ -1458,12 +1506,17 @@ def test_render_musical_reply_invalidates_cache_when_configured_provider_assets_
     ):
         asset.write_bytes(f"provider-v{index}".encode())
         music_reply.render_musical_reply("letter", "reply", output, **kwargs)
-        assert calls == {"minimax": index, "separate": index, "performance": index}
+        music_runs = index - 1 if asset == latentsync_checkpoint else index
+        assert calls == {
+            "minimax": music_runs,
+            "separate": music_runs,
+            "performance": index,
+        }
 
     minimax_node.unlink()
     music_reply.render_musical_reply("letter", "reply", output, **kwargs)
 
-    assert calls == {"minimax": 9, "separate": 9, "performance": 9}
+    assert calls == {"minimax": 8, "separate": 8, "performance": 9}
 
 @pytest.fixture(autouse=True)
 def _eligible_breeze_gpu(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Restores the dedicated 118-second official piano-performance plate for the music segment instead of reusing the ordinary spoken-action plate. Removes the launcher fallback that caused the mix-up, registers the verified on-demand asset, and preserves generated song/vocal stages when only the visual plate changes.\n\nVerification: 194 focused media/installer tests; 62 reply-routing tests; compileall; git diff --check.\n\nAsset: official-performance-lipsync-safe-2950f-v1.mp4, SHA-256 ee6e513d772fe8c70d4fef3c2176a4e8e33f4e973bef2a6be55fce0dd6688efd.