### PR TITLE
fix(release): restore mailbox navigation and manual resend

### DIFF
--- a/installer/build_windows_setup.py
+++ b/installer/build_windows_setup.py
@@ -1060,8 +1060,6 @@ def prepare_setup_payload(
         raise SetupBuildError("SETUP_PRIVATE_VIDEO_OFFLINE_REQUIRED")
     if distribution == "personal" and video_offline_root is not None:
         raise SetupBuildError("SETUP_VIDEO_OFFLINE_PRIVATE_ONLY")
-    if native_navigation_manifest is not None and not private_distribution:
-        raise SetupBuildError("SETUP_NATIVE_NAVIGATION_MANIFEST_PRIVATE_ONLY")
     if private_distribution and native_navigation_manifest is None:
         assert voice_reference is not None
         native_navigation_manifest = (

--- a/local_server.py
+++ b/local_server.py
@@ -1668,7 +1668,10 @@ async def handler(request: web.Request):
                 path,
                 body,
                 query,
-                defer_reply=(method == "POST" and canonical_path == "/toy/letter/send"),
+                defer_reply=(
+                    method == "POST"
+                    and canonical_path in {"/toy/letter/send", "/toy/letter/resend"}
+                ),
                 companion_confirmed=(
                     request.headers.get("X-Olivia-Companion-Action") == "confirmed"
                 ),
@@ -3267,8 +3270,7 @@ async def route(
                 "error_code": "LETTER_SUPERSEDED",
                 "replacement_letter_id": original["superseded_by"],
             })
-        _public_code, retryable = _public_llm_error(original.get("error_code"))
-        if original.get("letter_status") != "FAILED" or not retryable:
+        if original.get("letter_status") != "FAILED":
             return err(409, "LETTER_RESEND_NOT_ALLOWED", {
                 "status": "FAILED",
                 "error_code": "LETTER_RESEND_NOT_ALLOWED",

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -1859,6 +1859,93 @@ def test_llm_failure_can_be_retried_through_the_resend_route(
     assert len(local_server.store.letters) == 2
 
 
+def test_user_can_manually_resend_a_provider_rejected_letter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
+    outcomes: list[str | Exception] = [
+        local_server.LLMError("LLM_PROVIDER_REJECTED"),
+        "synthetic successful manual resend",
+    ]
+
+    def reply(_content, _context="", **_kwargs):
+        outcome = outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(local_server.letters_adapter, "reply", reply)
+    failed = asyncio.run(
+        local_server.route(
+            "POST", "/toy/letter/send", {"content": "synthetic manual retry"}, {}
+        )
+    )
+    retried = asyncio.run(
+        local_server.route(
+            "POST",
+            "/toy/letter/resend",
+            {"letter_id": failed["data"]["letter_id"]},
+            {},
+        )
+    )
+
+    assert failed["code"] == 503
+    assert failed["data"]["error_code"] == "LLM_PROVIDER_REJECTED"
+    assert failed["data"]["retryable"] is False
+    assert retried["code"] == 0
+    assert retried["data"]["status"] == "COMPLETED"
+
+
+def test_http_manual_resend_acknowledges_before_background_provider_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    import local_server
+
+    monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
+    failed_id = "synthetic-provider-rejected"
+    local_server.store.letters[:] = [
+        {
+            "letter_id": failed_id,
+            "content": "synthetic manual resend",
+            "material": {},
+            "letter_status": "FAILED",
+            "error_code": "LLM_PROVIDER_REJECTED",
+            "audit_status": 2,
+            "is_read": 1,
+            "created_at": int(time.time()),
+            "reply_text": "",
+        }
+    ]
+    scheduled: list[str] = []
+    monkeypatch.setattr(
+        local_server,
+        "_schedule_reply_job",
+        lambda letter_id, *_args, **_kwargs: scheduled.append(letter_id),
+    )
+
+    async def exercise() -> tuple[int, dict]:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", local_server.handler)
+        async with TestClient(TestServer(app, access_log=None)) as client:
+            response = await client.post(
+                "/toy/letter/resend", json={"letter_id": failed_id}
+            )
+            return response.status, await response.json()
+
+    status, payload = asyncio.run(exercise())
+
+    assert status == 200
+    assert payload["data"]["status"] == "PENDING"
+    assert scheduled == [payload["data"]["letter_id"]]
+
+
 def test_successful_retry_replaces_recent_failed_copy_in_current_mailbox(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/installer/test_windows_setup_exe.py
+++ b/tests/installer/test_windows_setup_exe.py
@@ -537,6 +537,33 @@ def test_prepare_setup_payload_injects_hash_locked_voice_reference(tmp_path: Pat
         )
 
 
+def test_prepare_public_payload_accepts_explicit_native_navigation_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source, offline, reference = _voice_setup_fixture(tmp_path, monkeypatch)
+    navigation_manifest = reference.parent / "native-navigation-compatibility.json"
+    destination = tmp_path / "public-payload"
+
+    prepare_setup_payload(
+        source,
+        offline,
+        destination,
+        distribution="public",
+        native_navigation_manifest=navigation_manifest,
+        validate_schema=False,
+    )
+
+    assert (
+        destination / "installer/native-navigation-compatibility.json"
+    ).read_bytes() == navigation_manifest.read_bytes()
+    assert not (destination / "offline/voice").exists()
+    assert not any(
+        path.suffix.casefold() in {".wav", ".mp3", ".safetensors", ".onnx"}
+        for path in destination.rglob("*")
+        if path.is_file()
+    )
+
+
 def test_prepare_private_payload_accepts_complete_split_bom_without_runtime_archive(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Restores the native mailbox navigation patch in public Windows setup builds and allows explicit manual resend for any failed letter. Resend now acknowledges as PENDING before the provider call, matching normal send behavior.\n\nVerification: 200 focused HTTP and installer tests passed.