### PR TITLE
persona: add private-safe distillation pipeline

### DIFF
--- a/baseline_hardening_scan.py
+++ b/baseline_hardening_scan.py
@@ -162,7 +162,10 @@ SECRET_PATTERNS = (
 )
 
 SENSITIVE_PATH_PATTERN = re.compile(
-    r"(?i)(?:^|/)(?:\.env(?:\.|$)|[^/]*(?:secret|token|credential|password)[^/]*|"
+    r"(?i)(?:^|/)\.private(?:/|$)|"
+    r"(?:^|/)[^/]*(?:holdout[-_]ids|persona[-_]distillation[-_]output|"
+    r"private[-_]corpus)[^/]*\.(?:json|jsonl|txt|csv)$|"
+    r"(?:^|/)(?:\.env(?:\.|$)|[^/]*(?:secret|token|credential|password)[^/]*|"
     r"[^/]+\.(?:pem|key|p12|pfx|crt|sqlite|sqlite3|db)|"
     r"[^/]+\.(?:safetensors|pth|pt|ckpt|onnx|gguf|bin|wav|flac|mp3|mp4|zip|7z|rar))$"
 )
@@ -329,6 +332,7 @@ def scan_sensitive_paths(root: Path, files: list[Path]) -> tuple[list[str], list
         "secret_token_credential_paths",
         "private_key_paths",
         "model_media_archive_paths",
+        "private_corpus_and_holdout_artifact_paths",
     ]
 
 

--- a/contracts/persona_corpus_manifest.schema.json
+++ b/contracts/persona_corpus_manifest.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "p02.persona-corpus-manifest.v1",
+  "title": "Local persona corpus per-file role manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "entries"],
+  "properties": {
+    "schema_version": {"const": "p02.persona-corpus-manifest.v1"},
+    "entries": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/entry"}
+    }
+  },
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["relative_path", "correspondence_id", "evidence_role"],
+      "properties": {
+        "relative_path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500,
+          "pattern": "^(?![A-Za-z]:)(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\u0000-\\u001F\\u007F]+\\.txt$"
+        },
+        "correspondence_id": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9._:-]{1,96}$"
+        },
+        "evidence_role": {
+          "enum": ["user_letter", "canonical_character_reply"]
+        }
+      }
+    }
+  }
+}

--- a/contracts/persona_distillation_input.schema.json
+++ b/contracts/persona_distillation_input.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "p02.persona-distillation-input.v1",
+  "title": "Local-only persona distillation input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "documents", "holdout_source_ids"],
+  "properties": {
+    "schema_version": {"const": "p02.persona-distillation-input.v1"},
+    "documents": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/document"}
+    },
+    "holdout_source_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/identifier"}
+    }
+  },
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._:-]{1,96}$"
+    },
+    "document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_id",
+        "partition_id",
+        "text",
+        "source_kind",
+        "rights_status",
+        "evidence_role"
+      ],
+      "properties": {
+        "source_id": {"$ref": "#/$defs/identifier"},
+        "partition_id": {"$ref": "#/$defs/identifier"},
+        "text": {"type": "string", "minLength": 1, "maxLength": 200000},
+        "source_kind": {
+          "enum": ["public_document", "local_private_correspondence"]
+        },
+        "rights_status": {
+          "enum": ["REDISTRIBUTABLE", "SUMMARY_ONLY", "LOCAL_PRIVATE_ONLY"]
+        },
+        "evidence_role": {
+          "enum": [
+            "user_letter",
+            "canonical_character_reply",
+            "public_character_source"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "source_kind": {"const": "local_private_correspondence"}
+            }
+          },
+          "then": {
+            "properties": {
+              "rights_status": {"const": "LOCAL_PRIVATE_ONLY"},
+              "evidence_role": {
+                "enum": ["user_letter", "canonical_character_reply"]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {"source_kind": {"const": "public_document"}}
+          },
+          "then": {
+            "properties": {
+              "rights_status": {"enum": ["REDISTRIBUTABLE", "SUMMARY_ONLY"]},
+              "evidence_role": {"const": "public_character_source"}
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/docs/PERSONA_DISTILLATION_TASK.md
+++ b/docs/PERSONA_DISTILLATION_TASK.md
@@ -129,3 +129,44 @@
 6. `CHANGELOG.md`：每次事实/推断/边界变化的原因、证据和回滚方式。
 
 完成定义：来源登记完整、事实/推断/未知可区分、玩家隐私零混入、长原文零提交、反例与保留集测试全绿、独立 Luna Max 审查通过。任何一项未完成都只能标为“人格任务书执行中”，不能标为最终林离人格。
+
+## 10. 本地蒸馏管线
+
+仓库只保存输入契约和校验代码，不保存往来语料、参与者目录名、来源记录
+ID、holdout 划分或蒸馏结果。`docs/persona-sources/` 提供经审查的公开或授权
+摘要；操作员提供的往来目录仅在本机读取。
+
+先运行不会输出私密内容的清点命令：
+
+```powershell
+python -m runtime.persona.persona_distillation --corpus-root <local-corpus-root>
+```
+
+直接子目录按用户整体分组，经 NFC 规范化和 SHA-256 排序后轮转分配到五折；
+第 0 折为 holdout，其正文不会被读取。命令只输出数量、视频排除状态和语料
+指纹，不输出名称、路径、来源 ID 或正文。
+
+每份文档必须标记为用户来信、已投递的角色 canonical reply 或公开角色来源。
+只有后两类能授权 declaration 或助手风格样例；用户来信即使内容看似可信也会
+被拒绝。`PersonaTopicExtractor` 仅收到训练折，按固定主题顺序产出候选；最终器
+拒绝 holdout 引用、由本地往来支持的公开发布声明、重复 ID、无效分类和与训练
+来源存在连续 7 字重合的私有派生样例，并使用规范排序和 JSON 序列化生成稳定
+结果摘要。
+
+若目录同时包含原信与角色正式回信，必须另提供逐文件角色清单：
+
+```powershell
+python -m runtime.persona.persona_distillation `
+  --corpus-root <local-corpus-root> `
+  --role-manifest <local-role-manifest.json>
+```
+
+清单遵循 `contracts/persona_corpus_manifest.schema.json`，逐项声明相对路径、
+往来 ID 和 `user_letter` / `canonical_character_reply` 角色，并完整覆盖目录内
+所有文本。角色回信必须与同一往来 ID、同一顶层用户 partition 的用户原信成对
+出现；同一往来 ID 不得跨顶层用户 partition，避免跨训练/holdout 用户配对。
+运行时不根据文件名或正文猜测角色。未提供清单时，所有文本一律按
+`user_letter` 处理，状态保持 `LOCAL_PRIVATE_INPUT_ONLY`。
+
+蒸馏结果只能作为本机审查工件。不得把结果、holdout 清单或语料导出加入 Git；
+只有单独审查过的摘要和合成回归夹具可以进入跟踪资产。

--- a/runtime/persona/persona_distillation.py
+++ b/runtime/persona/persona_distillation.py
@@ -1,0 +1,607 @@
+"""Deterministic, local-only persona distillation contracts and safeguards."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import argparse
+from enum import StrEnum
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+from typing import Protocol
+from unicodedata import normalize
+
+from .style_exemplar_builder import (
+    StyleExemplarBuildError,
+    build_style_exemplar,
+)
+
+
+DISTILLATION_TOPICS = (
+    "family_background",
+    "living_arrangements",
+    "current_practice_repertoire",
+    "original_compositions",
+    "singing_self_report_and_performance",
+    "music_taste_and_collection",
+    "reading_interests",
+    "daily_habits_and_aesthetics",
+    "name_origin",
+    "instruments_and_equipment",
+    "explicit_boundaries",
+)
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
+_FACETS = frozenset(
+    {
+        "POLICY",
+        "IDENTITY",
+        "BACKGROUND",
+        "CORE_TRAIT",
+        "AUTONOMY",
+        "KNOWLEDGE_BOUNDARY",
+        "EXPRESSION_STYLE",
+        "RELATIONSHIP_STYLE",
+        "MEMORY_CONTINUITY",
+        "UNCERTAINTY",
+        "MODE_STYLE",
+        "SAFETY",
+    }
+)
+_TIERS = frozenset(
+    {"CONSTITUTION", "PUBLIC_CANON", "COMMUNITY_SOFT_CANON", "INFERRED", "UNCERTAINTY", "MODE_STYLE"}
+)
+_CONFIDENCE = frozenset({"LOW", "MEDIUM", "HIGH"})
+_MODES = frozenset({"text_letter", "spoken_video", "musical_video", "future_im"})
+
+
+class DistillationBuildError(ValueError):
+    pass
+
+
+class DistillationSourceKind(StrEnum):
+    PUBLIC_DOCUMENT = "public_document"
+    LOCAL_PRIVATE_CORRESPONDENCE = "local_private_correspondence"
+
+
+class DistillationEvidenceRole(StrEnum):
+    USER_LETTER = "user_letter"
+    CANONICAL_CHARACTER_REPLY = "canonical_character_reply"
+    PUBLIC_CHARACTER_SOURCE = "public_character_source"
+
+
+@dataclass(frozen=True)
+class DistillationDocument:
+    source_id: str
+    partition_id: str
+    text: str
+    source_kind: DistillationSourceKind
+    rights_status: str
+    evidence_role: DistillationEvidenceRole
+
+    def __post_init__(self) -> None:
+        if any(
+            not isinstance(value, str) or not _ID_RE.fullmatch(value)
+            for value in (self.source_id, self.partition_id)
+        ):
+            raise DistillationBuildError("DISTILLATION_SOURCE_ID_INVALID")
+        if (
+            not isinstance(self.text, str)
+            or not self.text.strip()
+            or len(self.text) > 200_000
+        ):
+            raise DistillationBuildError("DISTILLATION_SOURCE_TEXT_INVALID")
+        if not isinstance(self.source_kind, DistillationSourceKind):
+            raise DistillationBuildError("DISTILLATION_SOURCE_KIND_INVALID")
+        if not isinstance(self.evidence_role, DistillationEvidenceRole):
+            raise DistillationBuildError("DISTILLATION_EVIDENCE_ROLE_INVALID")
+        if self.source_kind is DistillationSourceKind.PUBLIC_DOCUMENT:
+            valid_role = (
+                self.evidence_role is DistillationEvidenceRole.PUBLIC_CHARACTER_SOURCE
+            )
+        else:
+            valid_role = self.evidence_role in {
+                DistillationEvidenceRole.USER_LETTER,
+                DistillationEvidenceRole.CANONICAL_CHARACTER_REPLY,
+            }
+        if not valid_role:
+            raise DistillationBuildError("DISTILLATION_EVIDENCE_ROLE_INVALID")
+        expected = (
+            "LOCAL_PRIVATE_ONLY"
+            if self.source_kind
+            is DistillationSourceKind.LOCAL_PRIVATE_CORRESPONDENCE
+            else {"REDISTRIBUTABLE", "SUMMARY_ONLY"}
+        )
+        if isinstance(expected, str):
+            valid_rights = self.rights_status == expected
+        else:
+            valid_rights = self.rights_status in expected
+        if not valid_rights:
+            raise DistillationBuildError("DISTILLATION_SOURCE_RIGHTS_INVALID")
+
+
+@dataclass(frozen=True)
+class CandidateDeclaration:
+    declaration_id: str
+    source_id: str
+    topic: str
+    statement: str
+    confidence: str
+    facet: str
+    tier: str
+    mode: str | None = None
+    allowed_public_release: bool = False
+
+    def __post_init__(self) -> None:
+        if any(
+            not isinstance(value, str) or not _ID_RE.fullmatch(value)
+            for value in (self.declaration_id, self.source_id)
+        ):
+            raise DistillationBuildError("DISTILLATION_DECLARATION_ID_INVALID")
+        if self.topic not in DISTILLATION_TOPICS:
+            raise DistillationBuildError("DISTILLATION_TOPIC_INVALID")
+        if (
+            not isinstance(self.statement, str)
+            or not self.statement.strip()
+            or len(self.statement) > 600
+        ):
+            raise DistillationBuildError("DISTILLATION_STATEMENT_INVALID")
+        if self.confidence not in _CONFIDENCE or self.facet not in _FACETS:
+            raise DistillationBuildError("DISTILLATION_CLASSIFICATION_INVALID")
+        if self.tier not in _TIERS:
+            raise DistillationBuildError("DISTILLATION_TIER_INVALID")
+        if (self.tier == "MODE_STYLE") != (self.mode is not None):
+            raise DistillationBuildError("DISTILLATION_MODE_STYLE_INVALID")
+        if self.mode is not None and self.mode not in _MODES:
+            raise DistillationBuildError("DISTILLATION_MODE_INVALID")
+        if type(self.allowed_public_release) is not bool:
+            raise DistillationBuildError("DISTILLATION_RELEASE_FLAG_INVALID")
+
+
+@dataclass(frozen=True)
+class CandidateStyleExemplar:
+    exemplar_id: str
+    source_id: str
+    mode: str
+    situation: str
+    user_text: str
+    assistant_text: str
+    user_text_is_synthetic: bool
+
+    def __post_init__(self) -> None:
+        if any(
+            not isinstance(value, str) or not _ID_RE.fullmatch(value)
+            for value in (self.exemplar_id, self.source_id, self.situation)
+        ):
+            raise DistillationBuildError("DISTILLATION_EXEMPLAR_ID_INVALID")
+        if type(self.user_text_is_synthetic) is not bool:
+            raise DistillationBuildError(
+                "DISTILLATION_EXEMPLAR_USER_TEXT_PROVENANCE_INVALID"
+            )
+
+
+@dataclass(frozen=True)
+class TopicExtraction:
+    declarations: tuple[CandidateDeclaration, ...] = ()
+    style_exemplars: tuple[CandidateStyleExemplar, ...] = ()
+
+    def __post_init__(self) -> None:
+        if isinstance(self.declarations, (str, bytes)) or any(
+            not isinstance(item, CandidateDeclaration) for item in self.declarations
+        ):
+            raise DistillationBuildError("DISTILLATION_DECLARATIONS_INVALID")
+        if isinstance(self.style_exemplars, (str, bytes)) or any(
+            not isinstance(item, CandidateStyleExemplar)
+            for item in self.style_exemplars
+        ):
+            raise DistillationBuildError("DISTILLATION_EXEMPLARS_INVALID")
+
+
+class PersonaTopicExtractor(Protocol):
+    def extract(
+        self,
+        topic: str,
+        documents: tuple[DistillationDocument, ...],
+    ) -> TopicExtraction: ...
+
+
+@dataclass(frozen=True)
+class DistillationResult:
+    declarations: tuple[dict[str, object], ...]
+    style_exemplars: tuple[dict[str, object], ...]
+    training_source_count: int
+    holdout_source_count: int
+    unresolved_topics: tuple[str, ...]
+
+    def canonical_json(self) -> str:
+        return json.dumps(
+            {
+                "declarations": self.declarations,
+                "holdout_source_count": self.holdout_source_count,
+                "style_exemplars": self.style_exemplars,
+                "training_source_count": self.training_source_count,
+                "unresolved_topics": self.unresolved_topics,
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    @property
+    def result_sha256(self) -> str:
+        return hashlib.sha256(self.canonical_json().encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class CorpusInventory:
+    user_partition_count: int
+    document_count: int
+    training_document_count: int
+    holdout_document_count: int
+    video_count: int
+    corpus_sha256: str
+    character_evidence_document_count: int = 0
+
+    def public_report_json(self) -> str:
+        return json.dumps(
+            {
+                "corpus_sha256": self.corpus_sha256,
+                "document_count": self.document_count,
+                "holdout_document_count": self.holdout_document_count,
+                "character_evidence_document_count": (
+                    self.character_evidence_document_count
+                ),
+                "status": (
+                    "LOCAL_PRIVATE_READY"
+                    if self.character_evidence_document_count
+                    else "LOCAL_PRIVATE_INPUT_ONLY"
+                ),
+                "training_document_count": self.training_document_count,
+                "user_partition_count": self.user_partition_count,
+                "video_count": self.video_count,
+                "videos_excluded": True,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+
+def assign_user_folds(
+    user_partition_ids: tuple[str, ...],
+    *,
+    fold_count: int = 5,
+) -> dict[str, int]:
+    if type(fold_count) is not int or fold_count < 2:
+        raise DistillationBuildError("DISTILLATION_FOLD_COUNT_INVALID")
+    normalized = tuple(normalize("NFC", item) for item in user_partition_ids)
+    if len(normalized) != len(set(normalized)):
+        raise DistillationBuildError("DISTILLATION_PARTITIONS_NOT_UNIQUE")
+    ordered = sorted(
+        normalized,
+        key=lambda item: hashlib.sha256(item.encode("utf-8")).hexdigest(),
+    )
+    return {partition: index % fold_count for index, partition in enumerate(ordered)}
+
+
+def _load_role_manifest(
+    manifest_path: Path | None,
+    source_paths: tuple[str, ...],
+) -> dict[str, tuple[str, DistillationEvidenceRole]] | None:
+    if manifest_path is None:
+        return None
+    try:
+        payload = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise DistillationBuildError(
+            "DISTILLATION_ROLE_MANIFEST_INVALID"
+        ) from exc
+    if not isinstance(payload, dict) or set(payload) != {
+        "schema_version",
+        "entries",
+    } or payload["schema_version"] != "p02.persona-corpus-manifest.v1":
+        raise DistillationBuildError("DISTILLATION_ROLE_MANIFEST_INVALID")
+    entries = payload["entries"]
+    if not isinstance(entries, list):
+        raise DistillationBuildError("DISTILLATION_ROLE_MANIFEST_INVALID")
+    roles: dict[str, tuple[str, DistillationEvidenceRole]] = {}
+    correspondence_roles: dict[
+        tuple[str, str], set[DistillationEvidenceRole]
+    ] = {}
+    correspondence_partitions: dict[str, set[str]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict) or set(entry) != {
+            "relative_path",
+            "correspondence_id",
+            "evidence_role",
+        }:
+            raise DistillationBuildError("DISTILLATION_ROLE_MANIFEST_INVALID")
+        relative = entry["relative_path"]
+        correspondence_id = entry["correspondence_id"]
+        try:
+            role = DistillationEvidenceRole(entry["evidence_role"])
+        except (TypeError, ValueError) as exc:
+            raise DistillationBuildError(
+                "DISTILLATION_ROLE_MANIFEST_INVALID"
+            ) from exc
+        relative_path = PurePosixPath(relative) if isinstance(relative, str) else None
+        if (
+            relative_path is None
+            or relative_path.is_absolute()
+            or relative_path.suffix.casefold() != ".txt"
+            or ".." in relative_path.parts
+            or "\\" in relative
+            or not isinstance(correspondence_id, str)
+            or not _ID_RE.fullmatch(correspondence_id)
+            or role is DistillationEvidenceRole.PUBLIC_CHARACTER_SOURCE
+            or relative in roles
+        ):
+            raise DistillationBuildError("DISTILLATION_ROLE_MANIFEST_INVALID")
+        partition = relative_path.parts[0]
+        roles[relative] = (correspondence_id, role)
+        correspondence_roles.setdefault((partition, correspondence_id), set()).add(role)
+        correspondence_partitions.setdefault(correspondence_id, set()).add(partition)
+    if set(roles) != set(source_paths):
+        raise DistillationBuildError(
+            "DISTILLATION_ROLE_MANIFEST_COVERAGE_INVALID"
+        )
+    if (
+        any(len(grouped) != 1 for grouped in correspondence_partitions.values())
+        or any(
+            DistillationEvidenceRole.CANONICAL_CHARACTER_REPLY in grouped
+            and DistillationEvidenceRole.USER_LETTER not in grouped
+            for grouped in correspondence_roles.values()
+        )
+    ):
+        raise DistillationBuildError("DISTILLATION_ROLE_MANIFEST_PAIR_INVALID")
+    return roles
+
+
+def load_local_corpus(
+    root: Path,
+    *,
+    fold_count: int = 5,
+    holdout_fold: int = 0,
+    role_manifest_path: Path | None = None,
+) -> tuple[tuple[DistillationDocument, ...], tuple[str, ...], CorpusInventory]:
+    path = Path(root)
+    if not path.is_dir() or not 0 <= holdout_fold < fold_count:
+        raise DistillationBuildError("DISTILLATION_CORPUS_INVALID")
+    partitions = tuple(sorted(item.name for item in path.iterdir() if item.is_dir()))
+    folds = assign_user_folds(partitions, fold_count=fold_count)
+    source_paths = tuple(
+        sorted(
+            item.relative_to(path).as_posix()
+            for item in path.rglob("*.txt")
+            if item.is_file()
+        )
+    )
+    role_manifest = _load_role_manifest(role_manifest_path, source_paths)
+    documents: list[DistillationDocument] = []
+    digest_rows: list[str] = []
+    holdout_ids: list[str] = []
+    for partition in partitions:
+        partition_path = path / partition
+        partition_digest = hashlib.sha256(
+            normalize("NFC", partition).encode("utf-8")
+        ).hexdigest()[:32]
+        for source_path in sorted(partition_path.rglob("*.txt")):
+            relative = source_path.relative_to(path).as_posix()
+            source_digest = hashlib.sha256(
+                normalize("NFC", relative).encode("utf-8")
+            ).hexdigest()[:32]
+            source_id = f"private-letter:{source_digest}"
+            evidence_role = (
+                role_manifest[relative][1]
+                if role_manifest is not None
+                else DistillationEvidenceRole.USER_LETTER
+            )
+            if folds[partition] == holdout_fold:
+                holdout_ids.append(source_id)
+                digest_rows.append(
+                    f"holdout:{source_digest}:{source_path.stat().st_size}"
+                )
+                continue
+            raw = source_path.read_bytes()
+            try:
+                source_text = raw.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise DistillationBuildError(
+                    "DISTILLATION_CORPUS_ENCODING_INVALID"
+                ) from exc
+            documents.append(
+                DistillationDocument(
+                    source_id=source_id,
+                    partition_id=f"private-user:{partition_digest}",
+                    text=source_text,
+                    source_kind=(
+                        DistillationSourceKind.LOCAL_PRIVATE_CORRESPONDENCE
+                    ),
+                    rights_status="LOCAL_PRIVATE_ONLY",
+                    evidence_role=evidence_role,
+                )
+            )
+            digest_rows.append(
+                f"{source_digest}:{hashlib.sha256(raw).hexdigest()}"
+            )
+    videos = sum(1 for item in path.rglob("*.mp4") if item.is_file())
+    corpus_digest = hashlib.sha256(
+        "\n".join(sorted(digest_rows)).encode("ascii")
+    ).hexdigest()
+    inventory = CorpusInventory(
+        user_partition_count=len(partitions),
+        document_count=len(documents) + len(holdout_ids),
+        training_document_count=len(documents),
+        holdout_document_count=len(holdout_ids),
+        video_count=videos,
+        corpus_sha256=corpus_digest,
+        character_evidence_document_count=(
+            sum(
+                role is DistillationEvidenceRole.CANONICAL_CHARACTER_REPLY
+                for _, role in role_manifest.values()
+            )
+            if role_manifest is not None
+            else 0
+        ),
+    )
+    return tuple(documents), tuple(sorted(holdout_ids)), inventory
+
+
+def inventory_local_corpus(
+    root: Path,
+    *,
+    fold_count: int = 5,
+    holdout_fold: int = 0,
+    role_manifest_path: Path | None = None,
+) -> CorpusInventory:
+    return load_local_corpus(
+        root,
+        fold_count=fold_count,
+        holdout_fold=holdout_fold,
+        role_manifest_path=role_manifest_path,
+    )[2]
+
+
+def distill_persona(
+    documents: tuple[DistillationDocument, ...],
+    holdout_source_ids: tuple[str, ...],
+    extractor: PersonaTopicExtractor,
+) -> DistillationResult:
+    supplied = tuple(sorted(documents, key=lambda item: item.source_id))
+    if any(not isinstance(item, DistillationDocument) for item in supplied):
+        raise DistillationBuildError("DISTILLATION_SOURCE_INVALID")
+    by_id = {item.source_id: item for item in supplied}
+    if len(by_id) != len(supplied):
+        raise DistillationBuildError("DISTILLATION_SOURCE_ID_DUPLICATE")
+    holdout = frozenset(holdout_source_ids)
+    if any(not isinstance(item, str) or not _ID_RE.fullmatch(item) for item in holdout):
+        raise DistillationBuildError("DISTILLATION_HOLDOUT_INVALID")
+    training = tuple(item for item in supplied if item.source_id not in holdout)
+    if not training:
+        raise DistillationBuildError("DISTILLATION_TRAINING_EMPTY")
+
+    declarations: list[dict[str, object]] = []
+    exemplars: list[dict[str, object]] = []
+    unresolved: list[str] = []
+    for topic in DISTILLATION_TOPICS:
+        extracted = extractor.extract(topic, training)
+        if not isinstance(extracted, TopicExtraction):
+            raise DistillationBuildError("DISTILLATION_EXTRACTOR_RESULT_INVALID")
+        if not extracted.declarations and not extracted.style_exemplars:
+            unresolved.append(topic)
+        for candidate in extracted.declarations:
+            if candidate.source_id in holdout:
+                raise DistillationBuildError("HOLDOUT_SOURCE_REFERENCED")
+            source = by_id.get(candidate.source_id)
+            if source is None or candidate.topic != topic:
+                raise DistillationBuildError("DISTILLATION_EVIDENCE_INVALID")
+            if source.evidence_role is DistillationEvidenceRole.USER_LETTER:
+                raise DistillationBuildError(
+                    "USER_LETTER_NOT_CHARACTER_EVIDENCE"
+                )
+            if candidate.allowed_public_release and source.source_kind is not (
+                DistillationSourceKind.PUBLIC_DOCUMENT
+            ):
+                raise DistillationBuildError("PUBLIC_RELEASE_SOURCE_INVALID")
+            row: dict[str, object] = {
+                "declaration_id": candidate.declaration_id,
+                "source_id": candidate.source_id,
+                "tier": candidate.tier,
+                "facet": candidate.facet,
+                "confidence": candidate.confidence,
+                "rights_status": source.rights_status,
+                "allowed_public_release": candidate.allowed_public_release,
+                "statement": candidate.statement,
+            }
+            if candidate.mode is not None:
+                row["mode"] = candidate.mode
+            declarations.append(row)
+        for candidate in extracted.style_exemplars:
+            if candidate.source_id in holdout:
+                raise DistillationBuildError("HOLDOUT_SOURCE_REFERENCED")
+            source = by_id.get(candidate.source_id)
+            if source is None:
+                raise DistillationBuildError("DISTILLATION_EVIDENCE_INVALID")
+            if source.evidence_role is DistillationEvidenceRole.USER_LETTER:
+                raise DistillationBuildError(
+                    "USER_LETTER_NOT_CHARACTER_EVIDENCE"
+                )
+            try:
+                exemplars.append(
+                    build_style_exemplar(
+                        exemplar_id=candidate.exemplar_id,
+                        source_id=candidate.source_id,
+                        mode=candidate.mode,
+                        situation=candidate.situation,
+                        user_text=candidate.user_text,
+                        assistant_text=candidate.assistant_text,
+                        source_texts=(item.text for item in training),
+                        user_text_is_synthetic=(
+                            candidate.user_text_is_synthetic
+                        ),
+                        derivation="PRIVATE_CORPUS_ABSTRACTION",
+                        rights_status=source.rights_status,
+                        allowed_public_release=False,
+                    )
+                )
+            except StyleExemplarBuildError as exc:
+                raise DistillationBuildError(str(exc)) from exc
+
+    declarations.sort(key=lambda item: str(item["declaration_id"]))
+    exemplars.sort(key=lambda item: str(item["exemplar_id"]))
+    if len({item["declaration_id"] for item in declarations}) != len(declarations):
+        raise DistillationBuildError("DISTILLATION_DECLARATION_ID_DUPLICATE")
+    if len({item["exemplar_id"] for item in exemplars}) != len(exemplars):
+        raise DistillationBuildError("DISTILLATION_EXEMPLAR_ID_DUPLICATE")
+    return DistillationResult(
+        declarations=tuple(declarations),
+        style_exemplars=tuple(exemplars),
+        training_source_count=len(training),
+        holdout_source_count=len(holdout),
+        unresolved_topics=tuple(unresolved),
+    )
+
+
+__all__ = [
+    "CandidateDeclaration",
+    "CandidateStyleExemplar",
+    "CorpusInventory",
+    "DISTILLATION_TOPICS",
+    "DistillationBuildError",
+    "DistillationDocument",
+    "DistillationEvidenceRole",
+    "DistillationResult",
+    "DistillationSourceKind",
+    "PersonaTopicExtractor",
+    "TopicExtraction",
+    "assign_user_folds",
+    "distill_persona",
+    "inventory_local_corpus",
+    "load_local_corpus",
+]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Inventory a local-only persona corpus without printing private data."
+    )
+    parser.add_argument("--corpus-root", type=Path, required=True)
+    parser.add_argument("--fold-count", type=int, default=5)
+    parser.add_argument("--holdout-fold", type=int, default=0)
+    parser.add_argument("--role-manifest", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        inventory = inventory_local_corpus(
+            args.corpus_root,
+            fold_count=args.fold_count,
+            holdout_fold=args.holdout_fold,
+            role_manifest_path=args.role_manifest,
+        )
+    except (OSError, DistillationBuildError):
+        print('{"status":"LOCAL_PRIVATE_UNAVAILABLE"}')
+        return 2
+    print(inventory.public_report_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/persona/style_exemplar_builder.py
+++ b/runtime/persona/style_exemplar_builder.py
@@ -1,0 +1,91 @@
+"""Build-time safeguards for non-verbatim persona style exemplars."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from unicodedata import normalize
+
+
+_OVERLAP_WIDTH = 7
+_MODES = frozenset({"text_letter", "spoken_video", "musical_video", "future_im"})
+
+
+class StyleExemplarBuildError(ValueError):
+    """Raised when a style exemplar cannot satisfy its publication contract."""
+
+
+def contiguous_overlap_count(
+    assistant_text: str,
+    source_texts: Iterable[str],
+    *,
+    width: int = _OVERLAP_WIDTH,
+) -> int:
+    """Count candidate windows that occur verbatim in any NFC-normalized source."""
+
+    if width < 1:
+        raise ValueError("width must be positive")
+    candidate = normalize("NFC", assistant_text)
+    sources = tuple(normalize("NFC", source) for source in source_texts)
+    if len(candidate) < width:
+        return 0
+    return sum(
+        any(candidate[index : index + width] in source for source in sources)
+        for index in range(len(candidate) - width + 1)
+    )
+
+
+def build_style_exemplar(
+    *,
+    exemplar_id: str,
+    source_id: str,
+    mode: str,
+    situation: str,
+    user_text: str,
+    assistant_text: str,
+    source_texts: Iterable[str],
+    user_text_is_synthetic: bool,
+    derivation: str = "SYNTHETIC",
+    rights_status: str = "REDISTRIBUTABLE",
+    allowed_public_release: bool = True,
+) -> dict[str, object]:
+    """Build a schema-ready exemplar after enforcing the non-verbatim boundary."""
+
+    if mode not in _MODES:
+        raise StyleExemplarBuildError("STYLE_EXEMPLAR_MODE_INVALID")
+    if derivation not in {"SYNTHETIC", "PRIVATE_CORPUS_ABSTRACTION"}:
+        raise StyleExemplarBuildError("STYLE_EXEMPLAR_DERIVATION_INVALID")
+    if not 1 <= len(user_text) <= 240:
+        raise StyleExemplarBuildError("STYLE_EXEMPLAR_USER_TEXT_INVALID")
+    if not 1 <= len(assistant_text) <= 400:
+        raise StyleExemplarBuildError("STYLE_EXEMPLAR_ASSISTANT_TEXT_INVALID")
+    if user_text_is_synthetic is not True:
+        raise StyleExemplarBuildError("STYLE_EXEMPLAR_USER_TEXT_NOT_SYNTHETIC")
+    sources = tuple(source_texts)
+    if contiguous_overlap_count(user_text, sources) or contiguous_overlap_count(
+        assistant_text,
+        sources,
+    ):
+        raise StyleExemplarBuildError("STYLE_EXEMPLAR_SOURCE_OVERLAP")
+
+    return {
+        "exemplar_id": exemplar_id,
+        "source_id": source_id,
+        "derivation": derivation,
+        "rights_status": rights_status,
+        "allowed_public_release": allowed_public_release,
+        "mode": mode,
+        "situation": situation,
+        "user_text": user_text,
+        "assistant_text": assistant_text,
+        "style_only": True,
+        "factual_authority": False,
+        "user_text_is_synthetic": user_text_is_synthetic,
+        "assistant_text_is_verbatim": False,
+    }
+
+
+__all__ = [
+    "StyleExemplarBuildError",
+    "build_style_exemplar",
+    "contiguous_overlap_count",
+]

--- a/tests/persona/test_persona_distillation.py
+++ b/tests/persona/test_persona_distillation.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from runtime.persona.persona_distillation import (
+    CandidateDeclaration,
+    CandidateStyleExemplar,
+    DistillationBuildError,
+    DistillationDocument,
+    DistillationEvidenceRole,
+    DistillationSourceKind,
+    TopicExtraction,
+    assign_user_folds,
+    distill_persona,
+    inventory_local_corpus,
+    load_local_corpus,
+)
+
+
+class SyntheticExtractor:
+    def extract(self, topic, documents):
+        if topic != "explicit_boundaries":
+            return TopicExtraction()
+        return TopicExtraction(
+            declarations=(
+                CandidateDeclaration(
+                    declaration_id="private.boundary.synthetic",
+                    source_id=documents[0].source_id,
+                    topic=topic,
+                    statement="The character explicitly declines a synthetic request.",
+                    confidence="HIGH",
+                    facet="AUTONOMY",
+                    tier="COMMUNITY_SOFT_CANON",
+                ),
+            ),
+            style_exemplars=(
+                CandidateStyleExemplar(
+                    exemplar_id="style.private.synthetic",
+                    source_id=documents[0].source_id,
+                    mode="text_letter",
+                    situation="boundary_refusal",
+                    user_text="Please accept this synthetic request.",
+                    assistant_text="No. I can decide what I agree to.",
+                    user_text_is_synthetic=True,
+                ),
+            ),
+        )
+
+
+def _private_document(source_id: str, text: str = "Completely different fixture."):
+    return DistillationDocument(
+        source_id=source_id,
+        partition_id="partition.synthetic",
+        text=text,
+        source_kind=DistillationSourceKind.LOCAL_PRIVATE_CORRESPONDENCE,
+        rights_status="LOCAL_PRIVATE_ONLY",
+        evidence_role=DistillationEvidenceRole.CANONICAL_CHARACTER_REPLY,
+    )
+
+
+def test_same_inputs_produce_byte_identical_distillation_results() -> None:
+    documents = (_private_document("letter.synthetic.1"),)
+
+    first = distill_persona(documents, (), SyntheticExtractor())
+    second = distill_persona(tuple(reversed(documents)), (), SyntheticExtractor())
+
+    assert first.canonical_json() == second.canonical_json()
+    assert first.result_sha256 == second.result_sha256
+    assert first.declarations[0]["rights_status"] == "LOCAL_PRIVATE_ONLY"
+    assert first.declarations[0]["allowed_public_release"] is False
+    assert first.style_exemplars[0]["derivation"] == "PRIVATE_CORPUS_ABSTRACTION"
+    assert first.style_exemplars[0]["allowed_public_release"] is False
+
+
+def test_holdout_source_cannot_appear_in_any_candidate() -> None:
+    class HoldoutReferencingExtractor:
+        def extract(self, topic, documents):
+            if topic != "family_background":
+                return TopicExtraction()
+            return TopicExtraction(
+                declarations=(
+                    CandidateDeclaration(
+                        declaration_id="private.holdout.leak",
+                        source_id="letter.synthetic.holdout",
+                        topic=topic,
+                        statement="A synthetic leak attempt.",
+                        confidence="HIGH",
+                        facet="BACKGROUND",
+                        tier="COMMUNITY_SOFT_CANON",
+                    ),
+                )
+            )
+
+    documents = (
+        _private_document("letter.synthetic.training"),
+        _private_document("letter.synthetic.holdout"),
+    )
+
+    with pytest.raises(DistillationBuildError, match="HOLDOUT_SOURCE_REFERENCED"):
+        distill_persona(
+            documents,
+            ("letter.synthetic.holdout",),
+            HoldoutReferencingExtractor(),
+        )
+
+
+def test_private_style_exemplar_still_enforces_seven_character_overlap() -> None:
+    overlapping = _private_document(
+        "letter.synthetic.1",
+        "The character says: I can decide what I agree to.",
+    )
+
+    with pytest.raises(
+        DistillationBuildError,
+        match="STYLE_EXEMPLAR_SOURCE_OVERLAP",
+    ):
+        distill_persona((overlapping,), (), SyntheticExtractor())
+
+
+def test_public_release_requires_a_public_non_private_source() -> None:
+    class PublicClaimExtractor:
+        def extract(self, topic, documents):
+            if topic != "family_background":
+                return TopicExtraction()
+            return TopicExtraction(
+                declarations=(
+                    CandidateDeclaration(
+                        declaration_id="public.synthetic",
+                        source_id=documents[0].source_id,
+                        topic=topic,
+                        statement="A synthetic public fact.",
+                        confidence="HIGH",
+                        facet="BACKGROUND",
+                        tier="PUBLIC_CANON",
+                        allowed_public_release=True,
+                    ),
+                )
+            )
+
+    with pytest.raises(DistillationBuildError, match="PUBLIC_RELEASE_SOURCE_INVALID"):
+        distill_persona(
+            (_private_document("letter.synthetic.1"),),
+            (),
+            PublicClaimExtractor(),
+        )
+
+
+def test_user_letter_cannot_authorize_character_fact_or_style_output() -> None:
+    class UserClaimExtractor:
+        def extract(self, topic, documents):
+            if topic != "family_background":
+                return TopicExtraction()
+            return TopicExtraction(
+                declarations=(
+                    CandidateDeclaration(
+                        declaration_id="private.user.claim",
+                        source_id="letter.synthetic.user",
+                        topic=topic,
+                        statement="The user claims a character fact.",
+                        confidence="HIGH",
+                        facet="BACKGROUND",
+                        tier="COMMUNITY_SOFT_CANON",
+                    ),
+                )
+            )
+
+    user_letter = DistillationDocument(
+        source_id="letter.synthetic.user",
+        partition_id="partition.synthetic",
+        text="A synthetic user-authored claim.",
+        source_kind=DistillationSourceKind.LOCAL_PRIVATE_CORRESPONDENCE,
+        rights_status="LOCAL_PRIVATE_ONLY",
+        evidence_role=DistillationEvidenceRole.USER_LETTER,
+    )
+
+    with pytest.raises(
+        DistillationBuildError,
+        match="USER_LETTER_NOT_CHARACTER_EVIDENCE",
+    ):
+        distill_persona((user_letter,), (), UserClaimExtractor())
+
+
+def test_user_fold_assignment_and_inventory_are_stable_and_sanitized(
+    tmp_path: Path,
+) -> None:
+    for user, count in (("private-alice", 2), ("private-bob", 1)):
+        folder = tmp_path / user
+        folder.mkdir()
+        for index in range(count):
+            (folder / f"{index + 1:03d}.txt").write_text(
+                f"Synthetic correspondence {index}.",
+                encoding="utf-8",
+            )
+    (tmp_path / "private-alice" / "video.mp4").write_bytes(b"synthetic")
+
+    folds = assign_user_folds(("private-bob", "private-alice"), fold_count=2)
+    inventory = inventory_local_corpus(tmp_path, fold_count=2, holdout_fold=0)
+
+    assert folds == assign_user_folds(("private-alice", "private-bob"), fold_count=2)
+    assert inventory.document_count == 3
+    assert inventory.video_count == 1
+    assert inventory.user_partition_count == 2
+    serialized = inventory.public_report_json()
+    assert "private-alice" not in serialized
+    assert "private-bob" not in serialized
+    assert "Synthetic correspondence" not in serialized
+
+
+def test_local_distillation_input_contract_is_valid_and_private_by_default() -> None:
+    root = Path(__file__).resolve().parents[2]
+    schema = json.loads(
+        (root / "contracts" / "persona_distillation_input.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    payload = {
+        "schema_version": "p02.persona-distillation-input.v1",
+        "documents": [
+            {
+                "source_id": "letter.synthetic.1",
+                "partition_id": "partition.synthetic",
+                "text": "Synthetic private correspondence.",
+                "source_kind": "local_private_correspondence",
+                "rights_status": "LOCAL_PRIVATE_ONLY",
+                "evidence_role": "canonical_character_reply",
+            }
+        ],
+        "holdout_source_ids": [],
+    }
+
+    Draft202012Validator.check_schema(schema)
+    assert list(Draft202012Validator(schema).iter_errors(payload)) == []
+
+
+def test_explicit_file_manifest_assigns_correspondence_roles_without_text_guessing(
+    tmp_path: Path,
+) -> None:
+    corpus = tmp_path / "corpus"
+    partition = corpus / "user-a"
+    partition.mkdir(parents=True)
+    (partition / "001.txt").write_text(
+        "This text deliberately contains no role hint.",
+        encoding="utf-8",
+    )
+    (partition / "002.txt").write_text(
+        "This text also deliberately contains no role hint.",
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "roles.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "p02.persona-corpus-manifest.v1",
+                "entries": [
+                    {
+                        "relative_path": "user-a/001.txt",
+                        "correspondence_id": "correspondence.synthetic.1",
+                        "evidence_role": "user_letter",
+                    },
+                    {
+                        "relative_path": "user-a/002.txt",
+                        "correspondence_id": "correspondence.synthetic.1",
+                        "evidence_role": "canonical_character_reply",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    documents, holdout_ids, inventory = load_local_corpus(
+        corpus,
+        fold_count=2,
+        holdout_fold=1,
+        role_manifest_path=manifest,
+    )
+
+    assert holdout_ids == ()
+    assert tuple(item.evidence_role for item in documents) == (
+        DistillationEvidenceRole.USER_LETTER,
+        DistillationEvidenceRole.CANONICAL_CHARACTER_REPLY,
+    )
+    assert inventory.character_evidence_document_count == 1
+
+
+def test_manifest_must_cover_every_text_file_and_pair_character_replies(
+    tmp_path: Path,
+) -> None:
+    corpus = tmp_path / "corpus"
+    partition = corpus / "user-a"
+    partition.mkdir(parents=True)
+    (partition / "001.txt").write_text("Synthetic text.", encoding="utf-8")
+    manifest = tmp_path / "roles.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "p02.persona-corpus-manifest.v1",
+                "entries": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        DistillationBuildError,
+        match="DISTILLATION_ROLE_MANIFEST_COVERAGE_INVALID",
+    ):
+        load_local_corpus(
+            corpus,
+            fold_count=2,
+            holdout_fold=1,
+            role_manifest_path=manifest,
+        )
+
+
+def test_manifest_rejects_correspondence_pairs_across_user_partitions(
+    tmp_path: Path,
+) -> None:
+    corpus = tmp_path / "corpus"
+    holdout_partition = corpus / "holdout-user"
+    training_partition = corpus / "training-user"
+    holdout_partition.mkdir(parents=True)
+    training_partition.mkdir(parents=True)
+    (holdout_partition / "original.txt").write_text(
+        "Synthetic user letter.",
+        encoding="utf-8",
+    )
+    (training_partition / "reply.txt").write_text(
+        "Synthetic canonical character reply.",
+        encoding="utf-8",
+    )
+    assert assign_user_folds(
+        ("holdout-user", "training-user"),
+        fold_count=5,
+    ) == {"holdout-user": 0, "training-user": 1}
+    manifest = tmp_path / "roles.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "p02.persona-corpus-manifest.v1",
+                "entries": [
+                    {
+                        "relative_path": "holdout-user/original.txt",
+                        "correspondence_id": "correspondence.synthetic.cross-user",
+                        "evidence_role": "user_letter",
+                    },
+                    {
+                        "relative_path": "training-user/reply.txt",
+                        "correspondence_id": "correspondence.synthetic.cross-user",
+                        "evidence_role": "canonical_character_reply",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        DistillationBuildError,
+        match="DISTILLATION_ROLE_MANIFEST_PAIR_INVALID",
+    ):
+        load_local_corpus(
+            corpus,
+            fold_count=5,
+            holdout_fold=0,
+            role_manifest_path=manifest,
+        )
+
+
+def test_per_file_role_manifest_has_a_closed_schema_contract() -> None:
+    root = Path(__file__).resolve().parents[2]
+    schema = json.loads(
+        (root / "contracts" / "persona_corpus_manifest.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    payload = {
+        "schema_version": "p02.persona-corpus-manifest.v1",
+        "entries": [
+            {
+                "relative_path": "user-a/001.txt",
+                "correspondence_id": "correspondence.synthetic.1",
+                "evidence_role": "user_letter",
+            },
+            {
+                "relative_path": "user-a/002.txt",
+                "correspondence_id": "correspondence.synthetic.1",
+                "evidence_role": "canonical_character_reply",
+            },
+        ],
+    }
+
+    Draft202012Validator.check_schema(schema)
+    assert list(Draft202012Validator(schema).iter_errors(payload)) == []

--- a/tests/persona/test_style_exemplar_builder.py
+++ b/tests/persona/test_style_exemplar_builder.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+from runtime.persona.style_exemplar_builder import (
+    StyleExemplarBuildError,
+    build_style_exemplar,
+    contiguous_overlap_count,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _valid_exemplar() -> dict[str, object]:
+    return {
+        "exemplar_id": "style.synthetic.greeting",
+        "source_id": "source.synthetic",
+        "derivation": "SYNTHETIC",
+        "rights_status": "REDISTRIBUTABLE",
+        "allowed_public_release": True,
+        "mode": "text_letter",
+        "situation": "brief_greeting",
+        "user_text": "今天还好吗？",
+        "assistant_text": "还行。你呢。",
+        "style_only": True,
+        "factual_authority": False,
+        "user_text_is_synthetic": True,
+        "assistant_text_is_verbatim": False,
+    }
+
+
+def test_source_overlap_of_seven_contiguous_characters_fails_build() -> None:
+    source = "她走到窗边看见一只鸟停在雨里。"
+
+    with pytest.raises(
+        StyleExemplarBuildError,
+        match="STYLE_EXEMPLAR_SOURCE_OVERLAP",
+    ):
+        build_style_exemplar(
+            exemplar_id="style.synthetic.overlap",
+            source_id="source.synthetic",
+            mode="text_letter",
+            situation="ordinary_smalltalk",
+            user_text="外面在下雨。",
+            assistant_text="我走到窗边看见一只鸟。",
+            source_texts=(source,),
+            user_text_is_synthetic=True,
+        )
+
+
+def test_private_source_overlap_in_synthetic_user_text_fails_build() -> None:
+    source = "用户原信里写着窗外的雨一直没有停。"
+
+    with pytest.raises(
+        StyleExemplarBuildError,
+        match="STYLE_EXEMPLAR_SOURCE_OVERLAP",
+    ):
+        build_style_exemplar(
+            exemplar_id="style.synthetic.user-overlap",
+            source_id="source.synthetic",
+            mode="text_letter",
+            situation="ordinary_smalltalk",
+            user_text="窗外的雨一直没有停。",
+            assistant_text="我听见了。",
+            source_texts=(source,),
+            user_text_is_synthetic=True,
+        )
+
+
+def test_builder_requires_explicit_synthetic_user_text_attestation() -> None:
+    with pytest.raises(
+        StyleExemplarBuildError,
+        match="STYLE_EXEMPLAR_USER_TEXT_NOT_SYNTHETIC",
+    ):
+        build_style_exemplar(
+            exemplar_id="style.synthetic.unverified-user",
+            source_id="source.synthetic",
+            mode="text_letter",
+            situation="ordinary_smalltalk",
+            user_text="这段输入没有被声明为合成文本。",
+            assistant_text="我明白。",
+            source_texts=(),
+            user_text_is_synthetic=False,
+        )
+
+
+def test_overlap_checker_is_unicode_normalized_and_counts_matching_windows() -> None:
+    assert contiguous_overlap_count("Cafe\u0301真安静。", ("Café真安静。",)) > 0
+    assert contiguous_overlap_count("这是一句完全不同的话。", ("没有相同片段。",)) == 0
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid"),
+    (
+        ("style_only", False),
+        ("factual_authority", True),
+        ("user_text_is_synthetic", False),
+        ("assistant_text_is_verbatim", True),
+    ),
+)
+def test_style_exemplar_const_contracts_are_enforced_by_schema(
+    field: str,
+    invalid: bool,
+) -> None:
+    schema = json.loads(
+        (ROOT / "contracts" / "persona_v2.schema.json").read_text(encoding="utf-8")
+    )
+    payload = _valid_exemplar()
+    payload[field] = invalid
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema["$defs"]["style_exemplar"]).validate(payload)
+
+
+def test_builder_emits_only_non_factual_synthetic_style_guidance() -> None:
+    built = build_style_exemplar(
+        exemplar_id="style.synthetic.safe",
+        source_id="source.synthetic",
+        mode="spoken_video",
+        situation="emotional_acknowledgement",
+        user_text="我有点累。",
+        assistant_text="那就先停一会儿。别急着跟今天较劲。",
+        source_texts=("一段仅用于测试的来源文本。",),
+        user_text_is_synthetic=True,
+    )
+
+    assert built["derivation"] == "SYNTHETIC"
+    assert built["style_only"] is True
+    assert built["factual_authority"] is False
+    assert built["user_text_is_synthetic"] is True
+    assert built["assistant_text_is_verbatim"] is False

--- a/tests/test_baseline_hardening.py
+++ b/tests/test_baseline_hardening.py
@@ -166,6 +166,21 @@ def test_b00_scanner_patterns_cover_variants_without_echoing_source() -> None:
     )
 
 
+def test_sensitive_path_scanner_blocks_private_corpus_and_holdout_artifacts() -> None:
+    import baseline_hardening_scan as scanner
+
+    for path in (
+        ".private/corpus/user/001.txt",
+        "artifacts/holdout_ids.json",
+        "artifacts/persona_distillation_output.jsonl",
+        "artifacts/private_corpus.csv",
+    ):
+        assert scanner.SENSITIVE_PATH_PATTERN.search(path), path
+    assert not scanner.SENSITIVE_PATH_PATTERN.search(
+        "contracts/persona_distillation_input.schema.json"
+    )
+
+
 def test_b00_scanner_covers_english_dependency_and_triple_quoted_docstrings(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Add closed input and per-file role manifest contracts for local Persona distillation.
- Keep whole top-level user partitions indivisible across deterministic five-fold assignment.
- Require canonical character replies to pair with user letters under the same correspondence ID and the same top-level user partition.
- Add deterministic, typed distillation and style-exemplar builders that fail closed on user-only evidence, holdout references, publishability violations, and contiguous seven-character overlap in either prompt or reply.
- Extend the hardening scanner to reject private corpus, holdout ID, and distillation output artifacts.

## Privacy boundary

- The repository contains contracts, code, documentation, and synthetic tests only.
- No letter body, participant directory name, corpus path, holdout list, or distillation result is committed.
- Without an explicit role manifest every text is treated as user_letter, so the corpus remains LOCAL_PRIVATE_INPUT_ONLY.
- The collected corpus currently inventories as 148 texts across 30 user partitions, 120 training and 28 holdout documents, 9 videos excluded, and zero character-evidence documents.

## Verification

- python -m pytest tests/persona/test_persona_distillation.py tests/persona/test_style_exemplar_builder.py tests/test_baseline_hardening.py -q: 63 passed.
- python baseline_hardening_scan.py --mode all: PASS; all finding categories 0.
- compileall for persona_distillation, style_exemplar_builder, and baseline_hardening_scan: passed.
- git diff --cached --check: passed before commit.
- Sanitized real-corpus inventory returned LOCAL_PRIVATE_INPUT_ONLY with zero character evidence; no private text or path was emitted.

## Scope

Nine files only. PrivateWorld model, ledger, delivery, relationship facts, ReplyContext, and reply policy remain outside this PR.