### PR TITLE
private-world: add v4 relationship facts

### DIFF
--- a/contracts/private_world.schema.json
+++ b/contracts/private_world.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "p02.private-world.v1",
+  "$id": "p02.private-world.v2",
   "title": "P02 PrivateWorld views",
   "oneOf": [
     {"$ref": "#/$defs/snapshot"},
@@ -56,6 +56,37 @@
           "minLength": 1,
           "maxLength": 200,
           "pattern": "^[^\\u0000-\\u001F\\u007F]+$"
+        }
+      }
+    },
+    "active_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["boundary_id", "set_at", "scope"],
+      "properties": {
+        "boundary_id": {"$ref": "#/$defs/identifier"},
+        "set_at": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](?:\\.[0-9]+)?(?:Z|\\+00:00)$"
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "pattern": "^[^\\u0000-\\u001F\\u007F]+$"
+        }
+      }
+    },
+    "acknowledged_affection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["intensity", "statement_ref_id", "scope"],
+      "properties": {
+        "intensity": {"enum": ["warmth", "care", "love"]},
+        "statement_ref_id": {"$ref": "#/$defs/identifier"},
+        "scope": {
+          "enum": ["this_reply", "ongoing_correspondence", "relationship"]
         }
       }
     },
@@ -153,7 +184,9 @@
         "continuation_facts",
         "intimacy_grants",
         "growth_window_start",
-        "growth_used"
+        "growth_used",
+        "active_boundaries",
+        "acknowledged_affection"
       ],
       "properties": {
         "view": {"const": "control"},
@@ -186,7 +219,18 @@
           "items": {"$ref": "#/$defs/intimacy_grant"}
         },
         "growth_window_start": {"$ref": "#/$defs/growth_window_start"},
-        "growth_used": {"$ref": "#/$defs/growth_used"}
+        "growth_used": {"$ref": "#/$defs/growth_used"},
+        "active_boundaries": {
+          "type": "array",
+          "maxItems": 16,
+          "items": {"$ref": "#/$defs/active_boundary"}
+        },
+        "acknowledged_affection": {
+          "oneOf": [
+            {"type": "null"},
+            {"$ref": "#/$defs/acknowledged_affection"}
+          ]
+        }
       }
     },
     "character": {
@@ -199,7 +243,9 @@
         "nickname_permissions",
         "home_history_allowed",
         "continuation_known",
-        "continuation_facts"
+        "continuation_facts",
+        "active_boundaries",
+        "acknowledged_affection"
       ],
       "properties": {
         "view": {"const": "character"},
@@ -219,6 +265,17 @@
           "type": "array",
           "maxItems": 32,
           "items": {"$ref": "#/$defs/character_fact"}
+        },
+        "active_boundaries": {
+          "type": "array",
+          "maxItems": 16,
+          "items": {"$ref": "#/$defs/active_boundary"}
+        },
+        "acknowledged_affection": {
+          "oneOf": [
+            {"type": "null"},
+            {"$ref": "#/$defs/acknowledged_affection"}
+          ]
         }
       }
     },
@@ -240,7 +297,9 @@
         "continuation_facts",
         "intimacy_grants",
         "growth_window_start",
-        "growth_used"
+        "growth_used",
+        "active_boundaries",
+        "acknowledged_affection"
       ],
       "properties": {
         "view": {"const": "snapshot"},
@@ -277,7 +336,18 @@
           "items": {"$ref": "#/$defs/intimacy_grant"}
         },
         "growth_window_start": {"$ref": "#/$defs/growth_window_start"},
-        "growth_used": {"$ref": "#/$defs/growth_used"}
+        "growth_used": {"$ref": "#/$defs/growth_used"},
+        "active_boundaries": {
+          "type": "array",
+          "maxItems": 16,
+          "items": {"$ref": "#/$defs/active_boundary"}
+        },
+        "acknowledged_affection": {
+          "oneOf": [
+            {"type": "null"},
+            {"$ref": "#/$defs/acknowledged_affection"}
+          ]
+        }
       }
     }
   }

--- a/contracts/private_world_runtime_health.schema.json
+++ b/contracts/private_world_runtime_health.schema.json
@@ -28,9 +28,15 @@
     "network_called": {"const": false}
   },
   "$defs": {
-    "current_schema": {"const": 3},
+    "current_schema": {"const": 4},
     "migration": {
-      "enum": ["created_v3", "current_v3", "migrated_v2_to_v3"]
+        "enum": [
+          "created_v4",
+          "current_v4",
+          "migrated_v1_to_v4",
+          "migrated_v2_to_v4",
+          "migrated_v3_to_v4"
+        ]
     },
     "unavailable_reason": {
       "enum": [

--- a/contracts/reply_context.schema.json
+++ b/contracts/reply_context.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "p02.reply-context.v2",
+  "$id": "p02.reply-context.v3",
   "title": "P02 ReplyContext contract",
   "type": "object",
   "additionalProperties": false,
@@ -155,6 +155,32 @@
         }
       }
     },
+    "known_active_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["boundary_id", "scope"],
+      "properties": {
+        "boundary_id": {"$ref": "#/$defs/identifier"},
+        "scope": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "pattern": "^[^\\u0000-\\u001F\\u007F]+$"
+        }
+      }
+    },
+    "known_acknowledged_affection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["intensity", "statement_ref_id", "scope"],
+      "properties": {
+        "intensity": {"enum": ["warmth", "care", "love"]},
+        "statement_ref_id": {"$ref": "#/$defs/identifier"},
+        "scope": {
+          "enum": ["this_reply", "ongoing_correspondence", "relationship"]
+        }
+      }
+    },
     "private_behavior": {
       "type": "object",
       "additionalProperties": false,
@@ -169,7 +195,9 @@
         "granted_intimacy",
         "nickname_permission",
         "home_history_allowed",
-        "known_continuations"
+        "known_continuations",
+        "active_boundaries",
+        "acknowledged_affection"
       ],
       "properties": {
         "familiarity": {
@@ -248,6 +276,17 @@
           "items": {
             "$ref": "#/$defs/known_continuation"
           }
+        },
+        "active_boundaries": {
+          "type": "array",
+          "maxItems": 16,
+          "items": {"$ref": "#/$defs/known_active_boundary"}
+        },
+        "acknowledged_affection": {
+          "oneOf": [
+            {"type": "null"},
+            {"$ref": "#/$defs/known_acknowledged_affection"}
+          ]
         }
       }
     },

--- a/docs/P02_10_PRIVATE_WORLD.md
+++ b/docs/P02_10_PRIVATE_WORLD.md
@@ -4,7 +4,7 @@
 `PrivateWorldSnapshot`, `PrivateWorldControlView`,
 `PrivateWorldCharacterView`, and disabled `NullPrivateWorldPort`.
 
-The schema v3 snapshot stores bounded relationship scores, relationship stage,
+The schema v4 snapshot stores bounded relationship scores, relationship stage,
 append-only `intimacy_grants`, the 7-day growth window, current nickname
 permissions, home access, legacy continuation awareness, and typed
 `LocalContinuationFact` records. Each grant has a stable identifier, bounded

--- a/runtime/memory/private_world_projection.py
+++ b/runtime/memory/private_world_projection.py
@@ -12,6 +12,8 @@ from runtime.reply.reply_context import (
     BehaviorLevel,
     IntimacyTier,
     KnownContinuationFact,
+    KnownAcknowledgedAffection,
+    KnownActiveBoundary,
     NicknamePermission,
     PrivateBehaviorView,
     RelationshipStage,
@@ -38,6 +40,10 @@ def _stage(value: str) -> RelationshipStage:
 
 def _known_fact(value: LocalContinuationFact) -> KnownContinuationFact:
     return KnownContinuationFact(value.fact_id, value.statement)
+
+
+def _known_boundary(value) -> KnownActiveBoundary:
+    return KnownActiveBoundary(value.boundary_id, value.scope)
 
 
 @dataclass(frozen=True)
@@ -75,6 +81,18 @@ def project_private_world(
     known_facts = tuple(
         _known_fact(fact) for fact in character.continuation_facts
     )
+    known_boundaries = tuple(
+        _known_boundary(boundary) for boundary in character.active_boundaries
+    )
+    known_affection = (
+        KnownAcknowledgedAffection(
+            intensity=character.acknowledged_affection.intensity.value,
+            statement_ref_id=character.acknowledged_affection.statement_ref_id,
+            scope=character.acknowledged_affection.scope.value,
+        )
+        if character.acknowledged_affection is not None
+        else None
+    )
     continuation_known = character.continuation_known
     stage = _stage(character.relationship_stage)
     intimacy_ceiling = intimacy_ceiling_for_stage(stage)
@@ -97,6 +115,8 @@ def project_private_world(
             character.home_history_allowed
         ),
         known_continuations=known_facts,
+        active_boundaries=known_boundaries,
+        acknowledged_affection=known_affection,
     )
     return ProjectedPrivateWorld(
         behavior=behavior,

--- a/runtime/private_world/ledger.py
+++ b/runtime/private_world/ledger.py
@@ -13,6 +13,10 @@ import sqlite3
 from typing import Iterator
 
 from .port import (
+    AcknowledgedAffection,
+    ActiveBoundary,
+    AffectionIntensity,
+    AffectionScope,
     ContinuationAwareness,
     HomeAccess,
     IntimacyGrant,
@@ -24,7 +28,7 @@ from .port import (
 from runtime.reply.reply_context import IntimacyTier
 
 
-PRIVATE_WORLD_LEDGER_SCHEMA_VERSION = 3
+PRIVATE_WORLD_LEDGER_SCHEMA_VERSION = 4
 _METADATA_KEY = "schema_version"
 _LEGACY_TABLES = frozenset(
     {"private_world_events", "private_world_snapshots"}
@@ -49,6 +53,10 @@ _V3_PAYLOAD_FIELDS = _V2_PAYLOAD_FIELDS | {
     "intimacy_grants",
     "growth_window_start",
     "growth_used",
+}
+_V4_PAYLOAD_FIELDS = _V3_PAYLOAD_FIELDS | {
+    "active_boundaries",
+    "acknowledged_affection",
 }
 
 
@@ -189,7 +197,7 @@ class SQLitePrivateWorldLedger:
             "%Y%m%dT%H%M%S%fZ"
         )
         backup = self._database_path.with_name(
-            f"{self._database_path.name}.pre-v3-{stamp}.bak"
+            f"{self._database_path.name}.pre-v4-{stamp}.bak"
         )
         created = False
         try:
@@ -234,6 +242,9 @@ class SQLitePrivateWorldLedger:
                         migrated_rows = self._validated_v2_rows(connection)
                     elif previous == 2:
                         migrated_rows = self._validated_v2_rows(connection)
+                        self._backup_legacy_database(connection)
+                    elif previous == 3:
+                        migrated_rows = self._validated_v3_rows(connection)
                         self._backup_legacy_database(connection)
                     connection.execute(
                         """CREATE TABLE IF NOT EXISTS private_world_events (
@@ -284,12 +295,12 @@ class SQLitePrivateWorldLedger:
             raise LedgerWriteError(
                 "private world schema initialization failed"
             ) from exc
-        if previous in {1, 2}:
-            self._migration_status = "migrated_v2_to_v3"
+        if previous in {1, 2, 3}:
+            self._migration_status = f"migrated_v{previous}_to_v4"
         elif previous == 0:
-            self._migration_status = "created_v3"
+            self._migration_status = "created_v4"
         else:
-            self._migration_status = "current_v3"
+            self._migration_status = "current_v4"
 
     def apply_once(
         self,
@@ -432,10 +443,22 @@ class SQLitePrivateWorldLedger:
 
     @staticmethod
     def _v2_snapshot_json(snapshot: PrivateWorldSnapshot) -> str:
-        payload = snapshot.to_dict()
+        payload = json.loads(SQLitePrivateWorldLedger._v3_snapshot_json(snapshot))
         payload.pop("intimacy_grants")
         payload.pop("growth_window_start")
         payload.pop("growth_used")
+        return json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    @staticmethod
+    def _v3_snapshot_json(snapshot: PrivateWorldSnapshot) -> str:
+        payload = snapshot.to_dict()
+        payload.pop("active_boundaries")
+        payload.pop("acknowledged_affection")
         return json.dumps(
             payload,
             ensure_ascii=False,
@@ -460,6 +483,8 @@ class SQLitePrivateWorldLedger:
         payload: dict[str, object],
         facts: tuple[LocalContinuationFact, ...],
         grants: tuple[IntimacyGrant, ...] = (),
+        boundaries: tuple[ActiveBoundary, ...] = (),
+        affection: AcknowledgedAffection | None = None,
     ) -> PrivateWorldSnapshot:
         return PrivateWorldSnapshot(
             version=payload["version"],
@@ -478,6 +503,8 @@ class SQLitePrivateWorldLedger:
             intimacy_grants=grants,
             growth_window_start=payload.get("growth_window_start", ""),
             growth_used=payload.get("growth_used", 0),
+            active_boundaries=boundaries,
+            acknowledged_affection=affection,
         )
 
     def _strict_v1_stored_snapshot(
@@ -576,6 +603,56 @@ class SQLitePrivateWorldLedger:
             migrated.append((stored_version, self._snapshot_json(snapshot)))
         return tuple(migrated)
 
+    def _validated_v3_rows(
+        self,
+        connection: sqlite3.Connection,
+    ) -> tuple[tuple[int, str], ...]:
+        rows = connection.execute(
+            """SELECT version, payload_json FROM private_world_snapshots
+               ORDER BY version"""
+        ).fetchall()
+        migrated: list[tuple[int, str]] = []
+        for stored_version, payload_json in rows:
+            if type(stored_version) is not int or stored_version < 1:
+                raise LedgerWriteError("stored v3 row version is invalid")
+            try:
+                payload = self._payload_object(payload_json)
+                if set(payload) != _V3_PAYLOAD_FIELDS:
+                    raise ValueError("stored v3 fields are invalid")
+                if payload["view"] != "snapshot":
+                    raise ValueError("stored v3 view is invalid")
+                facts = payload["continuation_facts"]
+                grants = payload["intimacy_grants"]
+                if not isinstance(facts, list) or not isinstance(grants, list):
+                    raise ValueError("stored v3 collections are invalid")
+                snapshot = self._snapshot_from_payload(
+                    payload,
+                    tuple(
+                        LocalContinuationFact(
+                            fact_id=item["fact_id"],
+                            statement=item["statement"],
+                            awareness=ContinuationAwareness(item["awareness"]),
+                        )
+                        for item in facts
+                    ),
+                    tuple(
+                        IntimacyGrant(
+                            grant_id=item["grant_id"],
+                            tier=IntimacyTier(item["tier"]),
+                            statement=item["statement"],
+                        )
+                        for item in grants
+                    ),
+                )
+            except (KeyError, TypeError, ValueError) as exc:
+                raise LedgerWriteError("stored v3 state is invalid") from exc
+            if snapshot.version != stored_version:
+                raise LedgerWriteError("stored v3 version does not match row")
+            if self._v3_snapshot_json(snapshot) != payload_json:
+                raise LedgerWriteError("stored v3 state is not canonical")
+            migrated.append((stored_version, self._snapshot_json(snapshot)))
+        return tuple(migrated)
+
     def _strict_stored_snapshot(
         self,
         stored_version: object,
@@ -587,7 +664,7 @@ class SQLitePrivateWorldLedger:
             raise LedgerWriteError("stored snapshot row version is invalid")
         try:
             payload = self._payload_object(payload_json)
-            if set(payload) != _V3_PAYLOAD_FIELDS:
+            if set(payload) != _V4_PAYLOAD_FIELDS:
                 raise ValueError("stored state fields are invalid")
             if payload["view"] != "snapshot":
                 raise ValueError("stored state view is invalid")
@@ -597,6 +674,14 @@ class SQLitePrivateWorldLedger:
             grants = payload["intimacy_grants"]
             if not isinstance(grants, list):
                 raise ValueError("stored intimacy grants must be a list")
+            boundaries = payload["active_boundaries"]
+            if not isinstance(boundaries, list):
+                raise ValueError("stored active boundaries must be a list")
+            affection_payload = payload["acknowledged_affection"]
+            if affection_payload is not None and not isinstance(
+                affection_payload, dict
+            ):
+                raise ValueError("stored acknowledged affection is invalid")
             snapshot = self._snapshot_from_payload(
                 payload,
                 tuple(
@@ -614,6 +699,25 @@ class SQLitePrivateWorldLedger:
                         statement=item["statement"],
                     )
                     for item in grants
+                ),
+                tuple(
+                    ActiveBoundary(
+                        boundary_id=item["boundary_id"],
+                        set_at=item["set_at"],
+                        scope=item["scope"],
+                    )
+                    for item in boundaries
+                ),
+                (
+                    AcknowledgedAffection(
+                        intensity=AffectionIntensity(
+                            affection_payload["intensity"]
+                        ),
+                        statement_ref_id=affection_payload["statement_ref_id"],
+                        scope=AffectionScope(affection_payload["scope"]),
+                    )
+                    if affection_payload is not None
+                    else None
                 ),
             )
         except (KeyError, TypeError, ValueError) as exc:

--- a/runtime/private_world/port.py
+++ b/runtime/private_world/port.py
@@ -28,6 +28,18 @@ class ContinuationAwareness(str, Enum):
     PENDING = "pending"
 
 
+class AffectionIntensity(str, Enum):
+    WARMTH = "warmth"
+    CARE = "care"
+    LOVE = "love"
+
+
+class AffectionScope(str, Enum):
+    THIS_REPLY = "this_reply"
+    ONGOING_CORRESPONDENCE = "ongoing_correspondence"
+    RELATIONSHIP = "relationship"
+
+
 _TOKEN_RE = re.compile(r"^[A-Za-z0-9._:-]{1,64}$")
 _UTC_TIMESTAMP_RE = re.compile(
     r"^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])"
@@ -135,6 +147,60 @@ class IntimacyGrant:
         }
 
 
+@dataclass(frozen=True)
+class ActiveBoundary:
+    boundary_id: str
+    set_at: str
+    scope: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.boundary_id, str) or not _TOKEN_RE.fullmatch(
+            self.boundary_id
+        ):
+            raise PrivateWorldError("boundary id is invalid")
+        object.__setattr__(
+            self,
+            "set_at",
+            _validate_utc_timestamp(self.set_at, field_name="boundary set time"),
+        )
+        object.__setattr__(
+            self,
+            "scope",
+            _plain_text(self.scope, field_name="boundary scope", max_length=200),
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "boundary_id": self.boundary_id,
+            "set_at": self.set_at,
+            "scope": self.scope,
+        }
+
+
+@dataclass(frozen=True)
+class AcknowledgedAffection:
+    intensity: AffectionIntensity
+    statement_ref_id: str
+    scope: AffectionScope
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.intensity, AffectionIntensity):
+            raise PrivateWorldError("affection intensity is invalid")
+        if not isinstance(self.statement_ref_id, str) or not _TOKEN_RE.fullmatch(
+            self.statement_ref_id
+        ):
+            raise PrivateWorldError("affection statement reference is invalid")
+        if not isinstance(self.scope, AffectionScope):
+            raise PrivateWorldError("affection scope is invalid")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "intensity": self.intensity.value,
+            "statement_ref_id": self.statement_ref_id,
+            "scope": self.scope.value,
+        }
+
+
 def _validate_facts(
     values: tuple[LocalContinuationFact, ...],
 ) -> tuple[LocalContinuationFact, ...]:
@@ -169,22 +235,43 @@ def _validate_grants(
     return values
 
 
-def _validate_growth_window_start(value: str) -> str:
-    if value == "":
-        return value
+def _validate_boundaries(
+    values: tuple[ActiveBoundary, ...],
+) -> tuple[ActiveBoundary, ...]:
+    if isinstance(values, (str, bytes)):
+        raise PrivateWorldError("active boundaries must be a sequence")
+    if not isinstance(values, tuple):
+        values = tuple(values)
+    if len(values) > 16 or any(
+        not isinstance(value, ActiveBoundary) for value in values
+    ):
+        raise PrivateWorldError("active boundaries must be typed and bounded")
+    identifiers = tuple(value.boundary_id for value in values)
+    if len(set(identifiers)) != len(identifiers):
+        raise PrivateWorldError("active boundary ids must be unique")
+    return values
+
+
+def _validate_utc_timestamp(value: str, *, field_name: str) -> str:
     if (
         not isinstance(value, str)
         or value != value.strip()
         or not _UTC_TIMESTAMP_RE.fullmatch(value)
     ):
-        raise PrivateWorldError("growth window start is invalid")
+        raise PrivateWorldError(f"{field_name} is invalid")
     try:
         instant = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError as exc:
-        raise PrivateWorldError("growth window start is invalid") from exc
+        raise PrivateWorldError(f"{field_name} is invalid") from exc
     if instant.tzinfo is None or instant.utcoffset() != timedelta(0):
-        raise PrivateWorldError("growth window start must be UTC")
+        raise PrivateWorldError(f"{field_name} must be UTC")
     return value
+
+
+def _validate_growth_window_start(value: str) -> str:
+    if value == "":
+        return value
+    return _validate_utc_timestamp(value, field_name="growth window start")
 
 
 def _validate_shared(
@@ -222,6 +309,8 @@ class PrivateWorldControlView:
     intimacy_grants: tuple[IntimacyGrant, ...] = ()
     growth_window_start: str = ""
     growth_used: int = 0
+    active_boundaries: tuple[ActiveBoundary, ...] = ()
+    acknowledged_affection: AcknowledgedAffection | None = None
 
     def __post_init__(self) -> None:
         for name in _HIDDEN_NAMES:
@@ -245,6 +334,15 @@ class PrivateWorldControlView:
             "growth_window_start",
             _validate_growth_window_start(self.growth_window_start),
         )
+        object.__setattr__(
+            self,
+            "active_boundaries",
+            _validate_boundaries(self.active_boundaries),
+        )
+        if self.acknowledged_affection is not None and not isinstance(
+            self.acknowledged_affection, AcknowledgedAffection
+        ):
+            raise PrivateWorldError("acknowledged affection is invalid")
         if type(self.growth_used) is not int or not 0 <= self.growth_used <= 255:
             raise PrivateWorldError("growth used must be an integer from 0 to 255")
 
@@ -264,6 +362,14 @@ class PrivateWorldControlView:
             ],
             "growth_window_start": self.growth_window_start,
             "growth_used": self.growth_used,
+            "active_boundaries": [
+                boundary.to_dict() for boundary in self.active_boundaries
+            ],
+            "acknowledged_affection": (
+                self.acknowledged_affection.to_dict()
+                if self.acknowledged_affection is not None
+                else None
+            ),
         }
 
 
@@ -275,6 +381,8 @@ class PrivateWorldCharacterView:
     continuation_known: bool
     continuation_facts: tuple[LocalContinuationFact, ...] = ()
     granted_intimacy: IntimacyTier = IntimacyTier.NONE
+    active_boundaries: tuple[ActiveBoundary, ...] = ()
+    acknowledged_affection: AcknowledgedAffection | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.relationship_stage, str) or not _TOKEN_RE.fullmatch(
@@ -301,6 +409,15 @@ class PrivateWorldCharacterView:
         object.__setattr__(self, "continuation_facts", facts)
         if not isinstance(self.granted_intimacy, IntimacyTier):
             raise PrivateWorldError("granted intimacy is invalid")
+        object.__setattr__(
+            self,
+            "active_boundaries",
+            _validate_boundaries(self.active_boundaries),
+        )
+        if self.acknowledged_affection is not None and not isinstance(
+            self.acknowledged_affection, AcknowledgedAffection
+        ):
+            raise PrivateWorldError("acknowledged affection is invalid")
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -313,6 +430,14 @@ class PrivateWorldCharacterView:
             "continuation_facts": [
                 fact.to_dict() for fact in self.continuation_facts
             ],
+            "active_boundaries": [
+                boundary.to_dict() for boundary in self.active_boundaries
+            ],
+            "acknowledged_affection": (
+                self.acknowledged_affection.to_dict()
+                if self.acknowledged_affection is not None
+                else None
+            ),
         }
 
 
@@ -332,6 +457,8 @@ class PrivateWorldSnapshot:
     intimacy_grants: tuple[IntimacyGrant, ...] = ()
     growth_window_start: str = ""
     growth_used: int = 0
+    active_boundaries: tuple[ActiveBoundary, ...] = ()
+    acknowledged_affection: AcknowledgedAffection | None = None
 
     def __post_init__(self) -> None:
         if type(self.version) is not int or self.version < 1:
@@ -357,6 +484,15 @@ class PrivateWorldSnapshot:
             "growth_window_start",
             _validate_growth_window_start(self.growth_window_start),
         )
+        object.__setattr__(
+            self,
+            "active_boundaries",
+            _validate_boundaries(self.active_boundaries),
+        )
+        if self.acknowledged_affection is not None and not isinstance(
+            self.acknowledged_affection, AcknowledgedAffection
+        ):
+            raise PrivateWorldError("acknowledged affection is invalid")
         if type(self.growth_used) is not int or not 0 <= self.growth_used <= 255:
             raise PrivateWorldError("growth used must be an integer from 0 to 255")
 
@@ -375,6 +511,8 @@ class PrivateWorldSnapshot:
             intimacy_grants=self.intimacy_grants,
             growth_window_start=self.growth_window_start,
             growth_used=self.growth_used,
+            active_boundaries=self.active_boundaries,
+            acknowledged_affection=self.acknowledged_affection,
         )
 
     def character_view(self) -> PrivateWorldCharacterView:
@@ -400,6 +538,8 @@ class PrivateWorldSnapshot:
             continuation_known=continuation_known,
             continuation_facts=known_facts,
             granted_intimacy=granted_intimacy,
+            active_boundaries=self.active_boundaries,
+            acknowledged_affection=self.acknowledged_affection,
         )
 
     def to_dict(self) -> dict[str, object]:

--- a/runtime/private_world/reducer.py
+++ b/runtime/private_world/reducer.py
@@ -24,6 +24,10 @@ from .commands import (
     UpsertContinuationFact,
 )
 from .port import (
+    AcknowledgedAffection,
+    ActiveBoundary,
+    AffectionIntensity,
+    AffectionScope,
     IntimacyGrant,
     LocalContinuationFact,
     PrivateWorldSnapshot,
@@ -51,6 +55,9 @@ class ReducerEventKind(str, Enum):
     REPEATED_PHRASE = "repeated_phrase"
     CONFESSION = "confession"
     INACTIVITY = "inactivity"
+    CHARACTER_BOUNDARY_SET = "character_boundary_set"
+    CHARACTER_BOUNDARY_WITHDRAWN = "character_boundary_withdrawn"
+    CHARACTER_AFFECTION_ACKNOWLEDGED = "character_affection_acknowledged"
 
 
 _TOKEN_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
@@ -63,6 +70,16 @@ _INTIMACY_TIER_ORDER = (
     IntimacyTier.LIGHT_CONTACT,
     IntimacyTier.CLOSE_CONTACT,
 )
+_AFFECTION_INTENSITY_ORDER = (
+    AffectionIntensity.WARMTH,
+    AffectionIntensity.CARE,
+    AffectionIntensity.LOVE,
+)
+_CHARACTER_FACT_KINDS = {
+    ReducerEventKind.CHARACTER_BOUNDARY_SET,
+    ReducerEventKind.CHARACTER_BOUNDARY_WITHDRAWN,
+    ReducerEventKind.CHARACTER_AFFECTION_ACKNOWLEDGED,
+}
 _NO_EFFECT_KINDS = {
     ReducerEventKind.CANONICAL_REPLY_DELIVERED,
     ReducerEventKind.HIGH_FREQUENCY_MESSAGE,
@@ -82,6 +99,11 @@ class ReducerEvent:
     target_stage: str | None = None
     basis_event_ids: tuple[str, ...] = ()
     intimacy_grant: IntimacyGrant | None = None
+    canonical_reply_id: str | None = None
+    boundary: ActiveBoundary | None = None
+    boundary_id: str | None = None
+    acknowledged_affection: AcknowledgedAffection | None = None
+    asserted_affection_scope: AffectionScope | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.kind, ReducerEventKind):
@@ -112,7 +134,53 @@ class ReducerEvent:
                 "basis_event_ids",
                 tuple(self.basis_event_ids),
             )
-        if self.kind is ReducerEventKind.STAGE_CONFIRMED:
+        if self.kind in _CHARACTER_FACT_KINDS:
+            if (
+                not isinstance(self.canonical_reply_id, str)
+                or not _TOKEN_RE.fullmatch(self.canonical_reply_id)
+            ):
+                raise ReducerInputError(
+                    "character fact requires a canonical reply reference"
+                )
+            if self.target_stage is not None or self.basis_event_ids or self.intimacy_grant:
+                raise ReducerInputError("character fact payload is invalid")
+            if self.kind is ReducerEventKind.CHARACTER_BOUNDARY_SET:
+                if not isinstance(self.boundary, ActiveBoundary):
+                    raise ReducerInputError("boundary set requires a typed boundary")
+                if datetime.fromisoformat(
+                    self.boundary.set_at.replace("Z", "+00:00")
+                ) != self.occurred_at.astimezone(timezone.utc):
+                    raise ReducerInputError("boundary set time must match delivery")
+                if (
+                    self.boundary_id is not None
+                    or self.acknowledged_affection is not None
+                    or self.asserted_affection_scope is not None
+                ):
+                    raise ReducerInputError("boundary set payload is invalid")
+            elif self.kind is ReducerEventKind.CHARACTER_BOUNDARY_WITHDRAWN:
+                if (
+                    not isinstance(self.boundary_id, str)
+                    or not _TOKEN_RE.fullmatch(self.boundary_id)
+                ):
+                    raise ReducerInputError("boundary withdrawal requires an id")
+                if (
+                    self.boundary is not None
+                    or self.acknowledged_affection is not None
+                    or self.asserted_affection_scope is not None
+                ):
+                    raise ReducerInputError("boundary withdrawal payload is invalid")
+            else:
+                if not isinstance(self.acknowledged_affection, AcknowledgedAffection):
+                    raise ReducerInputError(
+                        "affection acknowledgement requires a typed statement"
+                    )
+                if not isinstance(self.asserted_affection_scope, AffectionScope):
+                    raise ReducerInputError("affection scope evidence is required")
+                if self.acknowledged_affection.scope is not self.asserted_affection_scope:
+                    raise ReducerInputError("affection scope cannot be widened")
+                if self.boundary is not None or self.boundary_id is not None:
+                    raise ReducerInputError("affection payload is invalid")
+        elif self.kind is ReducerEventKind.STAGE_CONFIRMED:
             if self.intimacy_grant is not None:
                 raise ReducerInputError(
                     "stage confirmation cannot carry an intimacy grant"
@@ -152,6 +220,11 @@ class ReducerEvent:
             self.target_stage is not None
             or self.basis_event_ids
             or self.intimacy_grant is not None
+            or self.canonical_reply_id is not None
+            or self.boundary is not None
+            or self.boundary_id is not None
+            or self.acknowledged_affection is not None
+            or self.asserted_affection_scope is not None
         ):
             raise ReducerInputError(
                 "event payload is invalid for this event kind"
@@ -203,6 +276,21 @@ def _growth_window(
         if now_utc - started_at < _GROWTH_WINDOW:
             return snapshot.growth_window_start, snapshot.growth_used
     return now_utc.isoformat(), 0
+
+
+def _add_growth_metadata(
+    snapshot: PrivateWorldSnapshot,
+    now: datetime,
+    updates: dict[str, object],
+) -> None:
+    growth_start, growth_used = _growth_window(snapshot, now)
+    if growth_used + 1 <= _WEEKLY_GROWTH_CAP:
+        updates.update(
+            {
+                "growth_window_start": growth_start,
+                "growth_used": growth_used + 1,
+            }
+        )
 
 
 def _intimacy_exceeds_stage(
@@ -345,6 +433,43 @@ def reduce_private_world(
                 updates,
                 reason_code="GROWTH_CAP_REACHED",
             )
+    elif event.kind is ReducerEventKind.CHARACTER_BOUNDARY_SET:
+        boundary = event.boundary
+        if boundary is None:
+            raise ReducerInputError("boundary set event is invalid")
+        boundaries = list(snapshot.active_boundaries)
+        for index, existing in enumerate(boundaries):
+            if existing.boundary_id == boundary.boundary_id:
+                if existing == boundary:
+                    return _no_change(snapshot, "BOUNDARY_UNCHANGED")
+                boundaries[index] = boundary
+                break
+        else:
+            if len(boundaries) >= 16:
+                return _no_change(snapshot, "BOUNDARY_LIMIT_REACHED")
+            boundaries.append(boundary)
+        updates = {"active_boundaries": tuple(boundaries)}
+        _add_growth_metadata(snapshot, event.occurred_at, updates)
+    elif event.kind is ReducerEventKind.CHARACTER_BOUNDARY_WITHDRAWN:
+        remaining = tuple(
+            boundary
+            for boundary in snapshot.active_boundaries
+            if boundary.boundary_id != event.boundary_id
+        )
+        if len(remaining) == len(snapshot.active_boundaries):
+            return _no_change(snapshot, "BOUNDARY_NOT_FOUND")
+        updates = {"active_boundaries": remaining}
+    elif event.kind is ReducerEventKind.CHARACTER_AFFECTION_ACKNOWLEDGED:
+        affection = event.acknowledged_affection
+        if affection is None:
+            raise ReducerInputError("affection event is invalid")
+        existing = snapshot.acknowledged_affection
+        if existing is not None and _AFFECTION_INTENSITY_ORDER.index(
+            affection.intensity
+        ) <= _AFFECTION_INTENSITY_ORDER.index(existing.intensity):
+            return _no_change(snapshot, "AFFECTION_NOT_STRONGER")
+        updates = {"acknowledged_affection": affection}
+        _add_growth_metadata(snapshot, event.occurred_at, updates)
 
     return _apply_updates(
         snapshot,

--- a/runtime/reply/reply_context.py
+++ b/runtime/reply/reply_context.py
@@ -92,6 +92,7 @@ class NicknamePermission(str, Enum):
 
 _ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
 _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_PLAIN_TEXT_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 
 @dataclass(frozen=True)
@@ -179,6 +180,57 @@ class KnownContinuationFact:
 
 
 @dataclass(frozen=True)
+class KnownActiveBoundary:
+    boundary_id: str
+    scope: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.boundary_id, str) or not _ID_RE.fullmatch(
+            self.boundary_id
+        ):
+            raise ReplyContextError("boundary identifier must be stable")
+        if (
+            not isinstance(self.scope, str)
+            or not self.scope.strip()
+            or len(self.scope) > 200
+            or _PLAIN_TEXT_CONTROL_RE.search(self.scope)
+        ):
+            raise ReplyContextError("boundary scope is invalid")
+        object.__setattr__(self, "scope", self.scope.strip())
+
+    def to_dict(self) -> dict[str, str]:
+        return {"boundary_id": self.boundary_id, "scope": self.scope}
+
+
+@dataclass(frozen=True)
+class KnownAcknowledgedAffection:
+    intensity: str
+    statement_ref_id: str
+    scope: str
+
+    def __post_init__(self) -> None:
+        if self.intensity not in {"warmth", "care", "love"}:
+            raise ReplyContextError("affection intensity is invalid")
+        if not isinstance(self.statement_ref_id, str) or not _ID_RE.fullmatch(
+            self.statement_ref_id
+        ):
+            raise ReplyContextError("affection statement reference is invalid")
+        if self.scope not in {
+            "this_reply",
+            "ongoing_correspondence",
+            "relationship",
+        }:
+            raise ReplyContextError("affection scope is invalid")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "intensity": self.intensity,
+            "statement_ref_id": self.statement_ref_id,
+            "scope": self.scope,
+        }
+
+
+@dataclass(frozen=True)
 class PrivateBehaviorView:
     familiarity: BehaviorLevel = BehaviorLevel.UNKNOWN
     trust: BehaviorLevel = BehaviorLevel.UNKNOWN
@@ -191,6 +243,8 @@ class PrivateBehaviorView:
     nickname_permission: NicknamePermission = NicknamePermission.NOT_ALLOWED
     home_history_allowed: bool = False
     known_continuations: tuple[KnownContinuationFact, ...] = ()
+    active_boundaries: tuple[KnownActiveBoundary, ...] = ()
+    acknowledged_affection: KnownAcknowledgedAffection | None = None
 
     def __post_init__(self) -> None:
         expected_types = (
@@ -232,6 +286,21 @@ class PrivateBehaviorView:
                 "known continuations must be typed, unique, and bounded"
             )
         object.__setattr__(self, "known_continuations", facts)
+        if isinstance(self.active_boundaries, (str, bytes)):
+            raise ReplyContextError("active boundaries must be a typed sequence")
+        boundaries = tuple(self.active_boundaries)
+        if (
+            len(boundaries) > 16
+            or any(not isinstance(item, KnownActiveBoundary) for item in boundaries)
+            or len({item.boundary_id for item in boundaries}) != len(boundaries)
+        ):
+            raise ReplyContextError("active boundaries must be typed and unique")
+        object.__setattr__(self, "active_boundaries", boundaries)
+        if self.acknowledged_affection is not None and not isinstance(
+            self.acknowledged_affection,
+            KnownAcknowledgedAffection,
+        ):
+            raise ReplyContextError("acknowledged affection is invalid")
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -248,6 +317,14 @@ class PrivateBehaviorView:
             "known_continuations": [
                 fact.to_dict() for fact in self.known_continuations
             ],
+            "active_boundaries": [
+                boundary.to_dict() for boundary in self.active_boundaries
+            ],
+            "acknowledged_affection": (
+                self.acknowledged_affection.to_dict()
+                if self.acknowledged_affection is not None
+                else None
+            ),
         }
 
 

--- a/tests/persona/test_reply_context.py
+++ b/tests/persona/test_reply_context.py
@@ -11,6 +11,7 @@ from runtime.reply.reply_context import (
     BehaviorLevel,
     IntimacyRequest,
     IntimacyTier,
+    KnownActiveBoundary,
     PrivateBehaviorView,
     OutputChannel,
     OutputConstraints,
@@ -196,7 +197,7 @@ def test_schema_matches_runtime_mode_and_privacy_invariants() -> None:
         trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
     ).to_dict()
 
-    assert schema["$id"] == "p02.reply-context.v2"
+    assert schema["$id"] == "p02.reply-context.v3"
     assert list(validator.iter_errors(valid)) == []
 
     invalid_channel = {**valid, "output_constraints": {**valid["output_constraints"]}}
@@ -218,6 +219,26 @@ def test_schema_matches_runtime_mode_and_privacy_invariants() -> None:
     invalid_home_access["private_behavior"].pop("home_history_allowed")
     invalid_home_access["private_behavior"]["home_access"] = "visit_access"
     assert list(validator.iter_errors(invalid_home_access))
+
+
+def test_projected_boundary_scope_character_rules_match_schema() -> None:
+    schema = json.loads(
+        (ROOT / "contracts" / "reply_context.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    valid = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+    ).to_dict()
+    invalid = {**valid, "private_behavior": {**valid["private_behavior"]}}
+    invalid["private_behavior"]["active_boundaries"] = [
+        {"boundary_id": "boundary.synthetic", "scope": "bad\nscope"}
+    ]
+
+    with pytest.raises(ReplyContextError):
+        KnownActiveBoundary("boundary.synthetic", "bad\nscope")
+    assert list(Draft202012Validator(schema).iter_errors(invalid))
 
 
 def test_public_contract_documentation_names_api_errors_and_scope_boundary() -> None:

--- a/tests/private_world/test_private_world_ledger.py
+++ b/tests/private_world/test_private_world_ledger.py
@@ -76,6 +76,8 @@ def _legacy_v2_database(path: Path) -> None:
             payload.pop("intimacy_grants")
             payload.pop("growth_window_start")
             payload.pop("growth_used")
+            payload.pop("active_boundaries")
+            payload.pop("acknowledged_affection")
             connection.execute(
                 """INSERT INTO private_world_snapshots
                    (version, payload_json, event_id) VALUES (?, ?, ?)""",
@@ -117,7 +119,7 @@ def _legacy_v1_database(path: Path) -> None:
             )
 
 
-def test_v2_ledger_migrates_to_v3_without_losing_events_or_snapshots(
+def test_v2_ledger_migrates_to_v4_without_losing_events_or_snapshots(
     tmp_path: Path,
 ) -> None:
     database = tmp_path / "private-world.sqlite3"
@@ -125,8 +127,8 @@ def test_v2_ledger_migrates_to_v3_without_losing_events_or_snapshots(
 
     ledger = SQLitePrivateWorldLedger(database)
 
-    assert ledger.schema_version == PRIVATE_WORLD_LEDGER_SCHEMA_VERSION == 3
-    assert ledger.migration_status == "migrated_v2_to_v3"
+    assert ledger.schema_version == PRIVATE_WORLD_LEDGER_SCHEMA_VERSION == 4
+    assert ledger.migration_status == "migrated_v2_to_v4"
     assert ledger.events() == (_event(1), _event(2))
     assert ledger.snapshot() == PrivateWorldSnapshot(version=2, trust=2)
     with sqlite3.connect(database) as connection:
@@ -139,14 +141,16 @@ def test_v2_ledger_migrates_to_v3_without_losing_events_or_snapshots(
             json.loads(row[1])["intimacy_grants"] == []
             and json.loads(row[1])["growth_window_start"] == ""
             and json.loads(row[1])["growth_used"] == 0
+            and json.loads(row[1])["active_boundaries"] == []
+            and json.loads(row[1])["acknowledged_affection"] is None
             for row in rows
         )
-    backups = tuple(tmp_path.glob("private-world.sqlite3.pre-v3-*.bak"))
+    backups = tuple(tmp_path.glob("private-world.sqlite3.pre-v4-*.bak"))
     assert len(backups) == 1
     assert backups[0].is_file() and backups[0].stat().st_size > 0
 
 
-def test_v1_ledger_uses_the_validated_v2_to_v3_migration_chain(
+def test_v1_ledger_uses_the_validated_migration_chain_to_v4(
     tmp_path: Path,
 ) -> None:
     database = tmp_path / "private-world.sqlite3"
@@ -154,14 +158,14 @@ def test_v1_ledger_uses_the_validated_v2_to_v3_migration_chain(
 
     ledger = SQLitePrivateWorldLedger(database)
 
-    assert ledger.schema_version == 3
-    assert ledger.migration_status == "migrated_v2_to_v3"
+    assert ledger.schema_version == 4
+    assert ledger.migration_status == "migrated_v1_to_v4"
     assert ledger.events() == (_event(1), _event(2))
     assert ledger.snapshot() == PrivateWorldSnapshot(version=2, trust=2)
     with sqlite3.connect(database) as connection:
         assert connection.execute(
             "SELECT value FROM private_world_metadata WHERE key = 'schema_version'"
-        ).fetchone() == ("3",)
+        ).fetchone() == ("4",)
         payloads = connection.execute(
             "SELECT payload_json FROM private_world_snapshots ORDER BY version"
         ).fetchall()
@@ -170,23 +174,66 @@ def test_v1_ledger_uses_the_validated_v2_to_v3_migration_chain(
         "intimacy_grants",
         "growth_window_start",
         "growth_used",
+        "active_boundaries",
+        "acknowledged_affection",
     } for row in payloads)
-    assert len(tuple(tmp_path.glob("private-world.sqlite3.pre-v3-*.bak"))) == 1
+    assert len(tuple(tmp_path.glob("private-world.sqlite3.pre-v4-*.bak"))) == 1
 
 
-def test_v3_ledger_reopens_without_another_migration_or_backup(
+def test_v4_ledger_reopens_without_another_migration_or_backup(
     tmp_path: Path,
 ) -> None:
     database = tmp_path / "private-world.sqlite3"
     created = SQLitePrivateWorldLedger(database)
 
-    assert created.migration_status == "created_v3"
-    assert not tuple(tmp_path.glob("*.pre-v3-*.bak"))
+    assert created.migration_status == "created_v4"
+    assert not tuple(tmp_path.glob("*.pre-v4-*.bak"))
 
     reopened = SQLitePrivateWorldLedger(database)
 
-    assert reopened.migration_status == "current_v3"
-    assert not tuple(tmp_path.glob("*.pre-v3-*.bak"))
+    assert reopened.migration_status == "current_v4"
+    assert not tuple(tmp_path.glob("*.pre-v4-*.bak"))
+
+
+def test_v3_ledger_migrates_new_relationship_fields_to_empty_defaults(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "private-world.sqlite3"
+    ledger = SQLitePrivateWorldLedger(database)
+    ledger.apply_once(_event(1), PrivateWorldSnapshot(version=1, trust=2))
+    with sqlite3.connect(database) as connection:
+        row = connection.execute(
+            "SELECT payload_json FROM private_world_snapshots WHERE version = 1"
+        ).fetchone()
+        payload = json.loads(row[0])
+        payload.pop("active_boundaries")
+        payload.pop("acknowledged_affection")
+        connection.execute(
+            "UPDATE private_world_snapshots SET payload_json = ? WHERE version = 1",
+            (
+                json.dumps(
+                    payload,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+            ),
+        )
+        connection.execute(
+            "UPDATE private_world_metadata SET value = '3' WHERE key = 'schema_version'"
+        )
+
+    migrated = SQLitePrivateWorldLedger(database)
+
+    assert migrated.migration_status == "migrated_v3_to_v4"
+    assert migrated.snapshot() == PrivateWorldSnapshot(version=1, trust=2)
+    backups = tuple(tmp_path.glob("private-world.sqlite3.pre-v4-*.bak"))
+    assert len(backups) == 1
+
+    reopened = SQLitePrivateWorldLedger(database)
+
+    assert reopened.migration_status == "current_v4"
+    assert tuple(tmp_path.glob("*.pre-v4-*.bak")) == backups
 
 
 def test_apply_once_atomically_appends_event_and_snapshot(tmp_path: Path) -> None:

--- a/tests/private_world/test_private_world_port.py
+++ b/tests/private_world/test_private_world_port.py
@@ -6,6 +6,7 @@ import pytest
 from jsonschema import Draft202012Validator, FormatChecker
 
 from private_world_port import (
+    ActiveBoundary,
     ContinuationAwareness,
     HomeAccess,
     IntimacyGrant,
@@ -122,13 +123,15 @@ def test_snapshot_keeps_hidden_and_control_only_values_out_of_character_view() -
         "nickname_permissions": ["小河豚", "旅行者"],
         "home_history_allowed": True,
         "continuation_known": True,
-        "continuation_facts": [
+            "continuation_facts": [
             {
                 "fact_id": "class.known",
                 "statement": "她已经知道下周课程时间会调整。",
                 "awareness": "character_known",
-            }
-        ],
+                }
+            ],
+            "active_boundaries": [],
+            "acknowledged_affection": None,
     }
     serialized = repr(character)
     assert "pending" not in serialized
@@ -182,6 +185,8 @@ def test_snapshot_exposes_intimacy_control_state_without_leaking_grant_details()
         "home_history_allowed",
         "continuation_known",
         "continuation_facts",
+        "active_boundaries",
+        "acknowledged_affection",
     }
     assert "statement" not in repr(character)
     assert "growth_" not in repr(character)
@@ -227,6 +232,59 @@ def test_schema_rejects_invalid_utc_timestamps(
 
     validator = _private_world_validator(schema)
     assert list(validator.iter_errors(payload))
+
+
+@pytest.mark.parametrize(
+    "invalid_timestamp",
+    [
+        "2026-08-29T09:00:00+09:00",
+        "2026-08-29T00:00:00",
+    ],
+)
+def test_boundary_timestamp_is_utc_in_runtime_and_schema(
+    invalid_timestamp: str,
+) -> None:
+    schema = json.loads(
+        (ROOT / "contracts" / "private_world.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    payload = PrivateWorldSnapshot().to_dict()
+    payload["active_boundaries"] = [
+        {
+            "boundary_id": "boundary.synthetic",
+            "set_at": invalid_timestamp,
+            "scope": "synthetic scope",
+        }
+    ]
+
+    with pytest.raises(PrivateWorldError):
+        ActiveBoundary("boundary.synthetic", invalid_timestamp, "synthetic scope")
+    assert list(_private_world_validator(schema).iter_errors(payload))
+
+
+def test_boundary_scope_character_rules_match_runtime_and_schema() -> None:
+    schema = json.loads(
+        (ROOT / "contracts" / "private_world.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    payload = PrivateWorldSnapshot().to_dict()
+    payload["active_boundaries"] = [
+        {
+            "boundary_id": "boundary.synthetic",
+            "set_at": "2026-08-29T00:00:00+00:00",
+            "scope": "bad\nscope",
+        }
+    ]
+
+    with pytest.raises(PrivateWorldError):
+        ActiveBoundary(
+            "boundary.synthetic",
+            "2026-08-29T00:00:00+00:00",
+            "bad\nscope",
+        )
+    assert list(_private_world_validator(schema).iter_errors(payload))
 
 
 def test_contract_rejects_unbounded_or_ambiguous_values() -> None:

--- a/tests/private_world/test_private_world_runtime.py
+++ b/tests/private_world/test_private_world_runtime.py
@@ -115,24 +115,24 @@ def test_legacy_ledger_is_backed_up_and_migrated_once(tmp_path: Path) -> None:
 
     ledger = SQLitePrivateWorldLedger(database)
 
-    assert ledger.schema_version == PRIVATE_WORLD_LEDGER_SCHEMA_VERSION == 3
-    assert ledger.migration_status == "migrated_v2_to_v3"
+    assert ledger.schema_version == PRIVATE_WORLD_LEDGER_SCHEMA_VERSION == 4
+    assert ledger.migration_status == "migrated_v1_to_v4"
     assert ledger.snapshot() == PrivateWorldSnapshot(
         version=1,
         trust=3,
         relationship_stage="acquaintance",
     )
-    backups = tuple(tmp_path.glob("private_world.sqlite3.pre-v3-*.bak"))
+    backups = tuple(tmp_path.glob("private_world.sqlite3.pre-v4-*.bak"))
     assert len(backups) == 1
     assert backups[0].is_file() and backups[0].stat().st_size > 0
     with sqlite3.connect(database) as connection:
         assert connection.execute(
             "SELECT value FROM private_world_metadata WHERE key = 'schema_version'"
-        ).fetchone() == ("3",)
+        ).fetchone() == ("4",)
 
     reopened = SQLitePrivateWorldLedger(database)
-    assert reopened.migration_status == "current_v3"
-    assert tuple(tmp_path.glob("private_world.sqlite3.pre-v3-*.bak")) == backups
+    assert reopened.migration_status == "current_v4"
+    assert tuple(tmp_path.glob("private_world.sqlite3.pre-v4-*.bak")) == backups
 
 
 def test_later_metadata_less_v1_payload_with_continuation_facts_migrates(
@@ -143,7 +143,7 @@ def test_later_metadata_less_v1_payload_with_continuation_facts_migrates(
 
     ledger = SQLitePrivateWorldLedger(database)
 
-    assert ledger.migration_status == "migrated_v2_to_v3"
+    assert ledger.migration_status == "migrated_v1_to_v4"
     assert ledger.snapshot() == PrivateWorldSnapshot(
         version=1,
         trust=3,
@@ -195,7 +195,7 @@ def test_v1_migration_locks_the_validated_source_epoch_before_backup(
 
     assert competing_write == {"result": "locked"}
     assert ledger.snapshot().trust == 3
-    backup = next(tmp_path.glob("private_world.sqlite3.pre-v3-*.bak"))
+    backup = next(tmp_path.glob("private_world.sqlite3.pre-v4-*.bak"))
     with sqlite3.connect(backup) as connection:
         backup_payload = connection.execute(
             "SELECT payload_json FROM private_world_snapshots WHERE version = 1"
@@ -224,23 +224,23 @@ def test_invalid_v1_payload_does_not_modify_database_or_create_backup(
         SQLitePrivateWorldLedger(database)
 
     assert hashlib.sha256(database.read_bytes()).hexdigest() == original_hash
-    assert not tuple(tmp_path.glob("private_world.sqlite3.pre-v3-*.bak"))
+    assert not tuple(tmp_path.glob("private_world.sqlite3.pre-v4-*.bak"))
     with sqlite3.connect(database) as connection:
         assert connection.execute(
             "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'private_world_metadata'"
         ).fetchone() is None
 
 
-def test_new_ledger_records_v3_metadata_without_backup(tmp_path: Path) -> None:
+def test_new_ledger_records_v4_metadata_without_backup(tmp_path: Path) -> None:
     database = tmp_path / "private_world.sqlite3"
     ledger = SQLitePrivateWorldLedger(database)
 
-    assert ledger.migration_status == "created_v3"
-    assert not tuple(tmp_path.glob("*.pre-v3-*.bak"))
+    assert ledger.migration_status == "created_v4"
+    assert not tuple(tmp_path.glob("*.pre-v4-*.bak"))
     with sqlite3.connect(database) as connection:
         assert connection.execute(
             "SELECT value FROM private_world_metadata WHERE key = 'schema_version'"
-        ).fetchone() == ("3",)
+        ).fetchone() == ("4",)
 
 
 def test_newer_schema_is_rejected_without_modification(tmp_path: Path) -> None:
@@ -277,8 +277,8 @@ def test_default_runtime_uses_local_data_root_and_reports_sanitized_health(
         "provider": "sqlite",
         "reason_code": None,
         "enabled": True,
-        "schema_version": 3,
-        "migration_status": "created_v3",
+        "schema_version": 4,
+        "migration_status": "created_v4",
         "event_count": 0,
         "snapshot_count": 0,
         "probe": "in-process",
@@ -335,8 +335,8 @@ def test_public_private_world_health_matches_the_sanitized_schema(
             "provider": "none",
             "reason_code": None,
             "enabled": True,
-            "schema_version": 3,
-            "migration_status": "current_v3",
+            "schema_version": 4,
+            "migration_status": "current_v4",
             "event_count": 0,
             "snapshot_count": 0,
             "probe": "in-process",
@@ -371,8 +371,8 @@ def test_public_private_world_health_matches_the_sanitized_schema(
             "provider": "sqlite",
             "reason_code": "PRIVATE_WORLD_STORAGE_UNAVAILABLE",
             "enabled": True,
-            "schema_version": 3,
-            "migration_status": "current_v3",
+            "schema_version": 4,
+            "migration_status": "current_v4",
             "event_count": 0,
             "snapshot_count": 0,
             "probe": "in-process",
@@ -463,8 +463,8 @@ def test_runtime_health_fails_closed_when_sqlite_becomes_unavailable(
         "provider": "none",
         "reason_code": "PRIVATE_WORLD_STORAGE_UNAVAILABLE",
         "enabled": True,
-        "schema_version": 3,
-        "migration_status": "created_v3",
+        "schema_version": 4,
+        "migration_status": "created_v4",
         "event_count": 0,
         "snapshot_count": 0,
         "probe": "not-run",
@@ -501,8 +501,8 @@ def test_runtime_health_fails_closed_when_current_snapshot_is_semantically_corru
         "provider": "none",
         "reason_code": "PRIVATE_WORLD_STORAGE_UNAVAILABLE",
         "enabled": True,
-        "schema_version": 3,
-        "migration_status": "created_v3",
+        "schema_version": 4,
+        "migration_status": "created_v4",
         "event_count": 0,
         "snapshot_count": 0,
         "probe": "not-run",
@@ -789,6 +789,8 @@ def test_available_sqlite_projects_only_character_view_into_reply_context(
                 "statement": "角色已知的合成课程调整。",
             }
         ],
+        "active_boundaries": [],
+        "acknowledged_affection": None,
     }
     assert "合成称呼" in serialized_model_private_world
     assert "角色已知的合成课程调整。" in serialized_model_private_world

--- a/tests/private_world/test_private_world_runtime_wiring.py
+++ b/tests/private_world/test_private_world_runtime_wiring.py
@@ -282,8 +282,8 @@ def test_local_server_fresh_process_wires_default_private_world_runtime(
         "provider": "sqlite",
         "reason_code": None,
         "enabled": True,
-        "schema_version": 3,
-        "migration_status": "created_v3",
+        "schema_version": 4,
+        "migration_status": "created_v4",
         "event_count": 0,
         "snapshot_count": 0,
         "probe": "in-process",
@@ -496,4 +496,6 @@ def test_local_server_private_world_failure_uses_null_port_without_blocking_lett
         "nickname_permission": "not_allowed",
         "home_history_allowed": False,
         "known_continuations": [],
+        "active_boundaries": [],
+        "acknowledged_affection": None,
     }

--- a/tests/private_world/test_private_world_v4_relationship_model.py
+++ b/tests/private_world/test_private_world_v4_relationship_model.py
@@ -1,0 +1,149 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from private_world_port import (
+    AcknowledgedAffection,
+    ActiveBoundary,
+    AffectionIntensity,
+    AffectionScope,
+    PrivateWorldSnapshot,
+)
+from private_world_reducer import (
+    ReducerEvent,
+    ReducerEventKind,
+    ReducerInputError,
+    reduce_private_world,
+)
+from runtime.memory.private_world_projection import project_private_world
+
+
+NOW = datetime(2026, 9, 3, tzinfo=timezone.utc)
+
+
+def _event(kind: ReducerEventKind, **payload: object) -> ReducerEvent:
+    return ReducerEvent(
+        kind=kind,
+        occurred_at=NOW,
+        semantic_key=f"semantic.{kind.value}",
+        canonical_reply_id="reply.canonical.1",
+        **payload,
+    )
+
+
+def test_only_canonical_character_events_set_and_withdraw_boundaries() -> None:
+    boundary = ActiveBoundary(
+        boundary_id="boundary.no_offline_meeting",
+        set_at=NOW.isoformat(),
+        scope="offline_meeting",
+    )
+    established = reduce_private_world(
+        PrivateWorldSnapshot(),
+        _event(ReducerEventKind.CHARACTER_BOUNDARY_SET, boundary=boundary),
+    )
+
+    assert established.snapshot.active_boundaries == (boundary,)
+    assert reduce_private_world(
+        established.snapshot,
+        ReducerEvent(
+            kind=ReducerEventKind.CONFESSION,
+            occurred_at=NOW + timedelta(days=1),
+            semantic_key="user.claimed.boundary",
+        ),
+    ).snapshot.active_boundaries == (boundary,)
+
+    withdrawn = reduce_private_world(
+        established.snapshot,
+        _event(
+            ReducerEventKind.CHARACTER_BOUNDARY_WITHDRAWN,
+            boundary_id=boundary.boundary_id,
+        ),
+    )
+    assert withdrawn.snapshot.active_boundaries == ()
+
+
+def test_affection_only_increases_on_a_stronger_character_statement() -> None:
+    warmth = AcknowledgedAffection(
+        intensity=AffectionIntensity.WARMTH,
+        statement_ref_id="reply.canonical.1.line.2",
+        scope=AffectionScope.ONGOING_CORRESPONDENCE,
+    )
+    established = reduce_private_world(
+        PrivateWorldSnapshot(),
+        _event(
+            ReducerEventKind.CHARACTER_AFFECTION_ACKNOWLEDGED,
+            acknowledged_affection=warmth,
+            asserted_affection_scope=AffectionScope.ONGOING_CORRESPONDENCE,
+        ),
+    )
+    weaker = AcknowledgedAffection(
+        intensity=AffectionIntensity.WARMTH,
+        statement_ref_id="reply.canonical.2.line.1",
+        scope=AffectionScope.THIS_REPLY,
+    )
+    unchanged = reduce_private_world(
+        established.snapshot,
+        ReducerEvent(
+            kind=ReducerEventKind.CHARACTER_AFFECTION_ACKNOWLEDGED,
+            occurred_at=NOW + timedelta(days=1),
+            semantic_key="affection.weaker",
+            canonical_reply_id="reply.canonical.2",
+            acknowledged_affection=weaker,
+            asserted_affection_scope=AffectionScope.THIS_REPLY,
+        ),
+    )
+
+    assert unchanged.snapshot.acknowledged_affection == warmth
+    assert unchanged.delta.reason_code == "AFFECTION_NOT_STRONGER"
+
+
+def test_affection_scope_cannot_exceed_the_character_statement() -> None:
+    with pytest.raises(ReducerInputError, match="scope"):
+        _event(
+            ReducerEventKind.CHARACTER_AFFECTION_ACKNOWLEDGED,
+            acknowledged_affection=AcknowledgedAffection(
+                intensity=AffectionIntensity.CARE,
+                statement_ref_id="reply.canonical.1.line.3",
+                scope=AffectionScope.RELATIONSHIP,
+            ),
+            asserted_affection_scope=AffectionScope.THIS_REPLY,
+        )
+
+
+def test_v4_relationship_facts_project_without_hidden_control_state() -> None:
+    boundary = ActiveBoundary(
+        boundary_id="boundary.no_offline_meeting",
+        set_at=NOW.isoformat(),
+        scope="offline_meeting",
+    )
+    affection = AcknowledgedAffection(
+        intensity=AffectionIntensity.CARE,
+        statement_ref_id="reply.canonical.1.line.3",
+        scope=AffectionScope.ONGOING_CORRESPONDENCE,
+    )
+
+    projected = project_private_world(
+        PrivateWorldSnapshot(
+            active_boundaries=(boundary,),
+            acknowledged_affection=affection,
+        )
+    ).behavior.to_dict()
+
+    assert projected["active_boundaries"] == [
+        {
+            "boundary_id": "boundary.no_offline_meeting",
+            "scope": "offline_meeting",
+        }
+    ]
+    assert projected["acknowledged_affection"] == {
+        "intensity": "care",
+        "statement_ref_id": "reply.canonical.1.line.3",
+        "scope": "ongoing_correspondence",
+    }
+
+
+def test_old_snapshot_defaults_v4_relationship_facts_to_empty() -> None:
+    snapshot = PrivateWorldSnapshot(version=9, trust=30)
+
+    assert snapshot.active_boundaries == ()
+    assert snapshot.acknowledged_affection is None


### PR DESCRIPTION
## Summary

- Add bounded active-boundary and acknowledged-affection facts to PrivateWorld snapshot, control view, and character view.
- Add fail-closed reducer events for character-authored boundary set/withdrawal and stronger explicit affection acknowledgements.
- Migrate SQLite ledgers from v1, v2, or v3 to schema v4 with canonical validation and one recoverable pre-v4 backup.
- Project only bounded character-visible relationship facts into ReplyContext.
- Extend the ReplyContext data contract with typed boundary and affection projections required by the v4 projection.
- Update sanitized runtime-health schema and v4 documentation.

## Safety boundary

- Ordinary user events cannot set or withdraw character boundaries or acknowledge affection.
- Affection scope cannot exceed the explicit character statement and weaker statements do not overwrite stronger acknowledgements.
- Hidden scores, growth state, grants, pending/control-only continuations, and storage paths remain outside model context and public health.
- This PR contains no canonical delivery digest, relationship committer, trusted internal entry, or reply-policy authority change.

## Verification

- python -m pytest tests/private_world tests/persona/test_reply_context.py -q: 276 passed.
- python baseline_hardening_scan.py --mode all: PASS; all finding categories 0.
- compileall for runtime/private_world, private_world_projection, and reply_context: passed.
- git diff --cached --check: passed before commit.

## Scope

Fifteen files. ReplyContext data types move with projection because the projection cannot import independently without them; reply policy and all delivery/command wiring remain reserved for PR5.