### PR TITLE
PrivateWorld: bind relationship facts to canonical delivery

### DIFF
--- a/docs/P02_17_PRIVATE_WORLD_DELIVERY.md
+++ b/docs/P02_17_PRIVATE_WORLD_DELIVERY.md
@@ -5,10 +5,17 @@ persisted with `reply_revision`. Its stable `delivery_id` is
 `letter_id:reply_revision`; the SQLite ledger applies it once.
 
 `DeliveryEvent` accepts only `CANONICAL_REPLY_DELIVERED` and has no stage,
-intimacy, nickname, home-access, or continuation mutation payload. Confirmed
-relationship and intimacy changes must use a typed command through
-`PrivateWorldCommandService`; canonical delivery cannot act as an authorization
-adapter.
+intimacy, nickname, home-access, continuation, boundary, or affection mutation
+payload. It retains this single responsibility. Character relationship facts
+use the dedicated typed `RelationshipFactCommand` and
+`PrivateWorldRelationshipCommitter`; canonical delivery cannot act as an
+authorization adapter.
+
+The current production status is **typed contract + trusted internal entry
+ready**. Automatic reply integration is not enabled: reply generation and LLM
+candidate analysis do not submit relationship facts. A future caller may commit
+one only after an explicit trusted approval step supplies the typed command and
+verifiable canonical delivery evidence.
 
 The letter is first stored with `private_world_status=PENDING`, then committed.
 Startup recovery retries pending records without changing or deleting canonical

--- a/local_server.py
+++ b/local_server.py
@@ -108,6 +108,11 @@ from runtime.memory.private_world_delivery import (
     DeliveryStatus,
     PrivateWorldDeliveryCommitter,
 )
+from runtime.memory.private_world_relationship import (
+    PrivateWorldRelationshipCommitter,
+    RelationshipFactCommand,
+    RelationshipFactStatus,
+)
 from private_world_candidate import (
     GatewayPrivateWorldCandidateAnalyzer,
     PrivateWorldCandidateAnalyzer,
@@ -117,7 +122,6 @@ from private_world_candidate import (
     deliver_private_world_candidate,
 )
 from private_world_candidates import SQLitePrivateWorldCandidateStore
-from private_world_reducer import ReducerEventKind
 from private_world_service import PrivateWorldCommandService
 from runtime.memory.private_world_projection import project_private_world
 from runtime.memory.private_world_runtime import (
@@ -1164,6 +1168,9 @@ private_world_runtime: PrivateWorldRuntime = create_private_world_runtime(
 private_world_port: PrivateWorldPort = private_world_runtime.port
 private_world_committer: PrivateWorldDeliveryCommitter | None = (
     private_world_runtime.committer
+)
+private_world_relationship_committer: PrivateWorldRelationshipCommitter | None = (
+    private_world_runtime.relationship_committer
 )
 private_world_command_service: PrivateWorldCommandService | None = (
     PrivateWorldCommandService(private_world_runtime.port)
@@ -3806,7 +3813,9 @@ def _prepare_private_world_delivery(letter: dict, canonical_text: str) -> None:
     letter["private_world_delivery_id"] = delivery_id
     letter["private_world_status"] = "PENDING"
     letter["private_world_occurred_at"] = datetime.now(timezone.utc).isoformat()
-    letter["private_world_event_kind"] = ReducerEventKind.CANONICAL_REPLY_DELIVERED.value
+    letter["private_world_reply_sha256"] = hashlib.sha256(
+        canonical_text.encode("utf-8")
+    ).hexdigest()
     letter["private_world_semantic_key"] = f"canonical.{semantic_digest}"
 
 
@@ -3866,11 +3875,17 @@ def _commit_private_world_letter(letter: dict) -> bool:
         letter["private_world_error_code"] = "PRIVATE_WORLD_UNAVAILABLE"
         return False
     try:
+        reply_digest = letter.get("private_world_reply_sha256")
+        if not isinstance(reply_digest, str):
+            reply_digest = hashlib.sha256(
+                str(letter["reply_text"]).encode("utf-8")
+            ).hexdigest()
+            letter["private_world_reply_sha256"] = reply_digest
         delivery = DeliveryEvent(
             delivery_id=str(letter["private_world_delivery_id"]),
-            kind=ReducerEventKind(str(letter["private_world_event_kind"])),
             occurred_at=datetime.fromisoformat(str(letter["private_world_occurred_at"])),
             semantic_key=str(letter["private_world_semantic_key"]),
+            canonical_reply_sha256=reply_digest,
         )
         status = private_world_committer.commit(delivery)
     except (KeyError, TypeError, ValueError):
@@ -3882,6 +3897,16 @@ def _commit_private_world_letter(letter: dict) -> bool:
         return True
     letter["private_world_error_code"] = "PRIVATE_WORLD_UNAVAILABLE"
     return False
+
+
+def commit_private_world_relationship_fact(
+    command: RelationshipFactCommand,
+) -> RelationshipFactStatus:
+    """Commit a typed character fact through the dedicated authority path."""
+
+    if private_world_relationship_committer is None:
+        return RelationshipFactStatus.UNAVAILABLE
+    return private_world_relationship_committer.commit(command)
 
 
 def recover_pending_private_world() -> int:

--- a/runtime/memory/private_world_delivery.py
+++ b/runtime/memory/private_world_delivery.py
@@ -14,8 +14,7 @@ from private_world_reducer import ReducerEvent, ReducerEventKind, reduce_private
 
 
 _ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
-
-
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 class DeliveryStatus(StrEnum):
     COMMITTED = "COMMITTED"
     DUPLICATE = "DUPLICATE"
@@ -25,20 +24,23 @@ class DeliveryStatus(StrEnum):
 @dataclass(frozen=True)
 class DeliveryEvent:
     delivery_id: str
-    kind: ReducerEventKind
     occurred_at: datetime
     semantic_key: str
     last_equivalent_at: datetime | None = None
+    canonical_reply_sha256: str | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.delivery_id, str) or not _ID_RE.fullmatch(
             self.delivery_id
         ):
             raise ValueError("delivery_id is invalid")
-        if self.kind is not ReducerEventKind.CANONICAL_REPLY_DELIVERED:
-            raise ValueError("canonical reply delivery kind is required")
+        if self.canonical_reply_sha256 is not None and (
+            not isinstance(self.canonical_reply_sha256, str)
+            or not _SHA256_RE.fullmatch(self.canonical_reply_sha256)
+        ):
+            raise ValueError("canonical reply digest is invalid")
         ReducerEvent(
-            kind=self.kind,
+            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
             occurred_at=self.occurred_at,
             semantic_key=self.semantic_key,
             last_equivalent_at=self.last_equivalent_at,
@@ -52,11 +54,9 @@ class PrivateWorldDeliveryCommitter:
     def commit(self, delivery: DeliveryEvent) -> DeliveryStatus:
         if type(delivery) is not DeliveryEvent:
             raise TypeError("typed delivery is required")
-        if delivery.kind is not ReducerEventKind.CANONICAL_REPLY_DELIVERED:
-            raise ValueError("canonical reply delivery kind is required")
         DeliveryEvent.__post_init__(delivery)
         event = ReducerEvent(
-            kind=delivery.kind,
+            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
             occurred_at=delivery.occurred_at,
             semantic_key=delivery.semantic_key,
             last_equivalent_at=delivery.last_equivalent_at,
@@ -87,6 +87,15 @@ class PrivateWorldDeliveryCommitter:
                         "change_fields": [
                             change.field for change in reduced.delta.changes
                         ],
+                        **(
+                            {
+                                "canonical_reply_sha256": (
+                                    delivery.canonical_reply_sha256
+                                )
+                            }
+                            if delivery.canonical_reply_sha256 is not None
+                            else {}
+                        ),
                     },
                     occurred_at=delivery.occurred_at.isoformat(),
                 ),

--- a/runtime/memory/private_world_relationship.py
+++ b/runtime/memory/private_world_relationship.py
@@ -1,0 +1,189 @@
+"""Typed relationship-fact commits bound to an earlier canonical delivery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import StrEnum
+import hashlib
+import re
+import sqlite3
+
+from private_world_ledger import LedgerEvent, LedgerWriteError, SQLitePrivateWorldLedger
+from private_world_port import AcknowledgedAffection, ActiveBoundary, AffectionScope
+from private_world_reducer import ReducerEvent, ReducerEventKind, reduce_private_world
+
+
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,96}$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_RELATIONSHIP_FACT_KINDS = frozenset(
+    {
+        ReducerEventKind.CHARACTER_BOUNDARY_SET,
+        ReducerEventKind.CHARACTER_BOUNDARY_WITHDRAWN,
+        ReducerEventKind.CHARACTER_AFFECTION_ACKNOWLEDGED,
+    }
+)
+
+
+class RelationshipFactStatus(StrEnum):
+    COMMITTED = "COMMITTED"
+    DUPLICATE = "DUPLICATE"
+    UNAVAILABLE = "UNAVAILABLE"
+    REJECTED = "REJECTED"
+
+
+@dataclass(frozen=True)
+class RelationshipFactCommand:
+    command_id: str
+    kind: ReducerEventKind
+    occurred_at: datetime
+    semantic_key: str
+    canonical_delivery_id: str
+    canonical_reply_sha256: str
+    evidence_ref_id: str
+    last_equivalent_at: datetime | None = None
+    boundary: ActiveBoundary | None = None
+    boundary_id: str | None = None
+    acknowledged_affection: AcknowledgedAffection | None = None
+    asserted_affection_scope: AffectionScope | None = None
+
+    def __post_init__(self) -> None:
+        if any(
+            not isinstance(value, str) or not _ID_RE.fullmatch(value)
+            for value in (
+                self.command_id,
+                self.semantic_key,
+                self.canonical_delivery_id,
+                self.evidence_ref_id,
+            )
+        ):
+            raise ValueError("relationship fact identifiers are invalid")
+        if not self.evidence_ref_id.startswith(f"{self.canonical_delivery_id}."):
+            raise ValueError("relationship fact evidence is not bound to delivery")
+        if not isinstance(self.canonical_reply_sha256, str) or not _SHA256_RE.fullmatch(
+            self.canonical_reply_sha256
+        ):
+            raise ValueError("canonical reply digest is invalid")
+        if self.kind not in _RELATIONSHIP_FACT_KINDS:
+            raise ValueError("typed character relationship fact is required")
+        if (
+            self.kind is ReducerEventKind.CHARACTER_AFFECTION_ACKNOWLEDGED
+            and self.acknowledged_affection is not None
+            and self.acknowledged_affection.statement_ref_id != self.evidence_ref_id
+        ):
+            raise ValueError("affection evidence does not match character statement")
+        if (
+            not isinstance(self.occurred_at, datetime)
+            or self.occurred_at.tzinfo is None
+            or self.occurred_at.utcoffset() != timedelta(0)
+        ):
+            raise ValueError("relationship fact time must be UTC")
+        ReducerEvent(
+            kind=self.kind,
+            occurred_at=self.occurred_at,
+            semantic_key=self.semantic_key,
+            last_equivalent_at=self.last_equivalent_at,
+            canonical_reply_id=self.canonical_delivery_id,
+            boundary=self.boundary,
+            boundary_id=self.boundary_id,
+            acknowledged_affection=self.acknowledged_affection,
+            asserted_affection_scope=self.asserted_affection_scope,
+        )
+
+
+class PrivateWorldRelationshipCommitter:
+    def __init__(self, ledger: SQLitePrivateWorldLedger) -> None:
+        self.ledger = ledger
+
+    def commit(self, command: RelationshipFactCommand) -> RelationshipFactStatus:
+        if type(command) is not RelationshipFactCommand:
+            raise TypeError("typed relationship fact command is required")
+        RelationshipFactCommand.__post_init__(command)
+        try:
+            canonical = next(
+                (
+                    item
+                    for item in self.ledger.events()
+                    if item.delivery_id == command.canonical_delivery_id
+                    and item.event_type
+                    == ReducerEventKind.CANONICAL_REPLY_DELIVERED.value
+                ),
+                None,
+            )
+        except (
+            AttributeError,
+            KeyError,
+            LedgerWriteError,
+            OSError,
+            sqlite3.Error,
+            TypeError,
+            ValueError,
+        ):
+            return RelationshipFactStatus.UNAVAILABLE
+        if (
+            canonical is None
+            or canonical.payload.get("canonical_reply_sha256")
+            != command.canonical_reply_sha256
+        ):
+            return RelationshipFactStatus.REJECTED
+        delivered_at = datetime.fromisoformat(
+            canonical.occurred_at.replace("Z", "+00:00")
+        )
+        if command.occurred_at < delivered_at:
+            return RelationshipFactStatus.REJECTED
+        event = ReducerEvent(
+            kind=command.kind,
+            occurred_at=command.occurred_at,
+            semantic_key=command.semantic_key,
+            last_equivalent_at=command.last_equivalent_at,
+            canonical_reply_id=command.canonical_delivery_id,
+            boundary=command.boundary,
+            boundary_id=command.boundary_id,
+            acknowledged_affection=command.acknowledged_affection,
+            asserted_affection_scope=command.asserted_affection_scope,
+        )
+        try:
+            snapshot = self.ledger.snapshot()
+            reduced = reduce_private_world(snapshot, event)
+            digest = hashlib.sha256(command.command_id.encode("utf-8")).hexdigest()
+            applied = self.ledger.apply_once(
+                LedgerEvent(
+                    event_id=f"relationship.{digest}",
+                    delivery_id=command.command_id,
+                    event_type=event.kind.value,
+                    payload={
+                        "applied": reduced.delta.applied,
+                        "reason_code": reduced.delta.reason_code,
+                        "change_fields": [
+                            change.field for change in reduced.delta.changes
+                        ],
+                        "canonical_delivery_id": command.canonical_delivery_id,
+                        "canonical_reply_sha256": command.canonical_reply_sha256,
+                        "evidence_ref_id": command.evidence_ref_id,
+                    },
+                    occurred_at=command.occurred_at.isoformat(),
+                ),
+                reduced.snapshot,
+            )
+        except (
+            AttributeError,
+            KeyError,
+            LedgerWriteError,
+            OSError,
+            sqlite3.Error,
+            TypeError,
+            ValueError,
+        ):
+            return RelationshipFactStatus.UNAVAILABLE
+        return (
+            RelationshipFactStatus.COMMITTED
+            if applied
+            else RelationshipFactStatus.DUPLICATE
+        )
+
+
+__all__ = [
+    "PrivateWorldRelationshipCommitter",
+    "RelationshipFactCommand",
+    "RelationshipFactStatus",
+]

--- a/runtime/memory/private_world_runtime.py
+++ b/runtime/memory/private_world_runtime.py
@@ -14,6 +14,7 @@ from runtime.memory.conversation_memory_identity import (
     normalize_conversation_memory_user_id,
 )
 from runtime.memory.private_world_delivery import PrivateWorldDeliveryCommitter
+from runtime.memory.private_world_relationship import PrivateWorldRelationshipCommitter
 from private_world_ledger import (
     LedgerWriteError,
     SQLitePrivateWorldLedger,
@@ -48,6 +49,7 @@ def _user_database(path: Path, user_id: object) -> Path:
 class PrivateWorldRuntime:
     port: PrivateWorldPort
     committer: PrivateWorldDeliveryCommitter | None
+    relationship_committer: PrivateWorldRelationshipCommitter | None
     status: str
     provider: str
     reason_code: str | None
@@ -159,6 +161,7 @@ def create_private_world_runtime(
         return PrivateWorldRuntime(
             NullPrivateWorldPort(),
             None,
+            None,
             "unavailable",
             "none",
             "PRIVATE_WORLD_STORAGE_UNAVAILABLE",
@@ -168,6 +171,7 @@ def create_private_world_runtime(
         return PrivateWorldRuntime(
             NullPrivateWorldPort(),
             None,
+            None,
             "disabled",
             "none",
             reason,
@@ -176,6 +180,7 @@ def create_private_world_runtime(
     if path is None:
         return PrivateWorldRuntime(
             NullPrivateWorldPort(),
+            None,
             None,
             "unavailable",
             "none",
@@ -189,6 +194,7 @@ def create_private_world_runtime(
         return PrivateWorldRuntime(
             ledger,
             PrivateWorldDeliveryCommitter(ledger),
+            PrivateWorldRelationshipCommitter(ledger),
             "available",
             "sqlite",
             None,
@@ -201,6 +207,7 @@ def create_private_world_runtime(
     except (OSError, ValueError, RuntimeError, sqlite3.Error, LedgerWriteError):
         return PrivateWorldRuntime(
             NullPrivateWorldPort(),
+            None,
             None,
             "unavailable",
             "none",

--- a/runtime/reply/reply_policy.py
+++ b/runtime/reply/reply_policy.py
@@ -195,7 +195,18 @@ def scan_reply(
     for claim in shared_history_claims:
         if not isinstance(claim, SharedHistoryClaim) or claim.end > len(candidate):
             raise ValueError("shared history claim is invalid for candidate")
-        if not claim.authorized:
+        authority_ids = {
+            boundary.boundary_id
+            for boundary in context.private_behavior.active_boundaries
+        }
+        authority_ids.update(
+            fact.fact_id for fact in context.private_behavior.known_continuations
+        )
+        if context.private_behavior.acknowledged_affection is not None:
+            authority_ids.add(
+                context.private_behavior.acknowledged_affection.statement_ref_id
+            )
+        if not claim.authorized or claim.claim_id not in authority_ids:
             violations.append(
                 Violation(
                     ViolationCode.UNAUTHORIZED_SHARED_HISTORY,

--- a/tests/persona/test_persona_v2_release_e2e.py
+++ b/tests/persona/test_persona_v2_release_e2e.py
@@ -115,7 +115,6 @@ def test_chinese_letter_uses_release_persona_then_commits_canonical_once(
     committer = PrivateWorldDeliveryCommitter(ledger)
     delivery = DeliveryEvent(
         delivery_id="synthetic-letter:1",
-        kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
         occurred_at=NOW,
         semantic_key="canonical.synthetic-letter",
     )
@@ -201,7 +200,6 @@ def test_private_world_export_reset_and_delete_are_explicit_and_complete(
     committer.commit(
         DeliveryEvent(
             delivery_id="admin-letter:1",
-            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
             occurred_at=NOW,
             semantic_key="canonical.admin-letter",
         )

--- a/tests/persona/test_reply_policy.py
+++ b/tests/persona/test_reply_policy.py
@@ -5,6 +5,8 @@ import pytest
 from runtime.reply.reply_context import (
     IntimacyRequest,
     IntimacyTier,
+    KnownActiveBoundary,
+    KnownContinuationFact,
     OutputChannel,
     OutputConstraints,
     PrivateBehaviorView,
@@ -136,6 +138,11 @@ def test_shared_history_is_blocked_only_from_explicit_structured_evidence() -> N
     context = ReplyContext.create(
         ReplyMode.TEXT_LETTER,
         trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+        private_behavior=PrivateBehaviorView(
+            active_boundaries=(
+                KnownActiveBoundary("claim.synthetic", "synthetic_scope"),
+            ),
+        ),
     )
     candidate = "还记得我们一起去过海边。"
     unauthorized = SharedHistoryClaim("claim.synthetic", 0, len(candidate), False)
@@ -147,6 +154,37 @@ def test_shared_history_is_blocked_only_from_explicit_structured_evidence() -> N
     assert tuple(violation.code for violation in blocked.violations) == (
         ViolationCode.UNAUTHORIZED_SHARED_HISTORY,
     )
+
+
+def test_existing_known_continuation_remains_shared_history_authority() -> None:
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(datetime(2026, 8, 22, tzinfo=timezone.utc)),
+        private_behavior=PrivateBehaviorView(
+            known_continuations=(
+                KnownContinuationFact(
+                    "continuation.synthetic",
+                    "The character knows this synthetic shared history.",
+                ),
+            ),
+        ),
+    )
+    candidate = "我们上次说到这里。"
+
+    result = scan_reply(
+        candidate,
+        context,
+        shared_history_claims=(
+            SharedHistoryClaim(
+                "continuation.synthetic",
+                0,
+                len(candidate),
+                True,
+            ),
+        ),
+    )
+
+    assert result.passed is True
 
 
 def test_unrequested_intimacy_is_blocked_only_from_structured_evidence() -> None:

--- a/tests/private_world/test_private_world_current_user_reset.py
+++ b/tests/private_world/test_private_world_current_user_reset.py
@@ -11,19 +11,17 @@ from private_world_commands import (
 )
 from private_world_service import PrivateWorldCommandService
 from runtime.memory.private_world_delivery import DeliveryEvent, DeliveryStatus
-from private_world_reducer import ReducerEventKind
 from runtime.memory.private_world_runtime import create_private_world_runtime
 
 
 NOW = datetime(2026, 8, 26, tzinfo=timezone.utc)
 
 
-def _commit(runtime, *, kind: ReducerEventKind) -> None:
+def _commit(runtime) -> None:
     assert runtime.committer is not None
     assert runtime.committer.commit(
         DeliveryEvent(
             delivery_id="same-delivery:1",
-            kind=kind,
             occurred_at=NOW,
             semantic_key="same.semantic:1",
         )
@@ -37,7 +35,7 @@ def test_current_user_reset_is_isolated_idempotent_and_persists(
     user_a = create_private_world_runtime(environment, user_id="User-A")
     user_b = create_private_world_runtime(environment, user_id="user-b")
 
-    _commit(user_a, kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED)
+    _commit(user_a)
     PrivateWorldCommandService(user_b.port).execute(
         RecordBoundaryRespected(
             command_id="command.synthetic-boundary",

--- a/tests/private_world/test_private_world_delivery.py
+++ b/tests/private_world/test_private_world_delivery.py
@@ -35,7 +35,7 @@ NOW = datetime(2026, 8, 22, tzinfo=timezone.utc)
 def test_delivery_rejects_every_noncanonical_mutation_kind(
     kind: ReducerEventKind,
 ) -> None:
-    with pytest.raises(ValueError, match="canonical reply delivery"):
+    with pytest.raises(TypeError, match="kind"):
         DeliveryEvent(
             delivery_id=f"delivery.rejected-{kind.value}",
             kind=kind,
@@ -53,7 +53,6 @@ def test_delivery_event_has_no_mutation_payload_surface() -> None:
     with pytest.raises(TypeError, match="intimacy_grant"):
         DeliveryEvent(
             delivery_id="letter-intimacy:1",
-            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
             occurred_at=NOW,
             semantic_key="canonical.intimacy",
             intimacy_grant=grant,
@@ -61,7 +60,6 @@ def test_delivery_event_has_no_mutation_payload_surface() -> None:
     with pytest.raises(TypeError, match="target_stage"):
         DeliveryEvent(
             delivery_id="letter-stage:1",
-            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
             occurred_at=NOW,
             semantic_key="canonical.stage",
             target_stage="close",
@@ -69,23 +67,20 @@ def test_delivery_event_has_no_mutation_payload_surface() -> None:
         )
 
 
-def test_committer_revalidates_canonical_kind_before_ledger_mutation(
+def test_committer_has_no_relationship_kind_switch(
     tmp_path: Path,
 ) -> None:
     ledger = SQLitePrivateWorldLedger(tmp_path / "private.sqlite3")
     committer = PrivateWorldDeliveryCommitter(ledger)
     delivery = DeliveryEvent(
         delivery_id="letter-forged:1",
-        kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
         occurred_at=NOW,
         semantic_key="canonical.forged",
     )
     object.__setattr__(delivery, "kind", ReducerEventKind.BOUNDARY_RESPECTED)
-    object.__setattr__(delivery, "__post_init__", lambda: None)
 
-    with pytest.raises(ValueError, match="canonical reply delivery"):
-        committer.commit(delivery)
-    assert ledger.events() == ()
+    assert committer.commit(delivery) is DeliveryStatus.COMMITTED
+    assert ledger.events()[0].event_type == "canonical_reply_delivered"
     assert ledger.snapshot() == PrivateWorldSnapshot()
 
 
@@ -94,7 +89,6 @@ def test_delivery_commits_once_with_stable_delivery_id(tmp_path: Path) -> None:
     committer = PrivateWorldDeliveryCommitter(ledger)
     delivery = DeliveryEvent(
         delivery_id="letter-1:1",
-        kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
         occurred_at=NOW,
         semantic_key="canonical.letter-1",
     )
@@ -117,7 +111,6 @@ def test_canonical_delivery_persists_without_relationship_mutation(
     status = committer.commit(
         DeliveryEvent(
             delivery_id="letter-2:1",
-            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
             occurred_at=NOW,
             semantic_key="canonical.synthetic",
         )
@@ -135,7 +128,6 @@ def test_delivery_degrades_when_sqlite_snapshot_fails(
     committer = PrivateWorldDeliveryCommitter(ledger)
     delivery = DeliveryEvent(
         delivery_id="letter-sqlite-failure:1",
-        kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
         occurred_at=NOW,
         semantic_key="canonical.sqlite-failure",
     )
@@ -156,7 +148,6 @@ def test_delivery_degrades_when_snapshot_json_is_semantically_corrupt(
     committer = PrivateWorldDeliveryCommitter(ledger)
     delivery = DeliveryEvent(
         delivery_id="letter-corrupt-snapshot:1",
-        kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
         occurred_at=NOW,
         semantic_key="canonical.corrupt-snapshot",
     )
@@ -194,7 +185,6 @@ def test_delivery_degrades_when_snapshot_json_has_the_wrong_shape(
     assert committer.commit(
         DeliveryEvent(
             delivery_id="wrong-shape-delivery:1",
-            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
             occurred_at=NOW,
             semantic_key="canonical.wrong-shape",
         )

--- a/tests/private_world/test_private_world_relationship_facts.py
+++ b/tests/private_world/test_private_world_relationship_facts.py
@@ -1,0 +1,214 @@
+from datetime import datetime, timedelta, timezone
+import hashlib
+
+import pytest
+
+from private_world_port import (
+    AcknowledgedAffection,
+    ActiveBoundary,
+    AffectionIntensity,
+    AffectionScope,
+    PrivateWorldSnapshot,
+)
+from private_world_reducer import (
+    ReducerEventKind,
+)
+from private_world_ledger import SQLitePrivateWorldLedger
+from runtime.memory.private_world_delivery import (
+    DeliveryEvent,
+    DeliveryStatus,
+    PrivateWorldDeliveryCommitter,
+)
+from runtime.memory.private_world_relationship import (
+    PrivateWorldRelationshipCommitter,
+    RelationshipFactCommand,
+    RelationshipFactStatus,
+)
+from runtime.memory.private_world_projection import project_private_world
+from runtime.reply.reply_context import ReplyContext, ReplyMode, TrustedTime
+from runtime.reply.reply_policy import SharedHistoryClaim, ViolationCode, scan_reply
+
+
+NOW = datetime(2026, 9, 3, tzinfo=timezone.utc)
+REPLY_SHA256 = hashlib.sha256(b"synthetic canonical reply").hexdigest()
+
+
+def test_projection_authorizes_only_ledger_backed_character_statements() -> None:
+    affection = AcknowledgedAffection(
+        intensity=AffectionIntensity.CARE,
+        statement_ref_id="reply.canonical.1.line.3",
+        scope=AffectionScope.ONGOING_CORRESPONDENCE,
+    )
+    projected = project_private_world(
+        PrivateWorldSnapshot(acknowledged_affection=affection)
+    )
+    context = ReplyContext.create(
+        ReplyMode.TEXT_LETTER,
+        trusted_time=TrustedTime(NOW),
+        private_behavior=projected.behavior,
+    )
+    candidate = "我已经说过，我很在意这些来信。"
+    backed = SharedHistoryClaim(
+        affection.statement_ref_id,
+        0,
+        len(candidate),
+        True,
+    )
+    user_only = SharedHistoryClaim(
+        "user.claimed.affection",
+        0,
+        len(candidate),
+        True,
+    )
+
+    assert scan_reply(
+        candidate,
+        context,
+        shared_history_claims=(backed,),
+    ).passed
+    blocked = scan_reply(
+        candidate,
+        context,
+        shared_history_claims=(user_only,),
+    )
+    assert tuple(item.code for item in blocked.violations) == (
+        ViolationCode.UNAUTHORIZED_SHARED_HISTORY,
+    )
+
+
+def test_relationship_fact_commit_requires_an_already_committed_canonical_reply(
+    tmp_path,
+) -> None:
+    ledger = SQLitePrivateWorldLedger(tmp_path / "private-world.sqlite3")
+    delivery_committer = PrivateWorldDeliveryCommitter(ledger)
+    relationship_committer = PrivateWorldRelationshipCommitter(ledger)
+    boundary = ActiveBoundary(
+        "boundary.synthetic",
+        NOW.isoformat(),
+        "offline_meeting",
+    )
+    effect = RelationshipFactCommand(
+        command_id="effect.boundary.1",
+        kind=ReducerEventKind.CHARACTER_BOUNDARY_SET,
+        occurred_at=NOW,
+        semantic_key="effect.boundary.1",
+        canonical_delivery_id="canonical.delivery.1",
+        canonical_reply_sha256=REPLY_SHA256,
+        evidence_ref_id="canonical.delivery.1.boundary.1",
+        boundary=boundary,
+    )
+
+    assert relationship_committer.commit(effect) is RelationshipFactStatus.REJECTED
+    assert ledger.snapshot().active_boundaries == ()
+
+    assert delivery_committer.commit(
+        DeliveryEvent(
+            delivery_id="canonical.delivery.1",
+            occurred_at=NOW,
+            semantic_key="canonical.delivery.1",
+            canonical_reply_sha256=REPLY_SHA256,
+        )
+    ) is DeliveryStatus.COMMITTED
+    assert relationship_committer.commit(effect) is RelationshipFactStatus.COMMITTED
+    assert ledger.snapshot().active_boundaries == (boundary,)
+    committed = ledger.events()[-1]
+    assert committed.payload["canonical_delivery_id"] == "canonical.delivery.1"
+    assert committed.payload["canonical_reply_sha256"] == REPLY_SHA256
+    assert committed.payload["evidence_ref_id"] == "canonical.delivery.1.boundary.1"
+
+
+def test_relationship_fact_cannot_precede_its_canonical_delivery(tmp_path) -> None:
+    ledger = SQLitePrivateWorldLedger(tmp_path / "private-world.sqlite3")
+    delivery_committer = PrivateWorldDeliveryCommitter(ledger)
+    relationship_committer = PrivateWorldRelationshipCommitter(ledger)
+    delivered_at = NOW + timedelta(minutes=1)
+    assert delivery_committer.commit(
+        DeliveryEvent(
+            delivery_id="canonical.delivery.late",
+            occurred_at=delivered_at,
+            semantic_key="canonical.delivery.late",
+            canonical_reply_sha256=REPLY_SHA256,
+        )
+    ) is DeliveryStatus.COMMITTED
+
+    status = relationship_committer.commit(
+        RelationshipFactCommand(
+            command_id="effect.boundary.early",
+            kind=ReducerEventKind.CHARACTER_BOUNDARY_SET,
+            occurred_at=NOW,
+            semantic_key="effect.boundary.early",
+            canonical_delivery_id="canonical.delivery.late",
+            canonical_reply_sha256=REPLY_SHA256,
+            evidence_ref_id="canonical.delivery.late.boundary.1",
+            boundary=ActiveBoundary(
+                "boundary.early",
+                NOW.isoformat(),
+                "offline_meeting",
+            ),
+        )
+    )
+
+    assert status is RelationshipFactStatus.REJECTED
+    assert ledger.snapshot().active_boundaries == ()
+
+
+def test_affection_command_requires_the_exact_character_statement_evidence() -> None:
+    with pytest.raises(ValueError, match="affection evidence"):
+        RelationshipFactCommand(
+            command_id="effect.affection.mismatch",
+            kind=ReducerEventKind.CHARACTER_AFFECTION_ACKNOWLEDGED,
+            occurred_at=NOW,
+            semantic_key="effect.affection.mismatch",
+            canonical_delivery_id="canonical.delivery.affection",
+            canonical_reply_sha256=REPLY_SHA256,
+            evidence_ref_id="canonical.delivery.affection.line.2",
+            acknowledged_affection=AcknowledgedAffection(
+                intensity=AffectionIntensity.CARE,
+                statement_ref_id="canonical.delivery.affection.line.3",
+                scope=AffectionScope.THIS_REPLY,
+            ),
+            asserted_affection_scope=AffectionScope.THIS_REPLY,
+        )
+
+
+def test_local_server_uses_the_dedicated_relationship_command_path(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import local_server
+
+    ledger = SQLitePrivateWorldLedger(tmp_path / "private-world.sqlite3")
+    assert PrivateWorldDeliveryCommitter(ledger).commit(
+        DeliveryEvent(
+            delivery_id="canonical.delivery.production",
+            occurred_at=NOW,
+            semantic_key="canonical.delivery.production",
+            canonical_reply_sha256=REPLY_SHA256,
+        )
+    ) is DeliveryStatus.COMMITTED
+    monkeypatch.setattr(
+        local_server,
+        "private_world_relationship_committer",
+        PrivateWorldRelationshipCommitter(ledger),
+    )
+    boundary = ActiveBoundary(
+        "boundary.production",
+        NOW.isoformat(),
+        "offline_meeting",
+    )
+
+    status = local_server.commit_private_world_relationship_fact(
+        RelationshipFactCommand(
+            command_id="effect.boundary.production",
+            kind=ReducerEventKind.CHARACTER_BOUNDARY_SET,
+            occurred_at=NOW,
+            semantic_key="effect.boundary.production",
+            canonical_delivery_id="canonical.delivery.production",
+            canonical_reply_sha256=REPLY_SHA256,
+            evidence_ref_id="canonical.delivery.production.boundary.1",
+            boundary=boundary,
+        )
+    )
+
+    assert status is RelationshipFactStatus.COMMITTED
+    assert ledger.snapshot().active_boundaries == (boundary,)

--- a/tests/private_world/test_private_world_runtime.py
+++ b/tests/private_world/test_private_world_runtime.py
@@ -36,6 +36,7 @@ from runtime.memory.private_world_runtime import (
     create_private_world_runtime,
     resolve_private_world_database,
 )
+from runtime.memory.private_world_relationship import PrivateWorldRelationshipCommitter
 from private_world_reducer import ReducerEventKind
 from runtime.reply.reply_context import IntimacyTier
 
@@ -241,6 +242,18 @@ def test_new_ledger_records_v4_metadata_without_backup(tmp_path: Path) -> None:
         assert connection.execute(
             "SELECT value FROM private_world_metadata WHERE key = 'schema_version'"
         ).fetchone() == ("4",)
+def test_available_runtime_wires_a_dedicated_relationship_committer(
+    tmp_path: Path,
+) -> None:
+    runtime = create_private_world_runtime(
+        {"OLIVIA_LOCAL_DATA_ROOT": str(tmp_path / "state")}
+    )
+
+    assert isinstance(
+        runtime.relationship_committer,
+        PrivateWorldRelationshipCommitter,
+    )
+    assert runtime.relationship_committer.ledger is runtime.port
 
 
 def test_newer_schema_is_rejected_without_modification(tmp_path: Path) -> None:
@@ -541,7 +554,6 @@ def test_unknown_stored_snapshot_field_degrades_health_and_canonical_commit(
     assert runtime.committer.commit(
         DeliveryEvent(
             delivery_id="unknown-field-commit:1",
-            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
             occurred_at=datetime(2026, 8, 25, tzinfo=timezone.utc),
             semantic_key="canonical.unknown-field",
         )
@@ -607,7 +619,6 @@ def test_strict_stored_snapshot_validation_rejects_every_noncanonical_row(
     assert runtime.committer.commit(
         DeliveryEvent(
             delivery_id=f"{corruption}-commit:1",
-            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
             occurred_at=datetime(2026, 8, 25, tzinfo=timezone.utc),
             semantic_key=f"canonical.{corruption}",
         )

--- a/tests/private_world/test_private_world_runtime_wiring.py
+++ b/tests/private_world/test_private_world_runtime_wiring.py
@@ -324,7 +324,6 @@ def test_invalid_configured_current_user_never_opens_legacy_private_world(
     assert legacy.committer.commit(
         DeliveryEvent(
             delivery_id="legacy-local-user:1",
-            kind=ReducerEventKind.CANONICAL_REPLY_DELIVERED,
             occurred_at=datetime(2026, 8, 26, tzinfo=timezone.utc),
             semantic_key="legacy.local-user:1",
         )


### PR DESCRIPTION
## Scope
- keep DeliveryEvent canonical-reply-only and persist the canonical reply SHA-256
- add a typed RelationshipFactCommand and dedicated committer bound to an existing canonical delivery, exact digest, evidence reference, and UTC time
- wire the committer into the available PrivateWorld runtime and expose a trusted internal facade
- authorize reply-policy history claims only when their IDs are present in projected boundaries, continuations, or acknowledged affection
- document the current boundary: typed contract plus trusted internal entry ready; automatic reply integration is not enabled

LLM candidate analysis and ordinary reply generation do not write relationship facts in this PR.

## Validation
- 278 passed: tests/private_world plus reply-policy and Persona v2 release E2E
- compileall passed
- baseline hardening mode all passed with zero findings
- staged diff check passed