### PR TITLE
fix(persona): make progressive anchor disclosure actually fire

### DIFF
--- a/runtime/persona/persona_assembly.py
+++ b/runtime/persona/persona_assembly.py
@@ -50,6 +50,11 @@ _PERSONA_SUBJECTS = {"奥利维亚", "olivia", "林离", "你"}
 _CLAUSE_BOUNDARY_RE = re.compile(r"[，,。；;！？?!\n]")
 _DIRECT_QUERY_GAP_TOKENS = (
     "小时候",
+    "养过",
+    "曾经",
+    "知道",
+    "觉得",
+    "发现",
     "是不是",
     "喜欢不喜欢",
     "为什么",
@@ -112,6 +117,18 @@ _DIRECT_QUERY_GAP_TOKENS = (
     "在",
     "去",
     "有",
+    "养",
+)
+_DIRECT_QUERY_GAP_MAX_CHARS = 6
+_DIRECT_QUERY_TEMPORAL_REMAINDER_RE = re.compile(
+    r"(?:"
+    r"(?:今|昨|前|明|后)(?:天|日|晚|夜|早|晨|年|月)?|"
+    r"这(?:几)?(?:天|日|周|星期|月|年|早|晚)|"
+    r"(?:上|下|本|每)(?:周|星期|礼拜|月|年)|"
+    r"周末|星期末|礼拜末|早上|上午|中午|下午|晚上|今晚|今早|今晨|夜里|"
+    r"(?:春|夏|秋|冬)(?:天|季)?|放假|假期|期末|月初|月中|月底|年初|年中|年底|"
+    r"[0-9零〇一二两三四五六七八九十百]+(?:天|日|号|周|星期|月|年|点|时|分)"
+    r")+"
 )
 _DIRECT_QUERY_GAP_FILLER_RE = re.compile(r"[\s的地得呀啦嘛呢吧啊哦哈]")
 _RECIPROCAL_CUE_RE = re.compile(
@@ -464,9 +481,11 @@ def _select_soft_canon(
     recent_context = (*history[-2:], *evidence_summaries[-2:])
     context_query = "\n".join(item.text for item in recent_context)
     current_ranked = _rank_soft_anchors(anchors, user_input)
+    selection_query = user_input
     if current_ranked:
         ranked = current_ranked
     elif _CONTEXT_FOLLOW_UP_RE.fullmatch(user_input) is not None:
+        selection_query = context_query
         ranked = _rank_soft_anchors(anchors, context_query)
     else:
         ranked = []
@@ -477,6 +496,20 @@ def _select_soft_canon(
             ranked, key=lambda item: (-item[0], item[1])
         )[:_SOFT_ANCHOR_LIMIT]
     }
+    if not selected_ids:
+        rejected_ids = _lexically_matching_anchor_ids(anchors, selection_query)
+        ordered = tuple(
+            sorted(
+                item.declaration_id
+                for item in anchors
+                if item.declaration_id not in rejected_ids
+            )
+        )
+        if ordered:
+            digest = hashlib.sha256(user_input.encode("utf-8")).digest()
+            selected_ids = {
+                ordered[int.from_bytes(digest[:4], "big") % len(ordered)]
+            }
     return tuple(
         item
         for item in soft_canon
@@ -504,13 +537,40 @@ def _rank_soft_anchors(
     return ranked
 
 
+def _lexically_matching_anchor_ids(
+    anchors: tuple[PersonaDeclaration, ...],
+    query: str,
+) -> frozenset[str]:
+    return frozenset(
+        declaration.declaration_id
+        for declaration in anchors
+        if (
+            pattern := _ANCHOR_DISCLOSURE_PATTERNS.get(declaration.declaration_id)
+        )
+        is not None
+        and pattern.search(query) is not None
+    )
+
+
 def _anchor_match_is_persona_directed(query: str, start: int, end: int) -> bool:
-    preceding_boundaries = tuple(_CLAUSE_BOUNDARY_RE.finditer(query, 0, start))
+    direction_start = start
+    if query.startswith("最近", start):
+        action_starts = tuple(
+            position
+            for token in ("练", "弹")
+            if (position := query.find(token, start, end)) >= 0
+        )
+        if action_starts:
+            direction_start = min(action_starts)
+
+    preceding_boundaries = tuple(
+        _CLAUSE_BOUNDARY_RE.finditer(query, 0, direction_start)
+    )
     clause_start = preceding_boundaries[-1].end() if preceding_boundaries else 0
     following_boundary = _CLAUSE_BOUNDARY_RE.search(query, end)
     clause_end = following_boundary.start() if following_boundary else len(query)
     clause = query[clause_start:clause_end]
-    local_start = start - clause_start
+    local_start = direction_start - clause_start
 
     if _PERSONA_DISCLOSURE_CUE_RE.search(clause) is None:
         return _RECIPROCAL_CUE_RE.search(query, end) is not None
@@ -530,7 +590,10 @@ def _is_direct_query_gap(value: str) -> bool:
     remainder = _DIRECT_QUERY_GAP_FILLER_RE.sub("", value)
     for token in _DIRECT_QUERY_GAP_TOKENS:
         remainder = remainder.replace(token, "")
-    return remainder == ""
+    return not remainder or (
+        len(remainder) <= _DIRECT_QUERY_GAP_MAX_CHARS
+        and _DIRECT_QUERY_TEMPORAL_REMAINDER_RE.fullmatch(remainder) is not None
+    )
 
 
 def _select_style_exemplars(

--- a/tests/persona/test_persona_anchor_disclosure.py
+++ b/tests/persona/test_persona_anchor_disclosure.py
@@ -1,0 +1,158 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from llm_gateway import GatewayConfig
+from runtime.persona.persona_assembly import UntrustedFragment, assemble_persona
+from runtime.persona.persona_loader import load_persona
+from runtime.reply.reply_context import ReplyContext, ReplyMode, TrustedTime
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_PERSONA = ROOT / "linli_character" / "persona_release_v2.json"
+NOW = TrustedTime(datetime(2026, 9, 4, tzinfo=timezone.utc))
+
+
+def _assemble(user_input: str):
+    loaded = load_persona(RELEASE_PERSONA)
+    context = ReplyContext.create(ReplyMode.TEXT_LETTER, trusted_time=NOW)
+    return assemble_persona(
+        loaded.snapshot,
+        context,
+        user_input=user_input,
+        max_units=GatewayConfig().max_input_chars,
+    )
+
+
+def _anchor_ids(user_input: str) -> tuple[str, ...]:
+    return tuple(
+        item_id.removeprefix("declaration.")
+        for item_id in _assemble(user_input).budget_report.included_ids
+        if item_id.startswith("declaration.anchor.")
+    )
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    (
+        "你今天练琴了吗？",
+        "你昨天练琴了吗？",
+        "你这几天练琴了吗？",
+        "你周末练琴了吗？",
+        "你早上练琴了吗？",
+        "你今晚还练琴吗？",
+        "你练琴了吗？",
+        "你最近练琴了吗？",
+        "你现在练琴了吗？",
+        "你练琴练到几点？",
+        "你知道自己最近在练琴吗？",
+    ),
+)
+def test_current_piece_anchor_accepts_direct_questions(user_input: str) -> None:
+    assembled = _assemble(user_input)
+
+    assert '"declaration_id":"anchor.current_piece"' in assembled.system_content
+
+
+def test_cat_anchor_accepts_a_natural_direct_question() -> None:
+    assembled = _assemble("你养猫吗？")
+
+    assert '"declaration_id":"anchor.cat"' in assembled.system_content
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    ("今天下雨了。", "今天买的面包有点难吃。", "在吗？"),
+)
+def test_ordinary_letters_receive_exactly_one_anchor(user_input: str) -> None:
+    assembled = _assemble(user_input)
+
+    assert assembled.system_content.count('"declaration_id":"anchor.') == 1
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    (
+        "今天下雨了。",
+        "你今天练琴了吗？",
+        "你喜欢猫、甜食、黑胶和读书吗？你住在哪里，平时穿什么？",
+    ),
+)
+def test_anchor_disclosure_never_exceeds_the_limit(user_input: str) -> None:
+    assert len(_anchor_ids(user_input)) <= 4
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    (
+        "你有没有发现老师最近在练琴？",
+        "你有没有发现爸爸最近在练琴？",
+        "你有没有发现小王最近在练琴？",
+        "你叫小王最近练琴吗？",
+        "你爸爸最近练琴吗？",
+        "你老师最近练琴吗？",
+        "你妈妈最近练琴吗？",
+        "你有没有发现小王9最近在练琴？",
+        "你孩子最近练琴吗？",
+        "你丈夫最近练琴吗？",
+        "你邻居最近练琴吗？",
+        "你室友最近练琴吗？",
+        "你老板最近练琴吗？",
+        "你最近听室友练琴吗？",
+    ),
+)
+def test_short_gap_does_not_reassign_other_people_to_persona(user_input: str) -> None:
+    anchor_ids = _anchor_ids(user_input)
+
+    assert len(anchor_ids) == 1
+    assert "anchor.current_piece" not in anchor_ids
+
+
+def test_follow_up_fallback_does_not_restore_rejected_history_anchor() -> None:
+    loaded = load_persona(RELEASE_PERSONA)
+    context = ReplyContext.create(ReplyMode.TEXT_LETTER, trusted_time=NOW)
+
+    assembled = assemble_persona(
+        loaded.snapshot,
+        context,
+        user_input="怎么回事？",
+        history=(UntrustedFragment("history.friend", "你朋友养猫吗？"),),
+        max_units=GatewayConfig().max_input_chars,
+    )
+    anchor_ids = tuple(
+        item_id.removeprefix("declaration.")
+        for item_id in assembled.budget_report.included_ids
+        if item_id.startswith("declaration.anchor.")
+    )
+
+    assert len(anchor_ids) == 1
+    assert "anchor.cat" not in anchor_ids
+
+
+def test_baseline_anchor_is_deterministic_for_the_same_letter() -> None:
+    assert _anchor_ids("今天下雨了。") == ("anchor.everyday_taste",)
+
+
+def test_baseline_anchor_rotates_across_different_letters() -> None:
+    inputs = tuple(f"普通日常来信第{index}封。" for index in range(8))
+
+    selected = {_anchor_ids(user_input)[0] for user_input in inputs}
+
+    assert len(selected) > 1
+
+
+def test_anchor_disclosure_fits_default_budget_with_full_history() -> None:
+    loaded = load_persona(RELEASE_PERSONA)
+    context = ReplyContext.create(ReplyMode.TEXT_LETTER, trusted_time=NOW)
+
+    assembled = assemble_persona(
+        loaded.snapshot,
+        context,
+        user_input="来" * 2_000,
+        history=(UntrustedFragment("history.full", "历" * 3_600),),
+        max_units=GatewayConfig().max_input_chars,
+    )
+
+    assert assembled.system_content.count('"declaration_id":"anchor.') == 1
+    assert assembled.budget_report.dropped_ids == ()

--- a/tests/persona/test_persona_budget_fit.py
+++ b/tests/persona/test_persona_budget_fit.py
@@ -116,7 +116,7 @@ def test_release_persona_progressively_discloses_relevant_soft_anchors() -> None
     ).system_content
 
     assert '"declaration_id":"style.care_quota"' in ordinary
-    assert '"declaration_id":"anchor.' not in ordinary
+    assert ordinary.count('"declaration_id":"anchor.') == 1
     assert '"declaration_id":"anchor.everyday_taste"' in food
     assert '"declaration_id":"anchor.cat"' not in food
     assert '"declaration_id":"anchor.residence"' in residence
@@ -184,8 +184,8 @@ def test_progressive_disclosure_rejects_idioms_and_prioritizes_current_letter() 
         max_units=GatewayConfig().max_input_chars,
     ).system_content
 
-    assert '"declaration_id":"anchor.' not in idioms
-    assert '"declaration_id":"anchor.' not in own_topics
+    assert idioms.count('"declaration_id":"anchor.') == 1
+    assert own_topics.count('"declaration_id":"anchor.') == 1
     assert '"declaration_id":"anchor.cat"' in current_topic
     assert '"declaration_id":"anchor.everyday_taste"' not in current_topic
     assert '"declaration_id":"anchor.residence"' not in current_topic
@@ -250,7 +250,7 @@ def test_progressive_disclosure_does_not_treat_user_details_as_persona_details()
         for item in named_others
     )
     assert '"declaration_id":"anchor.current_piece"' not in cross_sentence
-    assert '"declaration_id":"anchor.' not in bare_name
+    assert bare_name.count('"declaration_id":"anchor.') == 1
 
 
 def test_current_persona_question_without_known_anchor_does_not_fall_back_to_history() -> None:


### PR DESCRIPTION
## Summary

- retain the six-character direct-query cap but fail closed: after the existing modifier stripping, only an empty gap or a short structured time expression is accepted
- validate direction from the core `练` / `弹` action when the existing `最近.{0,6}` match contains leading context, so an internal subject such as `听室友` cannot be hidden inside the regex match
- preserve natural direct forms such as `你养猫吗？` through the existing gap-token mechanism
- select exactly one deterministic anchor from the real release asset when no anchor matches
- exclude lexically matched but persona-rejected anchors from the active current/history query fallback pool so fallback cannot reintroduce another person's fact
- add public-interface coverage for direct questions, deterministic SHA-256 fallback, rotation, the four-anchor cap, arbitrary short possessive subjects, follow-up history isolation, and the full-history budget

## Before / after anchor counts

| Input | Before | After |
| --- | ---: | ---: |
| `今天下雨了。` | 0 | 1 |
| `你今天练琴了吗？` | 0 | 1 |
| `你养猫吗？` | 0 | 1 |
| `最近在练什么曲子？` | 0 | 1 |
| `在吗？` | 0 | 1 |
| `我先去忙了，晚点说。` | 0 | 1 |

The work order says nine inputs in prose, but section 0 contains six concrete inputs; all six are reported above. The direct-question regression table additionally covers eleven current-piece forms.

## Non-goals self-check

- [x] Kept `_select_soft_canon` and `_SOFT_ANCHOR_LIMIT = 4`
- [x] Did not change declaration statements, tiers, facets, or sources
- [x] Did not change any existing `_ANCHOR_DISCLOSURE_PATTERNS` regex
- [x] Did not change `max_input_chars`, `_DROP_ORDER`, or provenance
- [x] Did not touch reviewer, quality gate, intimacy, media, or installer code

## Local verification

- `python -m pytest -q` — `2274 passed, 5 skipped, 1 deselected`
- `python baseline_hardening_scan.py --mode all` — PASS
- `git diff --check --exit-code` — PASS
- `python -m pytest -q tests/persona` — `430 passed`
- focused anchor/budget regression — `48 passed`
