### PR TITLE
fix(persona): route common action phrasing to anchors

### DIFF
--- a/runtime/persona/persona_assembly.py
+++ b/runtime/persona/persona_assembly.py
@@ -120,14 +120,15 @@ _DIRECT_QUERY_GAP_TOKENS = (
     "养",
 )
 _DIRECT_QUERY_GAP_MAX_CHARS = 6
-_DIRECT_QUERY_TEMPORAL_REMAINDER_RE = re.compile(
+_DIRECT_QUERY_ALLOWED_REMAINDER_RE = re.compile(
     r"(?:"
     r"(?:今|昨|前|明|后)(?:天|日|晚|夜|早|晨|年|月)?|"
     r"这(?:几)?(?:天|日|周|星期|月|年|早|晚)|"
     r"(?:上|下|本|每)(?:周|星期|礼拜|月|年)|"
     r"周末|星期末|礼拜末|早上|上午|中午|下午|晚上|今晚|今早|今晨|夜里|"
     r"(?:春|夏|秋|冬)(?:天|季)?|放假|假期|期末|月初|月中|月底|年初|年中|年底|"
-    r"[0-9零〇一二两三四五六七八九十百]+(?:天|日|号|周|星期|月|年|点|时|分)"
+    r"[0-9零〇一二两三四五六七八九十百]+(?:天|日|号|周|星期|月|年|点|时|分)|"
+    r"听|弹"
     r")+"
 )
 _DIRECT_QUERY_GAP_FILLER_RE = re.compile(r"[\s的地得呀啦嘛呢吧啊哦哈]")
@@ -145,7 +146,7 @@ _ANCHOR_DISCLOSURE_PATTERNS = {
     "anchor.listening_shelf": re.compile(r"黑胶|王菲|Bill Evans|爵士|暗涌|听什么|歌单", re.I),
     "anchor.grandmother_traces": re.compile(r"外婆|小铃铛|合影|手抄.{0,4}(?:谱|乐谱)"),
     "anchor.desk_objects": re.compile(r"桌|窗台|行星|水星|火星|节拍器|眼镜|香薰"),
-    "anchor.stopping_ritual": re.compile(r"绿茶|茶叶|安静|放松|练琴前"),
+    "anchor.stopping_ritual": re.compile(r"绿茶|茶叶|喝.{0,2}茶|安静|放松|练琴前"),
     "anchor.everyday_taste": re.compile(r"喜欢吃|想吃|吃什么|好吃|口味|食物|菜|甜|辣|馄饨|葱油|糖醋|糯米藕"),
     "anchor.blue_butterflies": re.compile(r"蓝色?.{0,2}蝴蝶|工业区|凌晨四点"),
     "anchor.name_origin": re.compile(r"名字|姓名|为什么叫|离卦|名字.{0,4}离"),
@@ -155,7 +156,7 @@ _ANCHOR_DISCLOSURE_PATTERNS = {
     "anchor.singing": re.compile(r"唱歌|会唱|唱得|歌声"),
     "anchor.afraid_of_bugs": re.compile(r"虫|蜘蛛|云南|害怕什么"),
     "anchor.usual_outfit": re.compile(r"穿|衣服|毛衣|短裤|项链|打扮"),
-    "anchor.reading": re.compile(r"读书|看书|文学|书单|阅读|喜欢.{0,4}书"),
+    "anchor.reading": re.compile(r"读书|读.{0,4}书|看书|文学|书单|阅读|喜欢.{0,4}书"),
     "anchor.bilibili": re.compile(r"B站|bilibili|发过.{0,6}(?:视频|曲)|原神.{0,4}音乐", re.I),
     "anchor.father": re.compile(r"父亲|爸爸|父母|家人|英国|寄.{0,4}录音"),
     "anchor.hua": re.compile(r"《花》|写.{0,4}曲|作曲|磁带|谱子"),
@@ -592,7 +593,7 @@ def _is_direct_query_gap(value: str) -> bool:
         remainder = remainder.replace(token, "")
     return not remainder or (
         len(remainder) <= _DIRECT_QUERY_GAP_MAX_CHARS
-        and _DIRECT_QUERY_TEMPORAL_REMAINDER_RE.fullmatch(remainder) is not None
+        and _DIRECT_QUERY_ALLOWED_REMAINDER_RE.fullmatch(remainder) is not None
     )
 
 

--- a/tests/persona/test_persona_anchor_disclosure.py
+++ b/tests/persona/test_persona_anchor_disclosure.py
@@ -62,6 +62,20 @@ def test_cat_anchor_accepts_a_natural_direct_question() -> None:
 
 
 @pytest.mark.parametrize(
+    ("user_input", "expected_anchor"),
+    (
+        ("你听黑胶吗？", "anchor.listening_shelf"),
+        ("你读什么书？", "anchor.reading"),
+        ("你喝茶吗？", "anchor.stopping_ritual"),
+    ),
+)
+def test_action_phrasing_selects_the_relevant_anchor(
+    user_input: str, expected_anchor: str
+) -> None:
+    assert expected_anchor in _anchor_ids(user_input)
+
+
+@pytest.mark.parametrize(
     "user_input",
     ("今天下雨了。", "今天买的面包有点难吃。", "在吗？"),
 )
@@ -100,6 +114,7 @@ def test_anchor_disclosure_never_exceeds_the_limit(user_input: str) -> None:
         "你室友最近练琴吗？",
         "你老板最近练琴吗？",
         "你最近听室友练琴吗？",
+        "你听室友弹夜曲吗？",
     ),
 )
 def test_short_gap_does_not_reassign_other_people_to_persona(user_input: str) -> None:


### PR DESCRIPTION
## Summary

- allow the bounded direct-query gap to contain the exact action connectors `听` and `弹`
- match `你读什么书？` and `你喝茶吗？` to their relevant reading and stopping-ritual anchors
- keep mixed third-party gaps such as `听室友弹` fail-closed

## Verification

- `python -m pytest -q tests/persona` — `434 passed`
- `python baseline_hardening_scan.py --mode all` — PASS
- `git diff --check --exit-code` — PASS

This is a narrow follow-up to #371; no declaration content, budget, reviewer, media, installer, or relationship logic changed.
