### PR TITLE
fix: restore mailbox navigation after initial setup

### DIFF
--- a/installer/patch_native_user_settings.py
+++ b/installer/patch_native_user_settings.py
@@ -12,7 +12,10 @@ from pathlib import Path
 
 
 FALSE_WIDGET_PAIR = b"\x0amailWidget\x06\x05false\x0bmusicWidget\x06\x05false"
-TRUE_WIDGET_PAIR = b"\x0amailWidget\x06\x04true\x0bmusicWidget\x06\x04true"
+TRUE_WIDGET_PAIR = b"\x0amailWidget\x05\x04true\x0bmusicWidget\x05\x04true"
+# Earlier releases shortened the string but left the enclosing value length at 6.
+# Recognize only that exact malformed pair so an upgrade can repair it in place.
+_LEGACY_TRUE_WIDGET_PAIR = b"\x0amailWidget\x06\x04true\x0bmusicWidget\x06\x04true"
 _BACKUP_SUFFIX = ".native-nav.orig"
 _REPARSE_POINT = 0x00000400
 
@@ -176,9 +179,9 @@ def _logical_bytes(original: bytes) -> tuple[int, bytes]:
     return payload_size, original[:logical_end]
 
 
-def _patched_payload(original: bytes, payload_size: int, logical: bytes) -> bytes:
-    replaced = logical.replace(FALSE_WIDGET_PAIR, TRUE_WIDGET_PAIR, 1)
-    patched_size = payload_size - (len(FALSE_WIDGET_PAIR) - len(TRUE_WIDGET_PAIR))
+def _patched_payload(original: bytes, payload_size: int, logical: bytes, source: bytes) -> bytes:
+    replaced = logical.replace(source, TRUE_WIDGET_PAIR, 1)
+    patched_size = payload_size - (len(source) - len(TRUE_WIDGET_PAIR))
     patched_logical = struct.pack("<I", patched_size) + replaced[4:]
     return patched_logical + (b"\x00" * (len(original) - len(patched_logical)))
 
@@ -192,8 +195,9 @@ def _patch(settings_path: Path) -> NativeUserSettingsPatchResult:
     payload_size, logical = _logical_bytes(original)
     false_count = logical.count(FALSE_WIDGET_PAIR)
     true_count = logical.count(TRUE_WIDGET_PAIR)
+    legacy_count = logical.count(_LEGACY_TRUE_WIDGET_PAIR)
     original_sha256 = target_snapshot.sha256
-    if false_count + true_count > 1:
+    if false_count + true_count + legacy_count > 1:
         raise NativeUserSettingsPatchError("USER_SETTINGS_WIDGET_PAIR_AMBIGUOUS")
     if false_count == 0 and true_count == 1:
         return NativeUserSettingsPatchResult(
@@ -201,10 +205,11 @@ def _patch(settings_path: Path) -> NativeUserSettingsPatchResult:
             original_sha256=original_sha256,
             patched_sha256=original_sha256,
         )
-    if false_count != 1 or true_count != 0:
+    if false_count + legacy_count != 1 or true_count != 0:
         raise NativeUserSettingsPatchError("USER_SETTINGS_WIDGET_PAIR_UNSUPPORTED")
 
-    patched = _patched_payload(original, payload_size, logical)
+    source = FALSE_WIDGET_PAIR if false_count else _LEGACY_TRUE_WIDGET_PAIR
+    patched = _patched_payload(original, payload_size, logical, source)
     backup_path = settings_path.with_name(settings_path.name + _BACKUP_SUFFIX)
     try:
         _atomic_sidecar(backup_path, original)

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-SETTINGS_UI_VERSION = "p03.original-settings-manage.v17"
+SETTINGS_UI_VERSION = "p03.original-settings-manage.v17-mailbox1"
 
 BOOTSTRAP_JAVASCRIPT = r'''(() => {
   "use strict";
@@ -1817,6 +1817,50 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     document.querySelector(`[${ROOT_ATTR}]`)?.remove();
   };
 
+  // The lite client's mailbox is the original /collection view. Keep both
+  // destinations inside the main window: desktop widgets can be off-screen.
+  const mountMainNavigation = () => {
+    const route = window.location.hash.split("?")[0];
+    let nav = document.querySelector("[data-olivia-main-navigation]");
+    if (route !== "#/studio" && route !== "#/collection") {
+      nav?.remove();
+      return;
+    }
+    if (!nav) {
+      nav = document.createElement("nav");
+      nav.setAttribute("data-olivia-main-navigation", "");
+      nav.setAttribute("aria-label", "信箱与曲库");
+      Object.assign(nav.style, {
+        position: "fixed", top: "60px", left: "120px", zIndex: "20",
+        display: "flex", gap: "8px", WebkitAppRegion: "no-drag",
+      });
+      for (const [label, href] of [["信箱", "#/collection"], ["曲库", "#/studio"]]) {
+        const link = text("a", label, "text-body-m");
+        link.href = href;
+        Object.assign(link.style, {
+          display: "inline-flex", alignItems: "center", minHeight: "36px",
+          padding: "0 16px", borderRadius: "18px", border: "1px solid #6b7280",
+          textDecoration: "none", whiteSpace: "nowrap", pointerEvents: "auto",
+          WebkitAppRegion: "no-drag",
+        });
+        nav.append(link);
+      }
+      document.body.append(nav);
+    }
+    for (const link of nav.querySelectorAll("a")) {
+      const active = link.getAttribute("href") === route;
+      if (active) link.setAttribute("aria-current", "page");
+      else link.removeAttribute("aria-current");
+      link.style.color = active ? "#111827" : "#d1d5db";
+      link.style.background = active ? "#d9d2c8" : "#17181a";
+    }
+  };
+
+  const finishInitialSetup = async (skipped) => {
+    await requestSetup(SETUP_COMPLETE_PATH, { skipped });
+    window.location.hash = "#/collection";
+  };
+
   const openDialog = (initialMode = false, initialPanel = "llm") => {
     document.querySelector(`[${DIALOG_ATTR}]`)?.remove();
 
@@ -1901,7 +1945,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     const close = button(initialMode ? "稍后设置" : "关闭", async () => {
       if (initialMode) {
         try {
-          await requestSetup(SETUP_COMPLETE_PATH, { skipped: true });
+          await finishInitialSetup(true);
         } catch (_error) {
           return;
         }
@@ -1983,7 +2027,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       const finish = button("完成初始设置", async () => {
         setButtonsBusy([finish], true);
         try {
-          await requestSetup(SETUP_COMPLETE_PATH, { skipped: false });
+          await finishInitialSetup(false);
           backdrop.remove();
         } catch (_error) {
           status.textContent = "初始设置状态保存失败，请重试。";
@@ -2324,6 +2368,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
     window.requestAnimationFrame(() => {
       scheduled = false;
       constrainLetterInputs();
+      mountMainNavigation();
       mountShell();
       maybeOpenInitialSetup();
     });

--- a/tests/installer/test_mailbox_navigation.py
+++ b/tests/installer/test_mailbox_navigation.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+from original_client_settings_ui import BOOTSTRAP_JAVASCRIPT
+
+
+def test_mailbox_entry_survives_skipping_setup_and_music_navigation() -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js unavailable")
+    harness = r'''
+const vm = require('vm');
+const fs = require('fs');
+const assert = require('assert');
+let source = fs.readFileSync(0, 'utf8').replace(/\s*schedule\(\);\s*\}\)\(\);\s*$/, `
+ globalThis.navigation = { mountMainNavigation, finishInitialSetup };
+})();`);
+class Element {
+ constructor(tag) { this.tagName=tag; this.children=[]; this.style={}; this.attributes={}; this.listeners={}; }
+ setAttribute(k,v) { this.attributes[k]=v; }
+ getAttribute(k) { return k==='href' ? this.href : this.attributes[k]; }
+ removeAttribute(k) { delete this.attributes[k]; }
+ append(...items) { items.forEach(i=>{i.parent=this;this.children.push(i)}); }
+ remove() { if(this.parent) this.parent.children=this.parent.children.filter(x=>x!==this); }
+ addEventListener(k,fn) { this.listeners[k]=fn; }
+ querySelectorAll(selector) { return this.children.filter(x=>x.tagName==='a'); }
+}
+const body=new Element('body');
+const document={body,documentElement:body,currentScript:{dataset:{apiBase:'http://127.0.0.1:8899'}},
+ createElement:tag=>new Element(tag),
+ querySelector:selector=>body.children.find(x=>Object.hasOwn(x.attributes,'data-olivia-main-navigation')) || null};
+const window={location:{pathname:'/feapp/index.html',hash:'#/studio'},addEventListener(){},setTimeout,clearTimeout};
+const calls=[];
+const context={URL,AbortController,document,window,
+ fetch:async(url,options)=>{calls.push({path:url.pathname,body:JSON.parse(options.body)});return {ok:true,json:async()=>({status:'READY'})}},
+ MutationObserver:class{observe(){}}};
+vm.runInNewContext(source,context);
+(async()=>{
+ context.navigation.mountMainNavigation();
+ assert.equal(body.children.length,1);
+ assert.equal(body.children[0].children[0].href,'#/collection');
+ assert.equal(body.children[0].children[0].textContent,'信箱');
+ await context.navigation.finishInitialSetup(true);
+ assert.equal(window.location.hash,'#/collection');
+ assert.deepEqual(calls,[{path:'/toy/setup/complete',body:{skipped:true}}]);
+ context.navigation.mountMainNavigation();
+ context.navigation.mountMainNavigation();
+ assert.equal(body.children.length,1,'rerenders must not duplicate navigation');
+ assert.equal(body.children[0].children[0].getAttribute('aria-current'),'page');
+ window.location.hash='#/studio';
+ context.navigation.mountMainNavigation();
+ assert.equal(body.children[0].children[0].href,'#/collection','music must retain a mailbox entry');
+ assert.equal(body.children[0].children[1].getAttribute('aria-current'),'page');
+ window.location.hash='#/login';
+ context.navigation.mountMainNavigation();
+ assert.equal(body.children.length,0,'do not mount navigation on login');
+})().catch(e=>{console.error(e);process.exitCode=1});
+'''
+    result = subprocess.run([node, "-e", harness], input=BOOTSTRAP_JAVASCRIPT,
+                            text=True, encoding="utf-8", capture_output=True, timeout=20)
+    assert result.returncode == 0, result.stderr

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -157,7 +157,7 @@ const run = async () => { const [id, fn] = timers.entries().next().value; timers
 
 # The shipped CEF surface needs explicit no-drag/pointer and display-state guards.
 def test_original_settings_management_ui_has_fixed_bounded_contract() -> None:
-    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v17"
+    assert SETTINGS_UI_VERSION == "p03.original-settings-manage.v17-mailbox1"
     for declaration in (
             'const STATUS_PATH = "/toy/companion/status";',
             'const MEMORY_PATH = "/toy/companion/memory";',

--- a/tests/installer/test_patch_native_user_settings.py
+++ b/tests/installer/test_patch_native_user_settings.py
@@ -68,6 +68,39 @@ def test_format_prefix_is_not_hard_coded(tmp_path: Path) -> None:
     assert settings.read_bytes().count(TRUE_WIDGET_PAIR) == 1
 
 
+@pytest.mark.parametrize(
+    "widgets",
+    [
+        FALSE_WIDGET_PAIR,
+        b"\x0amailWidget\x06\x04true\x0bmusicWidget\x06\x04true",
+    ],
+    ids=["disabled", "previous-release-invalid-value-length"],
+)
+def test_widget_values_use_native_length_prefixed_encoding(tmp_path: Path, widgets: bytes) -> None:
+    settings = tmp_path / "usersettings.dat"
+    original = _settings_blob(widgets, prefix=b"", suffix=b"")
+    settings.write_bytes(original)
+
+    assert patch_native_user_settings(settings).status == "patched"
+    data = settings.read_bytes()
+    offset = 4
+    # The native store frames the serialized string with its own byte length.
+    # A true value is 5 bytes (04 + true), not false's 6 bytes (05 + false).
+    for expected_name in (b"mailWidget", b"musicWidget"):
+        name_length = data[offset]
+        offset += 1
+        assert data[offset:offset + name_length] == expected_name
+        offset += name_length
+        value_length = data[offset]
+        offset += 1
+        encoded = data[offset:offset + value_length]
+        assert encoded == b"\x04true"
+        offset += value_length
+    assert offset == 4 + struct.unpack_from("<I", data)[0]
+    assert settings.with_name("usersettings.dat.native-nav.orig").read_bytes() == original
+    assert patch_native_user_settings(settings).status == "already_enabled"
+
+
 def test_missing_settings_are_skipped_without_creating_sidecars(tmp_path: Path) -> None:
     settings = tmp_path / "usersettings.dat"
 

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -1424,6 +1424,14 @@ def test_restart_repairs_legacy_managed_worker_pair_before_ready(
     profile = worker.with_name("minimax_profile.py")
     profile.unlink()
     observed: list[dict[str, str]] = []
+    music_root = installer.install_root / "music_video"
+    original_walk = os.walk
+
+    def bounded_walk(top, *args, **kwargs):
+        assert Path(top) != music_root, "startup must not scan the complete music runtime"
+        return original_walk(top, *args, **kwargs)
+
+    monkeypatch.setattr(video_capability_install.os, "walk", bounded_walk)
 
     restarted = VideoCapabilityInstaller(
         data_root=data_root,
@@ -1999,6 +2007,26 @@ def _managed_worker_import_fixture(
         / "tools"
     )
     return installer, runtime_root, manifest_sha256, worker_directory
+
+
+def test_runtime_import_rejects_linked_managed_worker_ancestor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    installer, runtime_root, manifest_sha256, worker_directory = (
+        _managed_worker_import_fixture(tmp_path, monkeypatch)
+    )
+    outside = tmp_path / "outside-worker"
+    outside.mkdir()
+    worker_directory.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        worker_directory.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("creating directory links is unavailable")
+    with pytest.raises(VideoCapabilityError, match="VIDEO_RUNTIME_WORKER_UNAVAILABLE"):
+        installer.import_runtime_root(
+            runtime_root=runtime_root, manifest_sha256=manifest_sha256
+        )
+    assert list(outside.iterdir()) == []
 
 
 def test_runtime_import_reports_stable_worker_error_when_worker_directory_cannot_be_prepared(

--- a/tests/installer/test_windows_full_patch.py
+++ b/tests/installer/test_windows_full_patch.py
@@ -1861,7 +1861,7 @@ def test_install_isolated_copy_activates_original_client_surfaces(
         main = archive.read("assets/main-917d29fc.js").decode("utf-8")
     assert "assets/olivia-companion-settings.js" in names
     assert "data-olivia-companion-settings" in index
-    assert "data-ui-version=\"p03.original-settings-manage.v17\"" in index
+    assert "data-ui-version=\"p03.original-settings-manage.v17-mailbox1\"" in index
     assert (installed / "local_backend" / "original_client_setup_api.py").is_file()
     assert (installed / "local_backend" / "original_client_capability_api.py").is_file()
     assert (installed / "local_backend" / "original_client_update_api.py").is_file()

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -2250,7 +2250,18 @@ class VideoCapabilityInstaller:
             not source.is_file() or _is_reparse_point(source) for source in sources
         ):
             raise VideoCapabilityError("VIDEO_RUNTIME_WORKER_UNAVAILABLE")
-        _reject_reparse_tree(music)
+        # Only these two managed files are replaced. Validate their lexical
+        # ancestor chain before resolve(), not every model/runtime file nearby.
+        unresolved_worker = music / relative
+        unresolved_worker.relative_to(music)
+        for target in (unresolved_worker, unresolved_worker.with_name("minimax_profile.py")):
+            current = target
+            while True:
+                if os.path.lexists(current) and _is_reparse_point(current):
+                    raise VideoCapabilityError("VIDEO_REPARSE_POINT_FORBIDDEN")
+                if current == music:
+                    break
+                current = current.parent
         worker_target = _inside(music, music / relative)
         targets = (
             _inside(music, worker_target.with_name("minimax_profile.py")),


### PR DESCRIPTION
Fix the released client entry regression: skipping or completing initial setup now opens the native lite mailbox (/collection), and the main window retains mailbox/music navigation without requiring desktop widgets. Correct the native serialized true-value length and repair the exact malformed pair written by earlier versions. No letter data migration. Validation: 139 focused tests passed, one Windows symlink test skipped; headless browser checks at 1200px and 640px passed skip and round-trip navigation. Version 0.1.435 installed locally; frontend markers verified and the existing 39-letter state file remained byte-identical. PrivateWorld feature work is excluded from this hotfix. Original-client user acceptance after restart remains distinct from browser fixture validation.