### PR TITLE
Fix DeepSeek memory extraction and historical import recovery

### DIFF
--- a/original_client_server.py
+++ b/original_client_server.py
@@ -40,6 +40,7 @@ from mem0_embedding_install import Mem0EmbeddingInstaller
 from mem0_memory import Mem0Config
 from music_reply import video_reply_dependency_status
 from runtime.media.background_video_readiness import BackgroundVideoReadiness
+from runtime.diagnostics.support_bundle import BREEZE_INSTALL_DIAGNOSTIC_CODES
 from original_client_companion_api import mount_original_companion_read_api
 from original_client_companion_backend import (
     OriginalClientCompanionServiceBackend,
@@ -534,6 +535,9 @@ def _diagnostic_source(
                     reason = code(snapshot.get("reason_code"))
                     if reason:
                         entry["error_code"] = reason
+                    diagnostic = snapshot.get("diagnostic_code")
+                    if isinstance(diagnostic, str) and diagnostic in BREEZE_INSTALL_DIAGNOSTIC_CODES:
+                        entry["diagnostic_code"] = diagnostic
                     for field in ("downloaded_bytes", "total_bytes", "remaining_bytes", "checked_bytes"):
                         count = snapshot.get(field)
                         if type(count) is int and 0 <= count <= 10**15:

--- a/runtime/diagnostics/support_bundle.py
+++ b/runtime/diagnostics/support_bundle.py
@@ -21,6 +21,11 @@ DIAGNOSTIC_BUNDLE_MEMBERS = (
 )
 MAX_BUNDLE_BYTES = 1 << 20
 MAX_CHECKS = 32
+BREEZE_INSTALL_DIAGNOSTIC_CODES = frozenset({
+    "BREEZE_PIP_DISK_FULL", "BREEZE_PIP_MISSING_PIP", "BREEZE_PIP_UNSUPPORTED_WHEEL",
+    "BREEZE_PIP_HASH_MISMATCH", "BREEZE_PIP_WHEEL_UNAVAILABLE", "BREEZE_PIP_ACCESS_DENIED",
+    "BREEZE_PIP_TIMEOUT", "BREEZE_PIP_FAILED",
+})
 MAX_TAIL_RECORDS = 200
 _NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 _STATUS_RE = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
@@ -109,6 +114,9 @@ def _project_health(value: object) -> dict[str, object]:
         if "error_code" in check:
             entry["error_code"] = _code(check["error_code"])
         if name in {"video_ordinary", "video_music", "video_runtime"}:
+            diagnostic = check.get("diagnostic_code")
+            if isinstance(diagnostic, str) and diagnostic in BREEZE_INSTALL_DIAGNOSTIC_CODES:
+                entry["diagnostic_code"] = diagnostic
             for field in ("downloaded_bytes", "total_bytes", "remaining_bytes", "checked_bytes"):
                 if field in check:
                     count = check[field]

--- a/runtime/memory/conversation_memory_delivery.py
+++ b/runtime/memory/conversation_memory_delivery.py
@@ -284,7 +284,8 @@ class ConversationMemoryDeliveryCommitter:
             ),
             completed_failure=status is CanonicalMemoryDeliveryStatus.UNAVAILABLE and error_code in {
                 "MEM0_WRITE_FAILED", "MEM0_WRITE_ROLLBACK_FAILED",
-                "MEM0_EXTRACTION_RESPONSE_INVALID", "MEM0_LANGUAGE_MISMATCH",
+                "MEM0_EXTRACTION_RESPONSE_INVALID", "MEM0_EXTRACTION_RESPONSE_TRUNCATED",
+                "MEM0_LANGUAGE_MISMATCH",
                 "MEM0_LANGUAGE_MISMATCH_ROLLBACK_FAILED", "MEM0_CHARACTER_IDENTITY_MISMATCH",
                 "MEM0_CHARACTER_IDENTITY_MISMATCH_ROLLBACK_FAILED",
             },

--- a/runtime/memory/mem0_memory.py
+++ b/runtime/memory/mem0_memory.py
@@ -7,6 +7,7 @@ provider failures collapse to stable, privacy-safe states.
 
 from __future__ import annotations
 
+from contextlib import closing
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import hashlib
@@ -16,6 +17,7 @@ from numbers import Real
 import os
 from pathlib import Path
 import re
+import sqlite3
 import sys
 import threading
 import time
@@ -66,6 +68,16 @@ _HISTORY_CHARACTER_IDENTITY_MISMATCH_RE = re.compile(
     re.IGNORECASE,
 )
 _HISTORY_FIRST_PERSON_RE = re.compile(r"我")
+
+
+def _valid_history_character_identity(fact: str) -> bool:
+    # A first-person name annotation is not a third-person narrator.
+    identity_text = fact.replace("我（林离）", "我").replace("我(林离)", "我")
+    return bool(_HISTORY_FIRST_PERSON_RE.search(identity_text)) and not bool(
+        _HISTORY_CHARACTER_IDENTITY_MISMATCH_RE.search(identity_text)
+    )
+
+
 _HISTORY_ACTOR_KEY = "history_actor"
 _HISTORY_EXTRACTION_VERSION_KEY = "history_extraction_version"
 _HISTORY_EXTRACTION_VERSION = "relationship-v2"
@@ -1101,7 +1113,11 @@ class Mem0ConversationMemoryAdapter:
         user_id: str,
     ) -> MemoryWriteResult:
         user_id = self._normalized_user_id(user_id)
+        content_sha = hashlib.sha256(json.dumps(
+            [self.config.agent_id, user_message, assistant_message], ensure_ascii=False,
+        ).encode("utf-8")).hexdigest()
         for alias in self._configured_user_aliases(user_id):
+            audit_mismatch = False
             try:
                 exact_response = self.backend.get_all(
                     filters={**self._provider_filters(alias), "source_id": source_id},
@@ -1124,6 +1140,21 @@ class Mem0ConversationMemoryAdapter:
                     source_id,
                     error_code="MEM0_SOURCE_DEDUP_UNAVAILABLE",
                 )
+            if source_id.startswith("history:"):
+                try:
+                    audited_ids = self._history_audit(user_id=alias, source_id=source_id, content_sha=content_sha)
+                except (OSError, sqlite3.Error, ValueError):
+                    return MemoryWriteResult(MemoryWriteStatus.UNAVAILABLE, source_id,
+                        error_code="MEM0_SOURCE_DEDUP_UNAVAILABLE")
+                if audited_ids is not None and audited_ids == sorted(record.memory_id for record in source_records):
+                    return MemoryWriteResult(MemoryWriteStatus.DUPLICATE, source_id)
+                audit_mismatch = audited_ids is not None
+                if audit_mismatch:
+                    try:
+                        self._invalidate_history_audit(user_id=alias, source_id=source_id)
+                    except (OSError, sqlite3.Error):
+                        return MemoryWriteResult(MemoryWriteStatus.UNAVAILABLE, source_id,
+                            error_code="MEM0_SOURCE_DEDUP_UNAVAILABLE")
             if source_id.startswith("history:") and source_records:
                 exact_rows = self._exact_source_id_rows(exact_response)
                 actors = {
@@ -1139,7 +1170,8 @@ class Mem0ConversationMemoryAdapter:
                     == _HISTORY_LINLI_ACTOR
                 )
                 history_is_current = (
-                    actors == {_HISTORY_USER_ACTOR, _HISTORY_LINLI_ACTOR}
+                    not audit_mismatch
+                    and actors == {_HISTORY_USER_ACTOR, _HISTORY_LINLI_ACTOR}
                     and all(
                         isinstance(row.get("metadata"), Mapping)
                         and row["metadata"].get(_HISTORY_EXTRACTION_VERSION_KEY)
@@ -1148,8 +1180,7 @@ class Mem0ConversationMemoryAdapter:
                     )
                     and bool(linli_facts)
                     and all(
-                        _HISTORY_FIRST_PERSON_RE.search(fact)
-                        and not _HISTORY_CHARACTER_IDENTITY_MISMATCH_RE.search(fact)
+                        _valid_history_character_identity(fact)
                         for fact in linli_facts
                     )
                 )
@@ -1293,8 +1324,7 @@ class Mem0ConversationMemoryAdapter:
             invalid_identity_ids = {
                 memory_id
                 for memory_id, memory in acknowledgement_groups[1] or ()
-                if not _HISTORY_FIRST_PERSON_RE.search(memory)
-                or _HISTORY_CHARACTER_IDENTITY_MISMATCH_RE.search(memory)
+                if not _valid_history_character_identity(memory)
             }
         invalid_language_ids = (
             {
@@ -1382,6 +1412,13 @@ class Mem0ConversationMemoryAdapter:
         memory_ids = tuple(
             memory_id for group in valid_groups for memory_id, _memory in group
         )
+        if history_write:
+            try:
+                self._history_audit(user_id=user_id, source_id=source_id, content_sha=content_sha, memory_ids=memory_ids)
+            except (OSError, sqlite3.Error, ValueError):
+                pending_ids = self._delete_provider_memories(memory_ids)
+                return MemoryWriteResult(MemoryWriteStatus.UNAVAILABLE, source_id, pending_ids,
+                    error_code="MEM0_WRITE_ROLLBACK_FAILED" if pending_ids else "MEM0_WRITE_FAILED")
         return MemoryWriteResult(
             MemoryWriteStatus.WRITTEN
             if history_write or memory_ids
@@ -1389,6 +1426,34 @@ class Mem0ConversationMemoryAdapter:
             source_id,
             memory_ids,
         )
+
+    def _invalidate_history_audit(self, *, user_id: str, source_id: str) -> None:
+        path = self.config.data_root / "history-extraction-audit.sqlite3"
+        with closing(sqlite3.connect(path)) as connection, connection:
+            connection.execute("DELETE FROM completed WHERE user_id=? AND source_id=?",
+                (user_id, source_id))
+
+    def _history_audit(self, *, user_id: str, source_id: str, content_sha: str,
+                       memory_ids: tuple[str, ...] | None = None) -> list[str] | None:
+        """Record completed extraction, including zero facts, outside searchable memory."""
+        path = self.config.data_root / "history-extraction-audit.sqlite3"
+        if memory_ids is None and not path.exists():
+            return None
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with closing(sqlite3.connect(path)) as connection, connection:
+            connection.execute("CREATE TABLE IF NOT EXISTS completed (user_id TEXT, source_id TEXT, version TEXT, content_sha TEXT, ids TEXT, PRIMARY KEY(user_id, source_id))")
+            if memory_ids is not None:
+                connection.execute("INSERT OR REPLACE INTO completed VALUES (?, ?, ?, ?, ?)",
+                    (user_id, source_id, _HISTORY_EXTRACTION_VERSION, content_sha, json.dumps(sorted(memory_ids))))
+                return None
+            row = connection.execute("SELECT ids FROM completed WHERE user_id=? AND source_id=? AND version=? AND content_sha=?",
+                (user_id, source_id, _HISTORY_EXTRACTION_VERSION, content_sha)).fetchone()
+            if row is None:
+                return None
+            ids = json.loads(row[0])
+            if not isinstance(ids, list) or any(not isinstance(value, str) for value in ids):
+                raise ValueError("invalid history audit")
+            return ids
 
     def remember_exchange(
         self,
@@ -1603,6 +1668,11 @@ class Mem0ConversationMemoryAdapter:
             if self.list_memories(user_id=user_id, limit=1000):
                 self._last_error_code = "MEM0_CLEAR_FAILED"
                 return 0
+            audit_path = self.config.data_root / "history-extraction-audit.sqlite3"
+            if audit_path.exists():
+                with closing(sqlite3.connect(audit_path)) as connection, connection:
+                    for alias in self._configured_user_aliases(user_id):
+                        connection.execute("DELETE FROM completed WHERE user_id=?", (alias,))
             self._last_error_code = None
             return deleted
         except Mem0AdapterError:

--- a/runtime/memory/mem0_memory.py
+++ b/runtime/memory/mem0_memory.py
@@ -20,6 +20,7 @@ import sys
 import threading
 import time
 from typing import Callable, Mapping, Protocol, Sequence
+from urllib.parse import urlsplit
 
 from runtime.memory.bounded_daemon_call import BoundedDaemonCall
 from .conversation_memory_port import (
@@ -165,6 +166,19 @@ class Mem0AdapterError(RuntimeError):
     def __init__(self, code: str) -> None:
         self.code = code
         super().__init__(code)
+
+
+def _extraction_failure_code(error: BaseException) -> str:
+    # Upstream wraps extraction errors with LLMError; never copy its message.
+    for _ in range(8):
+        if isinstance(error, Mem0AdapterError) and error.code in {
+            "MEM0_EXTRACTION_RESPONSE_INVALID", "MEM0_EXTRACTION_RESPONSE_TRUNCATED",
+        }:
+            return error.code
+        if error.__cause__ is None:
+            break
+        error = error.__cause__
+    return "MEM0_WRITE_FAILED"
 
 
 class Mem0Backend(Protocol):
@@ -1234,7 +1248,7 @@ class Mem0ConversationMemoryAdapter:
                             infer=False,
                         )
                     )
-        except Exception:
+        except Exception as error:
             pending_ids = self._delete_provider_memories(tuple(created_ids))
             return MemoryWriteResult(
                 MemoryWriteStatus.UNAVAILABLE,
@@ -1243,7 +1257,7 @@ class Mem0ConversationMemoryAdapter:
                 error_code=(
                     "MEM0_WRITE_ROLLBACK_FAILED"
                     if pending_ids
-                    else "MEM0_WRITE_FAILED"
+                    else _extraction_failure_code(error)
                 ),
             )
         acknowledgement_groups = tuple(_add_acknowledgements(value) for value in values)
@@ -1694,6 +1708,29 @@ class _ValidatedExtractionLLM:
         return response
 
 
+def _guard_extraction_client(provider: object) -> None:
+    """Guard this memory-only client before upstream discards response metadata."""
+    client = getattr(provider, "client", None)
+    completions = getattr(getattr(client, "chat", None), "completions", None)
+    create = getattr(completions, "create", None)
+    if not callable(create):
+        return
+    official_deepseek = urlsplit(str(getattr(client, "base_url", ""))).hostname == "api.deepseek.com"
+
+    def guarded_create(*args: object, **kwargs: object) -> object:
+        if official_deepseek:
+            kwargs["extra_body"] = {
+                **(kwargs.get("extra_body") or {}), "thinking": {"type": "disabled"},
+            }
+        response = create(*args, **kwargs)
+        if any(getattr(choice, "finish_reason", None) == "length"
+               for choice in getattr(response, "choices", ())):
+            raise Mem0AdapterError("MEM0_EXTRACTION_RESPONSE_TRUNCATED")
+        return response
+
+    completions.create = guarded_create
+
+
 def _default_factory(config: Mapping[str, object]) -> Mem0Backend:
     module = _load_product_mem0_module()
     memory_type = getattr(module, "Memory", None)
@@ -1702,6 +1739,7 @@ def _default_factory(config: Mapping[str, object]) -> Mem0Backend:
     backend = memory_type.from_config(dict(config))
     provider = getattr(backend, "llm", None)
     if callable(getattr(provider, "generate_response", None)):
+        _guard_extraction_client(provider)
         backend.llm = _ValidatedExtractionLLM(provider)
     return backend
 

--- a/tests/http/test_diagnostic_support_bundle.py
+++ b/tests/http/test_diagnostic_support_bundle.py
@@ -70,6 +70,25 @@ def _source() -> dict[str, object]:
     }
 
 
+@pytest.mark.parametrize("diagnostic", [
+    "BREEZE_PIP_DISK_FULL", "BREEZE_PIP_MISSING_PIP", "BREEZE_PIP_UNSUPPORTED_WHEEL",
+    "BREEZE_PIP_HASH_MISMATCH", "BREEZE_PIP_WHEEL_UNAVAILABLE", "BREEZE_PIP_ACCESS_DENIED",
+    "BREEZE_PIP_TIMEOUT", "BREEZE_PIP_FAILED", "PRIVATE_KEY_SHOULD_NOT_LEAK",
+])
+def test_video_install_diagnostic_is_an_exact_allowlist(diagnostic):
+    source = _source()
+    source["health"]["checks"]["video_ordinary"] = {
+        "state": "failed", "diagnostic_code": diagnostic,
+    }
+    with zipfile.ZipFile(io.BytesIO(build_diagnostic_bundle(source))) as archive:
+        entry = json.loads(archive.read("health.json"))["checks"]["video_ordinary"]
+        if diagnostic.startswith("BREEZE_PIP_"):
+            assert entry["diagnostic_code"] == diagnostic
+        else:
+            assert "diagnostic_code" not in entry
+            assert diagnostic.encode() not in archive.read("health.json")
+
+
 def _contents(bundle: bytes) -> dict[str, bytes]:
     with zipfile.ZipFile(io.BytesIO(bundle)) as archive:
         return {name: archive.read(name) for name in archive.namelist()}

--- a/tests/http/test_history_memory_recovery.py
+++ b/tests/http/test_history_memory_recovery.py
@@ -1,0 +1,110 @@
+"""Synthetic route coverage: mailbox presence is not a memory import receipt."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from conversation_memory_port import MemoryWriteResult, MemoryWriteStatus
+from runtime.imports.offline_letter_pairs import (
+    apply_offline_letter_pair_recovery_to_adapter,
+    offline_letter_pair_exchanges,
+    plan_offline_letter_pair_recovery_with_adapter,
+)
+from runtime.memory.local_memory import LocalMemoryAdapter
+
+
+class SourceDeduplicatingMemory:
+    enabled = True
+
+    def __init__(self, persisted):
+        self.persisted = set(persisted)
+        self.provider_writes = []
+        self.fail_source = None
+
+    def status(self):
+        return SimpleNamespace(status="available")
+
+    def remember_exchange(self, **kwargs):
+        source = kwargs["source_id"]
+        if source in self.persisted:
+            return MemoryWriteResult(MemoryWriteStatus.DUPLICATE, source)
+        self.provider_writes.append(source)
+        if source == self.fail_source:
+            return MemoryWriteResult(
+                MemoryWriteStatus.UNAVAILABLE, source, error_code="MEM0_WRITE_FAILED"
+            )
+        self.persisted.add(source)
+        return MemoryWriteResult(MemoryWriteStatus.WRITTEN, source, (source,))
+
+    def delete_memory(self, memory_id, *, user_id):
+        self.persisted.discard(memory_id)
+        return True
+
+
+@pytest.mark.parametrize("count,completed", [(1, 0), (5, 0), (5, 3)])
+@pytest.mark.parametrize("fail_first", [False, True])
+def test_reimport_repairs_memory_when_all_mailbox_letters_already_exist(
+    tmp_path, monkeypatch, count, completed, fail_first
+):
+    import local_server
+
+    source = tmp_path / "letter_pairs.json"
+    source.write_text(json.dumps([
+        {"content": f"Synthetic question {i}", "reply": f"Synthetic answer {i}"}
+        for i in range(count)
+    ]), encoding="utf-8")
+    archive = LocalMemoryAdapter(tmp_path / "archive.sqlite3")
+    initial = apply_offline_letter_pair_recovery_to_adapter(source, adapter=archive)
+    assert initial.inserted == count
+    ids = [exchange.memory_source_id for exchange in offline_letter_pair_exchanges(source)]
+    memory = SourceDeduplicatingMemory(ids[:completed])
+    monkeypatch.setattr(local_server, "_default_offline_letter_pair_source", lambda: source)
+    monkeypatch.setattr(local_server, "_legacy_import_adapter", lambda: archive)
+    monkeypatch.setattr(local_server, "_official_history_preflight_error", lambda: None)
+    monkeypatch.setattr(local_server, "conversation_memory_adapter", memory)
+    # A prior relationship audit must not short-circuit the independent memory pass.
+    monkeypatch.setattr(local_server, "private_world_command_service", SimpleNamespace(
+        lookup_command=lambda command_id: object(),
+    ))
+    monkeypatch.setattr(local_server, "_update_official_import_progress", lambda **kwargs: None)
+
+    def post():
+        return asyncio.run(local_server.route(
+            "POST", "/toy/letter/legacy/local-import", {}, {}, companion_confirmed=True,
+        ))
+
+    try:
+        if fail_first:
+            memory.fail_source = ids[completed]
+            failed = post()
+            assert failed["code"] == 503
+            assert failed["data"]["memory_migration"]["status"] == "partial"
+            assert memory.persisted == set(ids[:completed])
+            assert plan_offline_letter_pair_recovery_with_adapter(
+                source, adapter=archive
+            ).duplicates == count
+            memory.fail_source = None
+            memory.provider_writes.clear()
+
+        repaired = post()
+        assert repaired["code"] == 0
+        assert repaired["data"]["inserted"] == 0
+        assert repaired["data"]["duplicates"] == count
+        migration = repaired["data"]["memory_migration"]
+        assert migration["status"] == "completed"
+        assert migration["written"] == count - completed
+        assert migration["duplicates"] == completed
+        assert memory.provider_writes == ids[completed:]
+        assert memory.persisted == set(ids)
+
+        memory.provider_writes.clear()
+        repeated = post()
+        assert repeated["data"]["inserted"] == 0
+        assert repeated["data"]["duplicates"] == count
+        assert repeated["data"]["memory_migration"]["written"] == 0
+        assert repeated["data"]["memory_migration"]["duplicates"] == count
+        assert memory.provider_writes == []
+    finally:
+        archive.close()

--- a/tests/http/test_original_client_diagnostics_api.py
+++ b/tests/http/test_original_client_diagnostics_api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 import asyncio
 import io
 import json
@@ -196,7 +198,8 @@ def test_safe_log_runtime_ring_is_bounded_and_drops_unknown_fields() -> None:
     )
 
 
-def test_video_diagnostic_reads_existing_state_without_starting_installation(monkeypatch):
+@pytest.mark.parametrize("diagnostic", ["BREEZE_PIP_DISK_FULL", "PRIVATE_KEY_SHOULD_NOT_LEAK"])
+def test_video_diagnostic_reads_existing_state_without_starting_installation(monkeypatch, diagnostic):
     from threading import Lock
     from types import SimpleNamespace
     from runtime.diagnostics.support_bundle import build_diagnostic_bundle
@@ -210,16 +213,20 @@ def test_video_diagnostic_reads_existing_state_without_starting_installation(mon
     def forbidden(): raise AssertionError("diagnostics must not call installer.status")
     installer = SimpleNamespace(_lock=Lock(), status=forbidden,
         _runtime_import={"state": "failed", "reason_code": "VIDEO_RUNTIME_TTS_CONFIG_UNAVAILABLE", "checked_bytes": 42, "private_path": "must-not-leak"},
-        _status={"music_video": SimpleNamespace(to_dict=lambda: {"state": "failed", "reason_code": "VIDEO_ARCHIVE_INVALID", "downloaded_bytes": 99, "total_bytes": 100, "remaining_bytes": 1, "path": "must-not-leak"})})
+        _status={"music_video": SimpleNamespace(to_dict=lambda: {"state": "failed", "reason_code": "VIDEO_ARCHIVE_INVALID", "downloaded_bytes": 99, "total_bytes": 100, "remaining_bytes": 1, "path": "must-not-leak", "diagnostic_code": diagnostic})})
     monkeypatch.setattr("original_client_update_api.running_component_version", lambda: {"version": "0.1.455"})
     collect = _diagnostic_source(Backend(), setup_service=None, launcher_tail_provider=None,
         runtime_tail_provider=None, video_capability_installer=installer)
     with zipfile.ZipFile(io.BytesIO(build_diagnostic_bundle(collect()))) as bundle:
         checks = json.loads(bundle.read("health.json"))["checks"]
-        assert checks["video_music"] == {"state": "failed", "error_code": "VIDEO_ARCHIVE_INVALID", "downloaded_bytes": 99, "total_bytes": 100, "remaining_bytes": 1}
+        expected = {"state": "failed", "error_code": "VIDEO_ARCHIVE_INVALID", "downloaded_bytes": 99, "total_bytes": 100, "remaining_bytes": 1}
+        if diagnostic == "BREEZE_PIP_DISK_FULL":
+            expected["diagnostic_code"] = diagnostic
+        assert checks["video_music"] == expected
         assert checks["video_runtime"]["checked_bytes"] == 42
         assert json.loads(bundle.read("summary.json"))["running_version"] == "0.1.455"
         assert all(b"must-not-leak" not in bundle.read(name) for name in bundle.namelist())
+        assert all(b"PRIVATE_KEY_SHOULD_NOT_LEAK" not in bundle.read(name) for name in bundle.namelist())
     installer._lock.acquire()
     try:
         assert collect()["health"]["checks"]["video_runtime"]["error_code"] == "VIDEO_DIAGNOSTIC_BUSY"

--- a/tests/installer/test_video_capability_install.py
+++ b/tests/installer/test_video_capability_install.py
@@ -439,8 +439,9 @@ def test_video_manifest_contains_every_hash_locked_breeze_wheel() -> None:
     assert set(locked) == set(wheels)
 
 
+@pytest.mark.parametrize("pip_failure", [False, True])
 def test_empty_capability_root_bootstraps_a_verified_breeze_runtime(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pip_failure: bool,
 ) -> None:
     artifacts = tmp_path / "artifacts"
     archive = artifacts / "runtime" / "python-fixture.zip"
@@ -478,6 +479,10 @@ def test_empty_capability_root_bootstraps_a_verified_breeze_runtime(
         assert status["state"] == "verifying"
         assert status["current_file"] == "安装本地运行依赖（无需联网）"
         runner_calls.append((python, site_packages, requirements))
+        if pip_failure:
+            monkeypatch.setattr(video_capability_install.subprocess, "run", lambda *a, **k:
+                SimpleNamespace(returncode=1, stdout="", stderr="[Errno 28] No space left on device private-secret"))
+            VideoCapabilityInstaller._install_breeze_runtime_packages(python, site_packages, requirements)
         (site_packages / "torch").mkdir()
         (site_packages / "torch" / "__init__.py").write_text(
             "__version__ = '2.9.1+cu128'\n", encoding="utf-8"
@@ -522,6 +527,14 @@ def test_empty_capability_root_bootstraps_a_verified_breeze_runtime(
 
     assert installer.start(bundle_id="ordinary_video", source_mode="official") == "APPLIED"
     state = _wait(installer, 0, "ready", "failed")
+    if pip_failure:
+        snapshot = installer.status()["bundles"][0]
+        assert state == "failed"
+        assert snapshot["reason_code"] == "BREEZE_TTS_RUNTIME_INSTALL_FAILED"
+        assert snapshot["diagnostic_code"] == "BREEZE_PIP_DISK_FULL"
+        assert "private-secret" not in json.dumps(snapshot)
+        assert not (installer.install_root / "ordinary_video" / ".ready.json").exists()
+        return
     assert state == "ready", installer.status()
 
     installed = installer.install_root / "ordinary_video"
@@ -572,6 +585,36 @@ def test_breeze_runtime_bootstrap_is_hash_locked_and_wheel_only(
     assert "--extra-index-url" not in command
     assert "--no-binary" not in command
     assert "--no-build-isolation" not in command
+
+
+@pytest.mark.parametrize("stderr, expected", [
+    ("[Errno 28] No space left on device", "DISK_FULL"),
+    ("[WinError 112] There is not enough space on the disk", "DISK_FULL"),
+    ("No module named pip", "MISSING_PIP"),
+    ("package.whl is not a supported wheel on this platform", "UNSUPPORTED_WHEEL"),
+    ("THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE", "HASH_MISMATCH"),
+    ("No matching distribution found for torch", "WHEEL_UNAVAILABLE"),
+    ("[WinError 5] Access is denied", "ACCESS_DENIED"),
+    ("unclassified failure", "FAILED"),
+])
+def test_breeze_pip_failure_has_only_fixed_diagnostic(tmp_path, monkeypatch, stderr, expected):
+    secret = r" C:\Users\private\secret-key.txt sk-private-token"
+    monkeypatch.setattr(video_capability_install.subprocess, "run", lambda *a, **k:
+        SimpleNamespace(returncode=1, stdout=secret, stderr=stderr + secret))
+    with pytest.raises(VideoCapabilityError, match="^BREEZE_TTS_RUNTIME_INSTALL_FAILED$") as caught:
+        VideoCapabilityInstaller._install_breeze_runtime_packages(tmp_path / "python.exe", tmp_path, tmp_path / "lock")
+    assert caught.value.diagnostic_code == "BREEZE_PIP_" + expected
+    assert "private" not in repr(caught.value.__dict__)
+
+
+def test_breeze_pip_timeout_has_fixed_diagnostic_without_output(tmp_path, monkeypatch):
+    def timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired("private-command", 7200, output=b"private-key", stderr=b"private-path")
+    monkeypatch.setattr(video_capability_install.subprocess, "run", timeout)
+    with pytest.raises(VideoCapabilityError, match="^BREEZE_TTS_RUNTIME_INSTALL_FAILED$") as caught:
+        VideoCapabilityInstaller._install_breeze_runtime_packages(tmp_path / "python.exe", tmp_path, tmp_path / "lock")
+    assert caught.value.diagnostic_code == "BREEZE_PIP_TIMEOUT"
+    assert caught.value.__suppress_context__
 
 
 def test_runtime_artifact_parts_are_verified_reassembled_and_removed_after_install(

--- a/tests/memory/test_conversation_memory_delivery.py
+++ b/tests/memory/test_conversation_memory_delivery.py
@@ -88,6 +88,14 @@ def _delivery(**changes: object) -> CanonicalMemoryDelivery:
     return CanonicalMemoryDelivery(**values)  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize("code", ["MEM0_EXTRACTION_RESPONSE_INVALID", "MEM0_EXTRACTION_RESPONSE_TRUNCATED"])
+def test_extraction_failures_still_consume_completed_write_retry_budget(code):
+    memory = FakeMemory(result_status=MemoryWriteStatus.UNAVAILABLE, error_code=code)
+    result = asyncio.run(ConversationMemoryDeliveryCommitter(memory).commit(_delivery()))
+    assert result.error_code == code
+    assert result.completed_failure is True
+
+
 def test_failure_budget_marks_completed_writes_not_waiting_or_preflight():
     async def scenario():
         broken = FakeMemory(result_status=MemoryWriteStatus.UNAVAILABLE)

--- a/tests/memory/test_mem0_extraction_validation.py
+++ b/tests/memory/test_mem0_extraction_validation.py
@@ -5,6 +5,47 @@ import pytest
 from runtime.memory import mem0_memory
 
 
+def _raw_response_backend(monkeypatch, base_url, finish_reason="stop", content='{"memory": []}'):
+    calls = []
+    response = SimpleNamespace(choices=[SimpleNamespace(finish_reason=finish_reason,
+        message=SimpleNamespace(content=content, reasoning_content="private reasoning"))])
+    def create(**kwargs):
+        calls.append(kwargs)
+        return response
+    completions = SimpleNamespace(create=create)
+    provider = SimpleNamespace(client=SimpleNamespace(base_url=base_url,
+        chat=SimpleNamespace(completions=completions)))
+    provider.generate_response = lambda **kwargs: completions.create(**kwargs).choices[0].message.content
+    memory = SimpleNamespace(llm=provider)
+    monkeypatch.setattr(mem0_memory, "_load_product_mem0_module", lambda: SimpleNamespace(
+        Memory=SimpleNamespace(from_config=lambda config: memory)))
+    return mem0_memory._default_factory({}), calls, create
+
+
+@pytest.mark.parametrize("base_url,disabled", [
+    ("https://api.deepseek.com/v1", True), ("https://api.deepseek.com", True),
+    ("https://api.deepseek.com.evil.invalid/v1", False), ("https://other.invalid/v1", False),
+])
+def test_memory_client_isolates_thinking_and_never_projects_reasoning(monkeypatch, base_url, disabled):
+    backend, calls, original_create = _raw_response_backend(monkeypatch, base_url)
+    extra = {"other": "preserved", "thinking": {"type": "enabled"}}
+    result = backend.llm.generate_response(messages=[], response_format={"type": "json_object"}, extra_body=extra)
+    assert result == '{"memory": []}'
+    assert calls[0]["extra_body"]["thinking"]["type"] == ("disabled" if disabled else "enabled")
+    assert calls[0]["extra_body"]["other"] == "preserved"
+    assert extra["thinking"]["type"] == "enabled"
+    # The original callable is unchanged and can still serve an independent client.
+    original_create(extra_body=extra)
+    assert calls[-1]["extra_body"]["thinking"]["type"] == "enabled"
+
+
+@pytest.mark.parametrize("content", ["", '{"memory": []}'])
+def test_memory_client_rejects_length_even_when_content_is_valid_json(monkeypatch, content):
+    backend, _, _ = _raw_response_backend(monkeypatch, "https://other.invalid/v1", "length", content)
+    with pytest.raises(mem0_memory.Mem0AdapterError, match="^MEM0_EXTRACTION_RESPONSE_TRUNCATED$"):
+        backend.llm.generate_response(messages=[], response_format={"type": "json_object"})
+
+
 def test_extraction_request_keeps_grounding_at_system_priority_without_mutating_input(monkeypatch):
     calls = []
     def generate(**kwargs):

--- a/tests/memory/test_mem0_memory.py
+++ b/tests/memory/test_mem0_memory.py
@@ -569,6 +569,29 @@ def test_wrapped_extraction_failure_preserves_only_allowlisted_code(tmp_path, co
     assert "private" not in repr(result)
 
 
+@pytest.mark.parametrize("empty_actors", [{"user"}, {"linli"}, {"user", "linli"}])
+def test_completed_empty_history_extraction_is_durable_and_clearable(tmp_path, empty_actors):
+    class EmptyActorMem0(FakeMem0):
+        def add(self, messages, **kwargs):
+            if kwargs["metadata"]["history_actor"] in empty_actors:
+                self.calls.append(("add", kwargs))
+                return {"results": []}
+            return super().add(messages, **kwargs)
+    backend = EmptyActorMem0()
+    config = _config(tmp_path)
+    arguments = dict(user_message="我喜欢钢琴。", assistant_message="我会继续练琴。",
+        occurred_at=NOW, source_id="history:empty-reviewed", user_id="local-user")
+    adapter = Mem0ConversationMemoryAdapter(backend, config)
+    assert adapter.remember_exchange(**arguments).status is MemoryWriteStatus.WRITTEN
+    count = sum(name == "add" for name, _ in backend.calls)
+    adapter = Mem0ConversationMemoryAdapter(backend, config)
+    assert adapter.remember_exchange(**arguments).status is MemoryWriteStatus.DUPLICATE
+    assert sum(name == "add" for name, _ in backend.calls) == count
+    adapter.clear_user(user_id="local-user")
+    assert adapter.remember_exchange(**arguments).status is MemoryWriteStatus.WRITTEN
+    assert sum(name == "add" for name, _ in backend.calls) == count + 2
+
+
 def test_provider_failures_degrade_without_echoing_private_text(tmp_path: Path) -> None:
     backend = FakeMem0()
     backend.fail.add("add")
@@ -584,6 +607,66 @@ def test_provider_failures_degrade_without_echoing_private_text(tmp_path: Path) 
     assert result.error_code == "MEM0_WRITE_FAILED"
     assert "private user text" not in repr(result)
     assert "private assistant text" not in repr(result)
+
+
+@pytest.mark.parametrize("rollback_fails", [False, True])
+def test_history_audit_write_failure_rolls_back_and_does_not_mark_complete(tmp_path, monkeypatch, rollback_fails):
+    backend = FakeMem0()
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+    original = adapter._history_audit
+    def fail_write(**kwargs):
+        if kwargs.get("memory_ids") is not None:
+            raise OSError("private path")
+        return original(**kwargs)
+    monkeypatch.setattr(adapter, "_history_audit", fail_write)
+    if rollback_fails:
+        backend.fail.add("delete")
+    result = adapter.remember_exchange(user_message="我喜欢钢琴。", assistant_message="我会练琴。",
+        occurred_at=NOW, source_id="history:audit-write-failure", user_id="local-user")
+    assert result.error_code == ("MEM0_WRITE_ROLLBACK_FAILED" if rollback_fails else "MEM0_WRITE_FAILED")
+    assert not (adapter.config.data_root / "history-extraction-audit.sqlite3").exists()
+    if not rollback_fails:
+        assert backend.rows == []
+
+
+def test_history_audit_does_not_skip_when_saved_memory_ids_disappear(tmp_path):
+    backend = FakeMem0()
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+    kwargs = dict(user_message="我喜欢钢琴。", assistant_message="我会练琴。",
+        occurred_at=NOW, source_id="history:audit-missing-ids", user_id="local-user")
+    assert adapter.remember_exchange(**kwargs).status is MemoryWriteStatus.WRITTEN
+    backend.rows.clear()
+    before = sum(name == "add" for name, _ in backend.calls)
+    assert adapter.remember_exchange(**kwargs).status is MemoryWriteStatus.WRITTEN
+    assert sum(name == "add" for name, _ in backend.calls) == before + 2
+
+
+@pytest.mark.parametrize("invalidation_fails", [False, True])
+def test_stale_empty_audit_is_invalidated_before_failed_reextraction(tmp_path, monkeypatch, invalidation_fails):
+    class EmptyThenFail(FakeMem0):
+        def add(self, messages, **kwargs):
+            self._raise("add")
+            return {"results": []}
+    backend = EmptyThenFail()
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+    arguments = dict(user_message="我喜欢钢琴。", assistant_message="我会练琴。",
+        occurred_at=NOW, source_id="history:stale-empty", user_id="local-user")
+    assert adapter.remember_exchange(**arguments).status is MemoryWriteStatus.WRITTEN
+    FakeMem0.add(backend, "旧记录", user_id=adapter._normalized_user_id("local-user"),
+        agent_id=adapter.config.agent_id, metadata={"domain": "conversation_memory",
+        "source_id": arguments["source_id"], "canonical": True})
+    backend.fail.add("add")
+    if invalidation_fails:
+        def fail_invalidation(**kwargs):
+            raise OSError("private path")
+        monkeypatch.setattr(adapter, "_invalidate_history_audit", fail_invalidation)
+        result = adapter.remember_exchange(**arguments)
+        assert result.error_code == "MEM0_SOURCE_DEDUP_UNAVAILABLE"
+        assert len(backend.rows) == 1
+        return
+    assert adapter.remember_exchange(**arguments).status is MemoryWriteStatus.UNAVAILABLE
+    assert backend.rows == []
+    assert adapter.remember_exchange(**arguments).status is MemoryWriteStatus.UNAVAILABLE
 
     backend.fail.clear()
     backend.fail.add("get_all")
@@ -779,9 +862,30 @@ def test_historical_linli_fact_uses_provider_compatible_user_shaped_input(
     assert add_calls[1]["metadata"]["history_actor"] == "linli"
 
 
+@pytest.mark.parametrize("fact", ["我（林离）答应下周继续练琴。", "我(林离)答应下周继续练琴。"])
+def test_history_first_person_name_annotation_is_valid_and_deduplicated(tmp_path, fact):
+    class AnnotatedMem0(FakeMem0):
+        def add(self, messages, **kwargs):
+            value = super().add(messages, **kwargs)
+            if kwargs["metadata"]["history_actor"] == "linli":
+                self.rows[-1]["memory"] = fact
+                value["results"][0]["memory"] = fact
+            return value
+    backend = AnnotatedMem0()
+    adapter = Mem0ConversationMemoryAdapter(backend, _config(tmp_path))
+    arguments = dict(user_message="我喜欢钢琴。", assistant_message="我答应下周继续练琴。",
+        occurred_at=NOW, source_id="history:annotated-first-person", user_id="local-user")
+    assert adapter.remember_exchange(**arguments).status is MemoryWriteStatus.WRITTEN
+    assert backend.rows[-1]["memory"] == fact
+    calls = len(backend.calls)
+    assert adapter.remember_exchange(**arguments).status is MemoryWriteStatus.DUPLICATE
+    assert len([name for name, _ in backend.calls[calls:] if name == "add"]) == 0
+
+
 @pytest.mark.parametrize(
     "bad_text",
-    ("AI 回复了来信。", "林离说她回复了来信。", "过去曾温柔地回复这封信。"),
+    ("AI 回复了来信。", "林离说她回复了来信。", "过去曾温柔地回复这封信。",
+     "我（林离）是AI助手。", "我听见林离说她回复了来信。"),
 )
 def test_historical_exchange_rejects_non_first_person_new_memory(
     tmp_path: Path, bad_text: str,

--- a/tests/memory/test_mem0_memory.py
+++ b/tests/memory/test_mem0_memory.py
@@ -547,6 +547,28 @@ def test_explicit_relationship_and_experience_fallback_store_only_relevant_sente
     assert "这件事" not in stored
 
 
+@pytest.mark.parametrize("code", ["MEM0_EXTRACTION_RESPONSE_INVALID", "MEM0_EXTRACTION_RESPONSE_TRUNCATED", "private secret"])
+@pytest.mark.parametrize("rollback_fails", [False, True])
+def test_wrapped_extraction_failure_preserves_only_allowlisted_code(tmp_path, code, rollback_fails):
+    class BrokenExtraction(FakeMem0):
+        def add(self, messages, **kwargs):
+            if not self.rows:
+                return super().add(messages, **kwargs)
+            try:
+                raise Mem0AdapterError(code)
+            except Mem0AdapterError as leaf:
+                raise RuntimeError("private upstream body and key") from leaf
+    backend = BrokenExtraction()
+    if rollback_fails:
+        backend.fail.add("delete")
+    result = Mem0ConversationMemoryAdapter(backend, _config(tmp_path)).remember_exchange(
+        user_message="我住在东京。", assistant_message="我记住了。", occurred_at=NOW,
+        source_id="history:wrapped-failure", user_id="local-user")
+    expected = "MEM0_WRITE_FAILED" if code == "private secret" else code
+    assert result.error_code == ("MEM0_WRITE_ROLLBACK_FAILED" if rollback_fails else expected)
+    assert "private" not in repr(result)
+
+
 def test_provider_failures_degrade_without_echoing_private_text(tmp_path: Path) -> None:
     backend = FakeMem0()
     backend.fail.add("add")

--- a/video_capability_install.py
+++ b/video_capability_install.py
@@ -133,6 +133,28 @@ class VideoCapabilityError(ValueError):
     """Raised for invalid manifests or unsafe installation inputs."""
 
 
+class _BreezeRuntimeInstallError(VideoCapabilityError):
+    def __init__(self, diagnostic_code: str):
+        super().__init__("BREEZE_TTS_RUNTIME_INSTALL_FAILED")
+        self.diagnostic_code = diagnostic_code
+
+
+def _breeze_pip_diagnostic(stderr: str) -> str:
+    # Only fixed categories leave this function; never retain subprocess output.
+    text = stderr.casefold()
+    for category, patterns in (
+        ("DISK_FULL", ("[errno 28]", "[winerror 112]", "no space left on device")),
+        ("MISSING_PIP", ("no module named pip", "no module named 'pip'")),
+        ("UNSUPPORTED_WHEEL", ("not a supported wheel on this platform",)),
+        ("HASH_MISMATCH", ("do not match the hashes",)),
+        ("WHEEL_UNAVAILABLE", ("no matching distribution found",)),
+        ("ACCESS_DENIED", ("[winerror 5]", "[errno 13]", "permission denied")),
+    ):
+        if any(pattern in text for pattern in patterns):
+            return f"BREEZE_PIP_{category}"
+    return "BREEZE_PIP_FAILED"
+
+
 class _RuntimeHostUnavailable(RuntimeError):
     """The portable runtime process could not start on this host."""
 
@@ -350,6 +372,7 @@ class VideoBundleStatus:
     current_file: str | None = None
     source: str | None = None
     reason_code: str | None = None
+    diagnostic_code: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         value: dict[str, object] = {
@@ -365,6 +388,8 @@ class VideoBundleStatus:
             value["source"] = self.source
         if self.reason_code:
             value["reason_code"] = self.reason_code
+        if self.diagnostic_code:
+            value["diagnostic_code"] = self.diagnostic_code
         return value
 
 
@@ -1455,8 +1480,8 @@ class VideoCapabilityInstaller:
             }
         self._report_runtime_progress("checking", checked_bytes, total_bytes)
 
-    def _set(self, bundle: VideoBundle, state: VideoCapabilityState, downloaded: int, *, current: str | None = None, source: str | None = None, reason: str | None = None) -> None:
-        self._status[bundle.identifier] = VideoBundleStatus(bundle.identifier, state, downloaded, sum(item.size_bytes for item in bundle.files), current, source, reason)
+    def _set(self, bundle: VideoBundle, state: VideoCapabilityState, downloaded: int, *, current: str | None = None, source: str | None = None, reason: str | None = None, diagnostic: str | None = None) -> None:
+        self._status[bundle.identifier] = VideoBundleStatus(bundle.identifier, state, downloaded, sum(item.size_bytes for item in bundle.files), current, source, reason, diagnostic)
 
     def _managed_runtime_path(
         self, environment: Mapping[str, str], key: str, *, directory: bool
@@ -2648,7 +2673,8 @@ class VideoCapabilityInstaller:
                     if isinstance(exc, VideoCapabilityError)
                     else "VIDEO_BUNDLE_INSTALL_FAILED"
                 )
-                self._set(bundle, VideoCapabilityState.FAILED, self._status.get(bundle.identifier, VideoBundleStatus(bundle.identifier, VideoCapabilityState.FAILED, 0, 0)).downloaded_bytes, source=source_used, reason=reason)
+                self._set(bundle, VideoCapabilityState.FAILED, self._status.get(bundle.identifier, VideoBundleStatus(bundle.identifier, VideoCapabilityState.FAILED, 0, 0)).downloaded_bytes, source=source_used, reason=reason,
+                          diagnostic=exc.diagnostic_code if isinstance(exc, _BreezeRuntimeInstallError) else None)
         finally:
             if root.exists():
                 shutil.rmtree(root, ignore_errors=True)
@@ -2960,34 +2986,38 @@ class VideoCapabilityInstaller:
             PYTHONNOUSERSITE="1",
             PYTHONSAFEPATH="1",
         )
-        completed = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "--isolated",
-                "install",
-                "--no-index",
-                "--require-hashes",
-                "--no-deps",
-                "--only-binary=:all:",
-                "--find-links",
-                str(python_path.parent.parent / "wheels"),
-                "--target",
-                str(site_packages),
-                "--requirement",
-                str(requirements),
-            ],
-            stdin=subprocess.DEVNULL,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=7200.0,
-            env=environment,
-            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
-        )
+        try:
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "--isolated",
+                    "install",
+                    "--no-index",
+                    "--require-hashes",
+                    "--no-deps",
+                    "--only-binary=:all:",
+                    "--find-links",
+                    str(python_path.parent.parent / "wheels"),
+                    "--target",
+                    str(site_packages),
+                    "--requirement",
+                    str(requirements),
+                ],
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                errors="replace",
+                check=False,
+                timeout=7200.0,
+                env=environment,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+        except subprocess.TimeoutExpired:
+            raise _BreezeRuntimeInstallError("BREEZE_PIP_TIMEOUT") from None
         if completed.returncode != 0:
-            raise VideoCapabilityError("BREEZE_TTS_RUNTIME_INSTALL_FAILED")
+            raise _BreezeRuntimeInstallError(_breeze_pip_diagnostic(completed.stderr or ""))
 
     @staticmethod
     def _verify_breeze_runtime_process(python_path: Path, runtime_root: Path) -> bool:


### PR DESCRIPTION
Official DeepSeek v4-flash exhausted Mem0's 2,000-token budget on reasoning and returned no JSON, making historical imports and subsequent memory-dependent sending fail. The memory client now disables thinking independently of reply generation and rejects truncated responses before Mem0 discards their finish status. Stable extraction errors survive upstream wrapping without exposing response text.

Historical extraction now records successful empty results outside searchable memory, so repeated imports do not call the model again. The receipt is invalidated before repairing changed provider records, and clearing memory removes it. First-person `我（林离）` annotations are accepted without weakening the rejection of AI/assistant identities. Existing mailbox letters do not prevent missing memory from being rebuilt.

Breeze installation failures additionally expose a fixed, sanitized diagnostic category while retaining the existing failure code; this improves diagnosis and does not claim to fix an unobserved pip failure.

Validation: 2,530 tests passed, 6 skipped, 1 deselected; the added recovery route tests passed separately (6). Hardening scan passed. Independent review found and verified the repair of a stale empty-receipt retry bug; no remaining P1/P2 findings in the reviewed memory changes.

Real official-provider checks: the same 500-character synthetic input changed from `length`, 2,000 reasoning tokens and empty content to `stop`, 141 output tokens and 5 persisted memories. A five-letter fixture imported successfully; repeated and fresh-process reimports made zero additional model calls. Keeping five archived letters while clearing isolated memory then reimporting restored memory with zero new mailbox entries. No user text or keys are included here.

Fresh local installation: the ten-file offline input set completed with zero downloader network calls, and the native backend reported both video bundles and runtime READY. This is component-install/readiness acceptance, not a new video-generation or listening evaluation.

Reviewed source base: aacf0a96 (release 0.1.457 lineage); candidate head: 7ae94407f5b3423bdcbb28e3184a77dfde004d6d. Local results are distinct from pending CI and release publication.
