### PR TITLE
修复记忆阻挡寄信恢复、配置保存与离线导入诊断

### DIFF
--- a/contracts/video_capability_status.schema.json
+++ b/contracts/video_capability_status.schema.json
@@ -6,6 +6,15 @@
   "additionalProperties": false,
   "required": ["schema_version", "status", "capability", "can_uninstall", "install_locations", "bundles"],
   "properties": {
+    "offline_action_failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["error_code", "stage"],
+      "properties": {
+        "error_code": {"enum": ["VIDEO_CAPABILITY_LOGIN_REQUIRED", "VIDEO_CAPABILITY_CONFIRMATION_REQUIRED", "VIDEO_OFFLINE_PICKER_UNAVAILABLE", "VIDEO_OFFLINE_ARCHIVE_INVALID", "VIDEO_CAPABILITY_ACTION_UNAVAILABLE", "VIDEO_CAPABILITY_RESULT_INVALID"]},
+        "stage": {"enum": ["authorization", "selection", "validation", "installation"]}
+      }
+    },
     "schema_version": {"const": "olivia.video-capability-status.v2"},
     "status": {"enum": ["READY", "UNAVAILABLE"]},
     "capability": {"const": "video"},

--- a/local_server.py
+++ b/local_server.py
@@ -3418,6 +3418,14 @@ async def route(
                 "error_code": "LETTER_RESEND_NOT_ALLOWED",
                 "retryable": False,
             })
+        if original.get("error_code") == "MEMORY_UNAVAILABLE":
+            try:
+                retry_exhausted_conversation_memory()
+            except Exception:
+                return err(503, "MEMORY_UNAVAILABLE", {
+                    "status": "FAILED", "error_code": "MEMORY_UNAVAILABLE", "retryable": True,
+                    "letter_id": lid,
+                })
         retried = await route(
             "POST",
             "/toy/letter/send",

--- a/original_client_server.py
+++ b/original_client_server.py
@@ -54,7 +54,7 @@ from original_client_companion_mutation_backend import (
 )
 from original_client_diagnostics_api import mount_original_client_diagnostics_api
 from original_client_capability_api import mount_original_client_capability_api
-from original_client_video_capability_api import mount_original_client_video_capability_api
+from original_client_video_capability_api import mount_original_client_video_capability_api, offline_action_failure
 from video_capability_install import (
     VideoCapabilityInstaller,
     load_video_manifest,
@@ -520,6 +520,9 @@ def _diagnostic_source(
             # status() may start runtime preparation. Export only a nonblocking
             # copy of existing state; never install or probe models here.
             installer = video_capability_installer
+            action_failure = offline_action_failure(installer)
+            if action_failure is not None:
+                checks["video_offline_action"] = {"state": "unavailable", **action_failure}
             if not installer._lock.acquire(blocking=False):
                 checks["video_runtime"] = {"state": "unavailable", "error_code": "VIDEO_DIAGNOSTIC_BUSY"}
             else:

--- a/original_client_settings_ui.py
+++ b/original_client_settings_ui.py
@@ -481,7 +481,11 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         || typeof payload.status !== "string"
         || (path === MEM0_CAPABILITY_PATH && payload.capability !== "long_term_memory")
       ) {
-        throw new Error("capability-unavailable");
+        const error = new Error("capability-unavailable");
+        error.code = payload && typeof payload.error_code === "string"
+          && /^[A-Z][A-Z0-9_]{0,95}$/.test(payload.error_code)
+          ? payload.error_code : "CAPABILITY_UNAVAILABLE";
+        throw error;
       }
       return payload;
     } finally {
@@ -1260,44 +1264,66 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         base.input.value = "https://opencode.ai/zen/go/v1";
         model.input.value = "deepseek-v4-flash";
       }
-      save.disabled = true;
+      invalidateTest();
     });
     const state = text("p", setup.llm.key_configured ? "已保存 API key。修改前请先测试连接。" : "请输入 API key 并测试连接。", "text-text-secondary text-body-m font-regular");
     state.setAttribute("aria-live", "polite");
+    const currentConfig = () => ({
+      base_url: base.input.value.trim(),
+      model: model.input.value.trim(),
+      api_key: key.input.value.trim(),
+    });
+    let testedConfig = null;
+    let setupBusy = false;
+    const matchesTest = () => {
+      const current = currentConfig();
+      return testedConfig !== null && Object.keys(current).every(name => current[name] === testedConfig[name]);
+    };
+    const invalidateTest = () => {
+      const valid = matchesTest();
+      setButtonsBusy([save], setupBusy || !valid);
+      if (!setupBusy && testedConfig !== null) {
+        state.textContent = valid ? "连接成功，可以保存。" : "配置已变化，请重新测试连接。";
+      }
+    };
     const testConnection = button("测试连接", async () => {
+      const requestedConfig = currentConfig();
+      testedConfig = null;
+      setupBusy = true;
       setButtonsBusy([testConnection, save], true);
       state.textContent = "正在测试连接……";
       try {
-        await requestSetup(LLM_TEST_PATH, {
-          base_url: base.input.value.trim(),
-          model: model.input.value.trim(),
-          api_key: key.input.value.trim(),
-        });
-        state.textContent = "连接成功，可以保存。";
-        setButtonsBusy([save], false);
+        await requestSetup(LLM_TEST_PATH, requestedConfig);
+        testedConfig = requestedConfig;
       } catch (_error) {
         state.textContent = "连接失败，请检查地址、模型和 API key。";
         save.disabled = true;
       } finally {
+        setupBusy = false;
         testConnection.disabled = false;
         testConnection.style.opacity = "1";
         testConnection.style.cursor = "pointer";
+        invalidateTest();
       }
     });
     const save = button("保存", async () => {
+      if (setupBusy || !matchesTest()) {
+        if (!setupBusy) state.textContent = "请重新测试连接后保存。";
+        return;
+      }
+      const requestedConfig = currentConfig();
+      setupBusy = true;
       setButtonsBusy([testConnection, save], true);
       state.textContent = "正在安全保存……";
       try {
-        await requestSetup(LLM_SAVE_PATH, {
-          base_url: base.input.value.trim(),
-          model: model.input.value.trim(),
-          api_key: key.input.value.trim(),
-        });
+        await requestSetup(LLM_SAVE_PATH, requestedConfig);
         key.input.value = "";
         state.textContent = "已保存。下一次发送立即生效。";
       } catch (_error) {
         state.textContent = "保存失败，请重新测试连接。";
       } finally {
+        setupBusy = false;
+        testedConfig = null;
         testConnection.disabled = false;
         testConnection.style.opacity = "1";
         testConnection.style.cursor = "pointer";
@@ -1309,6 +1335,8 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       if (!await confirmAction("确认删除这台电脑上保存的 API key？")) {
         return;
       }
+      testedConfig = null;
+      setupBusy = true;
       setButtonsBusy([testConnection, save, removeKey], true);
       try {
         await requestSetup(LLM_DELETE_PATH, {});
@@ -1317,13 +1345,14 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       } catch (_error) {
         state.textContent = "API key 删除失败，请重试。";
       } finally {
+        setupBusy = false;
         testConnection.disabled = false;
         removeKey.disabled = false;
         testConnection.style.opacity = "1";
         removeKey.style.opacity = "1";
+        invalidateTest();
       }
     });
-    const invalidateTest = () => { save.disabled = true; };
     base.input.addEventListener("input", invalidateTest);
     model.input.addEventListener("input", invalidateTest);
     key.input.addEventListener("input", invalidateTest);
@@ -1384,7 +1413,7 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
       queued: offlineImport ? "等待导入" : "等待下载",
       downloading: offlineImport ? "正在校验并导入离线包" : "下载中",
       verifying: "校验中",
-      ready: runtimeLoaded ? "已安装并已加载" : "已安装，重启 Olivia 后加载",
+      ready: runtimeLoaded ? "已安装并已加载" : "组件已安装，记忆尚未加载；请查看长期记忆页",
       paused: "已暂停",
       repair: "需修复",
       incompatible: "不兼容",
@@ -1708,14 +1737,18 @@ BOOTSTRAP_JAVASCRIPT = r'''(() => {
         await renderVideoCapabilityPanel(panel);
       } catch (_error) {
         importFinished = true;
+        const failureMessage = _error && typeof _error.code === "string"
+          && /^[A-Z][A-Z0-9_]{0,95}$/.test(_error.code)
+          ? `离线包导入未完成：${_error.code}。请保留诊断包。`
+          : "离线包导入未完成，请保留诊断包以检查原因。";
         try {
           const failed = await requestJson(VIDEO_CAPABILITY_PATH);
           const progress = failed && failed.runtime_import;
           result.textContent = progress && typeof progress === "object"
-            ? runtimeStepMessage(progress) || "离线包导入失败，请重新选择完整 ZIP。"
-            : "离线包导入失败，请重新选择完整 ZIP。";
+            ? runtimeStepMessage(progress) || failureMessage
+            : failureMessage;
         } catch (_statusError) {
-          result.textContent = "离线包导入失败，请重新选择完整 ZIP。";
+          result.textContent = failureMessage;
         }
       } finally {
         importFinished = true;

--- a/original_client_video_capability_api.py
+++ b/original_client_video_capability_api.py
@@ -27,6 +27,20 @@ _SHA256_RE = re.compile(r"[0-9a-f]{64}")
 _LOOPBACK_ORIGIN_RE = re.compile(r"^http://(?:127\.0\.0\.1|localhost):[0-9]{1,5}$")
 _ORIGINS_KEY = web.AppKey("original_client_video_capability_origins", frozenset)
 _MOUNTED_KEY = web.AppKey("original_client_video_capability_mounted", bool)
+OFFLINE_ACTION_ERROR_CODES = frozenset({
+    "VIDEO_CAPABILITY_LOGIN_REQUIRED", "VIDEO_CAPABILITY_CONFIRMATION_REQUIRED",
+    "VIDEO_OFFLINE_PICKER_UNAVAILABLE", "VIDEO_OFFLINE_ARCHIVE_INVALID",
+    "VIDEO_CAPABILITY_ACTION_UNAVAILABLE", "VIDEO_CAPABILITY_RESULT_INVALID",
+})
+OFFLINE_ACTION_STAGES = frozenset({"authorization", "selection", "validation", "installation"})
+
+
+def offline_action_failure(installer) -> dict[str, str] | None:
+    value = getattr(installer, "_offline_action_failure", None)
+    if (isinstance(value, dict) and value.get("error_code") in OFFLINE_ACTION_ERROR_CODES
+            and value.get("stage") in OFFLINE_ACTION_STAGES):
+        return {"error_code": value["error_code"], "stage": value["stage"]}
+    return None
 
 
 class VideoCapabilityAPIError(RuntimeError):
@@ -241,6 +255,11 @@ def mount_original_client_video_capability_api(
         try:
             return await handler(request)
         except VideoCapabilityAPIError as exc:
+            if request.get("offline_stage") in OFFLINE_ACTION_STAGES:
+                installer._offline_action_failure = {
+                    "error_code": exc.code if exc.code in OFFLINE_ACTION_ERROR_CODES else "VIDEO_CAPABILITY_ACTION_UNAVAILABLE",
+                    "stage": "validation" if exc.code == "VIDEO_OFFLINE_ARCHIVE_INVALID" else request["offline_stage"],
+                }
             return web.json_response({"status": "FAILED", "error_code": exc.code}, status=exc.status)
 
     app.middlewares.append(errors)
@@ -257,17 +276,22 @@ def mount_original_client_video_capability_api(
     async def status(request: web.Request) -> web.Response:
         origin = _authorize(request, confirmation=False)
         payload = await asyncio.to_thread(installer.status)
+        failure = offline_action_failure(installer)
+        if isinstance(payload, dict) and failure is not None:
+            payload = {**payload, "offline_action_failure": failure}
         if not isinstance(payload, dict) or payload.get("capability") != "video":
             raise VideoCapabilityAPIError("VIDEO_CAPABILITY_STATUS_INVALID", status=503)
         return web.json_response(payload, headers={"Access-Control-Allow-Origin": origin, "Cache-Control": "no-store"})
 
     async def action(request: web.Request) -> web.Response:
+        payload = await _body(request)
+        if payload.get("action") == "import_offline":
+            request["offline_stage"] = "authorization"
         origin = _authorize(request, confirmation=True)
         try:
             authorize_session(request.headers.get(SESSION_HEADER, ""))
         except Exception as exc:
             raise VideoCapabilityAPIError("VIDEO_CAPABILITY_LOGIN_REQUIRED", status=403) from exc
-        payload = await _body(request)
         action_name = payload.get("action")
         bundle_id = payload.get("bundle_id")
         source = payload.get("source", "auto")
@@ -347,8 +371,16 @@ def mount_original_client_video_capability_api(
         elif action_name == "import_offline":
             if set(payload) != {"action"}:
                 raise VideoCapabilityAPIError("VIDEO_CAPABILITY_FIELDS_INVALID", status=400)
-            selected = await asyncio.to_thread(offline_picker)
+            request["offline_stage"] = "selection"
+            try:
+                selected = await asyncio.to_thread(offline_picker)
+            except VideoCapabilityAPIError:
+                raise
+            except Exception as exc:
+                raise VideoCapabilityAPIError("VIDEO_OFFLINE_PICKER_UNAVAILABLE", status=503) from exc
+            request["offline_stage"] = "validation"
             if selected is None:
+                installer._offline_action_failure = None
                 return web.json_response(
                     {"status": "CANCELLED"},
                     headers={"Access-Control-Allow-Origin": origin, "Cache-Control": "no-store"},
@@ -357,6 +389,7 @@ def mount_original_client_video_capability_api(
             try:
                 async with control_lock:
                     if _is_runtime_archive(archive):
+                        request["offline_stage"] = "installation"
                         result = await asyncio.to_thread(
                             installer.start_runtime_archive_import,
                             runtime_archive=archive,
@@ -365,6 +398,7 @@ def mount_original_client_video_capability_api(
                             raise VideoCapabilityAPIError(
                                 "VIDEO_CAPABILITY_RESULT_INVALID", status=503
                             )
+                        installer._offline_action_failure = None
                         return web.json_response(
                             {"status": result},
                             headers={
@@ -372,6 +406,7 @@ def mount_original_client_video_capability_api(
                                 "Cache-Control": "no-store",
                             },
                         )
+                    request["offline_stage"] = "installation"
                     results = [
                         await asyncio.to_thread(
                             installer.import_offline,
@@ -391,6 +426,7 @@ def mount_original_client_video_capability_api(
                     "VIDEO_CAPABILITY_RESULT_INVALID", status=503
                 )
             result = "APPLIED" if "APPLIED" in results else "NOOP"
+            installer._offline_action_failure = None
             return web.json_response(
                 {"status": result},
                 headers={"Access-Control-Allow-Origin": origin, "Cache-Control": "no-store"},

--- a/runtime/diagnostics/support_bundle.py
+++ b/runtime/diagnostics/support_bundle.py
@@ -113,6 +113,11 @@ def _project_health(value: object) -> dict[str, object]:
         entry: dict[str, object] = {"state": _status(check.get("state"))}
         if "error_code" in check:
             entry["error_code"] = _code(check["error_code"])
+        if name == "video_offline_action":
+            from original_client_video_capability_api import OFFLINE_ACTION_ERROR_CODES, OFFLINE_ACTION_STAGES
+            if check.get("error_code") not in OFFLINE_ACTION_ERROR_CODES or check.get("stage") not in OFFLINE_ACTION_STAGES:
+                raise _invalid()
+            entry["stage"] = check["stage"]
         if name in {"video_ordinary", "video_music", "video_runtime"}:
             diagnostic = check.get("diagnostic_code")
             if isinstance(diagnostic, str) and diagnostic in BREEZE_INSTALL_DIAGNOSTIC_CODES:

--- a/runtime/memory/mem0_memory.py
+++ b/runtime/memory/mem0_memory.py
@@ -7,10 +7,11 @@ provider failures collapse to stable, privacy-safe states.
 
 from __future__ import annotations
 
-from contextlib import closing
+from contextlib import closing, contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import hashlib
+import errno
 import importlib
 import json
 from numbers import Real
@@ -178,6 +179,18 @@ class Mem0AdapterError(RuntimeError):
     def __init__(self, code: str) -> None:
         self.code = code
         super().__init__(code)
+
+
+def _initialization_error_code(error: BaseException) -> str:
+    if isinstance(error, PermissionError):
+        return "MEM0_STORAGE_PERMISSION_DENIED"
+    if isinstance(error, OSError) and error.errno == errno.ENOSPC:
+        return "MEM0_STORAGE_FULL"
+    if isinstance(error, RuntimeError) and str(error).startswith("Storage folder ") and (
+        " is already accessed by another instance of Qdrant client." in str(error)
+    ):
+        return "MEM0_STORAGE_LOCKED"
+    return "MEM0_INITIALIZATION_FAILED"
 
 
 def _extraction_failure_code(error: BaseException) -> str:
@@ -389,6 +402,9 @@ class DeferredConversationMemoryAdapter:
         self._ready_callbacks: list[Callable[[], None]] = []
         self._closed = False
         self._generation = 0
+        self._retired: list[ConversationMemoryPort] = []
+        self._active_calls = 0
+        self._calls_done = threading.Condition(self._lock)
 
     @property
     def closed(self) -> bool:
@@ -403,6 +419,8 @@ class DeferredConversationMemoryAdapter:
         with self._lock:
             self._generation += 1
             self.config, self._factory = config, factory
+            if self._delegate is not None:
+                self._retired.append(self._delegate)
             self._delegate = None
             self._reason_code, self._closed = "MEM0_INITIALIZING", False
         return True
@@ -430,54 +448,73 @@ class DeferredConversationMemoryAdapter:
         with self._lock:
             self._closed = True
             self._ready_callbacks.clear()
+            if self._delegate is not None:
+                self._retired.append(self._delegate)
+                self._delegate = None
+            if self._thread is None or not self._thread.is_alive():
+                self._thread = threading.Thread(target=self._initialize, name="olivia-mem0-closer", daemon=True)
+                self._thread.start()
 
     def status(self) -> ConversationMemoryStatus:
-        with self._lock:
-            delegate = self._delegate
-            reason_code = self._reason_code
-        if delegate is not None:
+        with self._using_current() as delegate:
             return delegate.status()
-        return ConversationMemoryStatus(
-            "unavailable",
-            True,
-            "mem0",
-            "qdrant-local",
-            reason_code=reason_code,
-        )
 
     def search_context(self, query: str, *, user_id: str, limit: int):
-        return self._current().search_context(query, user_id=user_id, limit=limit)
+        with self._using_current() as delegate:
+            return delegate.search_context(query, user_id=user_id, limit=limit)
 
     def remember_exchange(self, **kwargs):
-        return self._current().remember_exchange(**kwargs)
+        with self._using_current() as delegate:
+            return delegate.remember_exchange(**kwargs)
 
     @property
     def operation_pending(self) -> bool:
-        return getattr(self._current(), "operation_pending", False) is True
+        with self._using_current() as delegate:
+            return getattr(delegate, "operation_pending", False) is True
 
     def settle_exchange_write(self, *, source_id: str, user_id: str) -> MemoryWriteResult:
-        settle = getattr(self._current(), "settle_exchange_write", None)
-        if callable(settle):
-            return settle(source_id=source_id, user_id=user_id)
+        with self._using_current() as delegate:
+            settle = getattr(delegate, "settle_exchange_write", None)
+            if callable(settle):
+                return settle(source_id=source_id, user_id=user_id)
         return MemoryWriteResult(
             MemoryWriteStatus.UNAVAILABLE, source_id,
             error_code="MEM0_WRITE_UNCERTAIN",
         )
 
     def list_memories(self, *, user_id: str, limit: int = 100):
-        return self._current().list_memories(user_id=user_id, limit=limit)
+        with self._using_current() as delegate:
+            return delegate.list_memories(user_id=user_id, limit=limit)
 
     def add_manual_memory(self, text: str, *, user_id: str, source_id: str):
-        return self._current().add_manual_memory(text, user_id=user_id, source_id=source_id)
+        with self._using_current() as delegate:
+            return delegate.add_manual_memory(text, user_id=user_id, source_id=source_id)
 
     def delete_memory(self, memory_id: str, *, user_id: str) -> bool:
-        return self._current().delete_memory(memory_id, user_id=user_id)
+        with self._using_current() as delegate:
+            return delegate.delete_memory(memory_id, user_id=user_id)
 
     def clear_user(self, *, user_id: str) -> int:
-        return self._current().clear_user(user_id=user_id)
+        with self._using_current() as delegate:
+            return delegate.clear_user(user_id=user_id)
 
     def export_user(self, *, user_id: str) -> dict[str, object]:
-        return self._current().export_user(user_id=user_id)
+        with self._using_current() as delegate:
+            return delegate.export_user(user_id=user_id)
+
+    @contextmanager
+    def _using_current(self):
+        with self._lock:
+            delegate = self._delegate
+            if delegate is None:
+                delegate = UnavailableConversationMemoryPort(self._reason_code, config=self.config)
+            self._active_calls += 1
+        try:
+            yield delegate
+        finally:
+            with self._lock:
+                self._active_calls -= 1
+                self._calls_done.notify_all()
 
     def _current(self) -> ConversationMemoryPort:
         with self._lock:
@@ -489,19 +526,44 @@ class DeferredConversationMemoryAdapter:
     def _initialize(self) -> None:
         while True:
             with self._lock:
-                generation, factory = self._generation, self._factory
+                while self._active_calls:
+                    self._calls_done.wait()
+                retired, self._retired = self._retired, []
             try:
-                candidate = factory()
-                status = candidate.status()
-                reason_code = None if status.status == "available" and status.enabled is True else status.reason_code or "MEM0_INITIALIZATION_FAILED"
+                for delegate in retired:
+                    close = getattr(delegate, "close", None)
+                    if callable(close):
+                        close()
             except Exception:
-                candidate, reason_code = None, "MEM0_INITIALIZATION_FAILED"
+                with self._lock:
+                    self._retired.extend(retired)
+                    self._reason_code, self._thread = "MEM0_INITIALIZATION_FAILED", None
+                return
             with self._lock:
                 if self._closed:
                     self._thread = None
                     return
-                if generation != self._generation:
+                generation, factory = self._generation, self._factory
+            candidate = None
+            try:
+                candidate = factory()
+                status = candidate.status()
+                reason_code = None if status.status == "available" and status.enabled is True else status.reason_code or "MEM0_INITIALIZATION_FAILED"
+            except Exception as error:
+                reason_code = _initialization_error_code(error)
+            if reason_code is not None and candidate is not None:
+                close = getattr(candidate, "close", None)
+                try:
+                    if callable(close):
+                        close()
                     candidate = None
+                except Exception:
+                    pass
+            with self._lock:
+                if self._closed or generation != self._generation or reason_code is not None:
+                    if candidate is not None:
+                        self._retired.append(candidate)
+                if self._closed or generation != self._generation:
                     continue
                 if reason_code is not None:
                     self._reason_code, self._thread = reason_code, None
@@ -855,6 +917,19 @@ class Mem0ConversationMemoryAdapter:
             self._provider_call.inflight or self._write_call.inflight
             or self._pending_exchange_key is not None
         )
+
+    def close(self) -> None:
+        """Called after deferred dispatch drains; timeout workers still own resources."""
+        while self._provider_call.inflight or self._write_call.inflight:
+            time.sleep(0.01)
+        for resource in (
+            self.backend,
+            getattr(getattr(self.backend, "vector_store", None), "client", None),
+            getattr(getattr(self.backend, "llm", None), "client", None),
+        ):
+            close = getattr(resource, "close", None)
+            if callable(close):
+                close()
 
     def _filters(self, user_id: str) -> dict[str, object]:
         user_id = self._normalized_user_id(user_id)
@@ -1839,9 +1914,9 @@ def create_mem0_adapter(
         return UnavailableConversationMemoryPort(exc.code, config=active)
     except (ModuleNotFoundError, ImportError):
         return UnavailableConversationMemoryPort("MEM0_IMPORT_FAILED", config=active)
-    except (OSError, RuntimeError, TypeError, ValueError):
+    except (OSError, RuntimeError, TypeError, ValueError) as error:
         return UnavailableConversationMemoryPort(
-            "MEM0_INITIALIZATION_FAILED", config=active
+            _initialization_error_code(error), config=active
         )
 
 

--- a/tests/http/test_contract.py
+++ b/tests/http/test_contract.py
@@ -226,7 +226,7 @@ def test_http_startup_exposes_core_health_while_mem0_initializes(
         assert retry["data"]["status"] == "AVAILABLE"
         assert closed_after_first and memory.closed and local_server._start_ready_conversation_memory_runtime() is None
         assert failure_reason == "MEM0_IMPORT_FAILED" and recovered == "available"
-        assert factory_calls == ["old", "latest"]
+        assert factory_calls == ["old", "latest", "latest"]  # Reopening after close recreates released storage.
     finally:
         release.set()
 
@@ -1990,6 +1990,89 @@ def test_handler_rejects_malformed_json_and_wrong_methods() -> None:
     assert asyncio.run(exercise()) == (400, "INVALID_JSON", 405, "METHOD_NOT_ALLOWED")
 
 
+@pytest.mark.parametrize("provider_recovers", [False, True])
+def test_memory_failed_resend_grants_bounded_outbox_recovery_before_reply(tmp_path, monkeypatch, provider_recovers):
+    import local_server
+    from runtime.memory.conversation_memory_outbox import CanonicalMemoryOutbox
+    from runtime.memory.conversation_memory_delivery import ConversationMemoryDeliveryCommitter
+    from conversation_memory_port import ConversationMemoryStatus, MemoryWriteResult, MemoryWriteStatus
+    class Memory:
+        calls = 0
+        succeeds = False
+        def status(self):
+            return ConversationMemoryStatus("available", True, "mem0", "qdrant-local")
+        def remember_exchange(self, **kwargs):
+            self.calls += 1
+            return MemoryWriteResult(MemoryWriteStatus.WRITTEN if self.succeeds else MemoryWriteStatus.UNAVAILABLE,
+                kwargs["source_id"], error_code=None if self.succeeds else "MEM0_WRITE_FAILED")
+    memory = Memory()
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({"letters": [{"letter_id": "completed-earlier", "letter_status": "COMPLETED",
+        "reply_revision": 1, "content": "synthetic", "reply_text": "synthetic",
+        "private_world_occurred_at": "2026-09-06T00:00:00+00:00"}]}))
+    box = CanonicalMemoryOutbox(state, tmp_path / "delivery.sqlite3", ConversationMemoryDeliveryCommitter(memory))
+    original = {"letter_id": "failed-memory", "letter_status": "FAILED", "error_code": "MEMORY_UNAVAILABLE",
+        "content": "synthetic recovery", "material": {}}
+    local_server.store.letters[:] = [original]
+    monkeypatch.setattr(local_server, "retry_exhausted_conversation_memory", box.retry_exhausted_once)
+    monkeypatch.setattr(local_server, "_persist_store_state", lambda: None)
+    monkeypatch.setattr(local_server, "_conversation_memory_ready_for_reply", lambda: box.health()["status"] == "available")
+    monkeypatch.setattr(local_server, "_schedule_reply_job", lambda *a, **k: None)
+    generated = []
+    async def generate(*a, **k):
+        generated.append(True)
+        return True
+    monkeypatch.setattr(local_server, "_run_reply_job", generate)
+    async def scenario():
+        for _ in range(4):
+            await box.scan_once()
+        assert memory.calls == 3
+        memory.succeeds = provider_recovers
+        resent = await local_server.route("POST", "/toy/letter/resend", {"letter_id": original["letter_id"]}, {}, defer_reply=True)
+        assert resent["code"] == 0
+        assert generated == []
+        for _ in range(4):
+            await box.scan_once()
+        assert memory.calls == 4
+        replacement = resent["data"]["letter_id"]
+        assert await local_server._run_reply_when_memory_ready(replacement, "synthetic", idempotency_key=None,
+            ready_timeout_seconds=0) is provider_recovers
+        again = await local_server.route("POST", "/toy/letter/resend", {"letter_id": original["letter_id"]}, {})
+        assert again["code"] == 410
+        assert generated == ([True] if provider_recovers else [])
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("status,superseded", [("COMPLETED", False), ("FAILED", True)])
+def test_ineligible_resend_does_not_grant_memory_retries(monkeypatch, status, superseded):
+    import local_server
+    original = {"letter_id": "ineligible", "letter_status": status, "error_code": "MEMORY_UNAVAILABLE"}
+    if superseded:
+        original["superseded_by"] = "replacement"
+    local_server.store.letters[:] = [original]
+    calls = []
+    monkeypatch.setattr(local_server, "retry_exhausted_conversation_memory", lambda: calls.append(True))
+    response = asyncio.run(local_server.route("POST", "/toy/letter/resend", {"letter_id": "ineligible"}, {}))
+    assert response["code"] in {409, 410}
+    assert calls == []
+
+
+def test_resend_retry_storage_error_preserves_original_letter(monkeypatch):
+    import local_server
+    original = {"letter_id": "retry-storage-error", "letter_status": "FAILED",
+        "error_code": "MEMORY_UNAVAILABLE", "content": "synthetic"}
+    local_server.store.letters[:] = [original]
+    before = dict(original)
+    def fail():
+        raise RuntimeError("private storage detail")
+    monkeypatch.setattr(local_server, "retry_exhausted_conversation_memory", fail)
+    response = asyncio.run(local_server.route("POST", "/toy/letter/resend", {"letter_id": original["letter_id"]}, {}))
+    assert response["code"] == 503
+    assert response["data"]["error_code"] == "MEMORY_UNAVAILABLE"
+    assert "private" not in repr(response)
+    assert local_server.store.letters == [before]
+
+
 def test_llm_failure_can_be_retried_through_the_resend_route(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1997,6 +2080,9 @@ def test_llm_failure_can_be_retried_through_the_resend_route(
     import local_server
 
     monkeypatch.setenv("OLIVIA_LOCAL_DATA_ROOT", str(tmp_path))
+    def unexpected_memory_retry():
+        pytest.fail("LLM failure must not grant memory retries")
+    monkeypatch.setattr(local_server, "retry_exhausted_conversation_memory", unexpected_memory_retry)
     outcomes: list[str | Exception] = [
         local_server.LLMError("LLM_TIMEOUT"),
         "synthetic successful resend",

--- a/tests/http/test_video_offline_failure.py
+++ b/tests/http/test_video_offline_failure.py
@@ -1,0 +1,71 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import original_client_video_capability_api as api
+from runtime.diagnostics.support_bundle import _project_health
+
+
+@pytest.mark.parametrize("failure,code,stage", [
+    ("session", "VIDEO_CAPABILITY_LOGIN_REQUIRED", "authorization"),
+    ("picker", "VIDEO_OFFLINE_PICKER_UNAVAILABLE", "selection"),
+    ("archive", "VIDEO_OFFLINE_ARCHIVE_INVALID", "validation"),
+    ("decode", "VIDEO_OFFLINE_PICKER_UNAVAILABLE", "selection"),
+])
+def test_early_failure_is_safe_and_does_not_replace_ready(tmp_path, failure, code, stage):
+    installer = SimpleNamespace(status=lambda: {
+        "capability": "video", "status": "READY", "runtime_import": {"state": "ready"},
+    })
+
+    def authorize(token):
+        if failure == "session":
+            raise ValueError("private token/path must not escape")
+
+    def picker():
+        if failure == "decode":
+            raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "synthetic")
+        if failure == "picker":
+            raise api.VideoCapabilityAPIError("VIDEO_OFFLINE_PICKER_UNAVAILABLE", status=503)
+        return tmp_path / "private.zip"
+
+    async def run():
+        app = web.Application()
+        api.mount_original_client_video_capability_api(
+            app, installer, trusted_origins=(), authorize_session=authorize,
+            select_offline_archive=picker,
+        )
+        headers = {"Origin": "http://localhost:3000", "X-Olivia-Capability-Action": "confirmed"}
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(api.ACTION_PATH, json={"action": "import_offline"}, headers=headers)
+            assert (await response.json())["error_code"] == code
+            status = await client.get(api.STATUS_PATH, headers=headers)
+            payload = await status.json()
+            assert payload["status"] == "READY"
+            assert payload["runtime_import"] == {"state": "ready"}
+            assert payload["offline_action_failure"] == {"error_code": code, "stage": stage}
+            assert installer._offline_action_failure == payload["offline_action_failure"]
+    asyncio.run(run())
+
+
+def test_diagnostic_failure_projection_is_bounded():
+    failure = {"state": "unavailable", "error_code": "VIDEO_OFFLINE_ARCHIVE_INVALID", "stage": "validation"}
+    result = _project_health({"status": "available", "checks": {"video_offline_action": {**failure, "path": "private"}}})
+    assert result["checks"]["video_offline_action"] == failure
+    for field in ("stage", "error_code"):
+        with pytest.raises(Exception):
+            _project_health({"status": "available", "checks": {"video_offline_action": {**failure, field: "private"}}})
+
+
+def test_failure_status_extension_matches_contract():
+    import json
+    from pathlib import Path
+    from jsonschema import Draft202012Validator
+    schema = json.loads((Path(__file__).resolve().parents[2] / "contracts/video_capability_status.schema.json").read_text(encoding="utf-8"))
+    validator = Draft202012Validator(schema["properties"]["offline_action_failure"])
+    for code in api.OFFLINE_ACTION_ERROR_CODES:
+        for stage in api.OFFLINE_ACTION_STAGES:
+            validator.validate({"error_code": code, "stage": stage})
+    assert not validator.is_valid({"error_code": "PRIVATE", "stage": "selection"})

--- a/tests/installer/test_capability_error_display.py
+++ b/tests/installer/test_capability_error_display.py
@@ -1,0 +1,32 @@
+import shutil
+import subprocess
+
+import pytest
+
+from original_client_settings_ui import BOOTSTRAP_JAVASCRIPT
+
+
+@pytest.mark.parametrize("code,expected", [
+    ("VIDEO_OFFLINE_PICKER_UNAVAILABLE", "VIDEO_OFFLINE_PICKER_UNAVAILABLE"),
+    ("private/path/key", "CAPABILITY_UNAVAILABLE"),
+])
+def test_capability_request_keeps_only_safe_error_code(code, expected):
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required")
+    source = "const requestCapability =" + BOOTSTRAP_JAVASCRIPT.split(
+        "  const requestCapability =", 1
+    )[1].split("  const requestUpdate =", 1)[0]
+    harness = r'''
+const vm=require('node:vm'),fs=require('node:fs'),assert=require('node:assert/strict');
+const context={URL,AbortController,apiBase:'http://127.0.0.1:8899',
+ window:{setTimeout,clearTimeout},MEM0_CAPABILITY_PATH:'/memory',
+ fetch:async()=>({ok:false,json:async()=>({error_code:process.argv[1]})})};
+vm.runInNewContext(fs.readFileSync(0,'utf8')+';globalThis.request=requestCapability;',context);
+context.request('/video').then(()=>{throw Error('expected failure');},error=>{
+ assert.equal(error.code,process.argv[2]);
+}).catch(error=>{console.error(error);process.exitCode=1;});
+'''
+    result = subprocess.run([node, "-e", harness, code, expected], input=source,
+                            text=True, capture_output=True, timeout=20)
+    assert result.returncode == 0, result.stderr

--- a/tests/installer/test_llm_setup_save_state.py
+++ b/tests/installer/test_llm_setup_save_state.py
@@ -1,0 +1,77 @@
+import shutil
+import subprocess
+
+import pytest
+
+from original_client_settings_ui import BOOTSTRAP_JAVASCRIPT
+
+
+@pytest.mark.parametrize("scenario", ["same", "changed", "inflight", "save_body"])
+def test_generated_llm_panel_saves_only_tested_normalized_configuration(scenario):
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required")
+    source = BOOTSTRAP_JAVASCRIPT.split("  const setupInput =", 1)[1].split("  const formatBytes =", 1)[0]
+    source = "const setupInput =" + source
+    harness = r'''
+const vm=require('node:vm'), fs=require('node:fs'), assert=require('node:assert/strict');
+class Element {
+  constructor(tag) { this.tag=tag; this.children=[]; this.style={}; this.value=''; this.listeners={}; }
+  append(...items) { this.children.push(...items); }
+  replaceChildren(...items) { this.children=items; }
+  setAttribute() {}
+  addEventListener(event, fn) { this.listeners[event]=fn; }
+}
+const elements=[];
+const make=tag=>{const el=new Element(tag);elements.push(el);return el;};
+const text=(tag,value)=>{const el=make(tag);el.textContent=value;return el;};
+let resolveTest;
+const sent=[];
+const context={
+  document:{createElement:make}, text, actions:()=>make('div'),
+  button:(label,fn)=>{const el=text('button',label);el.click=fn;return el;},
+  setButtonsBusy:(buttons,busy)=>buttons.forEach(el=>{el.disabled=busy;el.style.opacity=busy?'0.5':'1';}),
+  SETUP_STATUS_PATH:'status', LLM_TEST_PATH:'test', LLM_SAVE_PATH:'save', LLM_DELETE_PATH:'delete',
+  requestSetup:async(path,body)=>{
+    if(path==='status') return {llm:{base_url:'https://api.deepseek.com',model:'model',key_configured:false}};
+    sent.push({path,body});
+    if(path==='test') return await new Promise(resolve=>resolveTest=resolve);
+    return {status:'SAVED'};
+  },
+};
+vm.runInNewContext(fs.readFileSync(0,'utf8')+';globalThis.render=renderLlmSetupPanel;',context);
+(async()=>{
+  await context.render(make('panel'));
+  const inputs=elements.filter(el=>el.tag==='input');
+  const [base,model,key]=inputs;
+  const test=elements.find(el=>el.textContent==='测试连接');
+  const save=elements.find(el=>el.textContent==='保存');
+  const status=elements.find(el=>el.textContent==='请输入 API key 并测试连接。');
+  key.value=' synthetic-key ';
+  const pending=test.click();
+  if(process.argv[1]==='inflight') {model.value='changed';model.listeners.input();}
+  resolveTest({status:'AVAILABLE'});await pending;
+  if(process.argv[1]==='inflight') {
+    assert.equal(save.disabled,true);assert.match(status.textContent,/重新测试/);return;
+  }
+  assert.equal(save.disabled,false);
+  if(process.argv[1]==='same') {
+    key.value='synthetic-key';key.listeners.input();
+    base.value=' https://api.deepseek.com ';base.listeners.input();
+    model.listeners.input();
+    assert.equal(save.disabled,false);assert.match(status.textContent,/可以保存/);
+  } else if(process.argv[1]==='changed') {
+    key.value='other-synthetic-key';key.listeners.input();
+    assert.equal(save.disabled,true);assert.match(status.textContent,/重新测试/);
+    await save.click();
+    assert.equal(sent.filter(call=>call.path==='save').length,0);
+  } else {
+    await save.click();
+    const request=sent.find(call=>call.path==='save');
+    assert.deepEqual(request.body,sent.find(call=>call.path==='test').body);
+    assert.equal(save.disabled,true);assert.equal(key.value,'');
+  }
+})().catch(error=>{console.error(error.stack);process.exitCode=1;});
+'''
+    result = subprocess.run([node, "-e", harness, scenario], input=source.encode("utf-8"), capture_output=True, timeout=15)
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")

--- a/tests/installer/test_original_client_settings_ui.py
+++ b/tests/installer/test_original_client_settings_ui.py
@@ -109,15 +109,15 @@ def test_ready_mem0_reports_loaded_when_companion_runtime_is_available() -> None
     assert _render_ready_mem0_status(companion_state="available") == "已安装并已加载"
 
 
-def test_ready_mem0_requests_restart_when_companion_runtime_is_unavailable() -> None:
+def test_ready_mem0_does_not_promise_restart_fixes_unavailable_runtime() -> None:
     assert _render_ready_mem0_status(companion_state="unavailable") == (
-        "已安装，重启 Olivia 后加载"
+        "组件已安装，记忆尚未加载；请查看长期记忆页"
     )
 
 
-def test_ready_mem0_preserves_restart_fallback_when_companion_is_offline() -> None:
+def test_ready_mem0_reports_not_loaded_when_companion_is_offline() -> None:
     assert _render_ready_mem0_status(companion_state=None) == (
-        "已安装，重启 Olivia 后加载"
+        "组件已安装，记忆尚未加载；请查看长期记忆页"
     )
 
 

--- a/tests/memory/test_mem0_lifecycle.py
+++ b/tests/memory/test_mem0_lifecycle.py
@@ -1,0 +1,99 @@
+import threading
+import errno
+import pytest
+from types import SimpleNamespace
+
+from runtime.memory.mem0_memory import DeferredConversationMemoryAdapter, Mem0Config, Mem0ConversationMemoryAdapter
+
+
+def _join(adapter):
+    thread = adapter._thread
+    if thread:
+        thread.join(2)
+        assert not thread.is_alive()
+
+
+def test_reconfigure_waits_for_timed_out_operation_before_closing_and_reopening(tmp_path):
+    entered, release, closed = threading.Event(), threading.Event(), threading.Event()
+    config = Mem0Config(enabled=True, data_root=tmp_path)
+    backend = SimpleNamespace(vector_store=SimpleNamespace(client=SimpleNamespace(close=closed.set)))
+    old = Mem0ConversationMemoryAdapter(backend, config)
+    old.status = lambda: SimpleNamespace(status="available", enabled=True)
+    deferred = DeferredConversationMemoryAdapter(config, lambda: old)
+    deferred.start_initialization()
+    _join(deferred)
+    def operation():
+        entered.set()
+        release.wait(2)
+        assert not closed.is_set()
+    assert old._write_call.call(operation, timeout_seconds=0.01)[0] == "timeout"
+    assert entered.is_set()
+    factories = []
+    def replacement():
+        assert closed.is_set()
+        factories.append(True)
+        return SimpleNamespace(status=lambda: SimpleNamespace(status="available", enabled=True))
+    deferred.reconfigure_from(DeferredConversationMemoryAdapter(config, replacement))
+    deferred.start_initialization()
+    assert not closed.wait(0.05)
+    assert not factories
+    release.set()
+    _join(deferred)
+    assert closed.is_set() and factories == [True]
+
+
+def test_close_releases_delegate_and_obsolete_initialization_candidate(tmp_path):
+    entered, release, closed = threading.Event(), threading.Event(), threading.Event()
+    def factory():
+        entered.set()
+        release.wait(2)
+        return SimpleNamespace(close=closed.set, status=lambda: SimpleNamespace(status="available", enabled=True))
+    adapter = DeferredConversationMemoryAdapter(Mem0Config(enabled=True, data_root=tmp_path), factory)
+    adapter.start_initialization()
+    assert entered.wait(1)
+    adapter.close()
+    release.set()
+    _join(adapter)
+    assert closed.is_set()
+
+
+def test_reconfigure_keeps_delegate_open_until_dispatched_call_returns(tmp_path):
+    entered, release, closed = threading.Event(), threading.Event(), threading.Event()
+    def read(**kwargs):
+        entered.set()
+        release.wait(2)
+        assert not closed.is_set()
+        return []
+    config = Mem0Config(enabled=True, data_root=tmp_path)
+    old = SimpleNamespace(close=closed.set, list_memories=read,
+        status=lambda: SimpleNamespace(status="available", enabled=True))
+    adapter = DeferredConversationMemoryAdapter(config, lambda: old)
+    adapter.start_initialization()
+    _join(adapter)
+    call = threading.Thread(target=lambda: adapter.list_memories(user_id="local-user"))
+    call.start()
+    assert entered.wait(1)
+    adapter.reconfigure_from(DeferredConversationMemoryAdapter(config,
+        lambda: SimpleNamespace(status=lambda: SimpleNamespace(status="available", enabled=True))))
+    adapter.start_initialization()
+    assert not closed.wait(0.05)
+    release.set()
+    call.join(2)
+    _join(adapter)
+    assert closed.is_set()
+
+
+@pytest.mark.parametrize("error,code", [
+    (PermissionError("private path"), "MEM0_STORAGE_PERMISSION_DENIED"),
+    (OSError(errno.ENOSPC, "private path"), "MEM0_STORAGE_FULL"),
+    (RuntimeError("Storage folder private path is already accessed by another instance of Qdrant client."), "MEM0_STORAGE_LOCKED"),
+    (RuntimeError("private key and content"), "MEM0_INITIALIZATION_FAILED"),
+])
+def test_initialization_failures_expose_only_fixed_metadata(tmp_path, error, code):
+    def fail():
+        raise error
+    adapter = DeferredConversationMemoryAdapter(Mem0Config(enabled=True, data_root=tmp_path), fail)
+    adapter.start_initialization()
+    _join(adapter)
+    assert adapter.status().reason_code == code
+    assert "private" not in repr(adapter.status())


### PR DESCRIPTION
修复记忆写入耗尽后重新寄信仍被永久阻挡的问题：仅用户主动重寄 MEMORY_UNAVAILABLE 失败信件时，授予已有耗尽任务一次额外重试，继续等待写入成功再生成回信；失败仍有界，原信保留。

重新配置或关闭记忆时，等待已派发调用及超时后仍运行的工作线程结束，再关闭旧 SQLite、Qdrant 和 LLM 客户端。另修复测试连接后的保存按钮状态，并保留视频离线包早期失败的安全错误码与诊断阶段，避免统一误报 ZIP 损坏。

验证：全套 2555 passed、6 skipped、1 deselected；随后新增寄信恢复相关测试组 103 passed、1 deselected。真实隔离 Qdrant 重配与关闭重开通过；独立生命周期审查未发现 P1/P2。仓库安全扫描和 diff 检查通过。未宣称已确定用户重启后初始化失败的具体原因，未重新执行完整 GPU 视频生成。
