### PR TITLE
fix: restore video length repair with disabled reviewer

### DIFF
--- a/runtime/reply/reply_quality_gate.py
+++ b/runtime/reply/reply_quality_gate.py
@@ -79,8 +79,11 @@ def _delivery_repair_disposition(
         frozenset(deterministic_codes)
         == frozenset({"VIDEO_REPLY_LENGTH_OUT_OF_RANGE"})
         and not any(item.severity == "hard" for item in review.violations)
-        and review.verdict
-        not in {ReviewVerdict.BLOCK, ReviewVerdict.UNAVAILABLE}
+        and review.verdict is not ReviewVerdict.BLOCK
+        and (
+            review.verdict is not ReviewVerdict.UNAVAILABLE
+            or review.status is ReviewStatus.DISABLED
+        )
     ):
         return DeliveryRepairDisposition.VIDEO_LENGTH
     return DeliveryRepairDisposition.NONE

--- a/tests/persona/test_reply_quality_gate.py
+++ b/tests/persona/test_reply_quality_gate.py
@@ -552,6 +552,19 @@ def test_video_length_with_hard_reviewer_finding_is_not_delivery_repairable() ->
     assert result.delivery_repair_disposition is DeliveryRepairDisposition.NONE
 
 
+def test_video_length_with_disabled_reviewer_keeps_delivery_repair() -> None:
+    result = run_reply_quality_gate(
+        "Too short.",
+        _video_context(),
+        reviewer=NullReviewer(),
+        rewriter=_Rewriter("Still short."),
+    )
+
+    assert result.status is QualityGateStatus.BLOCKED
+    assert result.violation_codes == ("VIDEO_REPLY_LENGTH_OUT_OF_RANGE",)
+    assert result.delivery_repair_disposition is DeliveryRepairDisposition.VIDEO_LENGTH
+
+
 def test_video_length_with_unavailable_reviewer_is_not_delivery_repairable() -> None:
     result = run_reply_quality_gate(
         "Too short.",


### PR DESCRIPTION
## Problem and change

With the reviewer explicitly disabled, a video reply that remained outside the required length after rewriting lost its delivery-repair disposition. The pipeline returned no repairable text and reported a failed letter instead of trying the existing bounded duration repair.

Preserve the video-length repair disposition for an explicitly disabled reviewer. An unavailable active reviewer, a block verdict, other deterministic violations, and hard review findings still prevent this repair. This does not accept an invalid-length reply or bypass final validation.

## Validation

- Regression failed before the change and passed after it.
- 115 tests passed across quality gate, reply pipeline, reply delay/media, and memory administration.
- `git diff --check` passed.
- Scope: two files; no installer/version change or user-data mutation. Full live video generation has not been rerun for this change.
