### PR TITLE
fix(tts): accept natural speech duration without seed retries

### DIFF
--- a/tests/tts/test_breeze_provider.py
+++ b/tests/tts/test_breeze_provider.py
@@ -405,11 +405,12 @@ def test_breeze_delivery_renders_one_complete_plan_and_reports_the_real_provider
 
 
 @pytest.mark.parametrize("durations,success,attempts", [
-    ([36.8, 43.0], True, 3), ([36.8, 36.8, 36.8], False, 3),
-    ([36.8], False, 0), ([36.8, 36.8, 36.8], False, 99),
+    ([36.8], True, 3), ([12.0], True, 3),
+    ([36.8], True, 0), ([36.8], True, 99),
     ([51.76], True, 3), ([61.0], True, 3),
+    ([0.0], False, 3),
 ])
-def test_breeze_duration_retries_without_asr_preserve_complete_request(tmp_path, monkeypatch, durations, success, attempts):
+def test_breeze_natural_duration_without_asr_generates_once(tmp_path, monkeypatch, durations, success, attempts):
     observed = []
     def fake_run(command, **kwargs):
         assert Path(command[1]).name == "external_breeze_worker.py", "no ASR or time stretching"
@@ -432,10 +433,10 @@ def test_breeze_duration_retries_without_asr_preserve_complete_request(tmp_path,
     output = tmp_path / "reply.wav"
     if success:
         result = delivery.render_delivery_wav(config, plan, output, enforce_content_gate=False)
-        assert result.duration_seconds == durations[-1]
+        assert result.duration_seconds == pytest.approx(durations[-1], abs=1 / 24000)
         assert result.quality_report is None
     else:
-        with pytest.raises(delivery.DeliveryAudioError, match="TTS_DELIVERY_DURATION_OUT_OF_RANGE"):
+        with pytest.raises(delivery.DeliveryAudioError, match="TTS_EXTERNAL_AUDIO_INVALID"):
             delivery.render_delivery_wav(config, plan, output, enforce_content_gate=False)
         assert not output.exists()
     assert len(observed) == len(durations)

--- a/tests/tts/test_delivery_contract.py
+++ b/tests/tts/test_delivery_contract.py
@@ -709,7 +709,7 @@ def test_three_rejected_candidates_never_replace_existing_output(
     assert output.read_bytes() == b"existing-output"
 
 
-def test_mixed_duration_failures_do_not_fabricate_three_quality_rejections(
+def test_short_audio_still_runs_content_gate_and_preserves_output(
     tmp_path,
     monkeypatch,
 ) -> None:
@@ -754,10 +754,10 @@ def test_mixed_duration_failures_do_not_fabricate_three_quality_rejections(
         short_instruction="声音柔软自然地承接，再缓缓托起给到力量",
     )
 
-    with pytest.raises(DeliveryAudioError, match="TTS_DELIVERY_DURATION_OUT_OF_RANGE"):
+    with pytest.raises(DeliveryAudioError, match="TTS_CONTENT_GATE_REJECTED"):
         render_delivery_wav(config, plan, output)
 
-    assert calls == {"tts": 3, "quality": 1}
+    assert calls == {"tts": 3, "quality": 3}
     assert output.read_bytes() == b"existing-output"
 
 

--- a/tts/delivery.py
+++ b/tts/delivery.py
@@ -96,13 +96,6 @@ def _validated_quality_report(
     return dict(value)
 
 
-def validate_delivery_duration(duration_seconds: float) -> None:
-    """Reject undersized speech; motion frames follow its natural upper duration."""
-
-    if float(duration_seconds) < 40.0:
-        raise DeliveryAudioError("TTS_DELIVERY_DURATION_OUT_OF_RANGE")
-
-
 def _normalized_instruct_text(value: str) -> str:
     """Leave the model control token exclusively at the instruction tail."""
 
@@ -227,6 +220,8 @@ def _validate_wav(path: Path) -> tuple[int, int]:
     try:
         with wave.open(str(path), "rb") as source:
             if source.getnchannels() != 1 or source.getsampwidth() != 2:
+                raise DeliveryAudioError("TTS_EXTERNAL_AUDIO_INVALID")
+            if source.getframerate() <= 0 or source.getnframes() <= 0:
                 raise DeliveryAudioError("TTS_EXTERNAL_AUDIO_INVALID")
             return source.getframerate(), source.getnframes()
     except (OSError, EOFError, wave.Error) as exc:
@@ -504,7 +499,6 @@ def render_delivery_wav(
             )
 
         quality_report: dict[str, object] | None = None
-        quality_rejection_count = 0
         synthesis_attempts = max(1, min(3, int(request.get("max_attempts", 1))))
         for attempt in range(synthesis_attempts):
             candidate = dict(request)
@@ -512,12 +506,6 @@ def render_delivery_wav(
             candidate["max_attempts"] = 1
             run_worker(candidate)
             sample_rate, frame_count = _validate_wav(temporary_output)
-            try:
-                validate_delivery_duration(frame_count / sample_rate)
-            except DeliveryAudioError as exc:
-                if str(exc) != "TTS_DELIVERY_DURATION_OUT_OF_RANGE":
-                    raise
-                continue
             if require_quality_gate:
                 quality_report = run_quality_gate(candidate)
                 quality_report.update(
@@ -527,13 +515,10 @@ def render_delivery_wav(
                 )
                 if quality_report["passed"] is True:
                     break
-                quality_rejection_count += 1
             else:
                 break
         else:
-            if quality_rejection_count == synthesis_attempts:
-                raise DeliveryAudioError("TTS_CONTENT_GATE_REJECTED")
-            raise DeliveryAudioError("TTS_DELIVERY_DURATION_OUT_OF_RANGE")
+            raise DeliveryAudioError("TTS_CONTENT_GATE_REJECTED")
         temporary_output.replace(output_path)
         return DeliveryAudioResult(
             duration_seconds=frame_count / sample_rate,
@@ -551,5 +536,4 @@ __all__ = [
     "DeliveryAudioResult",
     "build_external_delivery_request",
     "render_delivery_wav",
-    "validate_delivery_duration",
 ]


### PR DESCRIPTION
Valid speech shorter than 40 seconds was regenerated with new seeds and could fail after three attempts. Accept its natural duration on the first successful synthesis, while retaining WAV validation and the existing optional content gate. Reject empty WAV output explicitly.

Validation: 126 tests passed (`tests/tts` and `tests/http/test_reply_delay_and_media.py`); diff check clean. Local real TTS completed on its first attempt in 142.84 seconds with 33.44 seconds of audio, compared with the old duration-retry failure after 474.28 seconds. Short speaking-plus-music pipeline completed; a separate 39.76-second LatentSync replay completed in 293.09 seconds and passed full video decoding.

Review scope: three changed files, natural duration handling and regression coverage. No findings in the inspected diff. These local runs do not establish the cause or resolution of user-side LatentSync timeouts, and do not constitute full 110-second music acceptance.
