### PR TITLE
Align Python package metadata with version 1.1.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bside-olivia-local"
-version = "0.1.0.dev0"
+version = "1.1.10"
 description = "Local HTTP and media-state prototype for BSide Olivia Lin"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
将 pyproject.toml 的旧开发版本号统一为 1.1.10，与 installer/release-version.json 一致。已解析并验证两个版本字段相同，diff 检查通过。本次仅修正源码元数据，不重新制作或发布补丁。