### PR TITLE
Fix unfounded music work routing and improve diagnostics (1.1.22)

### DIFF
--- a/installer/release-version.json
+++ b/installer/release-version.json
@@ -1,1 +1,1 @@
-{"version": "1.1.21"}
+{"version": "1.1.21+qwen.diag1"}

--- a/installer/release-version.json
+++ b/installer/release-version.json
@@ -1,1 +1,1 @@
-{"version": "1.1.21+qwen.diag1"}
+{"version": "1.1.21+qwen.diag2"}

--- a/installer/release-version.json
+++ b/installer/release-version.json
@@ -1,1 +1,1 @@
-{"version": "1.1.21+qwen.diag2"}
+{"version": "1.1.22"}

--- a/letter_triage.py
+++ b/letter_triage.py
@@ -292,6 +292,10 @@ def _validated_result(
     if None in {direct, voice_better, music_better, willing}:
         return _invalid_result("route_booleans")
 
+    # Model-suggested context is not evidence of an actual current work.
+    if not context.to_model_dict()["current_music_work"]:
+        contexts = tuple(item for item in contexts if item != "current_work_relevance")
+
     voice_explicit = bool({"explicit_voice_reply_request", "explicit_video_reply_request"}.intersection(contexts))
     song_explicit = "explicit_performance_or_adaptation_request" in contexts
     both_explicit = "explicit_voice_and_song_request" in contexts or (voice_explicit and song_explicit)
@@ -311,8 +315,6 @@ def _validated_result(
     if disposition in {"fulfill", "refuse", "defer"}:
         return _invalid_result("route_disposition")
 
-    if "current_work_relevance" in contexts and not context.current_music_work:
-        return _invalid_result("route_current_work")
     if "melody_idea" in contexts:
         if role != "spontaneous_motif" or intent != "compose":
             return _invalid_result("route_music_context")
@@ -425,8 +427,14 @@ class LetterReplyRouter:
         if getattr(calls[0], "name", None) != "select_reply_mode":
             return _invalid_result("route_tool_name")
         arguments = getattr(calls[0], "arguments", None)
-        if not isinstance(arguments, Mapping) or set(arguments) != _TOOL_FIELDS:
+        if not isinstance(arguments, Mapping):
             return _invalid_result("route_fields")
+        if set(arguments) != _TOOL_FIELDS:
+            return _failed("router_invalid_result", diagnostic={
+                "failure_stage": "route_validation", "failure_detail": "route_fields",
+                "route_missing_fields": sorted(_TOOL_FIELDS - set(arguments)),
+                "route_extra_field_count": min(1000, len(set(arguments) - _TOOL_FIELDS)),
+            })
         return _validated_result(arguments, context)
 
 

--- a/letter_triage.py
+++ b/letter_triage.py
@@ -239,10 +239,16 @@ def _bool_field(value: Mapping[str, Any], name: str) -> bool | None:
     return item if type(item) is bool else None
 
 
+def _invalid_result(detail: str) -> TriageResult:
+    return _failed("router_invalid_result", diagnostic={
+        "failure_stage": "route_validation", "failure_detail": detail,
+    })
+
+
 def _validated_result(
     value: Mapping[str, Any],
     context: RoutingContext,
-) -> TriageResult | None:
+) -> TriageResult:
     mode = value.get("mode")
     reason = value.get("reason_code")
     emotion = value.get("emotion_level")
@@ -266,7 +272,7 @@ def _validated_result(
         or len(raw_contexts) > len(_ALLOWED_MUSIC_CONTEXTS)
         or any(type(item) is not str for item in raw_contexts)
     ):
-        return None
+        return _invalid_result("route_values")
 
     contexts = tuple(raw_contexts)
     if (
@@ -277,14 +283,14 @@ def _validated_result(
         )
         or _ROLE_INTENT[role] != intent
     ):
-        return None
+        return _invalid_result("route_contexts")
 
     direct = _bool_field(value, "direct_response_sufficient")
     voice_better = _bool_field(value, "voice_materially_better")
     music_better = _bool_field(value, "music_materially_better")
     willing = _bool_field(value, "character_willing")
     if None in {direct, voice_better, music_better, willing}:
-        return None
+        return _invalid_result("route_booleans")
 
     voice_explicit = bool({"explicit_voice_reply_request", "explicit_video_reply_request"}.intersection(contexts))
     song_explicit = "explicit_performance_or_adaptation_request" in contexts
@@ -303,27 +309,27 @@ def _validated_result(
             "fulfill" if available else "defer",
         )
     if disposition in {"fulfill", "refuse", "defer"}:
-        return None
+        return _invalid_result("route_disposition")
 
     if "current_work_relevance" in contexts and not context.current_music_work:
-        return None
+        return _invalid_result("route_current_work")
     if "melody_idea" in contexts:
         if role != "spontaneous_motif" or intent != "compose":
-            return None
+            return _invalid_result("route_music_context")
     elif role == "spontaneous_motif":
-        return None
+        return _invalid_result("route_music_context")
 
     if mode == "text_letter":
         if role in _ACTIVE_MUSIC_ROLES:
-            return None
+            return _invalid_result("route_text_constraints")
     elif mode == "voice_reply":
         if not context.available(mode) or direct or not voice_better or not willing or role != "none" or music_better:
-            return None
+            return _invalid_result("route_voice_constraints")
     else:
         if not context.available("singing_video" if mode == "musical_video" else mode) or direct or not music_better or not willing or not contexts or role not in _ACTIVE_MUSIC_ROLES:
-            return None
+            return _invalid_result("route_music_constraints")
         if mode == "voice_song_video" and not voice_better:
-            return None
+            return _invalid_result("route_music_constraints")
         # Old automatic musical decisions retain their song expression without adding speech.
         if mode == "musical_video":
             mode = "singing_video"
@@ -414,13 +420,14 @@ class LetterReplyRouter:
         except Exception as error:
             return _failed("router_unavailable", diagnostic=exception_context(error, "internal"))
 
-        if len(calls) != 1 or getattr(calls[0], "name", None) != "select_reply_mode":
-            return _failed("router_invalid_result")
+        if len(calls) != 1:
+            return _invalid_result("route_tool_count")
+        if getattr(calls[0], "name", None) != "select_reply_mode":
+            return _invalid_result("route_tool_name")
         arguments = getattr(calls[0], "arguments", None)
         if not isinstance(arguments, Mapping) or set(arguments) != _TOOL_FIELDS:
-            return _failed("router_invalid_result")
-        result = _validated_result(arguments, context)
-        return result or _failed("router_invalid_result")
+            return _invalid_result("route_fields")
+        return _validated_result(arguments, context)
 
 
 # Existing imports keep working while the behavior is upgraded from emotion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bside-olivia-local"
-version = "1.1.21+qwen.diag1"
+version = "1.1.21+qwen.diag2"
 description = "Local HTTP and media-state prototype for BSide Olivia Lin"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bside-olivia-local"
-version = "1.1.21+qwen.diag2"
+version = "1.1.22"
 description = "Local HTTP and media-state prototype for BSide Olivia Lin"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bside-olivia-local"
-version = "1.1.21"
+version = "1.1.21+qwen.diag1"
 description = "Local HTTP and media-state prototype for BSide Olivia Lin"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/runtime/diagnostics/failure_context.py
+++ b/runtime/diagnostics/failure_context.py
@@ -21,6 +21,16 @@ def project_failure_context(source):
     status = source.get("http_status")
     if type(status) is int and 100 <= status <= 599:
         result["http_status"] = status
+    fields = source.get("route_missing_fields")
+    allowed_fields = {"mode", "reason_code", "emotion_level", "music_contexts",
+        "music_role", "music_intent", "request_disposition", "direct_response_sufficient",
+        "voice_materially_better", "music_materially_better", "character_willing"}
+    if isinstance(fields, list):
+        result["route_missing_fields"] = sorted({item for item in fields
+            if isinstance(item, str) and item in allowed_fields})
+    count = source.get("route_extra_field_count")
+    if type(count) is int and 0 <= count <= 1000:
+        result["route_extra_field_count"] = count
     return result
 
 

--- a/runtime/diagnostics/failure_context.py
+++ b/runtime/diagnostics/failure_context.py
@@ -4,6 +4,12 @@ STAGES = {"configuration", "request", "http_response", "response_json", "tool_pa
 CODES = {"PROVIDER_QUOTA_EXHAUSTED", "PROVIDER_TIMEOUT", "PROVIDER_PROTOCOL", "PROVIDER_UNAVAILABLE", "PROVIDER_RETRYABLE", "PROVIDER_REJECTED", "GATEWAY_OTHER"}
 KINDS = {"TimeoutError", "TypeError", "ValueError", "AttributeError", "RuntimeError", "ClientConnectorError", "ClientConnectorCertificateError", "ClientConnectorSSLError", "ServerDisconnectedError", "ClientPayloadError", "OTHER"}
 DETAILS = {"invalid_json", "invalid_response_shape", "missing_tools", "invalid_tool_entry", "invalid_tool_name", "invalid_tool_arguments"}
+DETAILS |= {
+    "route_tool_count", "route_tool_name", "route_fields", "route_values",
+    "route_contexts", "route_booleans", "route_disposition", "route_current_work",
+    "route_music_context", "route_text_constraints", "route_voice_constraints",
+    "route_music_constraints",
+}
 
 
 def project_failure_context(source):

--- a/tests/http/test_reply_route_diagnostics.py
+++ b/tests/http/test_reply_route_diagnostics.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from collections import deque
 from types import SimpleNamespace
 
@@ -8,6 +9,51 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from runtime.diagnostics.support_bundle import _project_tail
 from runtime.video_reply_settings import VideoReplySettingsStore
+
+
+@pytest.mark.parametrize("change,detail", [
+    ({"extra": "private-letter"}, "route_fields"),
+    ({"reason_code": "private-invalid-reason"}, "route_values"),
+    ({"music_role": "performance"}, "route_contexts"),
+    ({"direct_response_sufficient": "true"}, "route_booleans"),
+    ({"request_disposition": "fulfill"}, "route_disposition"),
+    ({"music_contexts": ["current_work_relevance"]}, "route_current_work"),
+    ({"mode": "voice_reply"}, "route_voice_constraints"),
+])
+def test_qwen_route_validation_reason_survives_export(change, detail):
+    from llm_gateway import GatewayConfig, OpenAICompatibleAdapter
+    from letter_triage import LetterReplyRouter
+    import local_server as server
+
+    arguments = dict(mode="text_letter", reason_code="direct_words", emotion_level="normal",
+        music_contexts=[], music_role="none", music_intent="none", request_disposition="none",
+        direct_response_sufficient=True, voice_materially_better=False,
+        music_materially_better=False, character_willing=True)
+    arguments.update(change)
+
+    async def run():
+        async def provider(request):
+            body = await request.json()
+            assert body["model"] == "qwen3.8-flash"
+            assert body["enable_thinking"] is False
+            return web.json_response({"choices": [{"message": {"tool_calls": [{"function": {
+                "name": "select_reply_mode", "arguments": json.dumps(arguments),
+            }}]}}]})
+        app = web.Application()
+        app.router.add_post('/chat/completions', provider)
+        async with TestClient(TestServer(app)) as client:
+            gateway = OpenAICompatibleAdapter(GatewayConfig(
+                provider="openai_compatible", base_url=str(client.make_url('/')).rstrip('/'),
+                model="qwen3.8-flash", requires_api_key=False, max_retries=0))
+            return await LetterReplyRouter(gateway, environ={}).classify("private-letter")
+
+    result = asyncio.run(run())
+    assert result.reason_code == "router_invalid_result"
+    assert result.diagnostic == {"failure_stage": "route_validation", "failure_detail": detail}
+    record = server._runtime_diagnostic_record("reply_route_classification_failed", result.diagnostic)
+    exported = _project_tail([record], runtime=True)
+    assert detail.encode() in exported
+    assert b"private-" not in exported
 
 
 @pytest.mark.parametrize("reason,expected", [

--- a/tests/http/test_reply_route_diagnostics.py
+++ b/tests/http/test_reply_route_diagnostics.py
@@ -17,7 +17,6 @@ from runtime.video_reply_settings import VideoReplySettingsStore
     ({"music_role": "performance"}, "route_contexts"),
     ({"direct_response_sufficient": "true"}, "route_booleans"),
     ({"request_disposition": "fulfill"}, "route_disposition"),
-    ({"music_contexts": ["current_work_relevance"]}, "route_current_work"),
     ({"mode": "voice_reply"}, "route_voice_constraints"),
 ])
 def test_qwen_route_validation_reason_survives_export(change, detail):
@@ -49,7 +48,7 @@ def test_qwen_route_validation_reason_survives_export(change, detail):
 
     result = asyncio.run(run())
     assert result.reason_code == "router_invalid_result"
-    assert result.diagnostic == {"failure_stage": "route_validation", "failure_detail": detail}
+    assert result.diagnostic.items() >= {"failure_stage": "route_validation", "failure_detail": detail}.items()
     record = server._runtime_diagnostic_record("reply_route_classification_failed", result.diagnostic)
     exported = _project_tail([record], runtime=True)
     assert detail.encode() in exported

--- a/tests/http/test_route_context_repair.py
+++ b/tests/http/test_route_context_repair.py
@@ -1,0 +1,50 @@
+import asyncio
+from types import SimpleNamespace
+
+from letter_triage import LetterReplyRouter, RoutingContext
+from runtime.diagnostics.support_bundle import _project_tail
+
+
+def classify(**changes):
+    arguments = dict(mode='text_letter', reason_code='direct_words', emotion_level='normal',
+        music_contexts=['current_work_relevance'], music_role='none', music_intent='none',
+        request_disposition='none', direct_response_sufficient=True,
+        voice_materially_better=False, music_materially_better=False, character_willing=True)
+    arguments.update(changes)
+    arguments = {k: v for k, v in arguments.items() if v is not None}
+    class Gateway:
+        async def complete_with_tools(self, **kwargs):
+            return [SimpleNamespace(name='select_reply_mode', arguments=arguments)]
+    return asyncio.run(LetterReplyRouter(Gateway(), routing_context=RoutingContext(
+        musical_video_available=True, voice_reply_available=True)).classify('synthetic'))
+
+
+def test_unfounded_work_context_does_not_block_text():
+    result = classify()
+    assert result.status == 'completed'
+    assert result.reply_mode == 'text_letter'
+    assert result.music_contexts == ()
+
+
+def test_unfounded_work_context_cannot_authorize_music():
+    result = classify(mode='singing_video', music_role='performance', music_intent='perform',
+        direct_response_sufficient=False, music_materially_better=True)
+    assert result.status == 'unavailable'
+
+
+def test_explicit_voice_request_survives_work_context_repair():
+    result = classify(music_contexts=['current_work_relevance', 'explicit_voice_reply_request'])
+    assert result.status == 'completed'
+    assert result.reply_mode == 'voice_reply'
+    assert result.music_contexts == ('explicit_voice_reply_request',)
+
+
+def test_field_difference_survives_export_without_unknown_names():
+    result = classify(mode=None, emotion_level=None, **{'private-secret-name': 'private-value'})
+    assert result.status == 'unavailable'
+    assert result.diagnostic['route_missing_fields'] == ['emotion_level', 'mode']
+    assert result.diagnostic['route_extra_field_count'] == 1
+    exported = _project_tail([{'event': 'reply_route_classification_failed', **result.diagnostic}], runtime=True)
+    assert b'route_missing_fields' in exported and b'emotion_level' in exported
+    assert b'route_extra_field_count' in exported
+    assert b'private' not in exported


### PR DESCRIPTION
修复回信形式检测中，无依据的“当前音乐作品关联”导致整封信被拒绝的问题。模型返回的关联缺少当前作品依据时移除该关联，再按原规则校验回信形式；不把错误一律降级为文字，不依靠不存在的作品触发唱歌，保留明确媒体请求。

补充校验分支诊断，以及字段缺失白名单和多余字段数量。导出的诊断不包含未知字段名、模型原始结果、用户正文或 Key。版本更新为 1.1.22。

验证：相关测试 146 项通过；本地诊断版补丁重复构建字节一致，隔离安装及重复安装成功，合成 data/profile 保留。正式版冻结源码与 CI、安装产物验证将补充到本 PR。

范围限制：用户诊断包证实 route_current_work 与 route_fields；前者已修复，后者具体缺失/多余字段仍待新诊断确认。没有调用真实 Qwen 接口，不宣称所有 Qwen 路由失败已解决。
